### PR TITLE
feat: decisions.topic_id NOT NULL制約追加

### DIFF
--- a/migrations/0005_decisions_topic_id_not_null.sql
+++ b/migrations/0005_decisions_topic_id_not_null.sql
@@ -1,0 +1,95 @@
+-- Migration 005: decisions.topic_id NOT NULL制約追加とFTS5トリガー簡素化
+--
+-- 背景:
+--   decisions.topic_idは現在NULLableだが、運用上すべてのdecisionはtopicに紐づくべき。
+--   NOT NULL制約を追加し、FTS5トリガーのNULLケース分岐を簡素化する。
+--
+-- 変更内容:
+--   1. decisionsテーブルを再作成（SQLiteはALTER COLUMNでNOT NULL追加不可のため）
+--      - topic_id IS NULLのデータはfirst_topicに移行
+--   2. FTS5トリガーのWHEN条件（NULLチェック）を除去
+--   3. UPDATEトリガーを3分割から1つに統合（NULLケース不要）
+--
+-- depends: 0004_fix_decisions_update_trigger
+
+-- Step 1: topic_id IS NULLのレコードをfirst_topicに移行
+UPDATE decisions
+SET topic_id = (
+  SELECT dt.id
+  FROM discussion_topics dt
+  WHERE dt.title = 'first_topic'
+  LIMIT 1
+)
+WHERE topic_id IS NULL;
+
+-- Step 2: 旧テーブルをリネーム
+ALTER TABLE decisions RENAME TO decisions_old;
+
+-- Step 3: 新テーブル作成（topic_id NOT NULL）
+CREATE TABLE decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  topic_id INTEGER NOT NULL REFERENCES discussion_topics(id),
+  decision TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Step 4: データコピー
+INSERT INTO decisions (id, topic_id, decision, reason, created_at)
+SELECT id, topic_id, decision, reason, created_at
+FROM decisions_old;
+
+-- Step 5: 旧テーブル削除
+DROP TABLE decisions_old;
+
+-- Step 6: インデックス再作成
+CREATE INDEX IF NOT EXISTS idx_decisions_topic_id ON decisions(topic_id);
+
+-- Step 7: FTS5トリガーの簡素化
+-- 既存トリガーを削除
+DROP TRIGGER IF EXISTS trg_search_decisions_insert;
+DROP TRIGGER IF EXISTS trg_search_decisions_update;
+DROP TRIGGER IF EXISTS trg_search_decisions_update_remove;
+DROP TRIGGER IF EXISTS trg_search_decisions_update_add;
+DROP TRIGGER IF EXISTS trg_search_decisions_delete;
+
+-- INSERTトリガー（WHEN条件なし: topic_idは常にNOT NULL）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_insert
+AFTER INSERT ON decisions
+BEGIN
+  INSERT INTO search_index (source_type, source_id, subject_id, title)
+  VALUES ('decision', NEW.id,
+    (SELECT subject_id FROM discussion_topics WHERE id = NEW.topic_id),
+    NEW.decision);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.decision, NEW.reason);
+END;
+
+-- UPDATEトリガー（1つに統合: NULLケース不要）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_update
+AFTER UPDATE ON decisions
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  UPDATE search_index
+  SET title = NEW.decision,
+      subject_id = (SELECT subject_id FROM discussion_topics WHERE id = NEW.topic_id)
+  WHERE source_type = 'decision' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = NEW.id),
+    NEW.decision, NEW.reason);
+END;
+
+-- DELETEトリガー（WHEN条件なし: topic_idは常にNOT NULL）
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_delete
+AFTER DELETE ON decisions
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  DELETE FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id;
+END;

--- a/src/db.py
+++ b/src/db.py
@@ -114,7 +114,7 @@ def _migrate_fts5_search_index(conn: sqlite3.Connection) -> None:
         FROM discussion_topics
     """)
 
-    # decisions（topic_id IS NOT NULLのもののみ）
+    # decisions（topic_idは常にNOT NULL、JOINでsubject_idを取得）
     conn.execute("""
         INSERT OR IGNORE INTO search_index (source_type, source_id, subject_id, title)
         SELECT 'decision', d.id, dt.subject_id, d.decision

--- a/src/main.py
+++ b/src/main.py
@@ -319,7 +319,7 @@ def add_log(topic_id: int, content: str) -> dict:
 def add_decision(
     decision: str,
     reason: str,
-    topic_id: Optional[int] = None,
+    topic_id: int,
 ) -> dict:
     """決定事項を記録する。"""
     return decision_service.add_decision(decision, reason, topic_id)

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -7,7 +7,7 @@ from src.db import execute_insert, execute_query, row_to_dict
 def add_decision(
     decision: str,
     reason: str,
-    topic_id: Optional[int] = None,
+    topic_id: int,
 ) -> dict:
     """
     決定事項を記録する。
@@ -15,7 +15,7 @@ def add_decision(
     Args:
         decision: 決定内容
         reason: 決定の理由
-        topic_id: 関連するトピックのID（未指定も可）
+        topic_id: 関連するトピックのID（必須）
 
     Returns:
         作成された決定事項情報

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -125,15 +125,15 @@ def test_add_decision_success(test_subject):
 
 
 def test_add_decision_without_topic(temp_db):
-    """トピックIDなしで決定事項を追加できる"""
+    """topic_id=Noneで決定事項を追加するとCONSTRAINT_VIOLATIONが返る"""
     result = add_decision(
         decision="グローバルな決定事項",
         reason="サブジェクト全体に関わる",
+        topic_id=None,
     )
 
-    assert "error" not in result
-    assert result["decision_id"] > 0
-    assert result["topic_id"] is None
+    assert "error" in result
+    assert result["error"]["code"] == "CONSTRAINT_VIOLATION"
 
 
 def test_add_decision_multiple(test_subject):


### PR DESCRIPTION
## Summary

- `decisions.topic_id` に NOT NULL 制約を追加（SQLite の制約上、テーブル再作成で対応）
- topic_id IS NULL の既存データは `first_topic` に移行するマイグレーションを追加
- FTS5 トリガーから NULL チェックの WHEN 条件を除去してシンプル化
- UPDATE トリガーを 0004 の 3 分割から 1 つに統合
- `add_decision()` の `topic_id` パラメータを必須に変更（サービス層・MCP ツール両方）

## Changes

- `migrations/0005_decisions_topic_id_not_null.sql` - マイグレーションファイル新規追加
- `src/services/decision_service.py` - `topic_id: Optional[int] = None` → `topic_id: int`
- `src/main.py` - MCP ツール定義の `topic_id` を必須パラメータに変更
- `src/db.py` - `_migrate_fts5_search_index` のコメントを更新
- `tests/unit/test_topic_write.py` - `test_add_decision_without_topic` を CONSTRAINT_VIOLATION 検証に変更

## Test plan

- [ ] `uv run pytest -x` で 177 件全パス確認済み
- [ ] `topic_id=None` で `add_decision()` を呼ぶと `CONSTRAINT_VIOLATION` が返ることを検証
- [ ] FTS5 検索が引き続き動作することを確認（`test_fts5_search.py` 全パス）
- [ ] マイグレーション 0005 が yoyo で正常適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)