### PR TITLE
feat: DB初期化時に初期データを投入

### DIFF
--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -47,17 +47,19 @@ def test_add_project_duplicate_name(temp_db):
     assert result2["error"]["code"] == "DATABASE_ERROR"
 
 
-def test_get_projects_empty(temp_db):
-    """プロジェクトが存在しない場合、空の配列が返る"""
+def test_get_projects_includes_initial_data(temp_db):
+    """初期データ（first_project）が含まれる"""
     result = get_projects()
 
     assert "error" not in result
-    assert result["projects"] == []
+    # 初期データとして first_project が投入されている
+    assert len(result["projects"]) == 1
+    assert result["projects"][0]["name"] == "first_project"
 
 
 def test_get_projects_multiple(temp_db):
     """複数のプロジェクトを取得できる"""
-    # 3つプロジェクトを作成
+    # 3つプロジェクトを作成（初期データの first_project に追加）
     add_project(name="project-1", description="desc-1")
     add_project(name="project-2", description="desc-2")
     add_project(name="project-3", description="desc-3")
@@ -65,21 +67,24 @@ def test_get_projects_multiple(temp_db):
     result = get_projects()
 
     assert "error" not in result
-    assert len(result["projects"]) == 3
+    # 初期データ(1) + 追加(3) = 4件
+    assert len(result["projects"]) == 4
 
     # 作成日時の降順で返る（最新が先）
     assert result["projects"][0]["name"] == "project-3"
     assert result["projects"][1]["name"] == "project-2"
     assert result["projects"][2]["name"] == "project-1"
+    assert result["projects"][3]["name"] == "first_project"
 
 
 def test_get_projects_returns_all(temp_db):
     """全件取得されることを確認"""
-    # 35個プロジェクトを作成
+    # 35個プロジェクトを作成（初期データの first_project に追加）
     for i in range(35):
         add_project(name=f"project-{i}", description=f"Description {i}")
 
     result = get_projects()
 
     assert "error" not in result
-    assert len(result["projects"]) == 35
+    # 初期データ(1) + 追加(35) = 36件
+    assert len(result["projects"]) == 36

--- a/tests/integration/test_task_service.py
+++ b/tests/integration/test_task_service.py
@@ -197,6 +197,6 @@ class TestBlockedStatusWithTopicCreation:
 
         assert result1["topic_id"] != result2["topic_id"]
 
-        # トピックが2つ作成されている
+        # トピックが3つ存在（初期データ1 + 新規作成2）
         rows = execute_query("SELECT COUNT(*) as count FROM discussion_topics", ())
-        assert rows[0]["count"] == 2
+        assert rows[0]["count"] == 3

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -82,8 +82,8 @@ def test_get_connection_returns_row_factory(temp_db):
         )
         conn.commit()
 
-        # Row として取得できることを確認
-        cursor = conn.execute("SELECT * FROM projects")
+        # Row として取得できることを確認（追加したプロジェクトを名前で検索）
+        cursor = conn.execute("SELECT * FROM projects WHERE name = 'test-project'")
         row = cursor.fetchone()
         assert row["name"] == "test-project"  # 辞書ライクなアクセス
     finally:


### PR DESCRIPTION
## Summary
- `init_database()`でスキーマ適用後に初期データ（first_project, first_topic）を投入
- `INSERT OR IGNORE`で既存データがある場合は挿入しない
- Stopフックのdecisionチェック回避とセッション開始時のデフォルトメタタグ用

## Test plan
- [ ] 新規DBで初期データが投入されることを確認
- [ ] 既存DBで初期データが重複しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)