### PR TITLE
feat: タグnotesカラム追加・update_tagツール・遭遇時注入

### DIFF
--- a/migrations/0012_add_tag_notes.sql
+++ b/migrations/0012_add_tag_notes.sql
@@ -1,0 +1,3 @@
+-- depends: 0011_rename_task_to_activity
+
+ALTER TABLE tags ADD COLUMN notes TEXT;

--- a/src/main.py
+++ b/src/main.py
@@ -10,8 +10,8 @@ from src.services import (
     activity_service,
     knowledge_service,
 )
-from src.services.tag_service import list_tags as _list_tags
-from src.db import execute_query, row_to_dict
+from src.services.tag_service import list_tags as _list_tags, update_tag as _update_tag, collect_tag_notes_for_injection
+from src.db import execute_query, get_connection, row_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -315,6 +315,18 @@ def build_instructions() -> str:
     return RULES
 
 
+def _maybe_inject_tag_notes(result: dict, tag_strings: list[str]) -> dict:
+    """結果dictにtag_notesを注入する（notes があれば）"""
+    conn = get_connection()
+    try:
+        notes = collect_tag_notes_for_injection(conn, tag_strings)
+    finally:
+        conn.close()
+    if notes:
+        result["tag_notes"] = notes
+    return result
+
+
 # MCPサーバーを作成
 mcp = FastMCP("cc-memory", instructions=build_instructions())
 
