### PR TITLE
feat: scope:/mode:名前空間をintent:に統合

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: This skill determines implementation approach and technical decisions. Use when How/Interface/Edge cases need decisions, or when working on a cc-memory activity with [設計] prefix or mode:design tag.
+description: This skill determines implementation approach and technical decisions. Use when How/Interface/Edge cases need decisions, or when working on a cc-memory activity with [設計] prefix or intent:design tag.
 ---
 
 # 設計フェーズ Skill
@@ -47,7 +47,7 @@ description: This skill determines implementation approach and technical decisio
 
 開始前チェックをパスしたら：
 
-1. mode:design タグ付きアクティビティで起動された場合、そのアクティビティを対象とする
+1. intent:design タグ付きアクティビティで起動された場合、そのアクティビティを対象とする
 2. それ以外の場合、既存の `[設計]` アクティビティを探す（議論フェーズで作成済みの場合がある）
    - あれば → そのアクティビティを引き継ぐ（新規作成しない）
    - なければ → `[設計]` アクティビティを新規作成する

--- a/.claude/skills/discussion/SKILL.md
+++ b/.claude/skills/discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discussion
-description: This skill clarifies user requirements and removes ambiguity before design/work phases. Use when What/Why/Scope are not yet defined, or when working on a cc-memory activity with [議論] prefix or mode:discussion tag.
+description: This skill clarifies user requirements and removes ambiguity before design/work phases. Use when What/Why/Scope are not yet defined, or when working on a cc-memory activity with [議論] prefix or intent:discuss tag.
 ---
 
 # Discussion Skill
@@ -11,7 +11,7 @@ description: This skill clarifies user requirements and removes ambiguity before
 
 ## 開始時のアクション
 
-1. mode:discussion タグ付きアクティビティで起動された場合、そのアクティビティを対象とする
+1. intent:discuss タグ付きアクティビティで起動された場合、そのアクティビティを対象とする
 2. それ以外の場合、関連する `[議論]` アクティビティがなければ作成する（titleには `[議論]` プレフィックスをつける）
 
 ```

--- a/migrations/0014_intent_namespace.sql
+++ b/migrations/0014_intent_namespace.sql
@@ -83,24 +83,10 @@ DELETE FROM tags WHERE namespace = 'scope' AND name IN (
 UPDATE tags SET namespace = '' WHERE namespace = 'scope';
 
 -- ============================================
--- Step 2: mode:タグのintent:化
+-- Step 2: tagsテーブル再作成（CHECK制約更新 + mode:→intent:変換）
 -- ============================================
-
-UPDATE tags SET namespace = 'intent' WHERE namespace = 'mode';
-
--- ============================================
--- Step 3: intent:初期タグの投入
--- ============================================
-
-INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'design');
-INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'discuss');
-INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'investigate');
-INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'implement');
-INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'review');
-
--- ============================================
--- Step 4: tagsテーブル再作成（CHECK制約更新）
--- ============================================
+-- CHECK制約を先に更新しないと、後続のUPDATE/INSERTが制約違反になる。
+-- mode:→intent:の変換はコピー時にCASE WHENで同時に行う。
 
 CREATE TABLE tags_new (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -112,7 +98,20 @@ CREATE TABLE tags_new (
 );
 
 INSERT INTO tags_new (id, namespace, name, notes, created_at)
-SELECT id, namespace, name, notes, created_at FROM tags;
+SELECT id,
+  CASE WHEN namespace = 'mode' THEN 'intent' ELSE namespace END,
+  name, notes, created_at
+FROM tags;
 
 DROP TABLE tags;
 ALTER TABLE tags_new RENAME TO tags;
+
+-- ============================================
+-- Step 3: intent:初期タグの投入
+-- ============================================
+
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'design');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'discuss');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'investigate');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'implement');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'review');

--- a/migrations/0014_intent_namespace.sql
+++ b/migrations/0014_intent_namespace.sql
@@ -1,0 +1,118 @@
+-- Migration 014: scope:/mode: → intent: 名前空間統合
+--
+-- depends: 0013_add_materials
+--
+-- 変更内容:
+--   - scope:タグを素タグに降格（重複時はjunction tableの参照をマージ）
+--   - mode:タグをintent:に変換
+--   - intent:初期タグの投入
+--   - tagsテーブルのCHECK制約を ('', 'domain', 'intent') に更新
+
+-- ============================================
+-- Step 1: scope:タグの素タグ化（重複処理）
+-- ============================================
+
+-- 1a: 素タグと重複するscope:タグについて、4つのjunction tableの参照を付け替え
+--     重複 = tags に (scope, X) と ('', X) の両方が存在するケース
+--     OR IGNORE で、既に素タグ側にも紐付いているエンティティはスキップ
+
+UPDATE OR IGNORE topic_tags
+SET tag_id = (SELECT p.id FROM tags p WHERE p.namespace = '' AND p.name =
+  (SELECT s.name FROM tags s WHERE s.id = topic_tags.tag_id))
+WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+
+UPDATE OR IGNORE decision_tags
+SET tag_id = (SELECT p.id FROM tags p WHERE p.namespace = '' AND p.name =
+  (SELECT s.name FROM tags s WHERE s.id = decision_tags.tag_id))
+WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+
+UPDATE OR IGNORE log_tags
+SET tag_id = (SELECT p.id FROM tags p WHERE p.namespace = '' AND p.name =
+  (SELECT s.name FROM tags s WHERE s.id = log_tags.tag_id))
+WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+
+UPDATE OR IGNORE activity_tags
+SET tag_id = (SELECT p.id FROM tags p WHERE p.namespace = '' AND p.name =
+  (SELECT s.name FROM tags s WHERE s.id = activity_tags.tag_id))
+WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+
+-- 1b: OR IGNOREでスキップされた行（既に素タグ側に紐付いていた）を削除
+DELETE FROM topic_tags WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+DELETE FROM decision_tags WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+DELETE FROM log_tags WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+DELETE FROM activity_tags WHERE tag_id IN (
+  SELECT s.id FROM tags s
+  JOIN tags p ON p.namespace = '' AND p.name = s.name
+  WHERE s.namespace = 'scope'
+);
+
+-- 1c: 重複していたscope:タグレコード自体を削除
+DELETE FROM tags WHERE namespace = 'scope' AND name IN (
+  SELECT name FROM tags WHERE namespace = ''
+);
+
+-- 1d: 残りのscope:タグを素タグに変換（重複なし）
+UPDATE tags SET namespace = '' WHERE namespace = 'scope';
+
+-- ============================================
+-- Step 2: mode:タグのintent:化
+-- ============================================
+
+UPDATE tags SET namespace = 'intent' WHERE namespace = 'mode';
+
+-- ============================================
+-- Step 3: intent:初期タグの投入
+-- ============================================
+
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'design');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'discuss');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'investigate');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'implement');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'review');
+
+-- ============================================
+-- Step 4: tagsテーブル再作成（CHECK制約更新）
+-- ============================================
+
+CREATE TABLE tags_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  namespace TEXT NOT NULL DEFAULT '' CHECK(namespace IN ('', 'domain', 'intent')),
+  name TEXT NOT NULL,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(namespace, name)
+);
+
+INSERT INTO tags_new (id, namespace, name, notes, created_at)
+SELECT id, namespace, name, notes, created_at FROM tags;
+
+DROP TABLE tags;
+ALTER TABLE tags_new RENAME TO tags;

--- a/skills/check-in/SKILL.md
+++ b/skills/check-in/SKILL.md
@@ -24,6 +24,6 @@ check-in: {activity.title}
 topic: {topic.title}（topic がある場合のみ）
 
 ## 現在地
-status: {activity.status} | mode: {タグから抽出した mode 値、なければ「(未設定)」} | notes: {tag_notes の件数}件 | 資材: {materials の件数}件 | decisions: {recent_decisions の件数}件
+status: {activity.status} | intent: {タグから抽出した intent 値、なければ「(未設定)」} | notes: {tag_notes の件数}件 | 資材: {materials の件数}件 | decisions: {recent_decisions の件数}件
 {recent_decisions の各タイトルを箇条書き（最大5件、件数が多い場合は「他N件」と補足）}
 ```

