### PR TITLE
feat: トピック管理API（書き込み系）を実装

### DIFF
--- a/docs/logs/2025-12-11-pr3-topic-write-api.md
+++ b/docs/logs/2025-12-11-pr3-topic-write-api.md
@@ -1,0 +1,132 @@
+# 作業ログ: PR #3 トピック管理API（書き込み系）
+
+**日付**: 2025-12-11
+**担当**: Claude Code
+**ブランチ**: feature/pr3-topic-write-api
+**親ブランチ**: feature/pr2-project-api
+
+## 実施内容
+
+トピック管理API（書き込み系）の実装。`add-topic`, `add-log`, `add-decision`の3つのMCPツールを実装した。
+
+### 実装したMCPツール
+
+#### 1. add-topic
+新しい議論トピックを追加するツール。
+
+**パラメータ:**
+- `project_id` (必須): プロジェクトID
+- `title` (必須): トピックのタイトル
+- `description` (任意): トピックの説明
+- `parent_topic_id` (任意): 親トピックのID（未指定なら最上位トピック）
+
+**返却値:**
+```json
+{
+  "topic_id": 1,
+  "project_id": 1,
+  "title": "開発フローの詳細",
+  "description": "...",
+  "parent_topic_id": null,
+  "created_at": "2025-12-10T10:00:00Z"
+}
+```
+
+**機能:**
+- 親子関係を持つトピックツリーの構築が可能
+- プロジェクト単位でトピックを管理
+
+#### 2. add-log
+トピックに議論ログ（1やりとり）を追加するツール。
+
+**パラメータ:**
+- `topic_id` (必須): 対象トピックのID
+- `content` (必須): 議論内容（マークダウン可）
+
+**返却値:**
+```json
+{
+  "log_id": 1,
+  "topic_id": 1,
+  "content": "AI: ...\nユーザー：...",
+  "created_at": "2025-12-10T10:05:00Z"
+}
+```
+
+**機能:**
+- 議論のやりとりを時系列で記録
+- 外部キー制約により存在しないトピックIDはエラー
+
+#### 3. add-decision
+決定事項を記録するツール。
+
+**パラメータ:**
+- `decision` (必須): 決定内容
+- `reason` (必須): 決定の理由
+- `topic_id` (任意): 関連するトピックのID
+
+**返却値:**
+```json
+{
+  "decision_id": 1,
+  "topic_id": 1,
+  "decision": "設計議論フェーズではプランモード不要。",
+  "reason": "設計議論では自由に発散→収束させたい。",
+  "created_at": "2025-12-10T10:10:00Z"
+}
+```
+
+**機能:**
+- トピックに紐づく決定事項を記録
+- トピックIDなしでグローバルな決定事項も記録可能
+
+### コード変更
+
+#### src/main.py
+- `add_topic_impl()`, `add_log_impl()`, `add_decision_impl()` 実装
+- 対応するMCPツール定義を追加
+
+#### src/db.py
+- `get_connection()`に外部キー制約の有効化を追加
+  - `PRAGMA foreign_keys = ON`
+  - 存在しないtopic_idへの参照をエラーにする
+
+### テストコード
+
+#### tests/test_topic_write.py
+9つのテストケース（全てPASS）:
+1. `test_add_topic_success` - トピック追加の成功
+2. `test_add_topic_minimal` - 必須項目のみでの追加
+3. `test_add_topic_with_parent` - 親トピック指定
+4. `test_add_log_success` - ログ追加の成功
+5. `test_add_log_multiple` - 複数ログ追加
+6. `test_add_log_invalid_topic` - 存在しないトピックIDでエラー
+7. `test_add_decision_success` - 決定事項追加の成功
+8. `test_add_decision_without_topic` - トピックIDなしで追加
+9. `test_add_decision_multiple` - 複数決定事項の追加
+
+### テスト結果
+
+```
+============================= test session starts ==============================
+tests/test_db.py (5 tests) ............................ PASSED
+tests/test_main.py (7 tests) .......................... PASSED
+tests/test_topic_write.py (9 tests) ................... PASSED
+
+============================== 21 passed in 0.35s ==============================
+```
+
+全テストPASS（DB 5 + プロジェクトAPI 7 + トピック書き込みAPI 9 = 計21テスト）
+
+## 問題と解決
+
+### 1. SQLiteの外部キー制約が無効
+**問題**: 存在しないtopic_idを指定してもエラーにならず、レコードが挿入されてしまう
+
+**原因**: SQLiteは外部キー制約がデフォルトで無効
+
+**解決**: `src/db.py`の`get_connection()`で`PRAGMA foreign_keys = ON`を実行し、外部キー制約を有効化
+
+## 次のステップ
+
+PR #4 でトピック管理API（読み取り系：`get-topics`, `get-decided-topics`, `get-undecided-topics`, `get-topic-tree`, `get-logs`, `get-decisions`）を実装する。

