### PR TITLE
fix: nudgeメッセージ改善とメタタグ手順の明記

### DIFF
--- a/hooks/pretooluse_nudge_record.sh
+++ b/hooks/pretooluse_nudge_record.sh
@@ -28,7 +28,7 @@ if [ -f "$PENDING_FILE" ]; then
   rm -f "$PENDING_FILE"
 
   # additionalContextにリマインダーを注入
-  NUDGE_MSG="<system-reminder>The decision/topic recording tools (add_decision, add_topic) haven't been used recently. If there are any agreements, design choices, or noteworthy conclusions from the recent conversation, consider recording them with add_decision. Ignore if not applicable.</system-reminder>"
+  NUDGE_MSG="<system-reminder>Self-check before continuing: (1) Does your current topic still match the conversation? If the discussion has shifted, create a new topic with add_topic. (2) Have you and the user reached any agreements that should be recorded? Examples: design choices, naming conventions, scope boundaries, implementation approaches, or trade-off resolutions. If yes, record them now with add_decision before proceeding.</system-reminder>"
 
   jq -n --arg ctx "$NUDGE_MSG" '{
     "hookSpecificOutput": {

--- a/src/main.py
+++ b/src/main.py
@@ -134,10 +134,19 @@ Splitting topics later is far harder than splitting them upfront.
 When the conversation shifts to a different subject, create a new topic instead of overloading the existing one.
 Pay close attention to whether the conversation has shifted to a different subject. Always!
 
+If no existing topic fits, proactively create a new one using `add_topic`.
+This includes one-off or transient conversations — every response needs a valid topic,
+so create one even for short-lived discussions.
+
 The stop hook detects meta tags to track the current topic.
 If you don't output a meta tag, or output one with a wrong ID, your response will be blocked.
-So don't be lazy — review the current topic and output the correct meta tag.
-If no existing topic fits, proactively create a new one.
+
+**Procedure for outputting a meta tag:**
+1. Determine which topic this response belongs to.
+2. If no existing topic fits, call `add_topic` FIRST and obtain the returned topic ID.
+3. Output the meta tag at the end of your response using the confirmed (existing or newly created) topic ID.
+
+Never guess or predict a topic ID — only use IDs that already exist or that `add_topic` has just returned.
 
 Meta tag format: `<!-- [meta] subject: <name> (id: <N>) | topic: <name> (id: <M>) -->`
 


### PR DESCRIPTION
## Summary
- nudgeメッセージを「考慮して/該当しなければ無視」から具体的な自己チェック形式に変更（トピック乖離チェック＋decision記録漏れチェック）
- Topic Managementセクションに「add_topicで先にIDを取得してからメタタグに使う」手順を番号付きで明記
- 一時的・短命な会話でもトピック作成が必要なことを明示

## Test plan
- [ ] nudgeが発動した際に、新しいメッセージが表示されることを確認
- [ ] 新セッションでメタタグ出力時にadd_topicを先に呼ぶ動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)