### PR TITLE
docs: ブランチ作業にworktree必須ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Conventional Commits形式（scopeなし）。typeは英語、subjectは日本�
 ## ブランチ戦略
 
 - main直push禁止（pre-pushフックで防止）
-- ブランチは必ずorigin/mainの最新から切る
+- ブランチ作業は必ずgit worktreeで行うこと（作業ディレクトリで直接checkoutしない）
 - worktreeは`.trees/`配下に作成する
+- ブランチは必ずorigin/mainの最新から切る
 - 命名: `feature/<要約>`, `fix/<要約>`, `docs/<要約>`（英語ケバブケース）


### PR DESCRIPTION
## Summary
- CLAUDE.mdのブランチ戦略に「ブランチ作業は必ずgit worktreeで行うこと」を明記
- 作業ディレクトリで直接checkoutするとschema変更等が他ブランチに混入する問題の防止

## Test plan
- [ ] CLAUDE.mdの記述を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)