--- a/src/main.py
+++ b/src/main.py
@@ -340,7 +340,7 @@ def add_topic(
 ) -> dict:
     """新しい議論トピックを追加する。
 
-    tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
+    tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
     """
     result = topic_service.add_topic(title, description, tags)
     if "error" not in result:
@@ -357,7 +357,7 @@ def add_log(
 ) -> dict:
     """トピックに議論ログを追加する。
 
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
+    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
     """
     result = discussion_log_service.add_log(topic_id, title, content, tags)
     if "error" not in result and tags:
@@ -374,7 +374,7 @@ def add_decision(
 ) -> dict:
     """決定事項を記録する。
 
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
+    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
     """
     result = decision_service.add_decision(decision, reason, topic_id, tags)
     if "error" not in result and tags:
@@ -530,7 +530,7 @@ def add_activity(
     Args:
         title: アクティビティのタイトル
         description: アクティビティの詳細説明（必須）
-        tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
+        tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
 
     Returns:
         作成されたアクティビティ情報

--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def _get_recent_non_domain_tags() -> list[str]:
     topic_tags経由でトピックの作成日が直近7日のタグを取得する。
 
     Returns:
-        ["scope:design", "scope:implementation", "mode:discuss", "hooks", ...]（使用頻度降順）
+        ["intent:design", "intent:discuss", "hooks", ...]（使用頻度降順）
     """
     rows = execute_query(
         """
@@ -340,7 +340,7 @@ def add_topic(
 ) -> dict:
     """新しい議論トピックを追加する。
 
-    tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["domain:cc-memory", "scope:hook-system", "error-handling", "validation", "stdin"]
+    tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
     """
     result = topic_service.add_topic(title, description, tags)
     if "error" not in result:
@@ -357,7 +357,7 @@ def add_log(
 ) -> dict:
     """トピックに議論ログを追加する。
 
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["mode:discussion", "migration", "breaking-change", "schema"]
+    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
     """
     result = discussion_log_service.add_log(topic_id, title, content, tags)
     if "error" not in result and tags:
@@ -374,7 +374,7 @@ def add_decision(
 ) -> dict:
     """決定事項を記録する。
 
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["scope:data-model", "naming-convention", "backward-compat"]
+    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
     """
     result = decision_service.add_decision(decision, reason, topic_id, tags)
     if "error" not in result and tags:
@@ -489,7 +489,7 @@ def list_tags(
     namespaceでフィルタリング可能。
 
     Args:
-        namespace: namespaceでフィルタ（"domain", "scope", "mode", ""。未指定で全タグ）
+        namespace: namespaceでフィルタ（"domain", "intent", ""。未指定で全タグ）
 
     Returns:
         タグ一覧（tag, id, namespace, name, usage_count, notes）をusage_count降順で返す
@@ -525,12 +525,12 @@ def add_activity(
     新しいアクティビティを追加する。
 
     典型的な使い方:
-    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "mode:discuss", "scope:api-design", "search", "ranking"])
+    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search", "ranking"])
 
     Args:
         title: アクティビティのタイトル
         description: アクティビティの詳細説明（必須）
-        tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/scope:(作業の塊)/mode:(作業スタンス)/素タグ(キーワード)。例: ["domain:cc-memory", "mode:implementation", "scope:api-design", "search", "ranking"]
+        tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(作業意図と境界)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
 
     Returns:
         作成されたアクティビティ情報
@@ -589,7 +589,7 @@ def update_activity(
     - アクティビティ完了: update_activity(activity_id, new_status="completed")
     - タイトル変更: update_activity(activity_id, title="新しいタイトル")
     - 説明更新: update_activity(activity_id, description="新しい説明")
-    - タグ変更: update_activity(activity_id, tags=["domain:cc-memory", "scope:search"])
+    - タグ変更: update_activity(activity_id, tags=["domain:cc-memory", "intent:implement"])
 
     ワークフロー位置: アクティビティ進行状況の更新時
 

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -42,10 +42,10 @@ def _get_topic_info(conn, topic_id: int) -> dict | None:
     return {"id": row["id"], "title": row["title"]}
 
 
-def _extract_mode_tag(tags: list[str]) -> str:
-    """タグリストからmode:プレフィックスのタグを抽出する。なければ「(未設定)」。"""
+def _extract_intent_tag(tags: list[str]) -> str:
+    """タグリストからintent:プレフィックスのタグを抽出する。なければ「(未設定)」。"""
     for tag in tags:
-        if tag.startswith("mode:"):
+        if tag.startswith("intent:"):
             return tag.split(":", 1)[1]
     return "(未設定)"
 
@@ -69,15 +69,15 @@ def _build_summary(
 
     フォーマット:
         check-in: タイトル
-          notes: N件 (M行) | mode: xxx | 資材: N件
+          notes: N件 (M行) | intent: xxx | 資材: N件
     """
-    mode = _extract_mode_tag(tags)
+    intent = _extract_intent_tag(tags)
     notes_count = len(tag_notes)
     notes_lines = _count_notes_lines(tag_notes)
     materials_count = len(materials)
 
     line1 = f"check-in: {activity['title']}"
-    line2 = f"  notes: {notes_count}件 ({notes_lines}行) | mode: {mode} | 資材: {materials_count}件"
+    line2 = f"  notes: {notes_count}件 ({notes_lines}行) | intent: {intent} | 資材: {materials_count}件"
 
     return f"{line1}\n{line2}"
 

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 from src.db import execute_query, get_connection, row_to_dict
 
 
-VALID_NAMESPACES = {'', 'domain', 'scope', 'mode'}
+VALID_NAMESPACES = {'', 'domain', 'intent'}
 
 # Entity table mapping (for UNION inheritance queries)
 _ENTITY_TABLE = {
@@ -22,8 +22,7 @@ def parse_tag(tag_str: str) -> tuple[str, str]:
     例:
       "domain:cc-memory"  -> ("domain", "cc-memory")
       "hooks"             -> ("", "hooks")
-      "mode:design"       -> ("mode", "design")
-      "scope:parent-topic" -> ("scope", "parent-topic")
+      "intent:design"     -> ("intent", "design")
     """
     if ":" in tag_str:
         namespace, name = tag_str.split(":", 1)
@@ -397,7 +396,7 @@ def collect_tag_notes_for_injection(conn: sqlite3.Connection, tag_strings: list[
 
     Args:
         conn: DB接続
-        tag_strings: タグ文字列リスト（例: ["domain:cc-memory", "scope:design"]）
+        tag_strings: タグ文字列リスト（例: ["domain:cc-memory", "intent:design"]）
 
     Returns:
         notes があるタグの一覧。なければ None

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -38,12 +38,12 @@ def activity_id(temp_db):
 
 
 @pytest.fixture
-def activity_with_mode(temp_db):
-    """mode:タグ付きアクティビティを作成するフィクスチャ"""
+def activity_with_intent(temp_db):
+    """intent:タグ付きアクティビティを作成するフィクスチャ"""
     result = add_activity(
         title="[設計] API設計",
         description="APIの設計を行う",
-        tags=["domain:test", "mode:design"],
+        tags=["domain:test", "intent:design"],
     )
     return result["activity_id"]
 
@@ -153,22 +153,22 @@ class TestCheckInSummary:
         assert lines[0].startswith("check-in: ")
         assert "[作業] タグnotesカラム追加" in lines[0]
         assert "notes:" in lines[1]
-        assert "mode:" in lines[1]
+        assert "intent:" in lines[1]
         assert "資材:" in lines[1]
 
-    def test_summary_mode_from_tag(self, activity_with_mode):
-        """mode:タグがある場合、summaryにmode値が表示される"""
-        result = check_in(activity_with_mode)
+    def test_summary_intent_from_tag(self, activity_with_intent):
+        """intent:タグがある場合、summaryにintent値が表示される"""
+        result = check_in(activity_with_intent)
 
         assert "error" not in result
-        assert "mode: design" in result["summary"]
+        assert "intent: design" in result["summary"]
 
-    def test_summary_mode_unset(self, activity_id):
-        """mode:タグがない場合、(未設定)と表示される"""
+    def test_summary_intent_unset(self, activity_id):
+        """intent:タグがない場合、(未設定)と表示される"""
         result = check_in(activity_id)
 
         assert "error" not in result
-        assert "mode: (未設定)" in result["summary"]
+        assert "intent: (未設定)" in result["summary"]
 
     def test_summary_materials_count(self, activity_id):
         """summaryに資材の件数が反映される"""

--- a/tests/unit/test_active_context.py
+++ b/tests/unit/test_active_context.py
@@ -112,11 +112,11 @@ def test_get_active_domains_basic(temp_db):
 
 def test_get_active_domains_excludes_non_domain(temp_db):
     """domain以外のnamespaceは返らない"""
-    add_topic(title="Topic 1", description="Desc", tags=["scope:search"])
+    add_topic(title="Topic 1", description="Desc", tags=["intent:design"])
 
     domains = _get_active_domains()
     names = [d["name"] for d in domains]
-    assert "search" not in names
+    assert "design" not in names
 
 
 def test_get_active_domains_sorted_by_name(temp_db):
@@ -284,10 +284,10 @@ def test_get_active_activities_by_tag_empty(temp_db):
 
 def test_get_recent_non_domain_tags_basic(temp_db):
     """domain:以外のタグが返る"""
-    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "scope:search", "hooks"])
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "intent:design", "hooks"])
 
     tags = _get_recent_non_domain_tags()
-    assert "scope:search" in tags
+    assert "intent:design" in tags
     assert "hooks" in tags
     # domain:は含まれない
     assert "domain:test" not in tags
@@ -295,15 +295,15 @@ def test_get_recent_non_domain_tags_basic(temp_db):
 
 def test_get_recent_non_domain_tags_frequency_order(temp_db):
     """使用頻度降順"""
-    # scope:searchを2回使用、modeを1回使用
-    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "scope:search"])
-    add_topic(title="Topic 2", description="Desc", tags=["domain:test", "scope:search"])
-    add_topic(title="Topic 3", description="Desc", tags=["domain:test", "mode:discuss"])
+    # intent:designを2回使用、intent:discussを1回使用
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "intent:design"])
+    add_topic(title="Topic 2", description="Desc", tags=["domain:test", "intent:design"])
+    add_topic(title="Topic 3", description="Desc", tags=["domain:test", "intent:discuss"])
 
     tags = _get_recent_non_domain_tags()
