### PR TITLE
feat: セッション初動のactivity check-in強制hookを追加

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -1,7 +1,8 @@
 """hook共通: 状態ファイル管理クラス HookState
 
 hookが利用する状態ファイル（prev_topic, block_count, nudge_counter, nudge_pending,
-context_retrieved）の読み書きを一元管理する。標準ライブラリのみに依存。
+context_retrieved, approved_turns, activity_checkin）の読み書きを一元管理する。
+標準ライブラリのみに依存。
 """
 from pathlib import Path
 
@@ -95,6 +96,28 @@ class HookState:
             return True
         except FileNotFoundError:
             return False
+
+    # --- approved_turns ---
+
+    def get_approved_turns(self) -> int:
+        """approve済みターン数を取得。block時はインクリメントされない。"""
+        return self._read_int(self._path("approved_turns"), 0)
+
+    def increment_approved_turns(self) -> int:
+        """approve済みターン数を+1して返す。ステップ7(approve)でのみ呼ばれる。"""
+        new_val = self.get_approved_turns() + 1
+        self._write(self._path("approved_turns"), str(new_val))
+        return new_val
+
+    # --- activity_checkin ---
+
+    def has_activity_checkin(self) -> bool:
+        """activity check-in済みフラグを確認。one-shot block制御に使用。"""
+        return self._path("activity_checkin").exists()
+
+    def set_activity_checkin(self) -> None:
+        """activity check-in済みフラグを設定。以後のcheck-inチェックをスキップする。"""
+        self._write(self._path("activity_checkin"), "1")
 
     # --- context_retrieved ---
 

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -142,6 +142,17 @@ def has_recent_recording(entries: list[dict]) -> bool:
     return _has_tool_calls(entries, _RECORDING_TOOLS)
 
 
