### PR TITLE
fix: スキル自動発動のためinstructionsにプレフィックス→スキル対応を追記

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: This skill determines implementation approach and technical decisions. This skill should be used when design decisions (How/Interface/Edge cases) are missing before implementation, when the user asks "how should we build this?", "どう実装する？", "方針決めよう", or after discussion phase is complete but before coding starts.
+description: This skill determines implementation approach and technical decisions. Use when How/Interface/Edge cases need decisions, or when working on a cc-memory task with [設計] prefix.
 ---
 
 # 設計フェーズ Skill

--- a/.claude/skills/discussion/SKILL.md
+++ b/.claude/skills/discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discussion
-description: This skill clarifies user requirements and removes ambiguity before design/implementation phases. This skill should be used when the user asks to "discuss requirements", "clarify what we're building", "talk about this feature", "decide on the scope", "要件を整理したい", "話し合いたい", "何を作るか決めたい", "仕様を固めたい", "implement X", "build X feature", "こういう機能がほしい", "〇〇を実装したい", "こう考えてるんだけど", "こういう事があるんだけど", "相談なんだけど", or when What/Why/Scope are not yet defined.
+description: This skill clarifies user requirements and removes ambiguity before design/implementation phases. Use when What/Why/Scope are not yet defined, or when working on a cc-memory task with [議論] prefix.
 ---
 
 # Discussion Skill

--- a/.claude/skills/implementation/SKILL.md
+++ b/.claude/skills/implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation
-description: This skill writes code following the design decisions. This skill should be used when design decisions (How/Interface/Edge cases) are already recorded and the user asks "let's implement this", "コード書こう", "実装しよう", "作って", or when transitioning from design phase to coding.
+description: This skill writes code following the design decisions. Use when design decisions are already recorded and code needs to be written, or when working on a cc-memory task with [実装] prefix.
 ---
 
 # 実装フェーズ Skill

--- a/src/main.py
+++ b/src/main.py
@@ -134,6 +134,11 @@ Work proceeds through three distinct phases: **discussion**, **design**, and **i
 Do not mix phases — complete the current phase and get user confirmation before moving to the next.
 Task names should reflect their phase with a prefix: `[議論]`, `[設計]`, `[実装]`.
 
+When working on a task listed under "進行中タスク", use the corresponding skill based on the prefix:
+- `[議論]` → use the `discussion` skill
+- `[設計]` → use the `design` skill
+- `[実装]` → use the `implementation` skill
+
 ## Meta Tag
 
 You must output a meta tag at the end of every response. This tag is used by the stop hook


### PR DESCRIPTION
## Summary
- cc-memoryのinstructions（Task Phasesセクション）に、進行中タスクのプレフィックスに応じたスキル使用ルールを追加
- 各スキル（discussion/design/implementation）のdescriptionを簡潔化し、cc-memoryタスクプレフィックスによるトリガーを追加

## Test plan
- [ ] テスト全件パス確認済み（145 passed）
- [ ] 実際にcc-memoryに`[実装]`タスクがある状態で、implementationスキルが発動するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)