-    search_idx = tags.index("scope:search")
-    mode_idx = tags.index("mode:discuss")
-    assert search_idx < mode_idx
+    design_idx = tags.index("intent:design")
+    discuss_idx = tags.index("intent:discuss")
+    assert design_idx < discuss_idx
 
 
 def test_get_recent_non_domain_tags_empty(temp_db):
@@ -326,7 +326,7 @@ def test_get_recent_non_domain_tags_excludes_old(temp_db):
         topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
         from src.services.tag_service import ensure_tag_ids, link_tags
-        tag_ids = ensure_tag_ids(conn, [("scope", "old-scope")])
+        tag_ids = ensure_tag_ids(conn, [("intent", "old-intent")])
         link_tags(conn, "topic_tags", "topic_id", topic_id, tag_ids)
 
         conn.commit()
@@ -334,7 +334,7 @@ def test_get_recent_non_domain_tags_excludes_old(temp_db):
         conn.close()
 
     tags = _get_recent_non_domain_tags()
-    assert "scope:old-scope" not in tags
+    assert "intent:old-intent" not in tags
 
 
 # ========================================
@@ -393,12 +393,12 @@ def test_build_active_context_description_truncated(temp_db):
 
 def test_build_active_context_non_domain_tags(temp_db):
     """domain:以外のタグが「最近使われたタグ」セクションに列挙される"""
