### PR TITLE
fix: ドキュメント内のproject→subject残留箇所を修正

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -24,7 +24,7 @@ description: This skill determines implementation approach and technical decisio
 例: 「トピック検索機能」の設計を始める場合
 
 1. タスク一覧から [議論] タスクを探す
-   get_tasks(project_id=2)
+   get_tasks(subject_id=2)
    → { tasks: [{ id: 38, title: "[議論] トピック検索機能の要件整理", topic_id: 85, ... }] }
 
 2. そのタスクに紐づくトピックの決定事項を確認
@@ -55,7 +55,7 @@ description: This skill determines implementation approach and technical decisio
 
 1. 設計タスクを作成
    add_task(
-       project_id=2,
+       subject_id=2,
        title="[設計] トピック検索機能の方針決定",
        description="議論フェーズで決まったWhat/Why/Scope/Acceptanceをもとに、How/Interface/Edge cases/Verificationを決める"
    )
@@ -99,7 +99,7 @@ description: This skill determines implementation approach and technical decisio
 - 結果の並び順: created_at DESC（新しい順）
 
 【Interface】
-- MCPツール: search_topics(project_id: int, keyword: str, limit: int = 30)
+- MCPツール: search_topics(subject_id: int, keyword: str, limit: int = 30)
 - 戻り値: { topics: [{ id, title, description, parent_topic_id, created_at }, ...] }
 - エラー時: MCPの標準エラー形式で返す
 
@@ -108,7 +108,7 @@ description: This skill determines implementation approach and technical decisio
 - keywordが1文字 → 許可する（ただし結果が多くなる可能性あり）
 - 該当なし → 空配列を返す（エラーではない）
 - keywordに%や_が含まれる → エスケープしてリテラル検索する
-- project_idが存在しない → 空配列を返す（エラーではない）
+- subject_idが存在しない → 空配列を返す（エラーではない）
 
 【Verification】
 - 正常系
@@ -117,7 +117,7 @@ description: This skill determines implementation approach and technical decisio
   - descriptionに「自動記録」を含むトピック → 「自動記録」で検索してヒット
 - 異常系
   - 空文字で検索 → エラーが返る
-  - 存在しないproject_id=9999で検索 → 空配列が返る
+  - 存在しないsubject_id=9999で検索 → 空配列が返る
 - エッジケース
   - 「%」で検索 → %を含むトピックのみヒット（ワイルドカードとして解釈されない）
   - limit=1で検索 → 1件だけ返る
