### PR TITLE
fix: task→activityリネーム漏れを修正

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: This skill determines implementation approach and technical decisions. Use when How/Interface/Edge cases need decisions, or when working on a cc-memory task with [設計] prefix or mode:design tag.
+description: This skill determines implementation approach and technical decisions. Use when How/Interface/Edge cases need decisions, or when working on a cc-memory activity with [設計] prefix or mode:design tag.
 ---
 
 # 設計フェーズ Skill

--- a/.claude/skills/discussion/SKILL.md
+++ b/.claude/skills/discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discussion
-description: This skill clarifies user requirements and removes ambiguity before design/work phases. Use when What/Why/Scope are not yet defined, or when working on a cc-memory task with [議論] prefix or mode:discussion tag.
+description: This skill clarifies user requirements and removes ambiguity before design/work phases. Use when What/Why/Scope are not yet defined, or when working on a cc-memory activity with [議論] prefix or mode:discussion tag.
 ---
 
 # Discussion Skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 Conventional Commits形式（scopeなし）。typeは英語、subjectは日本語。
 
 - `feat:` / `fix:` / `docs:` / `refactor:` / `test:` / `chore:`
-- 例: `feat: tasksテーブルのスキーマを実装`
+- 例: `feat: searchにrecency boost追加`
 - bodyは変更理由が自明でない場合のみ
 
 ## ブランチ戦略

--- a/README.md
+++ b/README.md
@@ -45,16 +45,17 @@ claude --plugin-dir /path/to/claude-code-memory
 | トピック | `add_topic`, `get_topics` | 議論トピック管理 |
 | ログ | `add_log`, `get_logs` | 議論ログ記録 |
 | 決定 | `add_decision`, `get_decisions` | 決定事項管理 |
-| アクティビティ | `add_activity`, `get_activities`, `update_activity` | アクティビティ管理 |
-| 検索 | `search`, `get_by_ids` | FTS5+ベクトル横断検索 |
+| タスク | `add_task`, `get_tasks`, `update_task` | タスク管理 |
+| 検索 | `search`, `get_by_id` | FTS5横断検索 |
+| ナレッジ | `add_knowledge` | ナレッジファイル保存 |
 
 ## 提供されるスキル
 
 | スキル | 説明 |
 |--------|------|
 | `/research` | 調査タスクをサブエージェントに委譲 |
-| `/task-plan` | 作業タスクの実装計画を作成 |
-| `/task-execute` | plan.mdに基づいて実装を実行 |
+| `/task-delegate` | 複数タスクをまとめて実装→レビュー |
+| `/task-iterate` | 探索的タスクを試行錯誤で実行 |
 
 ## ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,16 @@ claude --plugin-dir /path/to/claude-code-memory
 | トピック | `add_topic`, `get_topics` | 議論トピック管理 |
 | ログ | `add_log`, `get_logs` | 議論ログ記録 |
 | 決定 | `add_decision`, `get_decisions` | 決定事項管理 |
-| タスク | `add_task`, `get_tasks`, `update_task` | タスク管理 |
-| 検索 | `search`, `get_by_id` | FTS5横断検索 |
-| ナレッジ | `add_knowledge` | ナレッジファイル保存 |
+| アクティビティ | `add_activity`, `get_activities`, `update_activity` | アクティビティ管理 |
+| 検索 | `search`, `get_by_ids` | FTS5+ベクトル横断検索 |
 
 ## 提供されるスキル
 
 | スキル | 説明 |
 |--------|------|
 | `/research` | 調査タスクをサブエージェントに委譲 |
-| `/task-delegate` | 複数タスクをまとめて実装→レビュー |
-| `/task-iterate` | 探索的タスクを試行錯誤で実行 |
+| `/task-plan` | 作業タスクの実装計画を作成 |
+| `/task-execute` | plan.mdに基づいて実装を実行 |
 
 ## ディレクトリ構成
 

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -147,7 +147,7 @@ _CONTEXT_RETRIEVAL_TOOLS = [
     "mcp__plugin_claude-code-memory_cc-memory__get_topics",
     "mcp__plugin_claude-code-memory_cc-memory__get_decisions",
     "mcp__plugin_claude-code-memory_cc-memory__get_logs",
-    "mcp__plugin_claude-code-memory_cc-memory__get_tasks",
+    "mcp__plugin_claude-code-memory_cc-memory__get_activities",
     "mcp__plugin_claude-code-memory_cc-memory__get_by_ids",
 ]
 

--- a/hooks/remind_task_on_decision.sh
+++ b/hooks/remind_task_on_decision.sh
@@ -11,4 +11,4 @@ set -e
 # ERRトラップ: エラー時も必ずJSONを返す
 trap 'echo "{\"decision\": \"approve\"}" >&1; exit 0' ERR
 
-echo '{"decision": "approve", "message": "決定事項を記録しました。関連するタスクの追加はありますか？（add_taskで追加できます）"}'
+echo '{"decision": "approve", "message": "決定事項を記録しました。関連するアクティビティの追加はありますか？（add_activityで追加できます）"}'

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -100,7 +100,7 @@ def main() -> None:
                 _output(
                     "block",
                     "応答の前に過去のコンテキストを取得してください。"
-                    "search / get_topics / get_decisions / get_logs / get_tasks / get_by_ids "
+                    "search / get_topics / get_decisions / get_logs / get_activities / get_by_ids "
                     "のいずれかを使ってください。",
                 )
                 return

--- a/tests/unit/test_hook_transcript.py
+++ b/tests/unit/test_hook_transcript.py
@@ -285,6 +285,10 @@ class TestHasContextRetrievalCalls:
         entries = [_make_assistant_entry(tool_calls=["mcp__plugin_claude-code-memory_cc-memory__search"])]
         assert has_context_retrieval_calls(entries) is True
 
+    def test_get_activities_detected(self):
+        entries = [_make_assistant_entry(tool_calls=["mcp__plugin_claude-code-memory_cc-memory__get_activities"])]
+        assert has_context_retrieval_calls(entries) is True
+
     def test_get_by_ids_detected(self):
         entries = [_make_assistant_entry(tool_calls=["mcp__plugin_claude-code-memory_cc-memory__get_by_ids"])]
         assert has_context_retrieval_calls(entries) is True


### PR DESCRIPTION
## Summary
- `stop_hook.py`のエラーメッセージ内の`get_tasks`を`get_activities`に修正
- `CLAUDE.md`のコミット例から廃止済みの`tasksテーブル`表記を除去

## Test plan
- [ ] stop hookのblock時メッセージに`get_activities`が表示されることを確認
- [ ] CLAUDE.mdの例が適切であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)