-    add_topic(title="Topic", description="Desc", tags=["domain:myapp", "scope:search", "hooks"])
+    add_topic(title="Topic", description="Desc", tags=["domain:myapp", "intent:design", "hooks"])
 
     result = _build_active_context()
 
     assert "## 最近使われたタグ" in result
-    assert "scope:search" in result
+    assert "intent:design" in result
     assert "hooks" in result
 
 
@@ -487,12 +487,12 @@ def test_build_active_context_only_non_domain_tags(temp_db):
         conn.close()
 
     # non-domainタグのみのトピックを追加
-    add_topic(title="Topic", description="Desc", tags=["scope:search"])
+    add_topic(title="Topic", description="Desc", tags=["intent:design"])
 
     result = _build_active_context()
 
     # domain:セクションはないがnon-domainタグセクションはある
-    # ただしscope:searchのトピックにはdomain:タグがないので
+    # ただしintent:designのトピックにはdomain:タグがないので
     # domainセクションは生成されない
     assert "## 最近使われたタグ" in result
-    assert "scope:search" in result
+    assert "intent:design" in result

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -85,7 +85,7 @@ def test_search_type_filter(temp_db):
 
 def test_search_with_tags(temp_db):
     """タグフィルタ: ANDで絞り込み"""
-    add_topic(title="タグ対象トピック一致テスト", description="テスト", tags=["domain:test", "scope:search"])
+    add_topic(title="タグ対象トピック一致テスト", description="テスト", tags=["domain:test", "intent:design"])
     add_topic(title="タグ対象外トピック一致テスト", description="テスト", tags=["domain:other"])
     result = search_service.search(keyword="タグ対象", tags=["domain:test"])
     assert "error" not in result