--- a/src/db.py
+++ b/src/db.py
@@ -23,6 +23,7 @@ def get_connection() -> sqlite3.Connection:
     db_path = get_db_path()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row  # 辞書ライクなアクセスを可能にする
+    conn.execute("PRAGMA foreign_keys = ON")  # 外部キー制約を有効化
     return conn
 
 

--- a/tests/test_topic_write.py
+++ b/tests/test_topic_write.py
@@ -1,0 +1,168 @@
+"""トピック管理API（書き込み系）のテスト"""
+import os
+import tempfile
+import pytest
+from src.db import init_database
+from src.main import (
+    add_project_impl as add_project,
+    add_topic_impl as add_topic,
+    add_log_impl as add_log,
+    add_decision_impl as add_decision,
+)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        # クリーンアップ
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def test_project(temp_db):
+    """テスト用プロジェクトを作成する"""
+    result = add_project(name="test-project")
+    return result["project_id"]
+
+
+def test_add_topic_success(test_project):
+    """トピックの追加が成功する"""
+    result = add_topic(
+        project_id=test_project,
+        title="開発フローの詳細",
+        description="プランモードの使い方、タスク分解の粒度を決定する",
+    )
+
+    assert "error" not in result
+    assert result["topic_id"] > 0
+    assert result["project_id"] == test_project
+    assert result["title"] == "開発フローの詳細"
+    assert result["description"] == "プランモードの使い方、タスク分解の粒度を決定する"
+    assert result["parent_topic_id"] is None
+    assert "created_at" in result
+
+
+def test_add_topic_minimal(test_project):
+    """必須項目のみでトピックを追加できる"""
+    result = add_topic(project_id=test_project, title="最小トピック")
+
+    assert "error" not in result
+    assert result["topic_id"] > 0
+    assert result["title"] == "最小トピック"
+    assert result["description"] is None
+    assert result["parent_topic_id"] is None
+
+
+def test_add_topic_with_parent(test_project):
+    """親トピックを指定してトピックを追加できる"""
+    # 親トピックを作成
+    parent = add_topic(project_id=test_project, title="親トピック")
+
+    # 子トピックを作成
+    result = add_topic(
+        project_id=test_project,
+        title="子トピック",
+        parent_topic_id=parent["topic_id"],
+    )
+
+    assert "error" not in result
+    assert result["parent_topic_id"] == parent["topic_id"]
+
+
+def test_add_log_success(test_project):
+    """議論ログの追加が成功する"""
+    # トピックを作成
+    topic = add_topic(project_id=test_project, title="テストトピック")
+
+    # ログを追加
+    result = add_log(
+        topic_id=topic["topic_id"],
+        content="AI: プランモードは設計議論フェーズでは不要だと考えます\nユーザー：同意します。",
+    )
+
+    assert "error" not in result
+    assert result["log_id"] > 0
+    assert result["topic_id"] == topic["topic_id"]
+    assert "AI: プランモードは設計議論フェーズでは不要だと考えます" in result["content"]
+    assert "created_at" in result
+
+
+def test_add_log_multiple(test_project):
+    """同じトピックに複数のログを追加できる"""
+    topic = add_topic(project_id=test_project, title="テストトピック")
+
+    # 3つのログを追加
+    log1 = add_log(topic_id=topic["topic_id"], content="ログ1")
+    log2 = add_log(topic_id=topic["topic_id"], content="ログ2")
+    log3 = add_log(topic_id=topic["topic_id"], content="ログ3")
+
+    assert "error" not in log1
+    assert "error" not in log2
+    assert "error" not in log3
+    assert log1["log_id"] != log2["log_id"] != log3["log_id"]
+
+
+def test_add_log_invalid_topic(test_project):
+    """存在しないトピックIDでエラーになる"""
+    result = add_log(topic_id=99999, content="test")
+
+    assert "error" in result
+    assert result["error"]["code"] == "DATABASE_ERROR"
+
+
+def test_add_decision_success(test_project):
+    """決定事項の追加が成功する"""
+    # トピックを作成
+    topic = add_topic(project_id=test_project, title="テストトピック")
+
+    # 決定事項を追加
+    result = add_decision(
+        topic_id=topic["topic_id"],
+        decision="設計議論フェーズではプランモード不要。",
+        reason="設計議論では自由に発散→収束させたい。",
+    )
+
+    assert "error" not in result
+    assert result["decision_id"] > 0
+    assert result["topic_id"] == topic["topic_id"]
+    assert result["decision"] == "設計議論フェーズではプランモード不要。"
+    assert result["reason"] == "設計議論では自由に発散→収束させたい。"
+    assert "created_at" in result
+
+
+def test_add_decision_without_topic(temp_db):
+    """トピックIDなしで決定事項を追加できる"""
+    result = add_decision(
+        decision="グローバルな決定事項",
+        reason="プロジェクト全体に関わる",
+    )
+
+    assert "error" not in result
+    assert result["decision_id"] > 0
+    assert result["topic_id"] is None
+
+
+def test_add_decision_multiple(test_project):
+    """複数の決定事項を追加できる"""
+    topic = add_topic(project_id=test_project, title="テストトピック")
+
+    dec1 = add_decision(
+        topic_id=topic["topic_id"],
+        decision="決定1",
+        reason="理由1",
+    )
+    dec2 = add_decision(
+        topic_id=topic["topic_id"],
+        decision="決定2",
+        reason="理由2",
+    )
+
+    assert "error" not in dec1
+    assert "error" not in dec2
+    assert dec1["decision_id"] != dec2["decision_id"]


