### PR TITLE
docs: add_projectのdocstringにProject定義と判断基準を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,21 @@ def add_project(
     description: str,
     asana_url: Optional[str] = None,
 ) -> dict:
-    """新しいプロジェクトを追加する。"""
+    """
+    新しいプロジェクトを追加する。
+
+    Projectとは「独立した関心事・取り組み」の単位。リポジトリではなく「何について話すか」で区切る。
+
+    新規作成すべきとき:
+    - 既存Projectのどれとも関係ない話題が始まった
+    - 別プロダクト・サービスの話になった
+    - 新しいAsanaタスクに取り組む
+
+    既存Projectを使うとき:
+    - 既存Projectの関心事の「中」の話（→ add_topicで新規Topic）
+
+    判断に迷ったらユーザーに「どのProjectで進める？」と確認すること。
+    """
     return project_service.add_project(name, description, asana_url)
 
 


### PR DESCRIPTION
## Summary
- `add_project` のdocstringにProjectの定義と判断基準を追加
- エージェントがProject新規作成 vs 既存Projectにトピック追加を判断できるようにした
- 迷った場合はユーザーに確認するよう明記

## Background
エージェントが「新しい話題 → Projectを切る？Topicを切る？」の判断基準がなく、既存Projectを使い回してしまう問題があった。

## Test plan
- [ ] MCPサーバーを起動して `add_project` のツール説明が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)