### PR TITLE
feat: system promptのアクティブタスク表示にpendingも追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,6 +66,7 @@ def _get_active_tasks(subject_id: int) -> list[dict]:
         ORDER BY
             CASE status WHEN 'in_progress' THEN 0 ELSE 1 END,
             updated_at DESC
+        LIMIT 20
         """,
         (subject_id,),
     )


### PR DESCRIPTION
## Summary
- `_get_in_progress_tasks` を `_get_active_tasks` にリネームし、`pending` ステータスも取得対象に追加
- system promptの「進行中タスク」セクションを「アクティブタスク」に変更し、各タスクにステータス表記を付与
- in_progressを先、pendingを後にソート

## Test plan
- [ ] 新セッションでsystem promptにpendingタスクが表示されることを確認
- [ ] in_progressタスクがpendingより先に表示されることを確認
- [ ] 各タスクにステータス（in_progress/pending）が括弧付きで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)