### PR TITLE
feat: Stopフックにtopic存在チェックを追加

### DIFF
--- a/hooks/check_topic_exists.py
+++ b/hooks/check_topic_exists.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""
+指定topic_idがDBに存在するかチェックするスクリプト。
+Stopフックからメタタグparse後に呼び出される。
+
+Usage:
+    python check_topic_exists.py <topic_id>
+
+Returns:
+    "true" if topic exists, "false" otherwise
+"""
+import sys
+from pathlib import Path
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from src.db import execute_query
+
+
+def main():
+    # 引数がない場合は「存在しない」として正常終了
+    if len(sys.argv) < 2:
+        print("false")
+        sys.exit(0)
+
+    try:
+        topic_id = int(sys.argv[1])
+    except ValueError:
+        # 不正な引数はエラー（exit 1）
+        print(f"Error: Invalid topic_id: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        rows = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (topic_id,),
+        )
+        if len(rows) > 0:
+            print("true")
+        else:
+            print("false")
+    except Exception as e:
+        # DBエラーはエラー（exit 1）
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/stop_hook.sh
+++ b/hooks/stop_hook.sh
@@ -4,8 +4,9 @@
 #
 # 処理フロー:
 # 1. メタタグチェック → なければblock
-# 2. トピック変更チェック → 前topicにdecisionなければblock
-# 3. approve + バックグラウンドでログ記録
+# 2. トピック存在チェック → 存在しなければblock
+# 3. トピック変更チェック → 前topicにdecisionなければblock
+# 4. approve + バックグラウンドでログ記録
 #
 # 無限ループ防止:
 #   record_log.py内でHaikuを呼ぶ際に --setting-sources "" を使用することで
@@ -47,7 +48,22 @@ fi
 
 CURRENT_TOPIC=$(echo "$META_RESULT" | jq -r '.topic_id')
 
-# 2. トピック変更チェック
+# 2. トピック存在チェック
+TOPIC_EXISTS=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_topic_exists.py" "$CURRENT_TOPIC" 2>&1)
+TOPIC_EXISTS_EXIT_CODE=$?
+
+if [ $TOPIC_EXISTS_EXIT_CODE -ne 0 ]; then
+  # スクリプト実行エラー
+  jq -n --arg reason "check_topic_exists.py failed: $TOPIC_EXISTS" '{decision: "block", reason: $reason}'
+  exit 0
+fi
+
+if [ "$TOPIC_EXISTS" = "false" ]; then
+  jq -n --arg topic "$CURRENT_TOPIC" '{decision: "block", reason: ("topic_id=" + $topic + " は存在しません。get_topics で正しいtopic_idを確認してください")}'
+  exit 0
+fi
+
+# 3. トピック変更チェック
 PREV_TOPIC_FILE="${STATE_DIR}/prev_topic_${SESSION_ID}"
 PREV_TOPIC=$(cat "$PREV_TOPIC_FILE" 2>/dev/null || echo "")
 
@@ -73,10 +89,10 @@ if [ -n "$PREV_TOPIC" ] && [ "$PREV_TOPIC" != "$CURRENT_TOPIC" ]; then
   fi
 fi
 
-# 3. 現在のトピックを保存
+# 4. 現在のトピックを保存
 echo "$CURRENT_TOPIC" > "$PREV_TOPIC_FILE"
 
-# 4. ターン数カウント & sync_memoryリマインダー
+# 5. ターン数カウント & sync_memoryリマインダー
 TURN_COUNT_FILE="${STATE_DIR}/turn_count_${SESSION_ID}"
 TURN_COUNT=$(cat "$TURN_COUNT_FILE" 2>/dev/null || echo "0")
 TURN_COUNT=$((TURN_COUNT + 1))
@@ -87,12 +103,12 @@ if [ $((TURN_COUNT % 3)) -eq 0 ]; then
   SYNC_REMINDER="<!-- [sync_memory推奨] ${TURN_COUNT}ターン経過しました。/sync_memory でセッション内容を記録することを検討してください。 -->"
 fi
 
-# 5. approve + バックグラウンドでログ記録
+# 6. approve + バックグラウンドでログ記録
 # nohupで完全にデタッチして、親プロセスの終了を待たせない
 nohup bash -c "cd '$PROJECT_ROOT' && uv run python '$SCRIPT_DIR/record_log.py' '$TRANSCRIPT_PATH' '$CURRENT_TOPIC'" >> "$LOG_DIR/record_log.log" 2>&1 &
 disown
 
-# 6. 結果を出力
+# 7. 結果を出力
 if [ -n "$SYNC_REMINDER" ]; then
   jq -n --arg reminder "$SYNC_REMINDER" '{decision: "approve", reason: $reminder}'
 else

--- a/hooks/test_check_topic_exists.py
+++ b/hooks/test_check_topic_exists.py
@@ -1,0 +1,158 @@
+"""check_topic_exists.py のユニットテスト"""
+
+import os
+import sys
+import tempfile
+import pytest
+from pathlib import Path
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from src.db import get_connection, init_database, execute_query
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+
+        # init_databaseで作成されたfirst_projectのIDを取得
+        conn = get_connection()
+        try:
+            cursor = conn.execute("SELECT id FROM projects WHERE name = 'first_project'")
+            row = cursor.fetchone()
+            project_id = row[0] if row else 1
+
+            # テスト用のトピックを追加作成
+            conn.execute(
+                "INSERT INTO discussion_topics (id, project_id, title, description) VALUES (100, ?, 'Test Topic', 'Description')",
+                (project_id,)
+            )
+            conn.execute(
+                "INSERT INTO discussion_topics (id, project_id, title, description) VALUES (200, ?, 'Another Topic', 'Description')",
+                (project_id,)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        yield db_path
+
+        # クリーンアップ
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+# check_topic_exists.py の関数をインポート（DB設定後）
+def get_check_topic_exists_main():
+    """temp_db fixture適用後にcheck_topic_exists.pyのmainをインポート"""
+    # モジュールを再読み込みしてDB設定を反映
+    import importlib
+    import check_topic_exists
+    importlib.reload(check_topic_exists)
+    return check_topic_exists
+
+
+class TestCheckTopicExists:
+    """check_topic_exists の動作テスト"""
+
+    def test_existing_topic_returns_true(self, temp_db, capsys):
+        """存在するtopic_idの場合、trueを返す"""
+        # 直接クエリでテスト
+        rows = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (100,),
+        )
+        assert len(rows) > 0
+
+    def test_non_existing_topic_returns_false(self, temp_db):
+        """存在しないtopic_idの場合、falseを返す"""
+        rows = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (99999,),
+        )
+        assert len(rows) == 0
+
+    def test_multiple_topics_exist(self, temp_db):
+        """複数トピックがある場合、それぞれ正しくチェックできる"""
+        # topic_id=100 は存在する
+        rows_100 = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (100,),
+        )
+        assert len(rows_100) > 0
+
+        # topic_id=200 も存在する
+        rows_200 = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (200,),
+        )
+        assert len(rows_200) > 0
+
+        # topic_id=300 は存在しない
+        rows_300 = execute_query(
+            "SELECT id FROM discussion_topics WHERE id = ?",
+            (300,),
+        )
+        assert len(rows_300) == 0
+
+
+class TestCheckTopicExistsScript:
+    """check_topic_exists.py スクリプトとしての動作テスト"""
+
+    def test_script_with_existing_topic(self, temp_db):
+        """スクリプト実行: 存在するtopic_idでtrueを出力"""
+        import subprocess
+        result = subprocess.run(
+            ["uv", "run", "python", "hooks/check_topic_exists.py", "100"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            env={**os.environ, "DISCUSSION_DB_PATH": temp_db},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "true"
+
+    def test_script_with_non_existing_topic(self, temp_db):
+        """スクリプト実行: 存在しないtopic_idでfalseを出力"""
+        import subprocess
+        result = subprocess.run(
+            ["uv", "run", "python", "hooks/check_topic_exists.py", "99999"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            env={**os.environ, "DISCUSSION_DB_PATH": temp_db},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "false"
+
+    def test_script_with_invalid_topic_id(self, temp_db):
+        """スクリプト実行: 不正なtopic_idでエラー"""
+        import subprocess
+        result = subprocess.run(
+            ["uv", "run", "python", "hooks/check_topic_exists.py", "invalid"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            env={**os.environ, "DISCUSSION_DB_PATH": temp_db},
+        )
+        assert result.returncode == 1
+        assert "Invalid topic_id" in result.stderr
+
+    def test_script_with_no_args(self, temp_db):
+        """スクリプト実行: 引数なしでfalseを出力"""
+        import subprocess
+        result = subprocess.run(
+            ["uv", "run", "python", "hooks/check_topic_exists.py"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            env={**os.environ, "DISCUSSION_DB_PATH": temp_db},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "false"


### PR DESCRIPTION
## Summary

- メタタグのtopic_idがDBに存在するかを検証するステップをStopフックに追加
- 存在しないtopic_idを出力した場合はblockされ、無限ループを防止
- parseの責務（テキスト抽出）と検証の責務（DB存在確認）を分離

## Changes

- `hooks/check_topic_exists.py`: topic_id存在チェックスクリプト（新規）
- `hooks/test_check_topic_exists.py`: テスト7ケース（新規）
- `hooks/stop_hook.sh`: メタタグparse後に存在チェックを追加

## Test plan

- [x] `uv run pytest hooks/test_check_topic_exists.py -v` でテスト通過
- [x] 全テスト（153件）通過確認
- [ ] 実際のセッションで存在しないtopic_idを出力してblockされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)