### PR TITLE
feat: get_tasks/get_topicsのtags引数をoptional化

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -363,13 +363,13 @@ def add_decision(
 
 @mcp.tool()
 def get_topics(
-    tags: list[str],
+    tags: list[str] | None = None,
     limit: int = 10,
     offset: int = 0,
 ) -> dict:
-    """タグでフィルタリングしてトピックを新しい順に取得する（ページネーション付き）。
+    """トピックを新しい順に取得する（ページネーション付き）。
 
-    tags: タグ配列（必須、1個以上）。AND条件でフィルタ。例: ["domain:cc-memory"]
+    tags: タグ配列（optional）。指定時はAND条件でフィルタ。未指定時は全件返す。例: ["domain:cc-memory"]
     """
     return topic_service.get_topics(tags, limit, offset)
 
@@ -485,7 +485,7 @@ def add_task(
 
 @mcp.tool()
 def get_tasks(
-    tags: list[str],
+    tags: list[str] | None = None,
     status: str = "active",
     limit: int = 5,
 ) -> dict:
@@ -493,15 +493,15 @@ def get_tasks(
     タスク一覧を取得する（tagsでフィルタリング、statusでフィルタリング可能）。
 
     典型的な使い方:
-    - 未着手+進行中のタスク確認: get_tasks(["domain:cc-memory"])
+    - 全タスク確認: get_tasks()
+    - ドメイン指定: get_tasks(["domain:cc-memory"])
     - 進行中のみ: get_tasks(["domain:cc-memory"], status="in_progress")
-    - 未着手のみ: get_tasks(["domain:cc-memory"], status="pending")
-    - 完了タスクの確認: get_tasks(["domain:cc-memory"], status="completed")
+    - 完了タスクの確認: get_tasks(status="completed")
 
     ワークフロー位置: タスク状況の確認時
 
     Args:
-        tags: タグ配列（必須、1個以上）。AND条件でフィルタ。例: ["domain:cc-memory"]
+        tags: タグ配列（optional）。指定時はAND条件でフィルタ。未指定時は全件返す。例: ["domain:cc-memory"]
         status: フィルタするステータス（active/pending/in_progress/completed、デフォルト: active）
                 "active"はpending+in_progressの両方を返すエイリアス
         limit: 取得件数上限（デフォルト: 5）

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -105,12 +105,12 @@ def add_task(title: str, description: str, tags: list[str]) -> dict:
         conn.close()
 
 
-def get_tasks(tags: list[str], status: str = "active", limit: int = 5) -> dict:
+def get_tasks(tags: list[str] | None = None, status: str = "active", limit: int = 5) -> dict:
     """
     タスク一覧を取得（tagsでフィルタリング、statusでフィルタリング）
 
     Args:
-        tags: タグ配列（必須、1個以上。AND条件でフィルタ）
+        tags: タグ配列（optional。指定時はAND条件でフィルタ、未指定時は全件）
         status: フィルタするステータス（active/pending/in_progress/completed、デフォルト: active）
                 "active"はpending+in_progressの両方を返すエイリアス
         limit: 取得件数上限（デフォルト: 5）
@@ -118,10 +118,12 @@ def get_tasks(tags: list[str], status: str = "active", limit: int = 5) -> dict:
     Returns:
         タスク一覧とtotal_count
     """
-    # タグのバリデーション
-    parsed_tags = validate_and_parse_tags(tags, required=True)
-    if isinstance(parsed_tags, dict):
-        return parsed_tags
+    # タグのバリデーション（tags指定時のみ）
+    parsed_tags = None
+    if tags is not None:
+        parsed_tags = validate_and_parse_tags(tags, required=True)
+        if isinstance(parsed_tags, dict):
+            return parsed_tags
 
     if limit < 1:
         return {
@@ -141,44 +143,56 @@ def get_tasks(tags: list[str], status: str = "active", limit: int = 5) -> dict:
 
     conn = get_connection()
     try:
-        # タグIDを取得（読み取り専用、INSERTしない）
-        tag_ids = resolve_tag_ids(conn, parsed_tags)
-        if not tag_ids or len(tag_ids) < len(parsed_tags):
-            return {"tasks": [], "total_count": 0}
-        tag_placeholders = ",".join("?" * len(tag_ids))
+        # タグフィルタでtask_idsを絞り込む（tags指定時のみ）
+        task_ids = None
+        if parsed_tags is not None:
+            tag_ids = resolve_tag_ids(conn, parsed_tags)
+            if not tag_ids or len(tag_ids) < len(parsed_tags):
+                return {"tasks": [], "total_count": 0}
+            tag_placeholders = ",".join("?" * len(tag_ids))
 
-        # AND結合: 全タグを持つtaskのみ
-        task_ids_rows = conn.execute(
-            f"""
-            SELECT task_id FROM task_tags
-            WHERE tag_id IN ({tag_placeholders})
-            GROUP BY task_id
-            HAVING COUNT(DISTINCT tag_id) = ?
-            """,
-            (*tag_ids, len(tag_ids)),
-        ).fetchall()
+            task_ids_rows = conn.execute(
+                f"""
+                SELECT task_id FROM task_tags
+                WHERE tag_id IN ({tag_placeholders})
+                GROUP BY task_id
+                HAVING COUNT(DISTINCT tag_id) = ?
+                """,
+                (*tag_ids, len(tag_ids)),
+            ).fetchall()
 
-        task_ids = [row["task_id"] for row in task_ids_rows]
+            task_ids = [row["task_id"] for row in task_ids_rows]
 
-        if not task_ids:
-            return {"tasks": [], "total_count": 0}
+            if not task_ids:
+                return {"tasks": [], "total_count": 0}
 
-        id_placeholders = ",".join("?" * len(task_ids))
+        # WHERE句・ORDER BY句・パラメータを組み立て
+        conditions = []
+        where_params = []
 
-        # WHERE句・ORDER BY句・パラメータをステータスに応じて組み立て
+        if task_ids is not None:
+            id_placeholders = ",".join("?" * len(task_ids))
+            conditions.append(f"id IN ({id_placeholders})")
+            where_params.extend(task_ids)
+
         if status == "active":
             status_placeholders = ", ".join("?" for _ in ACTIVE_STATUSES)
-            where_clause = f"id IN ({id_placeholders}) AND status IN ({status_placeholders})"
-            where_params = (*task_ids, *ACTIVE_STATUSES)
+            conditions.append(f"status IN ({status_placeholders})")
+            where_params.extend(ACTIVE_STATUSES)
             order_clause = "CASE status WHEN 'in_progress' THEN 0 ELSE 1 END, updated_at DESC"
         else:
-            where_clause = f"id IN ({id_placeholders}) AND status = ?"
-            where_params = (*task_ids, status)
+            conditions.append("status = ?")
+            where_params.append(status)
             order_clause = "created_at ASC, id ASC"
+
+        if conditions:
+            where_clause = "WHERE " + " AND ".join(conditions)
+        else:
+            where_clause = ""
 
         # 1. total_count取得（LIMITなし）
         count_row = conn.execute(
-            f"SELECT COUNT(*) as count FROM tasks WHERE {where_clause}",
+            f"SELECT COUNT(*) as count FROM tasks {where_clause}",
             where_params,
         ).fetchone()
         total_count = count_row["count"]
@@ -187,7 +201,7 @@ def get_tasks(tags: list[str], status: str = "active", limit: int = 5) -> dict:
         rows = conn.execute(
             f"""
             SELECT * FROM tasks
-            WHERE {where_clause}
+            {where_clause}
             ORDER BY {order_clause}
             LIMIT ?
             """,

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -94,25 +94,27 @@ def add_topic(
 
 
 def get_topics(
-    tags: list[str],
+    tags: list[str] | None = None,
     limit: int = 10,
     offset: int = 0,
 ) -> dict:
     """
-    タグでフィルタリングしてトピックを新しい順に取得する（ページネーション付き）。
+    トピックを新しい順に取得する（ページネーション付き）。
 
     Args:
-        tags: タグ配列（必須、1個以上。AND条件でフィルタ）
+        tags: タグ配列（optional。指定時はAND条件でフィルタ、未指定時は全件）
         limit: 取得件数（デフォルト10）
         offset: スキップ件数（デフォルト0）
 
     Returns:
         トピック一覧（total_count付き）
     """
-    # タグのバリデーション
-    parsed_tags = validate_and_parse_tags(tags, required=True)
-    if isinstance(parsed_tags, dict):
-        return parsed_tags
+    # タグのバリデーション（tags指定時のみ）
+    parsed_tags = None
+    if tags is not None:
+        parsed_tags = validate_and_parse_tags(tags, required=True)
+        if isinstance(parsed_tags, dict):
+            return parsed_tags
 
     try:
         if limit < 1:
@@ -132,40 +134,52 @@ def get_topics(
 
         conn = get_connection()
         try:
-            # タグIDを取得（読み取り専用、INSERTしない）
-            tag_ids = resolve_tag_ids(conn, parsed_tags)
-            if not tag_ids or len(tag_ids) < len(parsed_tags):
-                return {"topics": [], "total_count": 0}
-            placeholders = ",".join("?" * len(tag_ids))
+            # タグフィルタでtopic_idsを絞り込む（tags指定時のみ）
+            topic_ids = None
+            if parsed_tags is not None:
+                tag_ids = resolve_tag_ids(conn, parsed_tags)
+                if not tag_ids or len(tag_ids) < len(parsed_tags):
+                    return {"topics": [], "total_count": 0}
+                placeholders = ",".join("?" * len(tag_ids))
 
-            # AND結合: 全タグを持つtopicのみ
-            topic_ids_rows = conn.execute(
-                f"""
-                SELECT topic_id FROM topic_tags
-                WHERE tag_id IN ({placeholders})
-                GROUP BY topic_id
-                HAVING COUNT(DISTINCT tag_id) = ?
-                """,
-                (*tag_ids, len(tag_ids)),
-            ).fetchall()
+                topic_ids_rows = conn.execute(
+                    f"""
+                    SELECT topic_id FROM topic_tags
+                    WHERE tag_id IN ({placeholders})
+                    GROUP BY topic_id
+                    HAVING COUNT(DISTINCT tag_id) = ?
+                    """,
+                    (*tag_ids, len(tag_ids)),
+                ).fetchall()
 
-            topic_ids = [row["topic_id"] for row in topic_ids_rows]
+                topic_ids = [row["topic_id"] for row in topic_ids_rows]
 
-            if not topic_ids:
-                return {"topics": [], "total_count": 0}
+                if not topic_ids:
+                    return {"topics": [], "total_count": 0}
 
-            total_count = len(topic_ids)
+            # クエリ組み立て
+            if topic_ids is not None:
+                id_placeholders = ",".join("?" * len(topic_ids))
+                where_clause = f"WHERE id IN ({id_placeholders})"
+                where_params = list(topic_ids)
+            else:
+                where_clause = ""
+                where_params = []
 
-            # トピック取得（新しい順）
-            id_placeholders = ",".join("?" * len(topic_ids))
+            count_row = conn.execute(
+                f"SELECT COUNT(*) as count FROM discussion_topics {where_clause}",
+                where_params,
+            ).fetchone()
+            total_count = count_row["count"]
+
             rows = conn.execute(
                 f"""
                 SELECT * FROM discussion_topics
-                WHERE id IN ({id_placeholders})
+                {where_clause}
                 ORDER BY created_at DESC, id DESC
                 LIMIT ? OFFSET ?
                 """,
-                (*topic_ids, limit, offset),
+                (*where_params, limit, offset),
             ).fetchall()
 
             # バッチでタグ取得

--- a/tests/integration/test_task_service.py
+++ b/tests/integration/test_task_service.py
@@ -98,6 +98,30 @@ class TestGetTasks:
         assert "error" in result
         assert result["error"]["code"] == "INVALID_STATUS"
 
+    def test_get_tasks_no_tags_returns_all(self, temp_db):
+        """tags未指定で全タスクを返す"""
+        add_task(title="Task A", description="Desc A", tags=["domain:test"])
+        add_task(title="Task B", description="Desc B", tags=["domain:other"])
+
+        result = get_tasks()
+
+        assert "error" not in result
+        assert result["total_count"] == 2
+        titles = {t["title"] for t in result["tasks"]}
+        assert titles == {"Task A", "Task B"}
+
+    def test_get_tasks_no_tags_with_status_filter(self, temp_db):
+        """tags未指定 + status指定で全ドメインからフィルタ"""
+        task_a = add_task(title="Task A", description="Desc", tags=["domain:test"])
+        add_task(title="Task B", description="Desc", tags=["domain:other"])
+        update_task(task_a["task_id"], new_status="completed")
+
+        result = get_tasks(status="completed")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["tasks"][0]["title"] == "Task A"
+
 
 
 class TestUpdateTask:

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -107,7 +107,35 @@ def test_get_topics_invalid_offset(temp_db):
     assert result["error"]["code"] == "INVALID_PARAMETER"
 
 
-def test_get_topics_tags_required(temp_db):
+def test_get_topics_no_tags_returns_all(temp_db):
+    """tags未指定で全トピックを返す（init_databaseのfirst_topic含む）"""
+    add_topic(title="Topic A", description="Desc A", tags=["domain:test"])
+    add_topic(title="Topic B", description="Desc B", tags=["domain:other"])
+
+    result = get_topics()
+
+    assert "error" not in result
+    # init_databaseで作成されるfirst_topicも含む
+    assert result["total_count"] >= 3
+    titles = {t["title"] for t in result["topics"]}
+    assert "Topic A" in titles
+    assert "Topic B" in titles
+
+
+def test_get_topics_no_tags_with_pagination(temp_db):
+    """tags未指定 + ページネーション"""
+    for i in range(5):
+        add_topic(title=f"Topic {i}", description=f"Desc {i}", tags=["domain:test"])
+
+    result = get_topics(limit=2, offset=0)
+
+    assert "error" not in result
+    assert len(result["topics"]) == 2
+    # first_topicも含むので6件以上
+    assert result["total_count"] >= 6
+
+
+def test_get_topics_tags_empty_list_error(temp_db):
     """tags=[]でTAGS_REQUIREDエラー"""
     result = get_topics(tags=[])
 


### PR DESCRIPTION
## Summary
- `get_tasks`/`get_topics`の`tags`引数を必須→optional（デフォルト`None`）に変更
- tags未指定時はタグフィルタなしで全件を返す（limitで件数制御）
- `tags=[]`は従来通り`TAGS_REQUIRED`エラー（`None`と明確に区別）
- WHERE句の組み立てを`topic_service`と`task_service`で統一パターンに整理

Closes task #420 (cc-memory)
Related: decision #1053（tags必須→optional化、#989撤回）

## Test plan
- [x] tags未指定で全件取得できることを確認（get_tasks/get_topics両方）
- [x] tags未指定 + status/paginationフィルタの組み合わせ
- [x] 既存のtags指定時の挙動が変わらないことを確認（394 passed）
- [x] `tags=[]`がTAGS_REQUIREDエラーを返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)