### PR TITLE
chore: CIとpre-commit設定を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests with pytest
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+      - id: pyupgrade
+        args: [--py312-plus]


### PR DESCRIPTION
## 概要
CI/CDワークフローとpre-commitフックを追加

## 変更内容
- GitHub Actions CI ワークフロー（`.github/workflows/test.yml`）
  - PR作成・更新時にpytestを自動実行
  - Python 3.12を使用
- pre-commit設定（`.pre-commit-config.yaml`）
  - 基本的なファイルチェック（trailing-whitespace、end-of-file-fixer等）
  - Python構文チェック（check-ast、pyupgrade）

## セットアップ手順
マージ後、以下を実行してpre-commitを有効化してください：

```bash
pip install pre-commit
pre-commit install
```

## テスト計画
- [ ] PRを作成してCIが実行されることを確認
- [ ] pytestが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)