### PR TITLE
fix: CIレビューのpull-requests権限をwriteに変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -71,5 +71,6 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          show_full_output: true
           claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
 


### PR DESCRIPTION
## Summary
- `pull-requests: read` → `write` に変更。`gh pr comment` によるレビューコメント投稿に書き込み権限が必要
- `show_full_output: true` を追加。permission denialのデバッグ情報を表示可能にする

## Background
PR #145 マージ後、CIレビューがpassしてもコメントが投稿されない問題が発生（permission_denials_count: 2）。
旧ワークフロー（PR #145前）ではコメント投稿が正常動作していたため、権限設定の変更が原因と推定。

## Test plan
- [ ] このPRマージ後、PR #147のワークフローをmainと同期してCIを再実行
- [ ] CIレビューがコメントを投稿することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)