### PR TITLE
feat: Recording Decisionsにtask作成の誘導文を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -166,6 +166,10 @@ Be specific. This information is critically important for future AI sessions tha
 Avoid vague language like "as appropriate" or "as needed" — use concrete conditions and values.
 Always include the reasoning behind the decision, not just the outcome.
 
+When a decision implies follow-up work, consider creating a task so the next session can pick it up.
+Choose the appropriate phase prefix based on readiness:
+`[実装]` if the spec is clear, `[設計]` if the approach needs to be worked out, or `[議論]` if requirements are still vague.
+
 ## Recording Logs
 
 Decisions capture conclusions. Logs capture the journey.


### PR DESCRIPTION
## Summary
- Recording Decisionsセクションの末尾に、decisionを記録した際にtaskも作るよう促すガイダンスを追加
- decisionだけ記録されてtaskが作られず、次セッションで文脈がロストする問題への対策
- エージェント判断（consider）で、readinessに応じて適切なフェーズプレフィックス（[実装]/[設計]/[議論]）を選択

## Test plan
- [ ] instructionsの文面が既存セクションの口調と整合していることを確認
- [ ] 次セッションでdecision記録時にtask作成が促されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)