### PR TITLE
fix: メタタグ正規表現が括弧を含む名前でマッチしない問題を修正

### DIFF
--- a/hooks/parse_meta_tag.py
+++ b/hooks/parse_meta_tag.py
@@ -77,7 +77,7 @@ def parse_meta_tag(text: str) -> dict | None:
     <!-- [meta] subject: xxx (id: 2) | topic: yyy (id: 55) -->
     """
     # HTMLコメント形式のメタタグを探す
-    pattern = r'<!--\s*\[meta\]\s*subject:\s*[^(]+\(id:\s*(\d+)\)\s*\|\s*topic:\s*[^(]+\(id:\s*(\d+)\)\s*-->'
+    pattern = r'<!--\s*\[meta\]\s*subject:\s*.+?\(id:\s*(\d+)\)\s*\|\s*topic:\s*.+?\(id:\s*(\d+)\)\s*-->'
     match = re.search(pattern, text)
 
     if match:

--- a/hooks/test_parse_meta_tag.py
+++ b/hooks/test_parse_meta_tag.py
@@ -59,6 +59,12 @@ class TestParseMetaTag:
         result = parse_meta_tag(text)
         assert result == {"found": True, "subject_id": 999999, "topic_id": 888888}
 
+    def test_name_with_parentheses(self):
+        """名前に括弧が含まれていてもパースできる"""
+        text = '<!-- [meta] subject: テスト(仮) (id: 2) | topic: 機能追加(v2) (id: 55) -->'
+        result = parse_meta_tag(text)
+        assert result == {"found": True, "subject_id": 2, "topic_id": 55}
+
     def test_old_project_format_not_matched(self):
         """旧フォーマット（project:）はマッチしない"""
         text = '<!-- [meta] project: old-format (id: 1) | topic: some topic (id: 2) -->'


### PR DESCRIPTION
## Summary
- `parse_meta_tag.py` の正規表現で `[^(]+` を `.+?` に変更
- サブジェクト名やトピック名に `(` が含まれるとパースに失敗していたバグを修正
- 括弧を含む名前のテストケースを追加

## 原因
`[^(]+` は文字クラスから `(` を除外するため、例えば `テスト(仮) (id: 2)` のような名前で `[^(]+` が `テスト` で止まり、後続の `\(id:` が `(仮)` にマッチしようとして失敗していた。

## 修正
`.+?`（非貪欲な任意文字マッチ）に変更。`\(id:\s*(\d+)\)` が十分具体的なアンカーとなるため、名前部分に括弧があっても正しくパースできる。

## Test plan
- [x] 既存テスト全15件パス
- [x] 新規テスト `test_name_with_parentheses` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)