### PR TITLE
docs: project-context.mdをタスク管理実装に合わせて更新

### DIFF
--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -220,7 +220,7 @@ CREATE TABLE tasks (
     CHECK(status IN ('pending', 'in_progress', 'blocked', 'completed')),
   topic_id INTEGER REFERENCES discussion_topics(id) ON DELETE SET NULL,  -- blockedの時に関連する議論トピック
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP  -- TRIGGERで自動更新
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
@@ -256,19 +256,14 @@ CREATE TABLE tasks (
 
 タスクの実行ログを記録するテーブル。将来的に実装予定。
 
-```sql
--- 将来の実装予定
-CREATE TABLE task_logs (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  task_id INTEGER NOT NULL REFERENCES tasks(id),
-  session_id TEXT NOT NULL,
-  summary TEXT NOT NULL,
-  purpose TEXT NOT NULL,
-  result TEXT NOT NULL,
-  issues TEXT,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-```
+**想定カラム**:
+- task_id: 関連タスク
+- session_id: セッション識別子
+- summary: 作業概要
+- purpose: 作業目的
+- result: 作業結果
+- issues: 発生した問題
+- created_at: 作成日時
 
 **原則**: RDBには事実のみ。改善提案（事実じゃない）、学んだこと（→ knowledgeへ）は記録しない。
 


### PR DESCRIPTION
## Summary

PR #18〜#21でタスク管理機能が実装されたことを受け、`docs/project-context.md`を現在の実装状態に合わせて更新。

## Changes

### テーブル設計の更新
- `tasksテーブル`: 実装に合わせて更新
  - `task_statuses`テーブル廃止 → `status`カラムにCHECK制約で直接管理
  - `topic_id`カラム追加（blocked時の自動トピック参照）
  - `completed_at`廃止
- `task_logsテーブル`: 「未実装」として明記

### 決定事項の追加
- タスク管理システムの実装完了を記載
  - MCPツール3つ（add_task, get_tasks, update_task_status）
  - blocked時の自動トピック作成機能

### 未決定事項リストの整理
- 実装済み項目を「実装済み」セクションに移動
  - MCPツール詳細設計
  - 既存タスク検索の方法
  - インデックス設計
  - DB接続ライブラリの選定
- MCPツールで未決定事項を管理している旨を追記

## Test plan
- [ ] ドキュメント内容が実装と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)