### PR TITLE
fix: CIレビューのプロンプトを日本語化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,16 +40,17 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            このPRをレビューして、以下の観点でフィードバックしてください：
+            - コード品質とベストプラクティス
+            - 潜在的なバグや問題
+            - パフォーマンスへの考慮
+            - セキュリティ上の懸念
+            - テストカバレッジ
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            レビューは必ず日本語で書いてください。
+            リポジトリのCLAUDE.mdを参照してスタイルと規約に従ってください。建設的で役に立つフィードバックをお願いします。
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            `gh pr comment` を使ってBashツールでPRにコメントとしてレビューを残してください。
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options


### PR DESCRIPTION
## Summary
- CIのPRレビュー（claude-code-review.yml）のプロンプトが英語だったため、レビューコメントが英語で出力されていた
- プロンプト全体を日本語に変更し、「レビューは必ず日本語で書いてください」の指示を明示的に追加

## Test plan
- [ ] 次回PRを作成した際に、レビューコメントが日本語で出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)