@@ -97,9 +97,9 @@ def test_search_with_tags(temp_db):
 
 def test_search_with_multiple_tags_and(temp_db):
     """タグフィルタ: 複数タグのAND条件"""
-    add_topic(title="複数タグAND対象テスト", description="テスト", tags=["domain:test", "scope:search"])
+    add_topic(title="複数タグAND対象テスト", description="テスト", tags=["domain:test", "intent:design"])
     add_topic(title="複数タグAND部分テスト", description="テスト", tags=["domain:test"])
-    result = search_service.search(keyword="複数タグAND", tags=["domain:test", "scope:search"])
+    result = search_service.search(keyword="複数タグAND", tags=["domain:test", "intent:design"])
     assert "error" not in result
     titles = [r["title"] for r in result["results"]]
     assert any("複数タグAND対象テスト" in t for t in titles)
@@ -229,10 +229,10 @@ def test_search_cross_type(temp_db):
 
 def test_search_decision_inherits_topic_tags(temp_db):
     """decisionはtopicのタグを継承してフィルタされる"""
-    topic = add_topic(title="継承テスト用トピック", description="テスト", tags=["domain:test", "scope:inherit"])
+    topic = add_topic(title="継承テスト用トピック", description="テスト", tags=["domain:test", "intent:investigate"])
     add_decision(topic_id=topic["topic_id"], decision="継承タグフィルタ決定テスト", reason="テスト")
-    # scope:inherit でフィルタ → topicを親に持つdecisionもヒット
-    result = search_service.search(keyword="継承タグフィルタ決定テスト", tags=["scope:inherit"])
+    # intent:investigate でフィルタ → topicを親に持つdecisionもヒット
+    result = search_service.search(keyword="継承タグフィルタ決定テスト", tags=["intent:investigate"])
     assert "error" not in result
     types = [r["type"] for r in result["results"]]
     assert "decision" in types
@@ -240,9 +240,9 @@ def test_search_decision_inherits_topic_tags(temp_db):
 
 def test_search_log_inherits_topic_tags(temp_db):
     """logはtopicのタグを継承してフィルタされる"""
-    topic = add_topic(title="ログ継承テスト用トピック", description="テスト", tags=["domain:test", "scope:loginherit"])
+    topic = add_topic(title="ログ継承テスト用トピック", description="テスト", tags=["domain:test", "loginherit"])
     add_log_entry(topic_id=topic["topic_id"], title="継承タグフィルタログテスト", content="テストログ内容")