+_ACTIVITY_CHECKIN_TOOLS = [
+    "mcp__plugin_claude-code-memory_cc-memory__check_in",
+    "mcp__plugin_claude-code-memory_cc-memory__add_activity",
+]
+
+
+def has_activity_checkin_calls(entries: list[dict]) -> bool:
+    """entriesにcheck_in/add_activityのツール呼び出しがあるかチェック。"""
+    return _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS)
+
+
 _CONTEXT_RETRIEVAL_TOOLS = [
     "mcp__plugin_claude-code-memory_cc-memory__search",
     "mcp__plugin_claude-code-memory_cc-memory__get_topics",

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -1,4 +1,4 @@
-"""Stop hook: メタタグ強制 + コンテキスト取得チェック + 記録強制 + nudgeカウンター
+"""Stop hook: メタタグ強制 + コンテキスト取得チェック + activity check-in + 記録強制 + nudgeカウンター
 
 処理フロー:
 1. stdin読み込み → JSON parse
@@ -7,6 +7,8 @@
    → なければblock
 4. get系API呼び出しチェック（セッション中1回以上）
    → なければblock
+4.5. activity check-inチェック（最初の3ターン、one-shot block）
+     → 3ターン経過 + check-in/add_activity未呼出 → block
 5. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
 6. nudgeカウンター管理
 7. 状態更新 → approve
@@ -26,6 +28,7 @@ from hooks.hook_transcript import (
     extract_text_from_entry,
     get_assistant_entries,
     get_last_assistant_entry,
+    has_activity_checkin_calls,
     has_context_retrieval_calls,
     has_recent_recording,
     parse_meta_tag,
@@ -105,6 +108,19 @@ def main() -> None:
                 )
                 return
 
+        # 4.5. Activity check-in チェック（最初の3ターン）
+        if not state.has_activity_checkin():
+            if has_activity_checkin_calls(all_entries):
+                state.set_activity_checkin()
+            elif state.get_approved_turns() >= 2:
+                state.set_activity_checkin()  # one-shot: 次回はスキップ
+                state.increment_block_count()
+                _output(
+                    "block",
+                    "アクティビティにcheck-inしてください。",
+                )
+                return
+
         # 5. トピック変更チェック → 記録がなければblock
         prev_topic = state.get_prev_topic()
         if prev_topic is not None and prev_topic != current_topic_name:
@@ -131,6 +147,7 @@ def main() -> None:
         # 7. 状態更新 + approve
         state.set_prev_topic(current_topic_name)
         state.reset_block_count()
+        state.increment_approved_turns()
         _output("approve")
 
     except Exception as e:

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -7,11 +7,11 @@
    → なければblock
 4. get系API呼び出しチェック（セッション中1回以上）
    → なければblock
-4.5. activity check-inチェック（最初の3ターン、one-shot block）
-     → 3ターン経過 + check-in/add_activity未呼出 → block
-5. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
-6. nudgeカウンター管理
-7. 状態更新 → approve
+5. activity check-inチェック（最初の3ターン、one-shot block）
+   → 3ターン経過 + check-in/add_activity未呼出 → block
+6. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
+7. nudgeカウンター管理
+8. 状態更新 → approve
 """
 import json
 import os
@@ -108,7 +108,7 @@ def main() -> None:
                 )
                 return
 
-        # 4.5. Activity check-in チェック（最初の3ターン）
+        # 5. Activity check-in チェック（最初の3ターン）
         if not state.has_activity_checkin():
             if has_activity_checkin_calls(all_entries):
                 state.set_activity_checkin()
@@ -121,7 +121,7 @@ def main() -> None:
                 )
                 return
 
-        # 5. トピック変更チェック → 記録がなければblock
+        # 6. トピック変更チェック → 記録がなければblock
         prev_topic = state.get_prev_topic()
         if prev_topic is not None and prev_topic != current_topic_name:
             recent_entries = all_entries[-5:] if all_entries else []
@@ -134,7 +134,7 @@ def main() -> None:
                 )
                 return
 
-        # 6. nudgeカウンター
+        # 7. nudgeカウンター
         nudge_count = state.increment_nudge_counter()
 
         if nudge_count % _NUDGE_INTERVAL == 0:
@@ -144,7 +144,7 @@ def main() -> None:
             else:
                 state.set_nudge_pending()
 
-        # 7. 状態更新 + approve
+        # 8. 状態更新 + approve
         state.set_prev_topic(current_topic_name)
         state.reset_block_count()
         state.increment_approved_turns()

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -518,6 +518,136 @@ class TestLastAssistantMessage:
         assert result["decision"] == "approve"
 
 
+class TestActivityCheckinBlock:
+    """activity check-in チェック"""
+
+    def test_no_checkin_after_3_turns_blocks(self, env_setup):
+        """3ターン目でcheck-in未呼出 → block"""
+        state_dir = Path(env_setup["state_dir"])
+        # approved_turns を 2 にセット（3ターン目）
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("2")
+        # context_retrieved フラグを設定
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        # transcript（check-in呼出なし）
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            CONTEXT_RETRIEVAL_ENTRY,
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "block"
+        assert "check-in" in result["reason"]
+        # block時にapproved_turnsがインクリメントされていないことを確認
+        assert turns_file.read_text().strip() == "2"
+
+    def test_checkin_called_approves(self, env_setup):
+        """check_in呼出済み → approve"""
+        state_dir = Path(env_setup["state_dir"])
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("2")
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(
+                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__check_in"],
+            ),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_add_activity_called_approves(self, env_setup):
+        """add_activity呼出済み → approve"""
+        state_dir = Path(env_setup["state_dir"])
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("2")
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(
+                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_activity"],
+            ),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_block_only_once(self, env_setup):
+        """activity_checkinフラグ設定済み → 2回目はblockしない"""
+        state_dir = Path(env_setup["state_dir"])
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("5")
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        checkin_file = state_dir / "activity_checkin_test-session"
+        checkin_file.write_text("1")
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_before_3_turns_no_block(self, env_setup):
+        """2ターン目ではblockしない（approved_turns=1）"""
+        state_dir = Path(env_setup["state_dir"])
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("1")
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        # check-in未呼出だが、まだ3ターン目未満
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_approved_turns_incremented_on_approve(self, env_setup):
+        """approve時にapproved_turnsがインクリメントされる"""
+        state_dir = Path(env_setup["state_dir"])
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+        # approved_turns が 1 にインクリメントされている
+        turns_file = state_dir / "approved_turns_test-session"
+        assert turns_file.exists()
+        assert turns_file.read_text().strip() == "1"
+
+
 class TestContextRetrievalCheck:
     """コンテキスト取得ツール呼び出しチェック"""
 

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -83,6 +83,29 @@ class TestNudgePending:
         assert hook_state.pop_nudge_pending() is False
 
 
+class TestApprovedTurns:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_approved_turns() == 0
+
+    def test_increment(self, hook_state):
+        assert hook_state.increment_approved_turns() == 1
+        assert hook_state.increment_approved_turns() == 2
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("approved_turns")
+        path.write_text("abc")
+        assert hook_state.get_approved_turns() == 0
+
+
+class TestActivityCheckin:
+    def test_has_returns_false_when_no_file(self, hook_state):
+        assert hook_state.has_activity_checkin() is False
+
+    def test_set_then_has(self, hook_state):
+        hook_state.set_activity_checkin()
+        assert hook_state.has_activity_checkin() is True
+
+
 class TestClearSession:
     def test_clears_all_state_files(self, tmp_path, monkeypatch):
         monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
@@ -93,6 +116,8 @@ class TestClearSession:
         state.increment_block_count()
         state.increment_nudge_counter()
         state.set_nudge_pending()
+        state.increment_approved_turns()
+        state.set_activity_checkin()
 
         # clear
         HookState.clear_session("sess-abc")
@@ -102,6 +127,8 @@ class TestClearSession:
         assert state.get_block_count() == 0
         assert state.get_nudge_counter() == 0
         assert state.pop_nudge_pending() is False
+        assert state.get_approved_turns() == 0
+        assert state.has_activity_checkin() is False
 
 
 class TestSessionIdSlash:


### PR DESCRIPTION
## Summary
- セッション開始3ターン以内にcheck_in/add_activityが呼ばれなかった場合、stop_hookで1回だけblockしてcheck-inを促す
- approved_turnsで正確なターン計測（blockリトライで水増しされない設計）
- hook_state.py / hook_transcript.py / stop_hook.py に変更、11件のテスト追加

## Test plan
- [ ] 全テスト通過確認（436 passed, 8 skipped）
- [ ] 3ターン経過 + check-in未呼出でblockされる
- [ ] check_in/add_activity呼出済みならblockされない
- [ ] blockは1回だけ（one-shot）
- [ ] 3ターン未満ではblockされない
- [ ] approve時にapproved_turnsがインクリメントされる
- [ ] block時にapproved_turnsがインクリメントされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)