@@ -330,7 +342,10 @@ def add_topic(
 
     tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["domain:cc-memory", "scope:hook-system", "error-handling", "validation", "stdin"]
     """
-    return topic_service.add_topic(title, description, tags)
+    result = topic_service.add_topic(title, description, tags)
+    if "error" not in result:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -344,7 +359,10 @@ def add_log(
 
     tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["mode:discussion", "migration", "breaking-change", "schema"]
     """
-    return discussion_log_service.add_log(topic_id, title, content, tags)
+    result = discussion_log_service.add_log(topic_id, title, content, tags)
+    if "error" not in result and tags:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -358,7 +376,10 @@ def add_decision(
 
     tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["scope:data-model", "naming-convention", "backward-compat"]
     """
-    return decision_service.add_decision(decision, reason, topic_id, tags)
+    result = decision_service.add_decision(decision, reason, topic_id, tags)
+    if "error" not in result and tags:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -371,7 +392,10 @@ def get_topics(
 
     tags: タグ配列（optional）。指定時はAND条件でフィルタ。未指定時は全件返す。例: ["domain:cc-memory"]
     """
-    return topic_service.get_topics(tags, limit, offset)
+    result = topic_service.get_topics(tags, limit, offset)
+    if "error" not in result and tags:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -419,7 +443,10 @@ def search(
         検索結果一覧（type, id, title, score, snippet）
         snippetは各typeの対応するソースカラムの先頭200文字。
     """
-    return search_service.search(keyword, tags, type_filter, limit)
+    result = search_service.search(keyword, tags, type_filter, limit)
+    if "error" not in result and tags:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -461,7 +488,15 @@ def get_by_ids(
     Returns:
         一括取得結果（各アイテムはget_by_idと同じ形式）
     """
-    return search_service.get_by_ids(items)
+    result = search_service.get_by_ids(items)
+    if "error" not in result:
+        all_tags = []
+        for item in result.get("results", []):
+            if "data" in item:
+                all_tags.extend(item["data"].get("tags", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+    return result
 
 
 @mcp.tool()
@@ -478,9 +513,27 @@ def list_tags(
         namespace: namespaceでフィルタ（"domain", "scope", "mode", ""。未指定で全タグ）
 
     Returns:
-        タグ一覧（tag, id, namespace, name, usage_count）をusage_count降順で返す
+        タグ一覧（tag, id, namespace, name, usage_count, notes）をusage_count降順で返す
     """
     return _list_tags(namespace)
+
+
+@mcp.tool()
+def update_tag(tag: str, notes: str) -> dict:
+    """
+    既存タグの notes（教訓・運用ルール）を更新する。上書き方式（全文置換）。
+
+    タグに紐づく教訓や運用ルールを記録する。CLAUDE.mdのタグ版として機能し、
+    そのタグの文脈で作業するときに自動的にAIに注入される。
+
+    Args:
+        tag: 対象タグ（例: "domain:cc-memory", "hooks"）
+        notes: 教訓・運用ルールのテキスト（全文置換）
+
+    Returns:
+        更新結果
+    """
+    return _update_tag(tag, notes)
 
 
 @mcp.tool()
@@ -503,7 +556,10 @@ def add_activity(
     Returns:
         作成されたアクティビティ情報
     """
-    return activity_service.add_activity(title, description, tags)
+    result = activity_service.add_activity(title, description, tags)
+    if "error" not in result:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()
@@ -532,7 +588,10 @@ def get_activities(
     Returns:
         アクティビティ一覧（total_countで該当ステータスの全件数を確認可能）
     """
-    return activity_service.get_activities(tags, status, limit)
+    result = activity_service.get_activities(tags, status, limit)
+    if "error" not in result and tags:
+        _maybe_inject_tag_notes(result, tags)
+    return result
 
 
 @mcp.tool()

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -2,7 +2,7 @@
 import sqlite3
 from typing import Optional, Union
 
-from src.db import execute_query, row_to_dict
+from src.db import execute_query, get_connection, row_to_dict
 
 
 VALID_NAMESPACES = {'', 'domain', 'scope', 'mode'}
@@ -290,12 +290,12 @@ def list_tags(namespace: Optional[str] = None) -> dict:
                    namespace=""で素タグ（namespaceなし）のみフィルタ。
 
     Returns:
-        タグ一覧（id, namespace, name, tag, usage_count）をusage_count降順で返す
+        タグ一覧（id, namespace, name, tag, usage_count, notes）をusage_count降順で返す
     """
     try:
         rows = execute_query(
             """
-            SELECT t.id, t.namespace, t.name,
+            SELECT t.id, t.namespace, t.name, t.notes,
               (SELECT COUNT(*) FROM topic_tags WHERE tag_id = t.id) +
               (SELECT COUNT(*) FROM activity_tags WHERE tag_id = t.id) +
               (SELECT COUNT(*) FROM decision_tags WHERE tag_id = t.id) +
@@ -318,6 +318,7 @@ def list_tags(namespace: Optional[str] = None) -> dict:
                 "namespace": ns,
                 "name": name,
                 "usage_count": r["usage_count"],
+                "notes": r["notes"],
             })
         return {"tags": tags}
 
@@ -328,3 +329,102 @@ def list_tags(namespace: Optional[str] = None) -> dict:
                 "message": str(e),
             }
         }
+
+
+def update_tag(tag: str, notes: str) -> dict:
+    """既存タグの notes（教訓・運用ルール）を更新する。
+
+    Args:
+        tag: タグ文字列（例: "domain:cc-memory", "hooks"）
+        notes: 教訓・運用ルールのテキスト（全文置換）
+
+    Returns:
+        成功時: {"tag": str, "notes": str, "updated": True}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    parsed = validate_and_parse_tags([tag])
+    if isinstance(parsed, dict):
+        return parsed
+    namespace, name = parsed[0]
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+            (namespace, name),
+        ).fetchone()
+
+        if not row:
+            tag_display = f"{namespace}:{name}" if namespace else name
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"Tag '{tag_display}' not found",
+                }
+            }
+
+        conn.execute(
+            "UPDATE tags SET notes = ? WHERE id = ?",
+            (notes, row["id"]),
+        )
+        conn.commit()
+
+        tag_str = f"{namespace}:{name}" if namespace else name
+        return {"tag": tag_str, "notes": notes, "updated": True}
+
+    except Exception as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()
+
+
+# ========================================
+# 遭遇時注入（Tag Notes Injection）
+# ========================================
+
+# モジュールレベルのグローバル変数（MCPサーバープロセスのライフサイクル = セッション）
+_injected_tags: set[str] = set()
+
+
+def collect_tag_notes_for_injection(conn: sqlite3.Connection, tag_strings: list[str]) -> list[dict] | None:
+    """未注入タグの notes を収集し、注入済みとしてマークする。
+
+    Args:
+        conn: DB接続
+        tag_strings: タグ文字列リスト（例: ["domain:cc-memory", "scope:design"]）
+
+    Returns:
+        notes があるタグの一覧。なければ None
+        [{"tag": "domain:cc-memory", "notes": "..."}, ...]
+    """
+    new_tags = [t for t in tag_strings if t not in _injected_tags]
+    if not new_tags:
+        return None
+
+    # 新規遭遇タグをすべてマーク（notes の有無に関わらず）
+    _injected_tags.update(new_tags)
+
+    # notes がある分だけ取得（バッチクエリ）
+    parsed = [parse_tag(t) for t in new_tags]
+    placeholders = " OR ".join(["(namespace = ? AND name = ?)"] * len(parsed))
+    params = [v for pair in parsed for v in pair]
+    rows = conn.execute(
+        f"SELECT namespace, name, notes FROM tags WHERE ({placeholders}) AND notes IS NOT NULL",
+        params
+    ).fetchall()
+
+    if not rows:
+        return None
+
+    results = []
+    for row in rows:
+        tag_str = f"{row['namespace']}:{row['name']}" if row["namespace"] else row["name"]
+        results.append({"tag": tag_str, "notes": row["notes"]})
+
+    return results if results else None

--- a/tests/unit/test_list_tags.py
+++ b/tests/unit/test_list_tags.py
@@ -151,6 +151,7 @@ def test_list_tags_response_format(temp_db):
     assert "namespace" in tag
     assert "name" in tag
     assert "usage_count" in tag
+    assert "notes" in tag
     assert isinstance(tag["id"], int)
     assert isinstance(tag["usage_count"], int)
 

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -1,0 +1,290 @@
+"""タグ notes 機能のユニットテスト
+
+- update_tag の正常系・エラー系
+- list_tags の notes 返却
+- 遭遇時注入の正常系・重複防止
+- get_by_ids での遭遇時注入
+"""
+import os
+import tempfile
+import pytest
+from src.db import init_database, get_connection
+from src.services.tag_service import (
+    update_tag,
+    list_tags,
+    ensure_tag_ids,
+    collect_tag_notes_for_injection,
+    _injected_tags,
+)
+from src.services.topic_service import add_topic
+from src.services.decision_service import add_decision
+from src.services.search_service import get_by_ids
+import src.services.embedding_service as emb
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture(autouse=True)
+def reset_injected_tags():
+    """各テスト前に注入済みタグをリセットする"""
+    _injected_tags.clear()
+    yield
+    _injected_tags.clear()
+
+
+# ========================================
+# update_tag テスト
+# ========================================
+
+
+class TestUpdateTag:
+    """update_tagのテスト"""
+
+    def test_update_existing_tag(self, temp_db):
+        """既存タグに notes を設定できる"""
+        # タグを作成
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+
+        result = update_tag("domain:test", "このドメインでは注意が必要")
+        assert "error" not in result
+        assert result["tag"] == "domain:test"
+        assert result["notes"] == "このドメインでは注意が必要"
+        assert result["updated"] is True
+
+    def test_update_bare_tag(self, temp_db):
+        """素タグに notes を設定できる"""
+        add_topic(title="Test", description="Desc", tags=["hooks"])
+
+        result = update_tag("hooks", "hookの教訓")
+        assert "error" not in result
+        assert result["tag"] == "hooks"
+        assert result["notes"] == "hookの教訓"
+        assert result["updated"] is True
+
+    def test_update_nonexistent_tag(self, temp_db):
+        """存在しないタグでNOT_FOUNDエラー"""
+        result = update_tag("domain:nonexistent", "notes text")
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_update_overwrite(self, temp_db):
+        """notes を上書きできる（全文置換）"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+
+        update_tag("domain:test", "初回 notes")
+        result = update_tag("domain:test", "更新後 notes")
+        assert result["notes"] == "更新後 notes"
+
+
+# ========================================
+# list_tags + notes テスト
+# ========================================
+
+
+class TestListTagsWithNotes:
+    """list_tags の notes 返却テスト"""
+
+    def test_notes_included_in_response(self, temp_db):
+        """list_tags の各タグに notes フィールドが含まれる"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト用 notes")
+
+        result = list_tags()
+        assert "error" not in result
+        test_tag = next(t for t in result["tags"] if t["tag"] == "domain:test")
+        assert "notes" in test_tag
+        assert test_tag["notes"] == "テスト用 notes"
+
+    def test_notes_null_when_not_set(self, temp_db):
+        """notes 未設定タグは None"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+
+        result = list_tags()
+        assert "error" not in result
+        test_tag = next(t for t in result["tags"] if t["tag"] == "domain:test")
+        assert test_tag["notes"] is None
+
+
+# ========================================
+# 遭遇時注入テスト
+# ========================================
+
+
+class TestTagNotesInjection:
+    """遭遇時注入ロジックのテスト"""
+
+    def test_first_encounter_injects_notes(self, temp_db):
+        """初回遭遇で notes が付加される"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "重要な教訓")
+
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert result is not None
+            assert len(result) == 1
+            assert result[0]["tag"] == "domain:test"
+            assert result[0]["notes"] == "重要な教訓"
+        finally:
+            conn.close()
+
+    def test_second_encounter_no_injection(self, temp_db):
+        """2回目の遭遇では注入されない"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "重要な教訓")
+
+        conn = get_connection()
+        try:
+            # 1回目
+            result1 = collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert result1 is not None
+
+            # 2回目
+            result2 = collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert result2 is None
+        finally:
+            conn.close()
+
+    def test_no_notes_returns_none(self, temp_db):
+        """notes がないタグでは None が返る"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert result is None
+        finally:
+            conn.close()
+
+    def test_mixed_tags_with_and_without_notes(self, temp_db):
+        """notes があるタグとないタグの混在"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        update_tag("domain:test", "テスト教訓")
+        # scope:search には notes を設定しない
+
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            assert result is not None
+            assert len(result) == 1
+            assert result[0]["tag"] == "domain:test"
+        finally:
+            conn.close()
+
+    def test_multiple_tags_with_notes(self, temp_db):
+        """複数タグに notes がある場合"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        update_tag("domain:test", "テスト教訓")
+        update_tag("scope:search", "検索の教訓")
+
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            assert result is not None
+            assert len(result) == 2
+            tag_strs = {r["tag"] for r in result}
+            assert "domain:test" in tag_strs
+            assert "scope:search" in tag_strs
+        finally:
+            conn.close()
+
+    def test_partial_new_tags(self, temp_db):
+        """一部が既に遭遇済み、一部が新規の場合"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        update_tag("domain:test", "テスト教訓")
+        update_tag("scope:search", "検索の教訓")
+
+        conn = get_connection()
+        try:
+            # domain:test だけ先に遭遇
+            collect_tag_notes_for_injection(conn, ["domain:test"])
+
+            # 両方渡すが、domain:test は既に遭遇済み
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            assert result is not None
+            assert len(result) == 1
+            assert result[0]["tag"] == "scope:search"
+        finally:
+            conn.close()
+
+    def test_nonexistent_tag_no_error(self, temp_db):
+        """DBに存在しないタグを渡してもエラーにならない"""
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(conn, ["domain:nonexistent"])
+            assert result is None
+        finally:
+            conn.close()
+
+
+# ========================================
+# get_by_ids 遭遇時注入テスト
+# ========================================
+
+
+class TestGetByIdsInjection:
+    """get_by_ids での遭遇時注入テスト
+
+    main.py の @mcp.tool() デコレータ付き関数は FunctionTool になるため直接呼べない。
+    search_service.get_by_ids + _maybe_inject_tag_notes の組み合わせをテストする。
+    """
+
+    def test_get_by_ids_injects_tag_notes(self, temp_db):
+        """get_by_ids の結果からタグ notes が注入される"""
+        from src.main import _maybe_inject_tag_notes
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        # search_service.get_by_ids で結果取得
+        result = get_by_ids([{"type": "topic", "id": topic["topic_id"]}])
+        assert "error" not in result
+
+        # main.py と同じパターンで注入
+        all_tags = []
+        for item in result.get("results", []):
+            if "data" in item:
+                all_tags.extend(item["data"].get("tags", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+
+        assert "tag_notes" in result
+        assert len(result["tag_notes"]) == 1
+        assert result["tag_notes"][0]["tag"] == "domain:test"
+        assert result["tag_notes"][0]["notes"] == "テスト教訓"
+
+    def test_get_by_ids_no_notes_no_key(self, temp_db):
+        """notes がない場合は tag_notes キーが含まれない"""
+        from src.main import _maybe_inject_tag_notes
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:test"])
+
+        result = get_by_ids([{"type": "topic", "id": topic["topic_id"]}])
+        assert "error" not in result
+
+        all_tags = []
+        for item in result.get("results", []):
+            if "data" in item:
+                all_tags.extend(item["data"].get("tags", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+
+        assert "tag_notes" not in result


### PR DESCRIPTION
## Summary
- tagsテーブルにnotesカラム（教訓・運用ルール）を追加
- `update_tag(tag, notes)` ツールを新設（既存タグのみ対象、上書き方式）
- タグ遭遇時にnotesをレスポンスに自動注入（セッション内初回のみ）

## Test plan
- [ ] `update_tag` で既存タグのnotesを設定できる
- [ ] 存在しないタグへの `update_tag` でエラーが返る
- [ ] `list_tags` でnotesが返る
- [ ] タグ指定ツール（get_topics, search等）の初回呼び出しでnotesが注入される
- [ ] 同一セッション内で同タグのnotesは2回注入されない
- [ ] get_by_ids の結果からもnotesが注入される
- [ ] テスト全パス（431 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)