### PR TITLE
feat: プロジェクト管理APIを実装

### DIFF
--- a/docs/logs/2025-12-11-pr2-project-api.md
+++ b/docs/logs/2025-12-11-pr2-project-api.md
@@ -1,0 +1,116 @@
+# 作業ログ: PR #2 プロジェクト管理API
+
+**日付**: 2025-12-11
+**担当**: Claude Code
+**ブランチ**: feature/pr2-project-api
+**親ブランチ**: feature/pr1-project-setup
+
+## 実施内容
+
+プロジェクト管理APIの実装。`add-project`と`get-projects`の2つのMCPツールを実装した。
+
+### 実装したMCPツール
+
+#### 1. add-project
+プロジェクトを追加するツール。
+
+**パラメータ:**
+- `name` (必須): プロジェクト名（ユニーク）
+- `description` (任意): プロジェクトの説明
+- `asana_url` (任意): AsanaプロジェクトタスクのURL
+
+**返却値:**
+```json
+{
+  "project_id": 1,
+  "name": "claude-code-exterminal-memory",
+  "description": "MCPサーバーを作るよ〜",
+  "asana_url": "https://app.asana.com/0/...",
+  "created_at": "2025-12-10T10:00:00Z"
+}
+```
+
+**エラー処理:**
+- 重複するnameの場合は`DATABASE_ERROR`を返す
+- その他のDB操作エラーも`DATABASE_ERROR`として返す
+
+#### 2. get-projects
+プロジェクト一覧を取得するツール。
+
+**パラメータ:**
+- `limit` (デフォルト: 30): 取得件数上限（最大30件）
+
+**返却値:**
+```json
+{
+  "projects": [
+    {
+      "id": 1,
+      "name": "project-name",
+      "description": "...",
+      "asana_url": "...",
+      "created_at": "..."
+    }
+  ]
+}
+```
+
+**仕様:**
+- 作成日時の降順（最新が先）で返す
+- 同じ作成日時の場合はIDの降順で返す
+
+### ソースコード
+
+#### src/main.py
+- `FastMCP`でMCPサーバーを作成
+- 実装ロジック（`_impl`関数）とMCPツール（デコレータ付き関数）を分離
+  - テストから直接呼べるようにするため
+  - FastMCPのデコレータを使うと`FunctionTool`オブジェクトになり直接呼び出せないため
+
+### テストコード
+
+#### tests/test_main.py
+7つのテストケース（全てPASS）:
+1. `test_add_project_success` - プロジェクト追加の成功
+2. `test_add_project_minimal` - 必須項目のみでの追加
+3. `test_add_project_duplicate_name` - 重複name時のエラー
+4. `test_get_projects_empty` - 空の場合
+5. `test_get_projects_multiple` - 複数取得・順序確認
+6. `test_get_projects_with_limit` - limit指定
+7. `test_get_projects_limit_max_30` - limitの最大30件制限
+
+### テスト結果
+
+```
+============================= test session starts ==============================
+tests/test_main.py::test_add_project_success PASSED                      [ 14%]
+tests/test_main.py::test_add_project_minimal PASSED                      [ 28%]
+tests/test_main.py::test_add_project_duplicate_name PASSED               [ 42%]
+tests/test_main.py::test_get_projects_empty PASSED                       [ 57%]
+tests/test_main.py::test_get_projects_multiple PASSED                    [ 71%]
+tests/test_main.py::test_get_projects_with_limit PASSED                  [ 85%]
+tests/test_main.py::test_get_projects_limit_max_30 PASSED                [100%]
+
+============================== 7 passed in 0.32s ===============================
+```
+
+全テストPASS（DB関連5 + API関連7 = 計12テスト）
+
+## 問題と解決
+
+### 1. FastMCPデコレータによる関数呼び出しエラー
+**問題**: `@mcp.tool()`デコレータを使うと関数が`FunctionTool`オブジェクトになり、テストから直接呼び出せない
+
+**解決**:
+- 実装ロジックを`_impl`サフィックス付き関数に分離
+- MCPツールは`_impl`関数を呼ぶラッパーとして定義
+- テストでは`_impl`関数を直接インポート
+
+### 2. 作成日時が同じ場合の順序不定
+**問題**: 同一ループ内で複数レコードを作成すると`created_at`が同じになり、順序が不定
+
+**解決**: `ORDER BY created_at DESC, id DESC`で同一日時の場合もIDの降順でソート
+
+## 次のステップ
+
+PR #3 でトピック管理API（書き込み系：`add-topic`, `add-log`, `add-decision`）を実装する。

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,131 @@
+"""MCPサーバーのメインエントリーポイント"""
+from fastmcp import FastMCP
+from typing import Optional
+from src.db import execute_insert, execute_query, row_to_dict, init_database
+
+# MCPサーバーを作成
+mcp = FastMCP("Discussion Recording System")
+
+
+# 実装ロジック（テストから直接呼べるようにMCPデコレータと分離）
+def add_project_impl(
+    name: str,
+    description: Optional[str] = None,
+    asana_url: Optional[str] = None,
+) -> dict:
+    """
+    新しいプロジェクトを追加する。
+
+    Args:
+        name: プロジェクト名（ユニーク）
+        description: プロジェクトの説明
+        asana_url: AsanaプロジェクトタスクのURL
+
+    Returns:
+        作成されたプロジェクト情報
+    """
+    try:
+        project_id = execute_insert(
+            "INSERT INTO projects (name, description, asana_url) VALUES (?, ?, ?)",
+            (name, description, asana_url),
+        )
+
+        # 作成したプロジェクトを取得
+        rows = execute_query(
+            "SELECT * FROM projects WHERE id = ?", (project_id,)
+        )
+        if rows:
+            project = row_to_dict(rows[0])
+            return {
+                "project_id": project["id"],
+                "name": project["name"],
+                "description": project["description"],
+                "asana_url": project["asana_url"],
+                "created_at": project["created_at"],
+            }
+        else:
+            raise Exception("Failed to retrieve created project")
+
+    except Exception as e:
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+
+
+def get_projects_impl(limit: int = 30) -> dict:
+    """
+    プロジェクト一覧を取得する。
+
+    Args:
+        limit: 取得件数上限（最大30件）
+
+    Returns:
+        プロジェクト一覧
+    """
+    try:
+        # limitを30件に制限
+        limit = min(limit, 30)
+
+        rows = execute_query(
+            "SELECT * FROM projects ORDER BY created_at DESC, id DESC LIMIT ?",
+            (limit,),
+        )
+
+        projects = []
+        for row in rows:
+            project = row_to_dict(row)
+            projects.append({
+                "id": project["id"],
+                "name": project["name"],
+                "description": project["description"],
+                "asana_url": project["asana_url"],
+                "created_at": project["created_at"],
+            })
+
+        return {"projects": projects}
+
+    except Exception as e:
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+
+
+# MCPツール定義
+@mcp.tool()
+def add_project(
+    name: str,
+    description: Optional[str] = None,
+    asana_url: Optional[str] = None,
+) -> dict:
+    """
+    新しいプロジェクトを追加する。
+
+    Args:
+        name: プロジェクト名（ユニーク）
+        description: プロジェクトの説明
+        asana_url: AsanaプロジェクトタスクのURL
+
+    Returns:
+        作成されたプロジェクト情報
+    """
+    return add_project_impl(name, description, asana_url)
+
+
+@mcp.tool()
+def get_projects(limit: int = 30) -> dict:
+    """
+    プロジェクト一覧を取得する。
+
+    Args:
+        limit: 取得件数上限（最大30件）
+
+    Returns:
+        プロジェクト一覧
+    """
+    return get_projects_impl(limit)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,109 @@
+"""MCPツールのテスト"""
+import os
+import tempfile
+import pytest
+from src.db import init_database
+from src.main import add_project_impl as add_project, get_projects_impl as get_projects
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        # クリーンアップ
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def test_add_project_success(temp_db):
+    """プロジェクトの追加が成功する"""
+    result = add_project(
+        name="test-project",
+        description="テストプロジェクト",
+        asana_url="https://app.asana.com/0/test",
+    )
+
+    assert "error" not in result
+    assert result["project_id"] > 0
+    assert result["name"] == "test-project"
+    assert result["description"] == "テストプロジェクト"
+    assert result["asana_url"] == "https://app.asana.com/0/test"
+    assert "created_at" in result
+
+
+def test_add_project_minimal(temp_db):
+    """必須項目のみでプロジェクトを追加できる"""
+    result = add_project(name="minimal-project")
+
+    assert "error" not in result
+    assert result["project_id"] > 0
+    assert result["name"] == "minimal-project"
+    assert result["description"] is None
+    assert result["asana_url"] is None
+
+
+def test_add_project_duplicate_name(temp_db):
+    """同じ名前のプロジェクトを追加するとエラーになる"""
+    # 1つ目は成功
+    result1 = add_project(name="duplicate-test")
+    assert "error" not in result1
+
+    # 2つ目はエラー
+    result2 = add_project(name="duplicate-test")
+    assert "error" in result2
+    assert result2["error"]["code"] == "DATABASE_ERROR"
+
+
+def test_get_projects_empty(temp_db):
+    """プロジェクトが存在しない場合、空の配列が返る"""
+    result = get_projects()
+
+    assert "error" not in result
+    assert result["projects"] == []
+
+
+def test_get_projects_multiple(temp_db):
+    """複数のプロジェクトを取得できる"""
+    # 3つプロジェクトを作成
+    add_project(name="project-1", description="desc-1")
+    add_project(name="project-2", description="desc-2")
+    add_project(name="project-3", description="desc-3")
+
+    result = get_projects()
+
+    assert "error" not in result
+    assert len(result["projects"]) == 3
+
+    # 作成日時の降順で返る（最新が先）
+    assert result["projects"][0]["name"] == "project-3"
+    assert result["projects"][1]["name"] == "project-2"
+    assert result["projects"][2]["name"] == "project-1"
+
+
+def test_get_projects_with_limit(temp_db):
+    """limit指定で取得件数を制限できる"""
+    # 5つプロジェクトを作成
+    for i in range(5):
+        add_project(name=f"project-{i}")
+
+    result = get_projects(limit=3)
+
+    assert "error" not in result
+    assert len(result["projects"]) == 3
+
+
+def test_get_projects_limit_max_30(temp_db):
+    """limitは最大30件に制限される"""
+    # 35個プロジェクトを作成
+    for i in range(35):
+        add_project(name=f"project-{i}")
+
+    # 50件要求しても30件まで
+    result = get_projects(limit=50)
+
+    assert "error" not in result
+    assert len(result["projects"]) == 30


