### PR TITLE
fix: nudgeリマインダーにadd_log催促を追加

### DIFF
--- a/hooks/pretooluse_hook.py
+++ b/hooks/pretooluse_hook.py
@@ -55,7 +55,11 @@ _RECORD_NUDGE_MESSAGE = (
     "(2) Have you and the user reached any agreements that should be recorded? "
     "Examples: design choices, naming conventions, scope boundaries, "
     "implementation approaches, or trade-off resolutions. "
-    "If yes, record them now with add_decision before proceeding."
+    "If yes, record them now with add_decision before proceeding. "
+    "(3) Has there been substantive discussion worth preserving? "
+    "Use add_log to capture the flow of conversation — "
+    "arguments considered, options explored, and reasoning behind choices. "
+    "Decisions record conclusions; logs preserve the path that led there."
     "</system-reminder>"
 )
 


### PR DESCRIPTION
## Summary
- pretooluse hookの記録リマインダー（`_RECORD_NUDGE_MESSAGE`）にadd_logの催促を追加
- 既存の(1)トピック確認、(2)add_decision催促に加えて、(3)議論の経緯をadd_logで残すよう促す文言を追加

## Test plan
- [x] `tests/e2e/test_pretooluse_hook.py` 全10件pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)