### PR TITLE
feat: searchのkeyword引数を配列対応しAND検索を実装

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -396,7 +396,7 @@ def get_decisions(
 
 @mcp.tool()
 def search(
-    keyword: str,
+    keyword: str | list[str],
     tags: Optional[list[str]] = None,
     type_filter: Optional[str] = None,
     limit: int = 10,
@@ -406,10 +406,11 @@ def search(
 
     FTS5 trigramとベクトル検索のハイブリッド。RRFスコアで統合・ランキング。
     2文字以上のキーワードを指定する。
+    配列で複数キーワードを渡すとAND検索（すべてを含む結果のみ返す）。
     tagsでフィルタリング可能（AND結合）。未指定で全件検索。
 
     Args:
-        keyword: 検索キーワード（2文字以上）
+        keyword: 検索キーワード（2文字以上）。配列で複数指定時はAND検索
         tags: タグフィルタ（AND条件。未指定=全件検索）
         type_filter: 検索対象の絞り込み（'topic', 'decision', 'task', 'log'。未指定で全種類）
         limit: 取得件数上限（デフォルト10件、最大50件）

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -125,13 +125,15 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
 
 
 def _fts_search(
-    keyword: str,
+    keywords: list[str],
     tag_ids: Optional[list[int]],
     type_filter: Optional[str],
     limit: int,
 ) -> list[dict]:
     """FTS5検索。結果はBM25ランク順のリスト。"""
-    escaped_keyword = _escape_fts5_query(keyword)
+    # 各キーワードをエスケープして AND 結合
+    escaped_parts = [_escape_fts5_query(kw) for kw in keywords]
+    escaped_keyword = " AND ".join(escaped_parts)
 
     if tag_ids:
         cte_sql, cte_params = _build_tag_filter_cte(tag_ids)
@@ -178,14 +180,16 @@ def _fts_search(
 
 
 def _vector_search(
-    keyword: str,
+    keywords: list[str],
     tag_ids: Optional[list[int]],
     type_filter: Optional[str],
     limit: int,
 ) -> Optional[list[dict]]:
     """ベクトル検索。ベクトル検索無効時はNoneを返す。"""
     try:
-        query_embedding = embedding_service.encode_query(keyword)
+        # 配列をスペースで結合して1つのembeddingを生成
+        combined_keyword = " ".join(keywords)
+        query_embedding = embedding_service.encode_query(combined_keyword)
         if query_embedding is None:
             return None
 
@@ -292,7 +296,7 @@ def _rrf_merge(
 
 
 def search(
-    keyword: str,
+    keyword: str | list[str],
     tags: Optional[list[str]] = None,
     type_filter: Optional[str] = None,
     limit: int = 10,
@@ -302,13 +306,14 @@ def search(
 
     FTS5 trigramとベクトル検索のハイブリッド。RRFスコアで統合・ランキング。
     2文字以上のキーワードを指定する。
+    配列で複数キーワードを渡すとAND検索（すべてを含む結果のみ返す）。
     3文字以上: FTS5 + ベクトル検索のハイブリッド。
     2文字: ベクトル検索のみ（ベクトル検索無効時はエラー）。
     tagsでフィルタリング可能（AND結合）。未指定で全件検索。
     詳細情報が必要な場合は get_by_id(type, id) で取得する。
 
     Args:
-        keyword: 検索キーワード（2文字以上）
+        keyword: 検索キーワード（2文字以上）。配列で複数指定時はAND検索
         tags: タグフィルタ（AND条件。未指定=全件検索）
         type_filter: 検索対象の絞り込み（'topic', 'decision', 'task', 'log'。未指定で全種類）
         limit: 取得件数上限（デフォルト10件、最大50件）
@@ -316,15 +321,30 @@ def search(
     Returns:
         検索結果一覧（type, id, title, score）
     """
-    # バリデーション
-    keyword = keyword.strip()
-    if len(keyword) < 2:
+    # 正規化: str → list[str]
+    if isinstance(keyword, str):
+        keywords = [keyword.strip()]
+    else:
+        keywords = [k.strip() for k in keyword]
+
+    # 空配列チェック
+    if not keywords:
         return {
             "error": {
                 "code": "KEYWORD_TOO_SHORT",
                 "message": "keyword must be at least 2 characters"
             }
         }
+
+    # バリデーション: 各要素2文字以上
+    for kw in keywords:
+        if len(kw) < 2:
+            return {
+                "error": {
+                    "code": "KEYWORD_TOO_SHORT",
+                    "message": "keyword must be at least 2 characters"
+                }
+            }
 
     if type_filter is not None and type_filter not in VALID_TYPES:
         return {
@@ -352,16 +372,17 @@ def search(
         # RRFで両ソースをマージした後にlimitで切るため、各ソースからlimitより多めに取得する
         fetch_limit = limit * 5
 
-        # FTS5検索: 3文字以上の場合のみ
+        # FTS5検索: 全キーワードが3文字以上の場合のみ
+        min_len = min(len(kw) for kw in keywords)
         fts_results = []
-        if len(keyword) >= 3:
-            fts_results = _fts_search(keyword, tag_ids, type_filter, fetch_limit)
+        if min_len >= 3:
+            fts_results = _fts_search(keywords, tag_ids, type_filter, fetch_limit)
 
         # ベクトル検索
-        vec_results = _vector_search(keyword, tag_ids, type_filter, fetch_limit)
+        vec_results = _vector_search(keywords, tag_ids, type_filter, fetch_limit)
 
         # 2文字キーワード + ベクトル検索無効 → エラー
-        if len(keyword) < 3 and vec_results is None:
+        if min_len < 3 and vec_results is None:
             return {
                 "error": {
                     "code": "KEYWORD_TOO_SHORT",

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -379,3 +379,54 @@ def test_add_log_empty_title_error(temp_db):
     assert "error" in result
     assert result["error"]["code"] == "VALIDATION_ERROR"
     assert "title must not be empty" in result["error"]["message"]
+
+
+# ========================================
+# keyword配列（AND検索）のテスト
+# ========================================
+
+
+def test_search_keyword_array_and(temp_db):
+    """配列keyword: AND検索で両キーワードを含む結果のみ返す"""
+    add_topic(title="メモリ管理の検索テスト", description="検索機能のテスト", tags=DEFAULT_TAGS)
+    add_topic(title="メモリ管理の設計ドキュメント", description="設計の詳細", tags=DEFAULT_TAGS)
+    add_topic(title="検索機能の改善提案", description="改善案", tags=DEFAULT_TAGS)
+    # "メモリ" AND "検索" → 両方含む最初のトピックのみヒット
+    result = search_service.search(keyword=["メモリ管理", "検索テスト"])
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    titles = [r["title"] for r in result["results"]]
+    assert any("メモリ管理の検索テスト" in t for t in titles)
+    # "メモリ管理の設計ドキュメント" は "検索テスト" を含まないのでヒットしない
+    assert all("メモリ管理の設計ドキュメント" not in t for t in titles)
+
+
+def test_search_keyword_array_element_too_short(temp_db):
+    """配列内に2文字未満の要素があるとKEYWORD_TOO_SHORTエラー"""
+    result = search_service.search(keyword=["テスト", "あ"])
+    assert "error" in result
+    assert result["error"]["code"] == "KEYWORD_TOO_SHORT"
+
+
+def test_search_keyword_empty_array(temp_db):
+    """空配列でKEYWORD_TOO_SHORTエラー"""
+    result = search_service.search(keyword=[])
+    assert "error" in result
+    assert result["error"]["code"] == "KEYWORD_TOO_SHORT"
+
+
+def test_search_keyword_single_string_backward_compat(temp_db):
+    """単一文字列の後方互換: 既存動作と同じ"""
+    add_topic(title="後方互換テスト用トピック検索", description="テスト", tags=DEFAULT_TAGS)
+    result = search_service.search(keyword="後方互換テスト用トピック検索")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+
+
+def test_search_keyword_array_with_2char_fts_skipped(temp_db):
+    """配列内に2文字キーワードがある場合、FTS5検索はスキップされる（ベクトル無効時エラー）"""
+    # embedding無効（autouse fixture）なので、2文字キーワードがあるとベクトルのみ→エラー
+    result = search_service.search(keyword=["テスト", "設計"])
+    assert "error" in result
+    assert result["error"]["code"] == "KEYWORD_TOO_SHORT"
+    assert "vector search is unavailable" in result["error"]["message"]

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -342,3 +342,57 @@ def test_hybrid_search_tag_isolation(temp_db, mock_embedding_model):
     assert "error" not in result
     for item in result["results"]:
         assert item["title"] != "分離テスト他タグトピック"
+
+
+# ========================================
+# keyword配列（AND検索）のテスト
+# ========================================
+
+
+def test_hybrid_keyword_array_and(temp_db, mock_embedding_model):
+    """配列keyword: ハイブリッド検索でAND動作"""
+    add_topic(
+        title="ハイブリッド配列検索テスト対象",
+        description="メモリ管理と検索機能の両方を扱うトピック",
+        tags=DEFAULT_TAGS,
+    )
+    add_topic(
+        title="ハイブリッド配列検索テスト対象外",
+        description="メモリ管理のみ",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword=["ハイブリッド配列検索", "テスト対象"])
+
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+
+
+def test_hybrid_keyword_array_vec_search(temp_db, mock_embedding_model):
+    """配列keyword: ベクトル検索が結果を返す"""
+    add_topic(
+        title="ベクトル配列検索テスト用トピック",
+        description="複数キーワードでのベクトル検索確認",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword=["ベクトル配列検索", "テスト用"])
+
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    assert isinstance(result["results"][0]["score"], float)
+
+
+def test_hybrid_keyword_array_2char_vec_only(temp_db, mock_embedding_model):
+    """配列内に2文字キーワード: ベクトル検索のみで動作"""
+    add_topic(
+        title="設計レビュー用ドキュメント",
+        description="設計の詳細レビュー",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword=["設計", "レビュー"])
+
+    assert "error" not in result
+    # ベクトル検索のみなので結果は返る（エラーにはならない）
+    assert "results" in result


### PR DESCRIPTION
## Summary
- searchのkeyword引数を `str | list[str]` に拡張し、複数キーワードのAND検索を実装
- FTS5側は `" AND "` 結合、ベクトル検索側はスペース結合で1 embedding生成
- 単一文字列は従来どおり動作（後方互換維持）

## Test plan
- [ ] 既存テスト49件がパスすること（後方互換）
- [ ] 配列keywordでFTS5 AND検索が動作すること
- [ ] 配列keywordでベクトル検索が動作すること
- [ ] 配列内の各要素に2文字以上バリデーションが適用されること
- [ ] 空配列でエラーが返ること
- [ ] 2文字キーワード含む配列でベクトルのみ検索になること

cc-memory task: #422
decision: #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)