### PR TITLE
chore: sqlite-vecの依存バージョンを明示

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastmcp",
     "pytest>=7.4.0",
     "pyyaml>=6.0",
-    "sqlite-vec",
+    "sqlite-vec>=0.1.6,<0.2",
     "yoyo-migrations>=9,<10",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "pytest" },
     { name = "pyyaml" },
+    { name = "sqlite-vec" },
     { name = "yoyo-migrations" },
 ]
 
@@ -202,7 +203,8 @@ requires-dist = [
     { name = "fastmcp" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "yoyo-migrations" },
+    { name = "sqlite-vec", specifier = ">=0.1.6,<0.2" },
+    { name = "yoyo-migrations", specifier = ">=9,<10" },
 ]
 
 [[package]]
@@ -1329,6 +1331,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075, upload-time = "2024-11-20T16:40:29.847Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242, upload-time = "2024-11-20T16:40:31.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704, upload-time = "2024-11-20T16:40:33.729Z" },
+    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556, upload-time = "2024-11-20T16:40:35.387Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540, upload-time = "2024-11-20T16:40:37.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `sqlite-vec` の依存定義にバージョン範囲 `>=0.1.6,<0.2` を追加
- 他の依存（`yoyo-migrations>=9,<10` 等）と同様のスタイルに統一
- 意図しないメジャーバージョン変更やダウングレードを防止

## Changes
- `pyproject.toml`: `"sqlite-vec"` → `"sqlite-vec>=0.1.6,<0.2"`
- `uv.lock`: 上記変更に伴うロックファイル更新

## Test plan
- [x] `uv lock` が正常に完了することを確認
- [x] `uv run pytest -v --tb=short` で全179テストが通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)