### PR TITLE
feat: add_task/update_taskにtopic_idパラメータを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -225,14 +225,14 @@ When working on a task, use the corresponding skill:
 
 Phase prefixes belong on **tasks only** — never on topics.
 Tasks define the purpose; topics are the discussion spaces that serve that purpose.
-Link tasks and topics by cross-referencing IDs in their descriptions:
+Link tasks and topics using the `topic_id` parameter:
 
 ```
-1. add_task(subject_id=2, title="[議論] 検索機能の要件整理", description="...")
-   → task id: 50
-
-2. add_topic(subject_id=2, title="検索機能の要件整理", description="task id:50 の議論用")
+1. add_topic(subject_id=2, title="検索機能の要件整理", description="...")
    → topic id: 85
+
+2. add_task(subject_id=2, title="[議論] 検索機能の要件整理", description="...", topic_id=85)
+   → task id: 50
 
 3. As discussion branches off, create child topics under topic 85.
    The task (id:50) remains the single source of purpose.
@@ -417,6 +417,7 @@ def add_task(
     subject_id: int,
     title: str,
     description: str,
+    topic_id: Optional[int] = None,
 ) -> dict:
     """
     新しいタスクを追加する。
@@ -430,11 +431,12 @@ def add_task(
         subject_id: サブジェクトID
         title: タスクのタイトル
         description: タスクの詳細説明（必須）
+        topic_id: 関連トピックID（optional）
 
     Returns:
         作成されたタスク情報
     """
-    return task_service.add_task(subject_id, title, description)
+    return task_service.add_task(subject_id, title, description, topic_id)
 
 
 @mcp.tool()
@@ -470,6 +472,7 @@ def update_task(
     new_status: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    topic_id: Optional[int] = None,
 ) -> dict:
     """
     タスクのステータス・タイトル・説明を更新する。
@@ -479,6 +482,7 @@ def update_task(
     - タスク完了: update_task(task_id, new_status="completed")
     - タイトル変更: update_task(task_id, title="新しいタイトル")
     - 説明更新: update_task(task_id, description="新しい説明")
+    - トピック紐付け: update_task(task_id, topic_id=85)
 
     ワークフロー位置: タスク進行状況の更新時
 
@@ -487,11 +491,12 @@ def update_task(
         new_status: 新しいステータス（pending/in_progress/completed）
         title: 新しいタイトル
         description: 新しい説明
+        topic_id: 関連トピックID
 
     Returns:
         更新されたタスク情報
     """
-    return task_service.update_task(task_id, new_status, title, description)
+    return task_service.update_task(task_id, new_status, title, description, topic_id)
 
 
 @mcp.tool()

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -37,7 +37,7 @@ def _task_to_response(task: dict) -> dict:
     }
 
 
-def add_task(subject_id: int, title: str, description: str) -> dict:
+def add_task(subject_id: int, title: str, description: str, topic_id: Optional[int] = None) -> dict:
     """
     タスクを作成してIDを返す
 
@@ -45,17 +45,22 @@ def add_task(subject_id: int, title: str, description: str) -> dict:
         subject_id: サブジェクトID
         title: タスクのタイトル
         description: タスクの説明
+        topic_id: 関連トピックID（optional）
 
     Returns:
         作成されたタスク情報
     """
     try:
-        task_id = _task_db._execute_insert({
+        insert_data = {
             'subject_id': subject_id,
             'title': title,
             'description': description,
-            'status': 'pending'
-        })
+            'status': 'pending',
+        }
+        if topic_id is not None:
+            insert_data['topic_id'] = topic_id
+
+        task_id = _task_db._execute_insert(insert_data)
 
         # embedding生成（失敗してもtask作成には影響しない）
         generate_and_store_embedding("task", task_id, build_embedding_text(title, description))
@@ -159,25 +164,27 @@ def update_task(
     new_status: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    topic_id: Optional[int] = None,
 ) -> dict:
     """
-    タスクを更新する（ステータス、タイトル、説明を変更可能）
+    タスクを更新する（ステータス、タイトル、説明、関連トピックを変更可能）
 
     Args:
         task_id: タスクID
         new_status: 新しいステータス（optional）
         title: 新しいタイトル（optional）
         description: 新しい説明（optional）
+        topic_id: 関連トピックID（optional）
 
     Returns:
         更新されたタスク情報
     """
     # 最低1つのオプショナルパラメータが必要
-    if new_status is None and title is None and description is None:
+    if new_status is None and title is None and description is None and topic_id is None:
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "At least one of new_status, title, or description must be provided",
+                "message": "At least one of new_status, title, description, or topic_id must be provided",
             }
         }
 
@@ -235,6 +242,10 @@ def update_task(
         if description is not None:
             set_parts.append("description = ?")
             values.append(description)
+
+        if topic_id is not None:
+            set_parts.append("topic_id = ?")
+            values.append(topic_id)
 
         set_parts.append("updated_at = CURRENT_TIMESTAMP")
 


### PR DESCRIPTION
## Summary
- `add_task`に`topic_id`（Optional[int]）パラメータを追加し、タスク作成時にトピックと紐付け可能にした
- `update_task`に`topic_id`パラメータを追加し、既存タスクのトピック紐付けを変更可能にした
- RULESのタスク-トピックリンク手順を`topic_id`パラメータ利用に更新

## Test plan
- [ ] `add_task`でtopic_id指定あり/なし両方でタスク作成できること
- [ ] `update_task`でtopic_idを指定して既存タスクのトピック紐付けを変更できること
- [ ] `update_task`でtopic_id以外のフィールドのみ更新する既存動作が壊れていないこと
- [ ] 存在しないtopic_idを指定した場合にFKエラーが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)