### PR TITLE
fix: SELECT関数のデッドコード削除とdecisionsトリガー条件修正

### DIFF
--- a/migrations/0004_fix_decisions_update_trigger.sql
+++ b/migrations/0004_fix_decisions_update_trigger.sql
@@ -1,0 +1,61 @@
+-- Migration 004: decisions更新トリガーのWHEN条件修正
+--
+-- 問題:
+--   trg_search_decisions_update は WHEN OLD.topic_id IS NOT NULL のみで発火するため、
+--   topic_id が非NULL→NULLに変更された場合に search_index のエントリが残り続ける。
+--   また topic_id が NULL→非NULLに変更された場合に search_index にエントリが作られない。
+--
+-- 修正:
+--   1つのトリガーを3つに分割し、全ケースを網羅する。
+--   - trg_search_decisions_update: 非NULL→非NULL（インデックス更新）
+--   - trg_search_decisions_update_remove: 非NULL→NULL（インデックス削除）
+--   - trg_search_decisions_update_add: NULL→非NULL（インデックス追加）
+--
+-- depends: 0003_project_to_subject
+
+-- 既存トリガーを削除
+DROP TRIGGER IF EXISTS trg_search_decisions_update;
+
+-- Case 1: topic_id 非NULL→非NULL（既存エントリを更新）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_update
+AFTER UPDATE ON decisions
+WHEN OLD.topic_id IS NOT NULL AND NEW.topic_id IS NOT NULL
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  UPDATE search_index
+  SET title = NEW.decision,
+      subject_id = (SELECT subject_id FROM discussion_topics WHERE id = NEW.topic_id)
+  WHERE source_type = 'decision' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = NEW.id),
+    NEW.decision, NEW.reason);
+END;
+
+-- Case 2: topic_id 非NULL→NULL（インデックスから削除）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_update_remove
+AFTER UPDATE ON decisions
+WHEN OLD.topic_id IS NOT NULL AND NEW.topic_id IS NULL
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  DELETE FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id;
+END;
+
+-- Case 3: topic_id NULL→非NULL（インデックスに追加）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_update_add
+AFTER UPDATE ON decisions
+WHEN OLD.topic_id IS NULL AND NEW.topic_id IS NOT NULL
+BEGIN
+  INSERT INTO search_index (source_type, source_id, subject_id, title)
+  VALUES ('decision', NEW.id,
+    (SELECT subject_id FROM discussion_topics WHERE id = NEW.topic_id),
+    NEW.decision);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.decision, NEW.reason);
+END;

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -112,13 +112,6 @@ def get_decisions(
 
         return {"decisions": decisions}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -105,13 +105,6 @@ def get_logs(
 
         return {"logs": logs}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {

--- a/src/services/project_service.py
+++ b/src/services/project_service.py
@@ -79,13 +79,6 @@ def list_projects() -> dict:
 
         return {"projects": projects}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,5 +1,4 @@
 """FTS5統合検索サービス"""
-import sqlite3
 from typing import Optional
 from src.db import execute_query, row_to_dict
 
@@ -95,13 +94,6 @@ def search(
 
         return {"results": results, "total_count": len(results)}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {
@@ -180,13 +172,6 @@ def get_by_id(type: str, id: int) -> dict:
 
         return {"type": type, "data": _format_row(type, row_to_dict(rows[0]))}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -171,13 +171,6 @@ def get_tasks(project_id: int, status: str = "in_progress", limit: int = 5) -> d
 
         return {"tasks": tasks, "total_count": total_count}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -109,13 +109,6 @@ def get_topics(
 
         return {"topics": topics}
 
-    except sqlite3.IntegrityError as e:
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         return {
             "error": {


### PR DESCRIPTION
## Summary
- SELECT文で到達不可能な `sqlite3.IntegrityError` キャッチを6サービス8関数から削除
- `trg_search_decisions_update` のWHEN条件を修正し、`topic_id` の全遷移パターン（非NULL→NULL / NULL→非NULL）を網羅

## Background
PR #83 のレビューで指摘された2点を修正するPR。

### 1. 不要なIntegrityErrorキャッチ
`IntegrityError` はINSERT/UPDATE/DELETE時の制約違反で発生する例外であり、SELECT文では発生しない。以下の関数からデッドコードを削除:
- `project_service.list_projects()`
- `topic_service.get_topics()`
- `decision_service.get_decisions()`
- `task_service.get_tasks()`
- `discussion_log_service.get_logs()`
- `search_service.search()`, `search_service.get_by_id()`

`search_service.py` はIntegrityErrorの参照がなくなったため `import sqlite3` も削除。

### 2. decisionsトリガーのWHEN条件漏れ
既存の `trg_search_decisions_update` は `WHEN OLD.topic_id IS NOT NULL` のみで発火するため:
- `topic_id` が非NULL→NULLに変更された場合、`search_index` にエントリが残り続ける
- `topic_id` がNULL→非NULLに変更された場合、`search_index` にエントリが作られない

1トリガーを3トリガーに分割して全ケースを網羅:
- `trg_search_decisions_update`: 非NULL→非NULL（更新）
- `trg_search_decisions_update_remove`: 非NULL→NULL（削除）
- `trg_search_decisions_update_add`: NULL→非NULL（追加）

## Test plan
- [ ] 既存テストが壊れていないこと（mainと同じ51 passed / 94 errors ※errorsはprojects→subjectsリネーム未反映の既存問題）
- [ ] migration 0004のSQL構文が正しいこと（検証済み）
- [ ] decisions.topic_idの全遷移パターンでsearch_indexが正しく同期されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)