### PR TITLE
refactor: MCPサーバー名を cc-memory に短縮

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,5 @@
 {
-    "claude-code-memory": {
+    "cc-memory": {
       "command": "uv",
       "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "python", "-m", "src.main"]
     }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -28,7 +28,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__claude-code-memory__add_decision",
+        "matcher": "mcp__cc-memory__add_decision",
         "hooks": [
           {
             "type": "command",

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.services import (
 )
 
 # MCPサーバーを作成
-mcp = FastMCP("claude-code-exterminal-memory")
+mcp = FastMCP("cc-memory")
 
 
 # MCPツール定義


### PR DESCRIPTION
## Summary
- Claude CodeのMCPツール名64文字制限に対応するため、サーバー名を短縮
- `claude-code-memory` → `cc-memory` に変更

## 変更箇所
- `.mcp.json`: キー名を変更
- `src/main.py`: FastMCP名を変更
- `hooks/hooks.json`: PostToolUseマッチャーを変更

## 変更しないもの
- リポジトリ名
- プラグイン名（plugin.json, marketplace.json）
- データディレクトリ（`~/.claude/.claude-code-memory/`）

## Test plan
- [ ] Claude Code再起動後、新しいツール名（`mcp__cc-memory__*`）で認識されることを確認
- [ ] 各MCPツールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)