### PR TITLE
feat: embeddingサーバーを新規作成

### DIFF
--- a/src/services/embedding_server.py
+++ b/src/services/embedding_server.py
@@ -10,6 +10,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 HOST = "localhost"
 PORT = 52836
 IDLE_TIMEOUT_SEC = 300  # 5分
+MAX_REQUEST_BYTES = 10 * 1024 * 1024  # 10MB
 
 MODEL_NAME = "cl-nagoya/ruri-v3-70m"
 DOC_PREFIX = "検索文書: "
@@ -82,10 +83,13 @@ class EmbeddingHandler(BaseHTTPRequestHandler):
         # リクエストボディをパース
         try:
             content_length = int(self.headers.get("Content-Length", 0))
+            if content_length > MAX_REQUEST_BYTES:
+                self._send_json(413, {"error": "Request body too large"})
+                return
             body = self.rfile.read(content_length)
             data = json.loads(body)
         except (json.JSONDecodeError, ValueError) as e:
-            self._send_json(400, {"error": f"Invalid JSON: {e}"})
+            self._send_json(400, {"error": "Invalid request body"})
             return
 
         # バリデーション
@@ -109,7 +113,7 @@ class EmbeddingHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"embeddings": result})
         except Exception as e:
             logger.error(f"encode failed: {e}")
-            self._send_json(500, {"error": f"Encoding failed: {e}"})
+            self._send_json(500, {"error": "Internal server error"})
 
 
 def _idle_watchdog(server: ThreadingHTTPServer):


### PR DESCRIPTION
## Summary
- embedding計算を1プロセスに集約するHTTPサーバー `embedding_server.py` を新規作成
- `http.server.ThreadingHTTPServer` で localhost:52836 にlisten
- `POST /encode`（バッチ対応）と `GET /health` の2エンドポイント
- 5分無アクセスで自動終了（idle watchdog）

## Details
- モデル: cl-nagoya/ruri-v3-70m (sentence-transformers)
- prefix付与はサーバー側で実行（DOC_PREFIX / QUERY_PREFIX）
- ログは `~/.cache/cc-memory/embedding-server.log` に出力、起動時トランケート
- server_bind() 失敗時は sys.exit(1) で確実に終了

## Test plan
- [ ] サーバーのユニットテストは次PR（#2）で追加
- [ ] `POST /encode` の正常系・異常系
- [ ] `GET /health` のレスポンス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc-memory task: #366
関連decision: #837, #838, #839, #844, #848, #849, #851, #852, #853, #855