### PR TITLE
feat: Stopフックにプロジェクト存在チェックを追加

### DIFF
--- a/hooks/check_project_exists.py
+++ b/hooks/check_project_exists.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""
+指定project_idがDBに存在するかチェックするスクリプト。
+Stopフックからメタタグparse後に呼び出される。
+
+Usage:
+    python check_project_exists.py <project_id>
+
+Returns:
+    "true" if project exists, "false" otherwise
+"""
+import sys
+from pathlib import Path
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from src.db import execute_query
+
+
+def main():
+    # 引数がない場合は「存在しない」として正常終了
+    if len(sys.argv) < 2:
+        print("false")
+        sys.exit(0)
+
+    try:
+        project_id = int(sys.argv[1])
+    except ValueError:
+        # 不正な引数はエラー（exit 1）
+        print(f"Error: Invalid project_id: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        rows = execute_query(
+            "SELECT id FROM projects WHERE id = ?",
+            (project_id,),
+        )
+        if len(rows) > 0:
+            print("true")
+        else:
+            print("false")
+    except Exception as e:
+        # DBエラーはエラー（exit 1）
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- メタタグのproject_idがDBに存在するか検証
- 存在しない場合はblockしてエラーメッセージを表示
- `check_project_exists.py`を新規追加

## 変更箇所
- `hooks/check_project_exists.py`: 新規追加
- `hooks/stop_hook.sh`: プロジェクト存在チェックのステップを追加

## Test plan
- [ ] 存在しないproject_idを出力した場合、blockされることを確認
- [ ] 正しいproject_idを出力した場合、approveされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)