### PR DESCRIPTION
## 概要

トピック管理API（書き込み系）を実装。`add-topic`, `add-log`, `add-decision`の3つのMCPツール。

## 実装内容

### MCPツール
- **add-topic** - 議論トピックを追加
  - パラメータ: project_id（必須）, title（必須）, description, parent_topic_id
  - 親子関係を持つトピックツリーをサポート
- **add-log** - 議論ログを追加
  - パラメータ: topic_id（必須）, content（必須）
  - 1やりとり = 1レコードで議論を記録
- **add-decision** - 決定事項を記録
  - パラメータ: decision（必須）, reason（必須）, topic_id
  - トピックに紐づく決定事項またはグローバルな決定事項を記録

### コード変更
- `src/main.py` - 3つのツールの実装ロジックとMCPツール定義
- `src/db.py` - 外部キー制約の有効化（`PRAGMA foreign_keys = ON`）

### テスト
- `tests/test_topic_write.py` - 9テストケース（全てPASS）
  - トピック追加（成功、必須項目のみ、親トピック指定）
  - ログ追加（成功、複数、不正なトピックID）
  - 決定事項追加（成功、トピックIDなし、複数）

## テスト結果

```
tests/test_db.py (5 tests) ............................ PASSED
tests/test_main.py (7 tests) .......................... PASSED
tests/test_topic_write.py (9 tests) ................... PASSED

============================== 21 passed in 0.35s ==============================
```

全体: 21テストPASS（DB 5 + プロジェクトAPI 7 + トピック書き込みAPI 9）

## 作業ログ
詳細は `docs/logs/2025-12-11-pr3-topic-write-api.md` を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)