### PR TITLE
feat: CIレビューでコード読み取りと重複チェックを有効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -47,13 +47,29 @@ jobs:
             - セキュリティ上の懸念
             - テストカバレッジ
 
+            ## 重要なルール
+
             レビューは必ず日本語で書いてください。
             問題点・改善提案のみを書いてください。良い点や褒めるコメントは不要です。
-            リポジトリのCLAUDE.mdを参照してスタイルと規約に従ってください。建設的で役に立つフィードバックをお願いします。
+            リポジトリのCLAUDE.mdを参照してスタイルと規約に従ってください。
+
+            ### コードを読んで確認してから指摘すること
+
+            diffだけを見て推測で指摘してはいけません。指摘を行う前に、必ず以下の手順を踏んでください：
+            1. `Read`や`Grep`ツールを使って、変更箇所の周辺コードや関連ファイルを確認する
+            2. 既存の実装パターンやAPI設計と照らし合わせて、本当に問題かどうか判断する
+            3. 「理論上問題になりうる」レベルではなく、実際にコードを読んで問題を確認できた場合のみ指摘する
+
+            ### 既存コメントとの重複を避けること
+
+            `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` で既存のレビューコメントを確認し、同じ指摘を繰り返さないでください。
+            また `gh pr view ${{ github.event.pull_request.number }} --comments` でPRコメントも確認してください。
+
+            ## 出力
 
             `gh pr comment` を使ってBashツールでPRにコメントとしてレビューを残してください。
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
 


### PR DESCRIPTION
## Summary
- `fetch-depth` を `1` → `0` に変更し、レビュアーがリポジトリ全体のコードを参照できるようにした
- `allowed-tools` に `Read`, `Grep`, `Glob`, `Bash(gh api:*)` を追加し、ソースコードの読み取りと既存PRコメントの確認を可能にした
- プロンプトに「diffだけで推測せずコードを読んでから指摘する」「既存コメントと重複しない」ルールを追加

## 背景
CIレビュー（claude[bot]）の指摘のうち、コードを読めば問題ないと分かるものが多かった（PR #140で6件中4件、PR #141で8件中6件がスルー対象）。原因はレビュアーがdiff情報のみで判断しており、実装の確認ができなかったこと。

## Test plan
- [ ] このPR自体にCIレビューが走り、新しいプロンプトで動作することを確認
- [ ] レビューコメントがコードを読んだ上での指摘になっているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)