@@ -176,7 +176,7 @@ add_decision(
 
 2. 実装タスクを作成（背景情報を詳しく）
 add_task(
-    project_id=<該当プロジェクトID>,
+    subject_id=<該当サブジェクトID>,
     title="[実装] トピック検索機能",
     description="""
 ## 背景
@@ -190,7 +190,7 @@ add_task(
 - 結果の並び順: created_at DESC
 
 【Interface】
-- MCPツール: search_topics(project_id: int, keyword: str, limit: int = 30)
+- MCPツール: search_topics(subject_id: int, keyword: str, limit: int = 30)
 - 戻り値: { topics: [{ id, title, description, parent_topic_id, created_at }, ...] }
 
 【Edge cases】
@@ -198,7 +198,7 @@ add_task(
 - keywordが1文字 → 許可する（ただし結果が多くなる可能性あり）
 - 該当なし → 空配列を返す（エラーではない）
 - keywordに%や_が含まれる → エスケープしてリテラル検索する
-- project_idが存在しない → 空配列を返す（エラーではない）
+- subject_idが存在しない → 空配列を返す（エラーではない）
 
 【Verification】
 - 「hook」で検索 → hooks関連トピックがヒット

--- a/.claude/skills/implementation/SKILL.md
+++ b/.claude/skills/implementation/SKILL.md
@@ -23,7 +23,7 @@ description: This skill writes code following the design decisions. Use when des
 例: 「トピック検索機能」の実装を始める場合
 
 1. タスク一覧から [設計] タスクを探す
-   get_tasks(project_id=2)
+   get_tasks(subject_id=2)
    → { tasks: [{ id: 39, title: "[設計] トピック検索機能の方針決定", topic_id: 85, ... }] }
 
 2. そのタスクに紐づくトピックの決定事項を確認
@@ -47,7 +47,7 @@ description: This skill writes code following the design decisions. Use when des
 
 1. 実装タスクを作成
    add_task(
-       project_id=2,
+       subject_id=2,
        title="[実装] トピック検索機能の実装",
        description="設計フェーズで決めたHow/Interface/Edge cases/Verificationに従って実装する"
    )
@@ -55,7 +55,7 @@ description: This skill writes code following the design decisions. Use when des
 2. 設計フェーズの決定事項をユーザーに共有
    「設計フェーズで以下が決まってるね：
    - How: SQLiteのLIKE句、title/description検索、大文字小文字区別なし
-   - Interface: search_topics(project_id, keyword, limit=30)
+   - Interface: search_topics(subject_id, keyword, limit=30)
    - Edge cases: 空文字→エラー、該当なし→空配列、%や_→エスケープ
    - Verification: 「hook」検索でヒット確認、空文字でエラー確認、等
 
@@ -106,29 +106,29 @@ description: This skill writes code following the design decisions. Use when des
 
 【正常系】
 ✓ 「hook」で検索
-  入力: search_topics(project_id=2, keyword="hook")
+  入力: search_topics(subject_id=2, keyword="hook")
   出力: { topics: [{ id: 55, title: "Stopフック実装", ... }, { id: 58, title: "PostToolUseフック", ... }] }
   期待: hooks関連のトピックがヒットする → OK
 
 ✓ 「HOOK」で検索（大文字小文字無視の確認）
-  入力: search_topics(project_id=2, keyword="HOOK")
+  入力: search_topics(subject_id=2, keyword="HOOK")
   出力: { topics: [{ id: 55, title: "Stopフック実装", ... }, { id: 58, title: "PostToolUseフック", ... }] }
   期待: 「hook」と同じ結果 → OK
 
 【異常系】
 ✓ 空文字で検索
-  入力: search_topics(project_id=2, keyword="")
+  入力: search_topics(subject_id=2, keyword="")
   出力: エラー "keyword must not be empty"
   期待: エラーが返る → OK
 
-✓ 存在しないproject_idで検索
-  入力: search_topics(project_id=9999, keyword="test")
+✓ 存在しないsubject_idで検索
+  入力: search_topics(subject_id=9999, keyword="test")
   出力: { topics: [] }
   期待: 空配列が返る → OK
 
 【エッジケース】
 ✓ 「%」で検索（ワイルドカードエスケープの確認）
-  入力: search_topics(project_id=2, keyword="%")
+  入力: search_topics(subject_id=2, keyword="%")
   出力: { topics: [] }
   期待: %を含むトピックのみヒット（ワイルドカードとして解釈されない）→ OK（該当トピックなし）
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ claude --plugin-dir /path/to/claude-code-memory
 
 | カテゴリ | ツール | 説明 |
 |---------|--------|------|
-| プロジェクト | `add_project`, `get_projects` | プロジェクト管理 |
+| サブジェクト | `add_subject`, `list_subjects` | サブジェクト管理 |
 | トピック | `add_topic`, `get_topics`, `get_decided_topics`, `get_undecided_topics`, `get_topic_tree`, `search_topics` | 議論トピック管理 |
 | ログ | `add_log`, `get_logs` | 議論ログ記録 |
 | 決定 | `add_decision`, `get_decisions`, `search_decisions` | 決定事項管理 |

--- a/skills/sync_memory/SKILL.md
+++ b/skills/sync_memory/SKILL.md
@@ -15,7 +15,7 @@ description: セッション終了前にtranscriptを解析し、トピック・
 
 **アクション:**
 - セッション中に使ったトピックの `get_decisions(topic_id=...)` を実行し、直近の決定事項を取得
-- `get_tasks(project_id=..., status="pending")` で未完了タスクを取得
+- `get_tasks(subject_id=..., status="pending")` で未完了タスクを取得
 - 取得した既存データと会話内容を照合し、**既に記録済みの内容は記録しない**
 
 **重複の判定基準:**


### PR DESCRIPTION
## Summary
- PR#96のproject→subjectリネーム後、ドキュメント内に残っていた`project_id`等の旧名称を`subject_id`に修正
- README.mdのMCPツール一覧で`add_project`/`get_projects`を`add_subject`/`list_subjects`に更新
- design/implementation/sync_memoryスキルのAPI例示コード内の`project_id`を`subject_id`に一括修正

## 変更ファイル（4件）
- `README.md`: ツール名・カテゴリ名の更新
- `.claude/skills/design/SKILL.md`: API例示の`project_id`→`subject_id`（8箇所）
- `.claude/skills/implementation/SKILL.md`: API例示の`project_id`→`subject_id`（9箇所）
- `skills/sync_memory/SKILL.md`: API例示の`project_id`→`subject_id`（1箇所）

## Test plan
- [ ] ドキュメント変更のみ。実コードの変更なし
- [ ] grepで`project_id`が残っていないことを確認済み（マイグレーション・PROJECT_ROOT等の対象外箇所を除く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)