### PR TITLE
feat: Stopフックによる自動ログ記録機能を追加

### DIFF
--- a/.claude/hooks/check_decision.py
+++ b/.claude/hooks/check_decision.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+指定トピックに決定事項があるかチェックするスクリプト。
+Stopフックからトピック変更時に呼び出される。
+
+Usage:
+    python check_decision.py <topic_id>
+
+Returns:
+    "true" if decisions exist, "false" otherwise
+"""
+import sys
+from pathlib import Path
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from src.services.decision_service import get_decisions
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("false")
+        sys.exit(1)
+
+    try:
+        topic_id = int(sys.argv[1])
+    except ValueError:
+        print("false")
+        sys.exit(1)
+
+    result = get_decisions(topic_id, limit=1)
+
+    if "error" in result:
+        print("false")
+        sys.exit(1)
+
+    decisions = result.get("decisions", [])
+    if len(decisions) > 0:
+        print("true")
+    else:
+        print("false")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/parse_meta_tag.py
+++ b/.claude/hooks/parse_meta_tag.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+transcriptの最後のassistant応答からメタタグをパースするスクリプト。
+
+Usage:
+    python parse_meta_tag.py <transcript_path>
+
+Output (JSON):
+    {"found": true, "project_id": 2, "topic_id": 55}
+    or
+    {"found": false}
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_last_assistant_entry(transcript_path: str) -> dict | None:
+    """transcriptから最後のassistantエントリを取得する"""
+    path = Path(transcript_path).expanduser()
+    if not path.exists():
+        return None
+
+    # 末尾から読んで最初のassistantエントリを見つける
+    try:
+        result = subprocess.run(
+            ["tail", "-n", "100", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = result.stdout.strip().split("\n")
+    except Exception:
+        with open(path) as f:
+            lines = f.readlines()[-100:]
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            if entry.get("type") == "assistant":
+                return entry
+        except json.JSONDecodeError:
+            continue
+
+    return None
+
+
+def extract_text_from_entry(entry: dict) -> str:
+    """エントリからテキスト内容を抽出する"""
+    message = entry.get("message", {})
+    content = message.get("content", [])
+
+    if isinstance(content, str):
+        return content
+
+    texts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            texts.append(block.get("text", ""))
+        elif isinstance(block, str):
+            texts.append(block)
+
+    return "\n".join(texts)
+
+
+def parse_meta_tag(text: str) -> dict | None:
+    """
+    テキストからメタタグをパースする。
+
+    フォーマット:
+    <!-- [meta] project: xxx (id: 2) | topic: yyy (id: 55) -->
+    """
+    # HTMLコメント形式のメタタグを探す
+    pattern = r'<!--\s*\[meta\]\s*project:\s*[^(]+\(id:\s*(\d+)\)\s*\|\s*topic:\s*[^(]+\(id:\s*(\d+)\)\s*-->'
+    match = re.search(pattern, text)
+
+    if match:
+        return {
+            "found": True,
+            "project_id": int(match.group(1)),
+            "topic_id": int(match.group(2)),
+        }
+
+    return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"found": False}))
+        sys.exit(0)
+
+    transcript_path = sys.argv[1]
+    entry = get_last_assistant_entry(transcript_path)
+
+    if not entry:
+        print(json.dumps({"found": False}))
+        sys.exit(0)
+
+    text = extract_text_from_entry(entry)
+    result = parse_meta_tag(text)
+
+    if result:
+        print(json.dumps(result))
+    else:
+        print(json.dumps({"found": False}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/record_log.py
+++ b/.claude/hooks/record_log.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Stopフックからバックグラウンドで呼び出されるログ記録スクリプト。
+transcriptから直近1リレーを抽出し、Haikuで要約してDBに保存する。
+
+Usage:
+    python record_log.py <transcript_path> <topic_id>
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from src.services.discussion_log_service import add_log
+
+
+def read_transcript_tail(transcript_path: str, max_lines: int = 1000) -> list[dict]:
+    """
+    transcriptファイルの末尾から指定行数を読み込む。
+    大きなファイルでもメモリ効率よく処理する。
+    """
+    entries = []
+    path = Path(transcript_path).expanduser()
+
+    if not path.exists():
+        return []
+
+    # tailコマンドで末尾を取得（macOS/Linux互換）
+    try:
+        result = subprocess.run(
+            ["tail", "-n", str(max_lines), str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = result.stdout.strip().split("\n")
+    except Exception:
+        # フォールバック: ファイル全体を読む
+        with open(path) as f:
+            lines = f.readlines()[-max_lines:]
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return entries
+
+
+def extract_last_relay(entries: list[dict]) -> list[dict]:
+    """
+    直近1リレーを抽出する。
+
+    1リレーの定義:
+    - 人間のユーザー発言（type=user, toolUseResultなし）から開始
+    - 次の人間のユーザー発言の直前まで
+    """
+    relay = []
+    found_human = False
+
+    for entry in reversed(entries):
+        entry_type = entry.get("type", "")
+
+        # システムエントリはスキップ
+        if entry_type in ("file-history-snapshot", "system", "summary"):
+            continue
+
+        # 人間のユーザー発言を判定
+        is_human = entry_type == "user" and "toolUseResult" not in entry
+
+        if is_human:
+            if found_human:
+                # 前のリレーに到達したので終了
+                break
+            found_human = True
+
+        relay.insert(0, entry)
+
+    return relay
+
+
+def extract_text_content(entry: dict) -> str:
+    """エントリからテキスト内容を抽出する"""
+    message = entry.get("message", {})
+    content = message.get("content", [])
+
+    if isinstance(content, str):
+        return content
+
+    texts = []
+    for block in content:
+        if isinstance(block, dict):
+            if block.get("type") == "text":
+                texts.append(block.get("text", ""))
+            elif block.get("type") == "tool_use":
+                texts.append(f"[Tool: {block.get('name', 'unknown')}]")
+        elif isinstance(block, str):
+            texts.append(block)
+
+    return "\n".join(texts)
+
+
+def format_relay_for_summary(relay: list[dict]) -> str:
+    """リレーを要約用にフォーマットする"""
+    parts = []
+
+    for entry in relay:
+        entry_type = entry.get("type", "")
+        content = extract_text_content(entry)
+
+        if not content:
+            continue
+
+        if entry_type == "user":
+            if "toolUseResult" in entry:
+                # ツール結果は省略
+                parts.append("[Tool Result]")
+            else:
+                parts.append(f"User: {content[:500]}")  # 長すぎる場合は切り詰め
+        elif entry_type == "assistant":
+            parts.append(f"Assistant: {content[:1000]}")
+
+    return "\n\n".join(parts)
+
+
+def summarize_with_haiku(relay_text: str) -> Optional[str]:
+    """Haikuで要約する"""
+    if not relay_text:
+        return None
+
+    prompt = f"""以下の会話を1〜2文で要約してください。
+形式: 「ユーザー: 〇〇について質問/依頼 → AI: △△と回答/実行」
+
+{relay_text}"""
+
+    try:
+        result = subprocess.run(
+            ["claude", "--model", "haiku", "--setting-sources", "", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        else:
+            return None
+    except Exception as e:
+        print(f"Error calling Haiku: {e}", file=sys.stderr)
+        return None
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: record_log.py <transcript_path> <topic_id>", file=sys.stderr)
+        sys.exit(1)
+
+    transcript_path = sys.argv[1]
+    try:
+        topic_id = int(sys.argv[2])
+    except ValueError:
+        print("Invalid topic_id", file=sys.stderr)
+        sys.exit(1)
+
+    # 1. transcriptから直近1リレーを抽出
+    entries = read_transcript_tail(transcript_path)
+    if not entries:
+        print("No entries found in transcript", file=sys.stderr)
+        sys.exit(1)
+
+    relay = extract_last_relay(entries)
+    if not relay:
+        print("No relay found", file=sys.stderr)
+        sys.exit(1)
+
+    # 2. 要約用にフォーマット
+    relay_text = format_relay_for_summary(relay)
+    if not relay_text:
+        print("Empty relay text", file=sys.stderr)
+        sys.exit(1)
+
+    # 3. Haikuで要約
+    summary = summarize_with_haiku(relay_text)
+    if not summary:
+        # 要約に失敗した場合は元のテキストを短縮して保存
+        summary = relay_text[:500] + "..." if len(relay_text) > 500 else relay_text
+
+    # 4. DBに保存
+    result = add_log(topic_id, summary)
+    if "error" in result:
+        print(f"Error saving log: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Log saved: {result.get('log_id')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/stop_hook.sh
+++ b/.claude/hooks/stop_hook.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Stopフック: 毎ターンの会話を自動でログに記録する
+#
+# 処理フロー:
+# 1. stop_hook_active=true → approve（無限ループ防止）
+# 2. メタタグチェック → なければblock
+# 3. トピック変更チェック → 前topicにdecisionなければblock
+# 4. approve + バックグラウンドでログ記録
+
+set -e
+
+# スクリプトのディレクトリを取得
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# stdinからJSON入力を読み込み
+INPUT=$(cat)
+echo "$INPUT" >> /tmp/stop_hook_input.log
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
+STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active')
+
+# 1. 無限ループ防止
+if [ "$STOP_ACTIVE" = "true" ]; then
+  echo '{"decision": "approve"}'
+  exit 0
+fi
+
+# 2. メタタグチェック
+META_RESULT=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/parse_meta_tag.py" "$TRANSCRIPT_PATH" 2>/dev/null || echo '{"found": false}')
+META_FOUND=$(echo "$META_RESULT" | jq -r '.found')
+
+if [ "$META_FOUND" != "true" ]; then
+  echo '{"decision": "block", "reason": "応答の最後にメタタグを出力してください。フォーマット: <!-- [meta] project: xxx (id: N) | topic: yyy (id: M) -->"}'
+  exit 0
+fi
+
+CURRENT_TOPIC=$(echo "$META_RESULT" | jq -r '.topic_id')
+
+# 3. トピック変更チェック
+PREV_TOPIC_FILE="/tmp/claude_prev_topic_${SESSION_ID}"
+PREV_TOPIC=$(cat "$PREV_TOPIC_FILE" 2>/dev/null || echo "")
+
+if [ -n "$PREV_TOPIC" ] && [ "$PREV_TOPIC" != "$CURRENT_TOPIC" ]; then
+  # 前のトピックにdecisionがあるかチェック
+  HAS_DECISION=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_decision.py" "$PREV_TOPIC" 2>/dev/null || echo "false")
+  if [ "$HAS_DECISION" = "false" ]; then
+    echo "{\"decision\": \"block\", \"reason\": \"トピックが変わりました。前のトピック(id=$PREV_TOPIC)に決定事項を記録してから移動してください\"}"
+    exit 0
+  fi
+fi
+
+# 4. 現在のトピックを保存
+echo "$CURRENT_TOPIC" > "$PREV_TOPIC_FILE"
+
+# 5. approve + バックグラウンドでログ記録
+# nohupで完全にデタッチして、親プロセスの終了を待たせない
+nohup bash -c "cd '$PROJECT_ROOT' && uv run python '$SCRIPT_DIR/record_log.py' '$TRANSCRIPT_PATH' '$CURRENT_TOPIC'" >> /tmp/claude_record_log.log 2>&1 &
+disown
+
+echo '{"decision": "approve"}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop_hook.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- エージェントの応答終了時にStopフックを実行し、メタタグ検証・決定事項チェック・会話ログ記録を自動化
- メタタグ（project_id, topic_id）が応答に含まれているか検証（parse_meta_tag.py）
- トピック変更時に未記録の決定事項がないかチェック（check_decision.py）
- Claude Haikuによる会話要約とMCPツールへのログ記録（record_log.py）
- 無限ループ防止のため `--setting-sources ""` オプションを使用

## Test plan
- [ ] メタタグなしの応答でエラーブロックが発生することを確認
- [ ] トピック変更時に決定事項チェックが実行されることを確認
- [ ] 会話ログがMCPツールに正しく記録されることを確認
- [ ] フック実行時に無限ループが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)