### PR TITLE
fix: _execute_insertのIntegrityError変換バグを修正

### DIFF
--- a/src/db_base.py
+++ b/src/db_base.py
@@ -62,6 +62,9 @@ class BaseDBService(ABC):
             )
             conn.commit()
             return cursor.lastrowid
+        except sqlite3.IntegrityError:
+            conn.rollback()
+            raise
         except sqlite3.Error as e:
             conn.rollback()
             raise sqlite3.Error(f"INSERT実行エラー: {e}") from e

--- a/tests/unit/test_db_base.py
+++ b/tests/unit/test_db_base.py
@@ -185,11 +185,9 @@ def test_insert_constraint_violation(temp_db):
     """制約違反の場合、例外が発生する"""
     service = TestTable()
 
-    with pytest.raises(sqlite3.Error) as exc_info:
+    with pytest.raises(sqlite3.IntegrityError):
         # nameはNOT NULL制約があるため、Noneを挿入するとエラー
         service._execute_insert({"name": None, "value": 1})
-
-    assert "INSERT実行エラー" in str(exc_info.value)
 
 
 def test_update_non_existing_id(temp_db):


### PR DESCRIPTION
## Summary
- `db_base.py`の`_execute_insert`が`except sqlite3.Error`で`IntegrityError`もキャッチし、`sqlite3.Error`に変換して再raiseしていた
- これにより`task_service.py`の`except sqlite3.IntegrityError`がFK制約違反を捕捉できず、`CONSTRAINT_VIOLATION`ではなく`DATABASE_ERROR`が返されていた
- `IntegrityError`を先にキャッチしてそのままraiseするよう修正

## Test plan
- [x] `test_add_task_invalid_subject` が PASSED
- [x] `test_insert_constraint_violation` の期待値を`sqlite3.IntegrityError`に修正
- [x] 全166テスト PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)