### PR TITLE
fix: CIレビューのトリガーをPR作成時+手動に変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,8 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened]
+  workflow_dispatch:
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
- `claude-code-review.yml`のトリガーから`synchronize`を削除し、pushごとの自動発火を停止
- `workflow_dispatch`を追加し、GitHub UIからの手動実行を可能に

## Test plan
- [ ] PRを新規作成してCIレビューが発火することを確認
- [ ] PRブランチにpushしてもCIレビューが発火しないことを確認
- [ ] Actions タブから手動実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)