### PR TITLE
fix: stop hookのrace conditionをリトライ機構で解消

### DIFF
--- a/hooks/parse_meta_tag.py
+++ b/hooks/parse_meta_tag.py
@@ -14,6 +14,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -95,19 +96,23 @@ def main():
         sys.exit(0)
 
     transcript_path = sys.argv[1]
-    entry = get_last_assistant_entry(transcript_path)
 
-    if not entry:
-        print(json.dumps({"found": False}))
-        sys.exit(0)
+    max_retries = 3
+    for attempt in range(max_retries):
+        entry = get_last_assistant_entry(transcript_path)
 
-    text = extract_text_from_entry(entry)
-    result = parse_meta_tag(text)
+        if entry:
+            text = extract_text_from_entry(entry)
+            result = parse_meta_tag(text)
 
-    if result:
-        print(json.dumps(result))
-    else:
-        print(json.dumps({"found": False}))
+            if result:
+                print(json.dumps(result))
+                return
+
+        if attempt < max_retries - 1:
+            time.sleep(0.3)
+
+    print(json.dumps({"found": False}))
 
 
 if __name__ == "__main__":

--- a/hooks/stop_hook.sh
+++ b/hooks/stop_hook.sh
@@ -30,7 +30,7 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
 
 # 1. メタタグチェック
-META_RESULT=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/parse_meta_tag.py" "$TRANSCRIPT_PATH" 2>&1)
+META_RESULT=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/parse_meta_tag.py" "$TRANSCRIPT_PATH" 2>>"$LOG_DIR/uv_stderr.log")
 META_EXIT_CODE=$?
 
 if [ $META_EXIT_CODE -ne 0 ]; then
@@ -49,7 +49,7 @@ fi
 CURRENT_TOPIC=$(echo "$META_RESULT" | jq -r '.topic_id')
 
 # 2. トピック存在チェック
-TOPIC_EXISTS=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_topic_exists.py" "$CURRENT_TOPIC" 2>&1)
+TOPIC_EXISTS=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_topic_exists.py" "$CURRENT_TOPIC" 2>>"$LOG_DIR/uv_stderr.log")
 TOPIC_EXISTS_EXIT_CODE=$?
 
 if [ $TOPIC_EXISTS_EXIT_CODE -ne 0 ]; then
@@ -73,7 +73,7 @@ if [ -n "$PREV_TOPIC" ] && [ "$PREV_TOPIC" != "$CURRENT_TOPIC" ]; then
     : # 何もしない（決定事項チェックをスキップ）
   else
     # 前のトピックにdecisionがあるかチェック
-    DECISION_RESULT=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_decision.py" "$PREV_TOPIC" 2>&1)
+    DECISION_RESULT=$(cd "$PROJECT_ROOT" && uv run python "$SCRIPT_DIR/check_decision.py" "$PREV_TOPIC" 2>>"$LOG_DIR/uv_stderr.log")
     DECISION_EXIT_CODE=$?
 
     if [ $DECISION_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary
- `parse_meta_tag.py`にリトライ機構を追加（0.3秒間隔、最大3回）でtranscript書き込みとのrace conditionを吸収
- `stop_hook.sh`の`2>&1`を`2>>"$LOG_DIR/uv_stderr.log"`に変更し、stderrがJSON出力に混ざるリスクを排除

## Test plan
- [ ] メタタグ付き応答でstop hookがblockしないことを確認
- [ ] テキストのみの短い応答でもblockされないことを確認
- [ ] `uv_stderr.log`にstderrが正しくリダイレクトされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)