-    result = search_service.search(keyword="継承タグフィルタログテスト", tags=["scope:loginherit"])
+    result = search_service.search(keyword="継承タグフィルタログテスト", tags=["loginherit"])
     assert "error" not in result
     types = [r["type"] for r in result["results"]]
     assert "log" in types

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -252,7 +252,7 @@ def test_hybrid_search_with_tags(temp_db, mock_embedding_model):
     add_topic(
         title="タグ付きハイブリッド検索対象テスト",
         description="これはヒットすべき",
-        tags=["domain:test", "scope:hybrid"],
+        tags=["domain:test", "intent:design"],
     )
     add_topic(
         title="タグ付きハイブリッド検索対象外テスト",
@@ -262,7 +262,7 @@ def test_hybrid_search_with_tags(temp_db, mock_embedding_model):
 
     result = search_service.search(
         keyword="タグ付きハイブリッド検索",
-        tags=["scope:hybrid"],
+        tags=["intent:design"],
     )
 
     assert "error" not in result

--- a/tests/unit/test_list_tags.py
+++ b/tests/unit/test_list_tags.py
@@ -52,7 +52,7 @@ def test_list_tags_usage_count(temp_db):
     # domain:test を3つのエンティティで使用
     topic = add_topic(title="Topic 1", description="Desc", tags=["domain:test"])
     add_activity(title="Activity 1", description="Desc", tags=["domain:test"])
-    add_decision(topic_id=topic["topic_id"], decision="Dec 1", reason="Reason", tags=["scope:search"])
+    add_decision(topic_id=topic["topic_id"], decision="Dec 1", reason="Reason", tags=["intent:design"])
 
     result = list_tags()
     assert "error" not in result
@@ -61,20 +61,20 @@ def test_list_tags_usage_count(temp_db):
     test_tag = next(t for t in result["tags"] if t["tag"] == "domain:test")
     assert test_tag["usage_count"] == 2
 
-    # scope:search は decision_tags(1) = 1
-    search_tag = next(t for t in result["tags"] if t["tag"] == "scope:search")
-    assert search_tag["usage_count"] == 1
+    # intent:design は decision_tags(1) = 1
+    design_tag = next(t for t in result["tags"] if t["tag"] == "intent:design")
+    assert design_tag["usage_count"] == 1
 
 
 def test_list_tags_usage_count_includes_logs(temp_db):
     """logのタグもusage_countに含まれる"""
     topic = add_topic(title="Topic", description="Desc", tags=["domain:test"])
-    add_log(topic_id=topic["topic_id"], title="Log 1", content="Content", tags=["scope:logcount"])
+    add_log(topic_id=topic["topic_id"], title="Log 1", content="Content", tags=["logcount"])
 
     result = list_tags()
     assert "error" not in result
 
-    logcount_tag = next(t for t in result["tags"] if t["tag"] == "scope:logcount")
+    logcount_tag = next(t for t in result["tags"] if t["tag"] == "logcount")
     assert logcount_tag["usage_count"] == 1
 
 
@@ -83,13 +83,13 @@ def test_list_tags_sorted_by_usage_count_desc(temp_db):
     # domain:test を2つのトピックで使用
     add_topic(title="Topic 1", description="Desc", tags=["domain:test"])
     add_topic(title="Topic 2", description="Desc", tags=["domain:test"])
-    # scope:rare を1つだけ
-    add_topic(title="Topic 3", description="Desc", tags=["scope:rare"])
+    # intent:investigate を1つだけ
+    add_topic(title="Topic 3", description="Desc", tags=["intent:investigate"])
 
     result = list_tags()
     assert "error" not in result
 
-    # domain:default(1), domain:test(2), scope:rare(1) のはず
+    # domain:default(1), domain:test(2), intent:investigate(1) のはず
     # usage_count降順で、domain:testが最初に来る
     tags = result["tags"]
     usage_counts = [t["usage_count"] for t in tags]
@@ -99,7 +99,7 @@ def test_list_tags_sorted_by_usage_count_desc(temp_db):
 
 def test_list_tags_namespace_filter(temp_db):
     """namespaceフィルタ: 指定namespaceのみ返る"""
-    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "scope:search"])
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "intent:design"])
 
     result = list_tags(namespace="domain")
     assert "error" not in result
@@ -107,15 +107,15 @@ def test_list_tags_namespace_filter(temp_db):
         assert t["namespace"] == "domain"
 
 
-def test_list_tags_namespace_filter_scope(temp_db):
-    """namespaceフィルタ: scopeで絞り込み"""
-    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "scope:search"])
+def test_list_tags_namespace_filter_intent(temp_db):
+    """namespaceフィルタ: intentで絞り込み"""
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "intent:design"])
 
-    result = list_tags(namespace="scope")
+    result = list_tags(namespace="intent")
     assert "error" not in result
     assert len(result["tags"]) >= 1
     for t in result["tags"]:
-        assert t["namespace"] == "scope"
+        assert t["namespace"] == "intent"
 
 
 def test_list_tags_namespace_filter_nonexistent(temp_db):
@@ -129,12 +129,12 @@ def test_list_tags_namespace_filter_nonexistent(temp_db):
 
 def test_list_tags_no_namespace_filter(temp_db):
     """namespace未指定: 全タグを返す"""
-    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "scope:search"])
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test", "intent:design"])
 
     result = list_tags()
     assert "error" not in result
     namespaces = {t["namespace"] for t in result["tags"]}
-    # domain と scope と (domain:defaultの) domain が含まれる
+    # domain と intent と (domain:defaultの) domain が含まれる
     assert "domain" in namespaces
 
 

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -176,13 +176,13 @@ class TestTagNotesInjection:
 
     def test_mixed_tags_with_and_without_notes(self, temp_db):
         """notes があるタグとないタグの混在"""
-        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        add_topic(title="Test", description="Desc", tags=["domain:test", "intent:design"])
         update_tag("domain:test", "テスト教訓")
-        # scope:search には notes を設定しない
+        # intent:design には notes を設定しない
 
         conn = get_connection()
         try:
-            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "intent:design"])
             assert result is not None
             assert len(result) == 1
             assert result[0]["tag"] == "domain:test"
