### PR TITLE
refactor: メタタグ出力位置を末尾から先頭に変更

### DIFF
--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -76,7 +76,7 @@ def main() -> None:
             state.increment_block_count()
             _output(
                 "block",
-                "応答の最後にメタタグを出力してください。フォーマット: "
+                "応答の最初にメタタグを出力してください。フォーマット: "
                 "<!-- [meta] subject: xxx (id: N) | topic: yyy (id: M) -->",
             )
             return
@@ -88,7 +88,7 @@ def main() -> None:
             state.increment_block_count()
             _output(
                 "block",
-                "応答の最後にメタタグを出力してください。フォーマット: "
+                "応答の最初にメタタグを出力してください。フォーマット: "
                 "<!-- [meta] subject: xxx (id: N) | topic: yyy (id: M) -->",
             )
             return

--- a/src/main.py
+++ b/src/main.py
@@ -153,7 +153,7 @@ If you don't output a meta tag, or output one with a wrong ID, your response wil
 **Procedure for outputting a meta tag:**
 1. Determine which topic this response belongs to.
 2. If no existing topic fits, call `add_topic` FIRST and obtain the returned topic ID.
-3. Output the meta tag at the end of your response using the confirmed (existing or newly created) topic ID.
+3. Output the meta tag as the **first line** of your response, before any other text.
 
 NEVER GUESS OR PREDICT A TOPIC ID. A FABRICATED ID DIRECTLY POLLUTES THE USER'S CONTEXT AND IS EXTREMELY DISRUPTIVE.
 Only use IDs that already exist or that `add_topic` has just returned. No exceptions.

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -167,7 +167,7 @@ class TestMetaTagWithExistingTopic:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )
@@ -186,7 +186,7 @@ class TestTopicNotExists:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG_NONEXISTENT}"),
+                _make_assistant_entry(text=f"{META_TAG_NONEXISTENT}\nresponse"),
             ],
             transcript,
         )
@@ -207,7 +207,7 @@ class TestTopicNameMismatch:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG_WRONG_NAME}"),
+                _make_assistant_entry(text=f"{META_TAG_WRONG_NAME}\nresponse"),
             ],
             transcript,
         )
@@ -242,7 +242,7 @@ class TestTopicChangeNoRecord:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG_TOPIC_200}"),
+                _make_assistant_entry(text=f"{META_TAG_TOPIC_200}\nresponse"),
             ],
             transcript,
         )
@@ -275,7 +275,7 @@ class TestTopicChangeWithRecord:
                     tool_inputs=[{"topic_id": 100}],
                 ),
                 _make_user_entry("continue"),
-                _make_assistant_entry(text=f"response\n{META_TAG_TOPIC_200}"),
+                _make_assistant_entry(text=f"{META_TAG_TOPIC_200}\nresponse"),
             ],
             transcript,
         )
@@ -332,7 +332,7 @@ class TestExceptionFailOpen:
             [
                 _make_user_entry("hi"),
                 # DBが壊れていてもメタタグなしでblockされるので、メタタグありにする
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )
@@ -360,7 +360,7 @@ class TestFirstTopicSkip:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )
@@ -387,7 +387,7 @@ class TestNudgeCounter:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )
@@ -416,7 +416,7 @@ class TestNudgeCounter:
                 _make_assistant_entry(
                     tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
                     tool_inputs=[{"topic_id": 100}],
-                    text=f"recorded\n{META_TAG}",
+                    text=f"{META_TAG}\nrecorded",
                 ),
             ],
             transcript,
@@ -442,7 +442,7 @@ class TestStateUpdatedOnApprove:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )
@@ -465,7 +465,7 @@ class TestStateUpdatedOnApprove:
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
             ],
             transcript,
         )


### PR DESCRIPTION
## Summary
- メタタグ（`<!-- [meta] ... -->`）の出力位置をレスポンス末尾→先頭（最初の行）に変更
- stop hookのブロックメッセージを「応答の最後に」→「応答の最初に」に更新
- E2Eテストのテストデータを先頭配置に合わせて修正

## Why
- 先にトピックを決めてからレスポンスを書く方が思考順序として自然
- 末尾だとメタタグの出力を忘れやすい
- ブロック時にレスポンス全体を再生成するコストを削減

## Note
- 検出ロジック（`parse_meta_tag`の`re.search`）は位置非依存のため変更不要
- Bug #6（`parse_meta_tag`が最初のマッチのみ返す件）は先頭化で自然解消
- stop hookの検出ロジックバグ（#382）は別タスクで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)