### PR TITLE
refactor: get_by_idツール廃止 → get_by_idsに統一

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -161,7 +161,7 @@ _RECORDING_TOOLS = [
 _TOPIC_TOOLS = [
     "mcp__plugin_claude-code-memory_cc-memory__get_topics",
     "mcp__plugin_claude-code-memory_cc-memory__search",
-    "mcp__plugin_claude-code-memory_cc-memory__get_by_id",
+    "mcp__plugin_claude-code-memory_cc-memory__get_by_ids",
     "mcp__plugin_claude-code-memory_cc-memory__add_topic",
 ]
 

--- a/src/main.py
+++ b/src/main.py
@@ -423,35 +423,14 @@ def search(
 
 
 @mcp.tool()
-def get_by_id(
-    type: str,
-    id: int,
-) -> dict:
-    """
-    search結果の詳細情報を取得する。
-
-    searchツールで得られたtype + idの組み合わせを指定して、
-    元データの完全な情報を取得する。
-
-    Args:
-        type: データ種別（'topic', 'decision', 'task', 'log'）
-        id: データのID
-
-    Returns:
-        指定した種別に応じた詳細情報
-    """
-    return search_service.get_by_id(type, id)
-
-
-@mcp.tool()
 def get_by_ids(
     items: list[dict],
 ) -> dict:
     """
-    複数のsearch結果の詳細情報を一括取得する。
+    search結果の詳細情報を取得する。
 
-    searchツールで得られた複数のtype + idペアを1回で取得し、
-    各アイテムの全文を返す。
+    searchツールで得られたtype + idペアを指定して、
+    各アイテムの全文を返す。1件でも複数件でも使える。
 
     Args:
         items: 取得対象のリスト。各要素は {type: str, id: int}（最大20件）
@@ -459,7 +438,7 @@ def get_by_ids(
                id: データのID
 
     Returns:
-        一括取得結果（各アイテムはget_by_idと同じ形式）
+        一括取得結果（各アイテムの詳細情報）
     """
     return search_service.get_by_ids(items)
 

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -249,70 +249,82 @@ def test_search_log_inherits_topic_tags(temp_db):
 
 
 # ========================================
-# get_by_id ツールのテスト
+# get_by_ids ツールのテスト
 # ========================================
 
 
-def test_get_by_id_topic(temp_db):
-    """get_by_id: topicの詳細取得"""
+def test_get_by_ids_single_topic(temp_db):
+    """get_by_ids: topicの詳細取得（1件）"""
     topic = add_topic(title="詳細取得テスト用トピック", description="テスト説明", tags=DEFAULT_TAGS)
-    result = search_service.get_by_id("topic", topic["topic_id"])
-    assert "error" not in result
-    assert result["type"] == "topic"
-    assert result["data"]["title"] == "詳細取得テスト用トピック"
-    assert result["data"]["description"] == "テスト説明"
-    assert "tags" in result["data"]
-    assert "domain:test" in result["data"]["tags"]
+    result = search_service.get_by_ids([{"type": "topic", "id": topic["topic_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "topic"
+    assert item["data"]["title"] == "詳細取得テスト用トピック"
+    assert item["data"]["description"] == "テスト説明"
+    assert "tags" in item["data"]
+    assert "domain:test" in item["data"]["tags"]
 
 
-def test_get_by_id_decision(temp_db):
-    """get_by_id: decisionの詳細取得"""
+def test_get_by_ids_single_decision(temp_db):
+    """get_by_ids: decisionの詳細取得（1件）"""
     topic = add_topic(title="トピック", description="テスト", tags=DEFAULT_TAGS)
     dec = add_decision(topic_id=topic["topic_id"], decision="詳細取得テスト決定", reason="テスト理由")
-    result = search_service.get_by_id("decision", dec["decision_id"])
-    assert "error" not in result
-    assert result["type"] == "decision"
-    assert result["data"]["decision"] == "詳細取得テスト決定"
-    assert "tags" in result["data"]
-    assert "domain:test" in result["data"]["tags"]
+    result = search_service.get_by_ids([{"type": "decision", "id": dec["decision_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "decision"
+    assert item["data"]["decision"] == "詳細取得テスト決定"
+    assert "tags" in item["data"]
+    assert "domain:test" in item["data"]["tags"]
 
 
-def test_get_by_id_task(temp_db):
-    """get_by_id: taskの詳細取得"""
+def test_get_by_ids_single_task(temp_db):
+    """get_by_ids: taskの詳細取得（1件）"""
     task = add_task(title="詳細取得テスト用タスク", description="テスト説明", tags=DEFAULT_TAGS)
-    result = search_service.get_by_id("task", task["task_id"])
-    assert "error" not in result
-    assert result["type"] == "task"
-    assert result["data"]["title"] == "詳細取得テスト用タスク"
-    assert "tags" in result["data"]
-    assert "domain:test" in result["data"]["tags"]
+    result = search_service.get_by_ids([{"type": "task", "id": task["task_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "task"
+    assert item["data"]["title"] == "詳細取得テスト用タスク"
+    assert "tags" in item["data"]
+    assert "domain:test" in item["data"]["tags"]
 
 
-def test_get_by_id_log(temp_db):
-    """get_by_id: logの詳細取得"""
+def test_get_by_ids_single_log(temp_db):
+    """get_by_ids: logの詳細取得（1件）"""
     topic = add_topic(title="トピック", description="テスト", tags=DEFAULT_TAGS)
     log = add_log_entry(topic_id=topic["topic_id"], title="詳細取得テストログ", content="テスト内容")
-    result = search_service.get_by_id("log", log["log_id"])
-    assert "error" not in result
-    assert result["type"] == "log"
-    assert result["data"]["title"] == "詳細取得テストログ"
-    assert result["data"]["content"] == "テスト内容"
-    assert "tags" in result["data"]
-    assert "domain:test" in result["data"]["tags"]
+    result = search_service.get_by_ids([{"type": "log", "id": log["log_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "log"
+    assert item["data"]["title"] == "詳細取得テストログ"
+    assert item["data"]["content"] == "テスト内容"
+    assert "tags" in item["data"]
+    assert "domain:test" in item["data"]["tags"]
 
 
-def test_get_by_id_not_found(temp_db):
-    """get_by_id: 存在しないIDでNOT_FOUNDエラー"""
-    result = search_service.get_by_id("topic", 999999)
-    assert "error" in result
-    assert result["error"]["code"] == "NOT_FOUND"
+def test_get_by_ids_not_found(temp_db):
+    """get_by_ids: 存在しないIDでNOT_FOUNDエラー"""
+    result = search_service.get_by_ids([{"type": "topic", "id": 999999}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" in item
+    assert item["error"]["code"] == "NOT_FOUND"
 
 
-def test_get_by_id_invalid_type(temp_db):
-    """get_by_id: 不正な種別でINVALID_TYPEエラー"""
-    result = search_service.get_by_id("invalid", 1)
-    assert "error" in result
-    assert result["error"]["code"] == "INVALID_TYPE"
+def test_get_by_ids_invalid_type(temp_db):
+    """get_by_ids: 不正な種別でINVALID_TYPEエラー"""
+    result = search_service.get_by_ids([{"type": "invalid", "id": 1}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" in item
+    assert item["error"]["code"] == "INVALID_TYPE"
 
 
 # ========================================
@@ -355,12 +367,13 @@ def test_search_cross_type_includes_log(temp_db):
 def test_search_log_title_fallback(temp_db):
     """logのtitleが空の場合、contentの先頭50文字をフォールバック"""
     # NOTE: add_log_entryはtitle空文字をバリデーションエラーにするため、
-    # ここではtitle付きで作成し、get_by_idでフォールバック動作を確認
+    # ここではtitle付きで作成し、get_by_idsでフォールバック動作を確認
     topic = add_topic(title="トピック", description="テスト", tags=DEFAULT_TAGS)
     log = add_log_entry(topic_id=topic["topic_id"], title="フォールバックテスト", content="テスト内容です")
-    result = search_service.get_by_id("log", log["log_id"])
-    assert "error" not in result
-    assert result["data"]["title"] == "フォールバックテスト"
+    result = search_service.get_by_ids([{"type": "log", "id": log["log_id"]}])
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["data"]["title"] == "フォールバックテスト"
 
 
 def test_add_log_empty_title_error(temp_db):


### PR DESCRIPTION
## Summary
- `get_by_id`ツール（MCPツール登録）を削除し、`get_by_ids`に統一
- `get_by_ids`は1件でも複数件でも使えるため完全上位互換
- 内部関数`search_service.get_by_id()`は`get_by_ids`が利用するため維持
- テストを`get_by_ids`経由に書き換え、hook_transcript.pyの参照を更新

## Test plan
- [x] `test_fts5_search.py` 全50テストパス
- [ ] プラグイン再読み込み後、`get_by_id`ツールが消えていることを確認
- [ ] `get_by_ids`で1件取得が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)