@@ -191,26 +191,26 @@ class TestTagNotesInjection:
 
     def test_multiple_tags_with_notes(self, temp_db):
         """複数タグに notes がある場合"""
-        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        add_topic(title="Test", description="Desc", tags=["domain:test", "intent:design"])
         update_tag("domain:test", "テスト教訓")
-        update_tag("scope:search", "検索の教訓")
+        update_tag("intent:design", "設計の教訓")
 
         conn = get_connection()
         try:
-            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "intent:design"])
             assert result is not None
             assert len(result) == 2
             tag_strs = {r["tag"] for r in result}
             assert "domain:test" in tag_strs
-            assert "scope:search" in tag_strs
+            assert "intent:design" in tag_strs
         finally:
             conn.close()
 
     def test_partial_new_tags(self, temp_db):
         """一部が既に遭遇済み、一部が新規の場合"""
-        add_topic(title="Test", description="Desc", tags=["domain:test", "scope:search"])
+        add_topic(title="Test", description="Desc", tags=["domain:test", "intent:design"])
         update_tag("domain:test", "テスト教訓")
-        update_tag("scope:search", "検索の教訓")
+        update_tag("intent:design", "設計の教訓")
 
         conn = get_connection()
         try:
@@ -218,10 +218,10 @@ class TestTagNotesInjection:
             collect_tag_notes_for_injection(conn, ["domain:test"])
 
             # 両方渡すが、domain:test は既に遭遇済み
-            result = collect_tag_notes_for_injection(conn, ["domain:test", "scope:search"])
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "intent:design"])
             assert result is not None
             assert len(result) == 1
-            assert result[0]["tag"] == "scope:search"
+            assert result[0]["tag"] == "intent:design"
         finally:
             conn.close()
 

--- a/tests/unit/test_tag_service.py
+++ b/tests/unit/test_tag_service.py
@@ -52,13 +52,9 @@ class TestParseTag:
         """素タグをパースできる"""
         assert parse_tag("hooks") == ("", "hooks")
 
-    def test_mode_namespace(self):
-        """mode namespaceをパースできる"""
-        assert parse_tag("mode:design") == ("mode", "design")
-
-    def test_scope_namespace(self):
-        """scope namespaceをパースできる"""
-        assert parse_tag("scope:parent-topic") == ("scope", "parent-topic")
+    def test_intent_namespace(self):
+        """intent namespaceをパースできる"""
+        assert parse_tag("intent:design") == ("intent", "design")
 
     def test_colon_in_name(self):
         """nameにコロンが含まれる場合、最初のコロンで分割"""
@@ -79,12 +75,12 @@ class TestValidateAndParseTags:
 
     def test_valid_tags(self):
         """正常なタグ配列をパースできる"""
-        result = validate_and_parse_tags(["domain:cc-memory", "hooks", "mode:design"])
+        result = validate_and_parse_tags(["domain:cc-memory", "hooks", "intent:design"])
         assert isinstance(result, list)
         assert len(result) == 3
         assert ("domain", "cc-memory") in result
         assert ("", "hooks") in result
-        assert ("mode", "design") in result
+        assert ("intent", "design") in result
 
     def test_deduplicate(self):
         """重複タグを排除する"""
@@ -178,7 +174,7 @@ class TestEnsureTagIds:
         """入力順序が保持される"""
         conn = get_connection()
         try:
-            tags = [("mode", "design"), ("domain", "alpha"), ("", "zebra")]
+            tags = [("intent", "design"), ("domain", "alpha"), ("", "zebra")]
             tag_ids = ensure_tag_ids(conn, tags)
             conn.commit()
             assert len(tag_ids) == 3
@@ -289,10 +285,10 @@ class TestFormatTags:
         rows = [
             MockRow("domain", "cc-memory"),
             MockRow("", "hooks"),
-            MockRow("mode", "design"),
+            MockRow("intent", "design"),
         ]
         result = format_tags(rows)
-        assert result == ["domain:cc-memory", "hooks", "mode:design"]
+        assert result == ["domain:cc-memory", "hooks", "intent:design"]
 
     def test_sorted(self):
         """アルファベット順ソート"""
@@ -348,7 +344,7 @@ class TestGetEffectiveTagsBatch:
             topic_id=topic["topic_id"],
             decision="Dec 1",
             reason="Reason 1",
-            tags=["scope:search"],
+            tags=["intent:design"],
         )
 
         conn = get_connection()
@@ -357,7 +353,7 @@ class TestGetEffectiveTagsBatch:
             assert dec["decision_id"] in result
             tags = result[dec["decision_id"]]
             assert "domain:test" in tags
-            assert "scope:search" in tags
+            assert "intent:design" in tags
         finally:
             conn.close()
 
@@ -385,7 +381,7 @@ class TestGetEffectiveTagsBatch:
             topic_id=topic["topic_id"],
             title="Log 2",
             content="Content 2",
-            tags=["scope:extra"],
+            tags=["extra"],
         )
 
         conn = get_connection()
