### PR TITLE
fix: FastMCP 2.0リソース実装のインポートエラーを修正

### DIFF
--- a/docs/references/fastmcp-resource-implementation.md
+++ b/docs/references/fastmcp-resource-implementation.md
@@ -1,0 +1,164 @@
+# FastMCP 2.0 リソース機能の実装方法
+
+## 概要
+
+本ドキュメントでは、FastMCP 2.0におけるリソース機能の正しい実装方法について記述する。MCPサーバー開発時に発生したモジュールインポートエラーの原因と解決方法を含む。
+
+## 発生した問題
+
+MCPサーバー（claude-code-exterminal-memory）が起動できなくなる事象が発生した。具体的には、以下のインポート文が原因でモジュールエラーが発生していた。
+
+```python
+import mcp.types as types
+```
+
+エラーメッセージ:
+```
+ModuleNotFoundError: No module named 'mcp.types'
+```
+
+## 原因
+
+FastMCP 2.0では、`mcp.types`モジュールは存在しない。リソース機能の実装方法がFastMCP 2.0で変更されており、以下の旧実装パターンは不要である：
+
+- `@mcp.list_resources()`デコレータによる手動リソースリスト管理
+- `@mcp.read_resource()`デコレータによる手動リソース読み取り処理
+- `mcp.types.Resource`クラスのインポート
+
+## 解決方法
+
+### 誤った実装（動作しない）
+
+```python
+import mcp.types as types
+
+@mcp.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [
+        types.Resource(
+            uri="docs://workflow",
+            name="議論管理ワークフロー",
+            mimeType="text/markdown",
+            description="MCPツールを使った議論管理の典型的なフロー"
+        )
+    ]
+
+@mcp.read_resource()
+async def read_resource(uri: str) -> str:
+    if uri == "docs://workflow":
+        return "..."
+    return ""
+```
+
+### 正しい実装（FastMCP 2.0）
+
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("server-name")
+
+@mcp.resource("docs://workflow")
+def workflow_docs() -> str:
+    """MCPツールを使った議論管理の典型的なフロー"""
+    return """# 議論管理ワークフロー
+
+## 内容
+...
+"""
+```
+
+## 実装パターン
+
+### 基本的な文字列リソース
+
+```python
+@mcp.resource("resource://greeting")
+def get_greeting() -> str:
+    """シンプルなグリーティングメッセージを提供する"""
+    return "Hello from FastMCP Resources!"
+```
+
+### JSON形式のリソース
+
+辞書を返すと自動的にJSONにシリアライズされる。
+
+```python
+@mcp.resource("data://config")
+def get_config() -> dict:
+    """アプリケーション設定をJSON形式で提供する"""
+    return {
+        "theme": "dark",
+        "version": "1.2.0",
+        "features": ["tools", "resources"],
+    }
+```
+
+### テンプレートリソース（パラメータ付き）
+
+URIにパラメータを含めることができる。
+
+```python
+@mcp.resource("weather://{city}/current")
+def get_weather(city: str) -> dict:
+    """特定都市の気象情報を提供する"""
+    return {
+        "city": city.capitalize(),
+        "temperature": 22,
+        "condition": "Sunny"
+    }
+```
+
+### メタデータ付きリソース
+
+```python
+@mcp.resource(
+    uri="data://app-status",
+    name="ApplicationStatus",
+    description="アプリケーションの現在の状態を提供する",
+    mime_type="application/json",
+    tags={"monitoring", "status"},
+    meta={"version": "2.1", "team": "infrastructure"}
+)
+def get_application_status() -> dict:
+    """アプリケーションステータスを返す"""
+    return {"status": "ok", "uptime": 12345}
+```
+
+## 重要なポイント
+
+1. **自動登録**: `@mcp.resource()`デコレータを使用すると、リソースは自動的にリソースリストに登録される
+2. **遅延評価**: リソースはクライアントからリクエストされた時点で初めて実行される
+3. **型の自動変換**: 文字列、辞書、リストなどの戻り値は自動的に適切な形式に変換される
+4. **メタデータの推論**: 関数名やドキュメント文字列から名前や説明が自動的に推論される
+
+## 調査手法に関する学び
+
+今回の問題調査において、以下の手法の有効性が確認された。
+
+### 推奨: Context7を使用したドキュメント調査
+
+Context7を使用することで、最新の公式ドキュメントから正確なコード例と実装パターンを取得できる。
+
+```
+1. resolve-library-id で "fastmcp" を検索
+2. /gofastmcp.com/llmstxt を選択
+3. "resources implementation decorator" をトピックに指定
+4. 正確な実装例を取得
+```
+
+### 非推奨: WebSearchによる調査
+
+WebSearchでは以下の問題が発生する可能性がある：
+- 古いバージョンの情報が混在する
+- 断片的な情報しか得られない
+- 複数の情報源を横断的に確認する必要がある
+
+## 参考情報
+
+- FastMCP 公式ドキュメント: https://gofastmcp.com/
+- FastMCP GitHub: https://github.com/jlowin/fastmcp
+- Context7 ライブラリID: `/gofastmcp.com/llmstxt`
+
+## 更新履歴
+
+- 2025-12-11: 初版作成（FastMCP 2.0リソース実装エラーの調査結果）

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from src.services import (
 )
 
 # MCPサーバーを作成
-mcp = FastMCP("Discussion Recording System")
+mcp = FastMCP("claude-code-exterminal-memory")
 
 
 # MCPツール定義
@@ -22,6 +22,11 @@ def add_project(
 ) -> dict:
     """
     新しいプロジェクトを追加する。
+
+    典型的な使い方:
+    - 新プロジェクト開始時: add_project("プロジェクト名", "説明", asana_url="...")
+
+    ワークフロー位置: プロジェクト管理の最初のステップ
 
     Args:
         name: プロジェクト名（ユニーク）
@@ -39,6 +44,11 @@ def get_projects() -> dict:
     """
     プロジェクト一覧を取得する（全件）。
 
+    典型的な使い方:
+    - セッション開始時にプロジェクト特定: get_projects() → project_id を確認
+
+    ワークフロー位置: 全ての議論管理の起点（最初のステップ）
+
     Returns:
         プロジェクト一覧
     """
@@ -54,6 +64,12 @@ def add_topic(
 ) -> dict:
     """
     新しい議論トピックを追加する。
+
+    典型的な使い方:
+    - 新しい設計議論を始める: add_topic(project_id, "○○機能の設計", "...")
+    - 既存トピックの詳細論点: add_topic(project_id, "詳細設計", "...", parent_topic_id=親ID)
+
+    ワークフロー位置: 議論開始時（最初のステップ）
 
     Args:
         project_id: プロジェクトID
@@ -71,6 +87,15 @@ def add_topic(
 def add_log(topic_id: int, content: str) -> dict:
     """
     トピックに議論ログ（1やりとり）を追加する。
+
+    典型的な使い方:
+    - AIとユーザーのやりとりを記録: add_log(topic_id, "AI: 提案\nユーザー: フィードバック")
+
+    ワークフロー位置: 議論中（重要な節目で記録）
+
+    記録タイミング:
+    - 重要な議論の節目（提案→フィードバック）
+    - 決定事項の前提となる議論
 
     Args:
         topic_id: 対象トピックのID
@@ -91,6 +116,13 @@ def add_decision(
     """
     決定事項を記録する。
 
+    典型的な使い方:
+    - 認識合わせ後の即座の記録: add_decision(decision="...", reason="...", topic_id=...)
+
+    ワークフロー位置: 認識合わせ→ユーザーOK直後（即座に記録）
+
+    重要: 後回しにせず、決定が確定した時点で記録すること
+
     Args:
         decision: 決定内容
         reason: 決定の理由
@@ -110,6 +142,12 @@ def get_topics(
     """
     指定した親トピックの直下の子トピックを取得する（1階層・全件）。
 
+    典型的な使い方:
+    - 最上位トピック確認: get_topics(project_id)
+    - 特定トピック配下の確認: get_topics(project_id, parent_topic_id=親ID)
+
+    ワークフロー位置: セッション開始時、トピック構造の確認時
+
     Args:
         project_id: プロジェクトID
         parent_topic_id: 親トピックのID（未指定なら最上位トピックのみ取得）
@@ -127,6 +165,12 @@ def get_decided_topics(
 ) -> dict:
     """
     指定した親トピックの直下の子トピックのうち、決定済み（decisionが存在する）トピックのみを取得する（1階層）。
+
+    典型的な使い方:
+    - 最上位の決定済み事項確認: get_decided_topics(project_id)
+    - 特定トピック配下の決定済み論点確認: get_decided_topics(project_id, parent_topic_id=親ID)
+
+    ワークフロー位置: 決定済み事項の確認時
 
     Args:
         project_id: プロジェクトID
@@ -146,6 +190,12 @@ def get_undecided_topics(
     """
     指定した親トピックの直下の子トピックのうち、未決定（decisionが存在しない）トピックのみを取得する（1階層）。
 
+    典型的な使い方:
+    - セッション開始時に未決定事項を確認: get_undecided_topics(project_id)
+    - 特定トピック配下の未解決論点を確認: get_undecided_topics(project_id, parent_topic_id=親ID)
+
+    ワークフロー位置: セッション開始時、次に議論すべきトピックの確認時
+
     Args:
         project_id: プロジェクトID
         parent_topic_id: 親トピックのID（未指定なら最上位トピックのみ取得）
@@ -164,6 +214,12 @@ def get_logs(
 ) -> dict:
     """
     指定トピックの議論ログを取得する。
+
+    典型的な使い方:
+    - トピックの議論履歴を確認: get_logs(topic_id)
+    - ページング: get_logs(topic_id, start_id=最後のID)
+
+    ワークフロー位置: 議論再開時、過去の議論確認時
 
     Args:
         topic_id: 対象トピックのID
@@ -185,6 +241,12 @@ def get_decisions(
     """
     指定トピックに関連する決定事項を取得する。
 
+    典型的な使い方:
+    - トピックの決定事項を確認: get_decisions(topic_id)
+    - ページング: get_decisions(topic_id, start_id=最後のID)
+
+    ワークフロー位置: 決定済み事項の確認時
+
     Args:
         topic_id: 対象トピックのID
         start_id: 取得開始位置の決定事項ID（ページネーション用）
@@ -204,6 +266,11 @@ def get_topic_tree(
 ) -> dict:
     """
     指定したトピックを起点に、再帰的に全ツリーを取得する。
+
+    典型的な使い方:
+    - トピック全体の構造を把握: get_topic_tree(project_id, topic_id)
+
+    ワークフロー位置: 議論全体の俯瞰時、構造確認時
 
     Args:
         project_id: プロジェクトID
@@ -225,6 +292,11 @@ def search_topics(
     """
     トピックをキーワード検索する。
 
+    典型的な使い方:
+    - 過去の議論を検索: search_topics(project_id, keyword="認証")
+
+    ワークフロー位置: 関連する過去の議論を探す時
+
     Args:
         project_id: プロジェクトID
         keyword: 検索キーワード（title, descriptionから部分一致）
@@ -245,6 +317,11 @@ def search_decisions(
     """
     決定事項をキーワード検索する。
 
+    典型的な使い方:
+    - 過去の決定を検索: search_decisions(project_id, keyword="API設計")
+
+    ワークフロー位置: 関連する過去の決定事項を探す時
+
     Args:
         project_id: プロジェクトID
         keyword: 検索キーワード（decision, reasonから部分一致）
@@ -254,3 +331,103 @@ def search_decisions(
         検索結果の決定事項一覧
     """
     return search_service.search_decisions(project_id, keyword, limit)
+
+
+# リソース機能
+@mcp.resource("docs://workflow")
+def workflow_docs() -> str:
+    """MCPツールを使った議論管理の典型的なフロー"""
+    return """# 議論管理ワークフロー
+
+## 1. プロジェクトの特定
+まず作業対象のプロジェクトを特定する。
+
+```
+get_projects() → project_id を確認
+```
+
+## 2. 設計議論の開始
+新しい議論トピックを作成する。
+
+```
+add_topic(project_id, title="○○機能の設計", description="...")
+→ topic_id が返される
+```
+
+## 3. 議論のやりとり記録
+AIとユーザーのやりとりを記録。
+
+```
+add_log(topic_id, content="AI: 提案\\nユーザー: フィードバック")
+```
+
+記録タイミング:
+- 重要な議論の節目
+- 決定事項の前提となる議論
+
+## 4. 決定事項の記録
+認識合わせ → ユーザーOK → 即座に記録。
+
+```
+add_decision(
+    decision="決定内容",
+    reason="理由",
+    topic_id=関連トピックID
+)
+```
+
+**重要**: 後回しにせず即座に記録すること。
+
+## 5. 議論状況の確認
+
+未決定事項:
+```
+get_undecided_topics(project_id)
+get_undecided_topics(project_id, parent_topic_id=親ID)
+```
+
+決定済み:
+```
+get_decided_topics(project_id)
+get_decisions(topic_id)
+```
+
+トピック構造:
+```
+get_topics(project_id)  # 最上位
+get_topic_tree(project_id, topic_id)  # ツリー全体
+```
+
+検索:
+```
+search_topics(project_id, keyword="...")
+search_decisions(project_id, keyword="...")
+```
+
+## 6. セッション開始時
+
+新しいセッション開始時の推奨フロー:
+1. get_projects() でプロジェクト特定
+2. get_topics(project_id) で最上位トピック確認
+3. get_undecided_topics(project_id) で未決定事項確認
+4. 必要に応じて get_topic_tree, get_logs, get_decisions
+
+## データベース構造
+
+```
+projects (プロジェクト)
+  ├── discussion_topics (議論トピック)
+  │     ├── discussion_logs (議論ログ)
+  │     └── decisions (決定事項)
+  └── tasks (タスク) ※未実装
+```
+
+主要な関係:
+- discussion_topics.parent_topic_id → discussion_topics.id (親子関係)
+- discussion_topics.project_id → projects.id
+- decisions.topic_id → discussion_topics.id
+"""
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary
- FastMCP 2.0のリソース機能実装時に発生したインポートエラーを修正
- `mcp.types`モジュール（存在しない）のインポートを削除
- `@mcp.resource()`デコレータへの移行で正しい実装パターンに修正
- 実装方法のドキュメントを追加

## Changes
- `import mcp.types as types`を削除
- `@mcp.list_resources()`と`@mcp.read_resource()`の手動実装を削除
- `@mcp.resource("docs://workflow")`デコレータに変更
- `docs/references/fastmcp-resource-implementation.md`を追加

## 背景
リソース機能追加時に誤って`mcp.types`モジュールをインポートしていたため、MCPサーバーが起動できない状態になっていた。FastMCP 2.0では`@mcp.resource()`デコレータのみで自動的にリソース登録が行われる仕様のため、手動実装は不要。

## Test plan
- [x] MCPサーバーの再接続に成功することを確認（`/mcp`コマンドで接続成功）
- [x] リソース機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)