### PR TITLE
fix: marketplace.jsonのsource pathを修正 & .mcp.json削除

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "claude-code-memory",
-      "source": ".",
+      "source": "./",
       "description": "Claude Codeの記憶を外部DBに保存し、セッション間で知識・決定事項・タスクを永続化する",
       "version": "0.1.0"
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "claude-code-memory": {
-      "command": "uv",
-      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "python", "-m", "src.main"],
-      "env": {}
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- `source: "."` を `"./"` に変更（他のpluginと形式を統一）
- ルートの `.mcp.json` を削除（plugin形式に統合済み）

## Test plan
- [ ] `/plugin marketplace add isizono/claude-code-exterminal-memory` でエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)