### PR TITLE
feat: instructionsにアクティブプロジェクト情報を動的注入

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 """MCPサーバーのメインエントリーポイント"""
+import logging
 from fastmcp import FastMCP
 from typing import Literal, Optional
+from src.db import execute_query
 from src.services import (
     project_service,
     topic_service,
@@ -10,6 +12,94 @@ from src.services import (
     task_service,
     knowledge_service,
 )
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_PROJECT_DAYS = 7
+RECENT_TOPICS_LIMIT = 3
+DESC_MAX_LEN = 30
+
+
+def _get_active_projects() -> list[dict]:
+    """直近7日以内にトピック更新があったプロジェクトを取得する"""
+    rows = execute_query(
+        """
+        SELECT DISTINCT p.id, p.name
+        FROM projects p
+        JOIN discussion_topics t ON p.id = t.project_id
+        WHERE t.created_at > datetime('now', ? || ' days')
+        ORDER BY p.id
+        """,
+        (f"-{ACTIVE_PROJECT_DAYS}",),
+    )
+    return [{"id": row["id"], "name": row["name"]} for row in rows]
+
+
+def _get_recent_topics(project_id: int) -> list[dict]:
+    """プロジェクトの最新トピック3件を取得する"""
+    rows = execute_query(
+        """
+        SELECT id, title, description
+        FROM discussion_topics
+        WHERE project_id = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        (project_id, RECENT_TOPICS_LIMIT),
+    )
+    results = []
+    for row in rows:
+        desc = row["description"] or ""
+        if len(desc) > DESC_MAX_LEN:
+            desc = desc[:DESC_MAX_LEN] + "..."
+        results.append({"id": row["id"], "title": row["title"], "description": desc})
+    return results
+
+
+def _get_in_progress_tasks(project_id: int) -> list[dict]:
+    """プロジェクトのin_progressタスクを取得する"""
+    rows = execute_query(
+        """
+        SELECT id, title
+        FROM tasks
+        WHERE project_id = ? AND status = 'in_progress'
+        ORDER BY updated_at DESC
+        """,
+        (project_id,),
+    )
+    return [{"id": row["id"], "title": row["title"]} for row in rows]
+
+
+def _build_active_context() -> str:
+    """アクティブプロジェクトのコンテキスト文字列を組み立てる"""
+    try:
+        projects = _get_active_projects()
+        if not projects:
+            return ""
+
+        lines = ["# アクティブプロジェクト（直近7日）\n"]
+        for p in projects:
+            lines.append(f"## {p['name']} (id: {p['id']})")
+
+            topics = _get_recent_topics(p["id"])
+            if topics:
+                lines.append("最新トピック:")
+                for t in topics:
+                    lines.append(f"- [{t['id']}] {t['title']}: {t['description']}")
+
+            tasks = _get_in_progress_tasks(p["id"])
+            if tasks:
+                lines.append("進行中タスク:")
+                for task in tasks:
+                    lines.append(f"- [{task['id']}] {task['title']}")
+
+            lines.append("")
+
+        return "\n".join(lines)
+    except Exception:
+        logger.warning("Failed to build active context", exc_info=True)
+        return ""
+
 
 # ルール文字列（rules/ディレクトリの内容を統合）
 RULES = """# cc-memory 運用ルール
@@ -37,8 +127,16 @@ RULES = """# cc-memory 運用ルール
 """
 
 
+def build_instructions() -> str:
+    """ルール + アクティブコンテキストを組み立てる"""
+    context = _build_active_context()
+    if context:
+        return f"{RULES}\n{context}"
+    return RULES
+
+
 # MCPサーバーを作成
-mcp = FastMCP("cc-memory", instructions=RULES)
+mcp = FastMCP("cc-memory", instructions=build_instructions())
 
 
 # MCPツール定義


### PR DESCRIPTION
## Summary
- SessionStartフックのstdoutがプラグインhookではキャプチャされない既知バグ([Issue #12151](https://github.com/anthropics/claude-code/issues/12151))の回避策
- FastMCPの`instructions`パラメータでアクティブプロジェクト情報を動的注入する方式を再導入
- MCPサーバー起動時（=`claude`コマンド実行時）にDBから最新のアクティブプロジェクト・トピック・タスクを取得

## 変更内容
- `src/main.py`: アクティブコンテキスト取得関数群を追加し、`build_instructions()`でRULES+コンテキストを結合

## Test plan
- [ ] プラグインリロード後、MCPサーバーのinstructionsにアクティブプロジェクト情報が含まれているか確認
- [ ] 新しいセッションを開始して、system promptにプロジェクト情報が表示されるか確認
- [ ] DBにデータがない場合（新規環境）でもエラーなく起動するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)