@@ -395,6 +391,6 @@ class TestGetEffectiveTagsBatch:
             assert log2["log_id"] in result
             assert "domain:test" in result[log1["log_id"]]
             assert "domain:test" in result[log2["log_id"]]
-            assert "scope:extra" in result[log2["log_id"]]
+            assert "extra" in result[log2["log_id"]]
         finally:
             conn.close()

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -167,11 +167,11 @@ def test_get_topics_partial_nonexistent_tags(temp_db):
 
 def test_get_topics_and_filter(temp_db):
     """複数タグAND条件"""
-    add_topic(title="Both Tags", description="Desc", tags=["domain:test", "scope:search"])
+    add_topic(title="Both Tags", description="Desc", tags=["domain:test", "intent:design"])
     add_topic(title="Only domain", description="Desc", tags=["domain:test"])
-    add_topic(title="Only scope", description="Desc", tags=["scope:search"])
+    add_topic(title="Only intent", description="Desc", tags=["intent:design"])
 
-    result = get_topics(tags=["domain:test", "scope:search"])
+    result = get_topics(tags=["domain:test", "intent:design"])
 
     assert "error" not in result
     assert result["total_count"] == 1
@@ -180,7 +180,7 @@ def test_get_topics_and_filter(temp_db):
 
 def test_get_topics_has_tags_field(temp_db):
     """各topicにtags付き"""
-    add_topic(title="Tagged Topic", description="Desc", tags=["domain:test", "scope:search"])
+    add_topic(title="Tagged Topic", description="Desc", tags=["domain:test", "intent:design"])
 
     result = get_topics(tags=["domain:test"])
 
@@ -189,7 +189,7 @@ def test_get_topics_has_tags_field(temp_db):
     topic = result["topics"][0]
     assert "tags" in topic
     assert "domain:test" in topic["tags"]
-    assert "scope:search" in topic["tags"]
+    assert "intent:design" in topic["tags"]
     # 旧フィールドが除去されている
     assert "subject_id" not in topic
     assert "parent_topic_id" not in topic
@@ -386,7 +386,7 @@ def test_get_decisions_with_extra_tags(temp_db):
         topic_id=topic["topic_id"],
         decision="Dec with extra tags",
         reason="Reason",
-        tags=["scope:search"],
+        tags=["intent:design"],
     )
 
     result = get_decisions(topic_id=topic["topic_id"])
@@ -398,4 +398,4 @@ def test_get_decisions_with_extra_tags(temp_db):
     # topicのタグを継承
     assert "domain:test" in dec["tags"]
     # decision個別のタグも含む
-    assert "scope:search" in dec["tags"]
+    assert "intent:design" in dec["tags"]

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -46,11 +46,11 @@ def test_add_topic_tags_stored(temp_db):
     result = add_topic(
         title="タグテスト",
         description="タグの永続化テスト",
-        tags=["domain:cc-memory", "hooks", "scope:search"],
+        tags=["domain:cc-memory", "hooks", "intent:design"],
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == ["domain:cc-memory", "hooks", "scope:search"]
+    assert sorted(result["tags"]) == ["domain:cc-memory", "hooks", "intent:design"]
 
     # DBで直接確認
     conn = get_connection()
@@ -249,7 +249,7 @@ def test_add_decision_with_tags(temp_db):
 
 def test_add_decision_without_tags(temp_db):
     """tags=NoneでtopicのタグのみがUNIONされる"""
-    topic = add_topic(title="テストトピック", description="Test description", tags=["domain:test", "scope:api"])
+    topic = add_topic(title="テストトピック", description="Test description", tags=["domain:test", "intent:design"])
 
     result = add_decision(
         topic_id=topic["topic_id"],

--- a/tests/unit/test_update_activity.py
+++ b/tests/unit/test_update_activity.py
@@ -176,11 +176,11 @@ class TestUpdateActivityTags:
 
     def test_update_tags(self, test_activity):
         """タグ全置換"""
-        result = update_activity(test_activity["activity_id"], tags=["scope:search", "domain:cc-memory"])
+        result = update_activity(test_activity["activity_id"], tags=["intent:design", "domain:cc-memory"])
 
         assert "error" not in result
         assert "tags" in result
-        assert "scope:search" in result["tags"]
+        assert "intent:design" in result["tags"]
         assert "domain:cc-memory" in result["tags"]
         # 旧タグは除去されている
         assert "domain:test" not in result["tags"]


### PR DESCRIPTION
## Summary
- タグの名前空間を4種類（素タグ/domain:/scope:/mode:）から3種類（素タグ/domain:/intent:）に整理
- scope:タグを素タグに降格（同名の素タグが既存の場合はjunction tableの参照をマージ）
- mode:タグをintent:に機械的リネーム
- intent:初期タグ5件（design, discuss, investigate, implement, review）を投入
- CHECK制約・VALID_NAMESPACES・ツールdescription・スキル定義・テストを全面更新

## Test plan
- [x] pytest全件パス（419 passed, 8 skipped）
- [ ] 既存DBでのマイグレーション実行確認（scope:/mode:データありの状態から）
- [ ] 新規DBでの初期化確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)