### PR TITLE
feat: check-inツールと/checkinスキルを追加

### DIFF
--- a/skills/checkin/SKILL.md
+++ b/skills/checkin/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: checkin
+description: アクティビティにcheck-inして関連情報を集約取得する
+---
+
+# checkin
+
+指定されたアクティビティに対して `check_in` ツールを呼び出してください。
+
+## 手順
+
+1. 引数で `activity_id` が指定されていればそのまま使う
+2. 指定されていなければ `get_activities()` で候補を表示し、ユーザーに選んでもらう
+3. `check_in(activity_id=...)` を呼び出す
+4. 返ってきた `summary` フィールドをそのまま出力する

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from src.services import (
     knowledge_service,
     material_service,
 )
+from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import list_tags as _list_tags, update_tag as _update_tag, collect_tag_notes_for_injection
 from src.db import execute_query, get_connection, row_to_dict
 
@@ -666,6 +667,27 @@ def list_materials(
         資材カタログ一覧（activity_id, materials[{material_id, activity_id, title, created_at}], total_count）
     """
     return material_service.list_materials(activity_id)
+
+
+@mcp.tool()
+def check_in(
+    activity_id: int,
+) -> dict:
+    """
+    アクティビティにcheck-inする。関連情報を集約取得しsummaryを返す。
+
+    既存アクティビティに関連する作業を始めるときに呼ぶ。
+    tag_notes・資材カタログ・関連decisionsを一括取得し、
+    statusがin_progress以外なら自動的にin_progressに更新する。
+    summaryフィールドをそのまま出力すること。
+
+    Args:
+        activity_id: アクティビティID
+
+    Returns:
+        check-in結果（activity, topic（topic_idがある場合のみ）, tag_notes, materials, recent_decisions, summary）
+    """
+    return _check_in(activity_id)
 
 
 @mcp.tool()

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -1,0 +1,195 @@
+"""check-inサービス"""
+import logging
+import sqlite3
+
+from src.db import get_connection, row_to_dict
+from src.services import activity_service, decision_service
+from src.services.material_service import get_materials_by_activity_with_conn
+from src.services.tag_service import (
+    collect_tag_notes_for_injection,
+    get_entity_tags,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_topic_id(conn, activity_id: int) -> int | None:
+    """activitiesテーブルからtopic_idを取得する。
+
+    topic_idカラムが存在しない場合やNULLの場合はNoneを返す。
+    """
+    try:
+        row = conn.execute(
+            "SELECT topic_id FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return row["topic_id"]
+    except sqlite3.OperationalError:
+        # topic_idカラムが存在しない場合（migration 0010で削除済み）
+        return None
+
+
+def _get_topic_info(conn, topic_id: int) -> dict | None:
+    """discussion_topicsからトピック情報を取得する。"""
+    row = conn.execute(
+        "SELECT id, title FROM discussion_topics WHERE id = ?",
+        (topic_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"id": row["id"], "title": row["title"]}
+
+
+def _extract_mode_tag(tags: list[str]) -> str:
+    """タグリストからmode:プレフィックスのタグを抽出する。なければ「(未設定)」。"""
+    for tag in tags:
+        if tag.startswith("mode:"):
+            return tag.split(":", 1)[1]
+    return "(未設定)"
+
+
+def _count_notes_lines(tag_notes: list[dict]) -> int:
+    """tag_notesの合計行数を数える。"""
+    total = 0
+    for note in tag_notes:
+        text = note["notes"]
+        total += text.count("\n") + 1 if text else 0
+    return total
+
+
+def _build_summary(
+    activity: dict,
+    tags: list[str],
+    tag_notes: list[dict],
+    materials: list[dict],
+) -> str:
+    """summary文字列を生成する。
+
+    フォーマット:
+        check-in: タイトル
+          notes: N件 (M行) | mode: xxx | 資材: N件
+    """
+    mode = _extract_mode_tag(tags)
+    notes_count = len(tag_notes)
+    notes_lines = _count_notes_lines(tag_notes)
+    materials_count = len(materials)
+
+    line1 = f"check-in: {activity['title']}"
+    line2 = f"  notes: {notes_count}件 ({notes_lines}行) | mode: {mode} | 資材: {materials_count}件"
+
+    return f"{line1}\n{line2}"
+
+
+def check_in(activity_id: int) -> dict:
+    """アクティビティにcheck-inする。
+
+    関連情報（tag_notes, materials, decisions）を集約取得し、
+    status自動更新とsummary生成を行う。
+
+    statusがin_progress以外（pending, completed含む）の場合はin_progressに自動更新する。
+    completedのアクティビティも再オープンされる（追加作業が発生したケースに対応）。
+
+    tag_notesはセッション内初回遭遇時のみ注入される（_injected_tags管理）。
+    同一セッションで同じタグを持つアクティビティに2回check-inすると、
+    2回目のtag_notesは空になる。これはtag_service側の設計による意図的な動作。
+
+    Args:
+        activity_id: アクティビティID
+
+    Returns:
+        check-in結果（activity, topic, tag_notes, materials, recent_decisions, summary）
+    """
+    conn = get_connection()
+    try:
+        # 1. activity取得
+        row = conn.execute(
+            "SELECT * FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        if row is None:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"Activity with id {activity_id} not found",
+                }
+            }
+
+        activity = row_to_dict(row)
+        tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+
+        # 2. topic取得（NULLなら省略）
+        topic_id = _get_topic_id(conn, activity_id)
+        topic_info = None
+        if topic_id is not None:
+            topic_info = _get_topic_info(conn, topic_id)
+
+        # 3. tag_notes収集
+        tag_notes = collect_tag_notes_for_injection(conn, tags) or []
+
+        # 4. materials取得（カタログ形式、共有コネクション使用）
+        materials = get_materials_by_activity_with_conn(conn, activity_id)
+
+        # 5. recent_decisions取得（topic_idがある場合のみ）
+        recent_decisions = []
+        if topic_id is not None:
+            decisions_result = decision_service.get_decisions(topic_id)
+            if "error" in decisions_result:
+                logger.warning(
+                    "Failed to get decisions for topic %d: %s",
+                    topic_id,
+                    decisions_result["error"],
+                )
+            else:
+                recent_decisions = [
+                    {"id": d["id"], "title": d["decision"]}
+                    for d in decisions_result.get("decisions", [])
+                ]
+
+        # 6. status自動更新（in_progress以外ならin_progressに変更）
+        # NOTE: update_activityは内部で別コネクションを使用する（既存APIの制約）。
+        # check_inのトランザクションとは独立してコミットされる。
+        if activity["status"] != "in_progress":
+            update_result = activity_service.update_activity(activity_id, new_status="in_progress")
+            if "error" in update_result:
+                logger.warning(
+                    "Failed to update activity %d status: %s",
+                    activity_id,
+                    update_result["error"],
+                )
+            else:
+                activity["status"] = "in_progress"
+
+        # 7. summary生成
+        summary = _build_summary(activity, tags, tag_notes, materials)
+
+        # 戻り値組み立て
+        result = {
+            "activity": {
+                "id": activity["id"],
+                "title": activity["title"],
+                "status": activity["status"],
+                "tags": tags,
+            },
+        }
+
+        if topic_info is not None:
+            result["topic"] = topic_info
+
+        result["tag_notes"] = tag_notes
+        result["materials"] = materials
+        result["recent_decisions"] = recent_decisions
+        result["summary"] = summary
+
+        return result
+
+    except Exception as e:
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -111,6 +111,24 @@ def add_material(activity_id: int, title: str, content: str) -> dict:
         conn.close()
 
 
+def get_materials_by_activity_with_conn(conn, activity_id: int) -> list[dict]:
+    """
+    アクティビティに紐づく資材一覧をカタログ形式で取得する（conn共有版）
+
+    Args:
+        conn: SQLiteコネクション
+        activity_id: アクティビティのID
+
+    Returns:
+        資材カタログのリスト [{"id": int, "title": str, "created_at": str}, ...]
+    """
+    rows = conn.execute(
+        "SELECT id, title, created_at FROM materials WHERE activity_id = ? ORDER BY created_at ASC",
+        (activity_id,),
+    ).fetchall()
+    return [{"id": row["id"], "title": row["title"], "created_at": row["created_at"]} for row in rows]
+
+
 def get_material(material_id: int) -> dict:
     """
     資材を全文取得する

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -1,0 +1,242 @@
+"""check-inサービスの統合テスト"""
+import os
+import tempfile
+import pytest
+from src.db import init_database, get_connection
+from src.services.activity_service import add_activity, update_activity
+from src.services.material_service import add_material
+from src.services.checkin_service import check_in
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        # tag_notes注入済みセットをリセット（テスト間の干渉防止）
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def activity_id(temp_db):
+    """テスト用アクティビティを作成してIDを返すフィクスチャ"""
+    result = add_activity(
+        title="[作業] タグnotesカラム追加",
+        description="タグnotesカラムを追加する作業",
+        tags=DEFAULT_TAGS,
+    )
+    return result["activity_id"]
+
+
+@pytest.fixture
+def activity_with_mode(temp_db):
+    """mode:タグ付きアクティビティを作成するフィクスチャ"""
+    result = add_activity(
+        title="[設計] API設計",
+        description="APIの設計を行う",
+        tags=["domain:test", "mode:design"],
+    )
+    return result["activity_id"]
+
+
+class TestCheckIn:
+    """check_inの統合テスト"""
+
+    def test_check_in_success(self, activity_id):
+        """check-inが成功し、必須フィールドがすべて返る"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert "activity" in result
+        assert result["activity"]["id"] == activity_id
+        assert result["activity"]["title"] == "[作業] タグnotesカラム追加"
+        assert result["activity"]["status"] == "in_progress"
+        assert "tags" in result["activity"]
+        assert "tag_notes" in result
+        assert "materials" in result
+        assert "recent_decisions" in result
+        assert "summary" in result
+
+    def test_check_in_status_updated_to_in_progress(self, activity_id):
+        """pendingのアクティビティがin_progressに自動更新される"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["activity"]["status"] == "in_progress"
+
+    def test_check_in_already_in_progress(self, activity_id):
+        """すでにin_progressの場合、status変更なしでcheck-in成功"""
+        # 先にin_progressに変更
+        update_activity(activity_id, new_status="in_progress")
+
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["activity"]["status"] == "in_progress"
+
+    def test_check_in_completed_activity(self, activity_id):
+        """completedのアクティビティもin_progressに戻る"""
+        update_activity(activity_id, new_status="completed")
+
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["activity"]["status"] == "in_progress"
+
+    def test_check_in_not_found(self, temp_db):
+        """存在しないactivity_idでNOT_FOUNDエラーになる"""
+        result = check_in(9999)
+
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+        assert "9999" in result["error"]["message"]
+
+    def test_check_in_topic_omitted_when_no_topic_id(self, activity_id):
+        """topic_idがない場合、topicフィールドが結果に含まれない"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        # activitiesテーブルにtopic_idカラムがないため、topicは省略される
+        assert "topic" not in result
+
+    def test_check_in_materials_empty(self, activity_id):
+        """materials 0件の場合、空リストが返る"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["materials"] == []
+
+    def test_check_in_with_materials(self, activity_id):
+        """materialsがある場合、カタログ形式で返る"""
+        add_material(activity_id, "設計書", "# 設計\n詳細内容")
+        add_material(activity_id, "調査結果", "# 調査\n結果内容")
+
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert len(result["materials"]) == 2
+        # カタログ形式: id, title, created_at のみ（contentなし）
+        for m in result["materials"]:
+            assert "id" in m
+            assert "title" in m
+            assert "created_at" in m
+            assert "content" not in m
+
+    def test_check_in_recent_decisions_empty_without_topic(self, activity_id):
+        """topic_idがない場合、recent_decisionsは空リスト"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["recent_decisions"] == []
+
+
+class TestCheckInSummary:
+    """summary文字列のフォーマット確認"""
+
+    def test_summary_format_basic(self, activity_id):
+        """summaryが仕様のフォーマットに従っている"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        summary = result["summary"]
+        lines = summary.split("\n")
+        assert len(lines) == 2
+        assert lines[0].startswith("check-in: ")
+        assert "[作業] タグnotesカラム追加" in lines[0]
+        assert "notes:" in lines[1]
+        assert "mode:" in lines[1]
+        assert "資材:" in lines[1]
+
+    def test_summary_mode_from_tag(self, activity_with_mode):
+        """mode:タグがある場合、summaryにmode値が表示される"""
+        result = check_in(activity_with_mode)
+
+        assert "error" not in result
+        assert "mode: design" in result["summary"]
+
+    def test_summary_mode_unset(self, activity_id):
+        """mode:タグがない場合、(未設定)と表示される"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert "mode: (未設定)" in result["summary"]
+
+    def test_summary_materials_count(self, activity_id):
+        """summaryに資材の件数が反映される"""
+        add_material(activity_id, "資材1", "内容1")
+        add_material(activity_id, "資材2", "内容2")
+        add_material(activity_id, "資材3", "内容3")
+
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert "資材: 3件" in result["summary"]
+
+    def test_summary_notes_count(self, temp_db):
+        """tag_notesがある場合、summaryにnotes件数と行数が反映される"""
+        # notesを持つタグを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "noted", "教訓1行目\n教訓2行目\n教訓3行目"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        activity = add_activity(
+            title="Test with notes",
+            description="Desc",
+            tags=["domain:noted"],
+        )
+
+        result = check_in(activity["activity_id"])
+
+        assert "error" not in result
+        assert "notes: 1件 (3行)" in result["summary"]
+
+
+class TestCheckInTagNotes:
+    """tag_notes注入の確認"""
+
+    def test_tag_notes_injected(self, temp_db):
+        """notesを持つタグがtag_notesに含まれる"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "withnotes", "重要な教訓"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        activity = add_activity(
+            title="Tag notes test",
+            description="Desc",
+            tags=["domain:withnotes"],
+        )
+
+        result = check_in(activity["activity_id"])
+
+        assert "error" not in result
+        assert len(result["tag_notes"]) == 1
+        assert result["tag_notes"][0]["tag"] == "domain:withnotes"
+        assert result["tag_notes"][0]["notes"] == "重要な教訓"
+
+    def test_tag_notes_empty_when_no_notes(self, activity_id):
+        """notesがないタグの場合、tag_notesは空リスト"""
+        result = check_in(activity_id)
+
+        assert "error" not in result
+        assert result["tag_notes"] == []


### PR DESCRIPTION
## Summary
- check-inツール（status自動更新 + summary生成）を追加
- list_materialsツール（activity_idで資材カタログ一覧取得）を追加
- /checkinスキル（SKILL.md）を追加

PR #175の変更をmainベースで再適用。
元PRのbaseが`feature/add-materials-table`だったため、#171マージ後にmainに到達しなかった問題を修正。

## Test plan
- [x] 全テスト通過（420 passed, 8 skipped）
- [ ] check-inツールの手動動作確認
- [ ] list_materialsツールの手動動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)