### PR DESCRIPTION
## 概要

プロジェクト管理API（add-project, get-projects）を実装。

## 実装内容

### MCPツール
- **add-project** - プロジェクトを追加
  - パラメータ: name（必須）, description, asana_url
  - エラーハンドリング: 重複name検知
- **get-projects** - プロジェクト一覧を取得
  - パラメータ: limit（デフォルト30、最大30）
  - 作成日時降順 + ID降順でソート

### ソースコード
- `src/main.py` - FastMCP使用
  - 実装ロジック（`_impl`関数）とMCPツールを分離
  - テストから直接呼べるように設計

### テスト
- `tests/test_main.py` - 7テストケース（全てPASS）
  - プロジェクト追加（成功、必須項目のみ、重複name）
  - プロジェクト取得（空、複数、limit指定、limit最大値）

## テスト結果

```
tests/test_main.py::test_add_project_success PASSED                      [ 14%]
tests/test_main.py::test_add_project_minimal PASSED                      [ 28%]
tests/test_main.py::test_add_project_duplicate_name PASSED               [ 42%]
tests/test_main.py::test_get_projects_empty PASSED                       [ 57%]
tests/test_main.py::test_get_projects_multiple PASSED                    [ 71%]
tests/test_main.py::test_get_projects_with_limit PASSED                  [ 85%]
tests/test_main.py::test_get_projects_limit_max_30 PASSED                [100%]

============================== 7 passed in 0.32s ===============================
```

全体: 12テストPASS（DB関連5 + API関連7）

## 作業ログ
詳細は `docs/logs/2025-12-11-pr2-project-api.md` を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)