### PR TITLE
feat: 起動時にDB自動作成処理を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -640,4 +640,6 @@ def tools_reference() -> str:
 
 
 if __name__ == "__main__":
+    from src.db import init_database
+    init_database()
     mcp.run()


### PR DESCRIPTION
## Summary
- MCPサーバー起動時に`init_database()`を呼び出し、DBが存在しない場合は自動作成する
- `CREATE IF NOT EXISTS`なので既存DBがあればスキップされる

## Test plan
- [ ] DBファイルがない状態でサーバー起動し、DBが作成されることを確認
- [ ] 既存DBがある状態で起動し、エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)