### PR TITLE
fix: SessionStartフックでPREV_TOPIC_FILEを初期化

### DIFF
--- a/.claude/hooks/load-undecided-topics.sh
+++ b/.claude/hooks/load-undecided-topics.sh
@@ -1,2 +1,24 @@
 #!/bin/bash
+#
+# SessionStart フック: セッション開始時の初期化処理
+#
+# 処理内容:
+# 1. PREV_TOPIC_FILE を削除（Stopフックのトピック変更チェック用）
+# 2. 未決定トピック確認のリマインドを出力
+#
+# このフックは以下のタイミングで発火する:
+# - startup: 新規セッション開始時
+# - resume: --resume, --continue, /resume で復帰時
+# - clear: /clear コマンド実行時
+# - compact: コンパクト実行時
+
+# stdinからJSON入力を読み込み
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
+
+# PREV_TOPIC_FILE を削除（存在しなくてもエラーにしない）
+# これにより、/clear後や新規セッション開始時に
+# 前のトピック情報が残って誤検知することを防ぐ
+rm -f "/tmp/claude_prev_topic_${SESSION_ID}" 2>/dev/null || true
+
 echo "セッション開始時: このプロジェクトの未決定トピックを get_undecided_topics で取得し、各トピックの決定事項（get_decisions）も把握しておいてください。必要に応じて議論ログ（get_logs）も取得可能です。"


### PR DESCRIPTION
## 背景

Stopフックには「トピック変更時に前のトピックに決定事項があるかチェックする」機能がある。
このチェックには `/tmp/claude_prev_topic_${SESSION_ID}` ファイルを使用している。

### 発生した問題

並列で複数のClaude Codeセッションを実行していた際、あるセッションで `/clear` を実行した後、
**関係ないトピックの決定事項を記録するよう求められる** という問題が発生した。

具体的には：
- セッションAがtopic 89で作業中
- セッションBで `/clear` を実行後、topic 92で作業開始
- セッションBのStopフックが「topic 89に決定事項を記録してから移動してください」と警告
- topic 89はセッションBとは無関係なトピック

### 原因の推測

正確な原因は特定できていないが、以下のいずれかと推測：

1. **`/clear` 後に前のセッションの状態が残る可能性**
   - `/clear` は会話履歴をクリアするが、`PREV_TOPIC_FILE` は残ったまま

2. **並列実行時の何らかの競合**
   - SESSION_IDでファイルを分けているため理論上は競合しないはずだが、
     何らかの理由で別セッションのtopic_idが混入した可能性

### 再現性

- 1回のみ発生
- 再現手順は不明

## 修正内容

**防御的な修正**として、SessionStartフックで `PREV_TOPIC_FILE` を削除するように変更。

SessionStartフックは以下のタイミングで発火する：
- `startup`: 新規セッション開始時
- `resume`: `--resume`, `--continue`, `/resume` で復帰時
- `clear`: `/clear` コマンド実行時
- `compact`: コンパクト実行時

これにより、セッション開始時（`/clear` 含む）は必ずクリーンな状態からスタートするようになる。

## 変更ファイル

- `.claude/hooks/load-undecided-topics.sh`
  - stdinからsession_idを取得
  - `/tmp/claude_prev_topic_${SESSION_ID}` を削除

## テスト計画

- [ ] 新規セッション開始時にPREV_TOPIC_FILEが削除されることを確認
- [ ] `/clear` 実行後にPREV_TOPIC_FILEが削除されることを確認
- [ ] Stopフックのトピック変更チェックが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)