### PR TITLE
feat: タグのあいまいマッチ（resolve_tags）コアロジック実装

### DIFF
--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -273,3 +273,113 @@ def backfill_embeddings() -> int:
         return 0
     finally:
         conn.close()
+
+
+# ========================================
+# Tag embedding ヘルパー
+# ========================================
+
+
+def _insert_tag_embedding_row(conn, tag_id: int, embedding: list[float]) -> None:
+    """tag_vecに1行UPSERT（DELETE+INSERT）する（コミットは呼び出し側の責任）。"""
+    blob = serialize_float32(embedding)
+    conn.execute("DELETE FROM tag_vec WHERE rowid = ?", (tag_id,))
+    conn.execute(
+        "INSERT INTO tag_vec(rowid, embedding) VALUES (?, ?)",
+        (tag_id, blob),
+    )
+
+
+def insert_tag_embedding(tag_id: int, embedding: list[float]) -> None:
+    """tag_vecにembeddingをINSERTする。"""
+    conn = get_connection()
+    try:
+        _insert_tag_embedding_row(conn, tag_id, embedding)
+        conn.commit()
+    except Exception as e:
+        logger.warning(f"Failed to insert tag embedding for tag_id={tag_id}: {e}")
+    finally:
+        conn.close()
+
+
+def generate_and_store_tag_embedding(tag_id: int, tag_name: str) -> None:
+    """タグ名からembeddingを生成しtag_vecに格納する。
+
+    サーバーダウン時は何もしない（graceful degradation）。
+    """
+    if not tag_name:
+        return
+    try:
+        embedding = encode_document(tag_name)
+        if embedding is not None:
+            insert_tag_embedding(tag_id, embedding)
+    except Exception as e:
+        logger.warning(f"Failed to generate tag embedding for tag_id={tag_id}: {e}")
+
+
+def search_similar_tags(query_text: str, k: int = 10) -> list[tuple[int, float]]:
+    """tag_vecでKNN検索し、(tag_id, distance)のリストを返す。
+
+    サーバーダウン時は空リストを返す。
+    """
+    try:
+        query_embedding = encode_query(query_text)
+        if query_embedding is None:
+            return []
+
+        blob = serialize_float32(query_embedding)
+        rows = execute_query(
+            "SELECT rowid, distance FROM tag_vec WHERE embedding MATCH ? AND k = ?",
+            (blob, k),
+        )
+        return [(row["rowid"], row["distance"]) for row in rows]
+    except Exception as e:
+        logger.warning(f"Tag similarity search failed: {e}")
+        return []
+
+
+def backfill_tag_embeddings() -> int:
+    """tag_vecが空のタグにembeddingを一括生成する。
+
+    Returns: 生成したembedding数
+    """
+    if not _is_server_running():
+        return 0
+
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.id, t.name
+            FROM tags t
+            LEFT JOIN tag_vec tv ON tv.rowid = t.id
+            WHERE tv.rowid IS NULL
+            """
+        ).fetchall()
+
+        if not rows:
+            return 0
+
+        ids = [row["id"] for row in rows]
+        texts = [row["name"] for row in rows]
+
+        try:
+            embeddings = _encode_batch(texts, "document")
+            if embeddings is None:
+                return 0
+            total = 0
+            for tag_id, embedding in zip(ids, embeddings):
+                _insert_tag_embedding_row(conn, tag_id, embedding)
+                total += 1
+            conn.commit()
+            logger.info(f"Backfilled {total} tag embeddings")
+            return total
+        except Exception as e:
+            logger.warning(f"Failed to backfill tag embeddings: {e}")
+            return 0
+
+    except Exception as e:
+        logger.warning(f"Tag embedding backfill failed: {e}")
+        return 0
+    finally:
+        conn.close()

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -12,7 +12,9 @@ VALID_NAMESPACES = {'', 'domain', 'intent'}
 
 # resolve_tags 定数
 MERGE_THRESHOLD = 0.15  # コサイン距離。これ未満なら統合
-KNN_K = 10              # KNN検索の取得数（namespace後フィルタ前）
+KNN_K = 10              # KNN検索の取得数（namespace後フィルタ前）。
+                        # namespace別タグ数が偏る場合、フィルタ後の候補が0件になりうる。
+                        # タグ総数が増加したら値の引き上げを検討すること。
 
 # Entity table mapping (for UNION inheritance queries)
 _ENTITY_TABLE = {
@@ -217,6 +219,10 @@ def resolve_tags(
                 continue
 
             # 3. force_new_tags=True → KNN検索スキップ、新規作成
+            # NOTE: ループ内で中間commit()している。generate_and_store_tag_embedding()が
+            # 別コネクションを開くため、未コミットの行は参照できない制約による。
+            # このため複数タグ処理の途中でエラーが発生した場合、前半のINSERTは
+            # rollbackされない（アトミック性を犠牲にしている）。
             if force_new_tags:
                 conn.execute(
                     "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1,11 +1,18 @@
 """タグ管理ユーティリティ"""
+import logging
 import sqlite3
 from typing import Optional, Union
 
 from src.db import execute_query, get_connection, row_to_dict
 
 
+logger = logging.getLogger(__name__)
+
 VALID_NAMESPACES = {'', 'domain', 'intent'}
+
+# resolve_tags 定数
+MERGE_THRESHOLD = 0.15  # コサイン距離。これ未満なら統合
+KNN_K = 10              # KNN検索の取得数（namespace後フィルタ前）
 
 # Entity table mapping (for UNION inheritance queries)
 _ENTITY_TABLE = {
@@ -121,6 +128,173 @@ def ensure_tag_ids(conn: sqlite3.Connection, parsed_tags: list[tuple[str, str]])
     ).fetchall()
     id_map = {(row["namespace"], row["name"]): row["id"] for row in rows}
     return [id_map[(ns, name)] for ns, name in parsed_tags]
+
+
+def resolve_tags(
+    tags: list[str],
+    force_new_tags: bool = False,
+) -> tuple[list[int], list[dict]] | dict:
+    """タグを解決する（あいまいマッチ付き）。
+
+    処理フロー（タグ1つあたり）:
+    1. パース: validate_and_parse_tags() を使用。namespace/name を lower().strip() で正規化
+    2. 完全一致チェック: SELECT id FROM tags WHERE namespace=? AND name=?
+    3. force_new_tags=True → 完全一致がなければ新規タグINSERT + embedding生成（KNN検索スキップ）
+    4. KNN検索: tag_vec に対して embedding MATCH → namespace 後フィルタ
+    5. 閾値判定: distance < MERGE_THRESHOLD → 既存タグIDに統合。なし → 新規作成 + embedding生成
+
+    Args:
+        tags: タグ文字列のリスト
+        force_new_tags: Trueの場合、KNN検索をスキップして新規作成する
+                        （ただし完全一致がある場合は既存IDを使用する）
+
+    Returns:
+        成功時: (tag_ids, merged_tags)
+            - tag_ids: 解決済みタグIDリスト
+            - merged_tags: [{"input": "hooks", "merged_to": "hook", "distance": 0.05}, ...]
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    from src.services.embedding_service import (
+        generate_and_store_tag_embedding,
+        search_similar_tags,
+    )
+
+    # 1. パース + 正規化 + バリデーション
+    # validate_and_parse_tags は正規化前にnamespace検証するため、
+    # resolve_tags では自前で parse_tag → lower/strip正規化 → バリデーション を行う
+    normalized = []
+    seen = set()
+    for tag_str in tags:
+        tag_str = tag_str.strip()
+        if not tag_str:
+            continue
+        ns, name = parse_tag(tag_str)
+        # 正規化: lower().strip()
+        ns = ns.lower().strip()
+        name = name.lower().strip()
+
+        if ns not in VALID_NAMESPACES:
+            return {"error": {
+                "code": "INVALID_TAG_NAMESPACE",
+                "message": f"Invalid namespace '{ns}' in tag '{tag_str}'. "
+                           f"Allowed: {sorted(VALID_NAMESPACES)}"
+            }}
+        if not name:
+            return {"error": {
+                "code": "INVALID_TAG_NAME",
+                "message": f"Tag name must not be empty in '{tag_str}'"
+            }}
+
+        key = (ns, name)
+        if key not in seen:
+            seen.add(key)
+            normalized.append(key)
+
+    if not normalized:
+        return ([], [])
+
+    conn = get_connection()
+    try:
+        resolved_ids: list[int] = []
+        merged_tags: list[dict] = []
+        seen_ids: set[int] = set()
+
+        for ns, name in normalized:
+            # 入力タグの表示用文字列
+            input_tag_str = f"{ns}:{name}" if ns else name
+
+            # 2. 完全一致チェック
+            row = conn.execute(
+                "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                (ns, name),
+            ).fetchone()
+
+            if row:
+                tag_id = row["id"]
+                if tag_id not in seen_ids:
+                    resolved_ids.append(tag_id)
+                    seen_ids.add(tag_id)
+                continue
+
+            # 3. force_new_tags=True → KNN検索スキップ、新規作成
+            if force_new_tags:
+                conn.execute(
+                    "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+                    (ns, name),
+                )
+                new_row = conn.execute(
+                    "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                    (ns, name),
+                ).fetchone()
+                tag_id = new_row["id"]
+                if tag_id not in seen_ids:
+                    resolved_ids.append(tag_id)
+                    seen_ids.add(tag_id)
+                conn.commit()
+                # embedding生成（失敗してもエラーにしない）
+                generate_and_store_tag_embedding(tag_id, name)
+                continue
+
+            # 4. KNN検索
+            similar = search_similar_tags(name, k=KNN_K)
+
+            # namespace後フィルタ + 閾値判定
+            best_match = None
+            for candidate_id, distance in similar:
+                if distance >= MERGE_THRESHOLD:
+                    continue
+                # candidateのnamespaceを確認
+                candidate_row = conn.execute(
+                    "SELECT namespace, name FROM tags WHERE id = ?",
+                    (candidate_id,),
+                ).fetchone()
+                if candidate_row and candidate_row["namespace"] == ns:
+                    best_match = (candidate_id, candidate_row["name"], distance)
+                    break  # distance順なので最初のマッチがベスト
+
+            if best_match:
+                # 5a. 統合
+                match_id, match_name, distance = best_match
+                if match_id not in seen_ids:
+                    resolved_ids.append(match_id)
+                    seen_ids.add(match_id)
+                merged_to_str = f"{ns}:{match_name}" if ns else match_name
+                merged_tags.append({
+                    "input": input_tag_str,
+                    "merged_to": merged_to_str,
+                    "distance": round(distance, 4),
+                })
+            else:
+                # 5b. 新規作成 + embedding生成
+                conn.execute(
+                    "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+                    (ns, name),
+                )
+                new_row = conn.execute(
+                    "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                    (ns, name),
+                ).fetchone()
+                tag_id = new_row["id"]
+                if tag_id not in seen_ids:
+                    resolved_ids.append(tag_id)
+                    seen_ids.add(tag_id)
+                conn.commit()
+                # embedding生成（失敗してもエラーにしない）
+                generate_and_store_tag_embedding(tag_id, name)
+
+        conn.commit()
+        return (resolved_ids, merged_tags)
+
+    except Exception as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()
 
 
 def link_tags(

--- a/tests/unit/test_tag_service.py
+++ b/tests/unit/test_tag_service.py
@@ -441,12 +441,12 @@ class TestResolveTags:
         # まずタグを作成
         conn = get_connection()
         try:
-            ensure_tag_ids(conn, [("", "hook")])
+            ids = ensure_tag_ids(conn, [("", "hook")])
             conn.commit()
         finally:
             conn.close()
         # embeddingも生成
-        emb.generate_and_store_tag_embedding(1, "hook")
+        emb.generate_and_store_tag_embedding(ids[0], "hook")
 
         result = resolve_tags(["hook"])
         assert not isinstance(result, dict), f"Expected tuple, got error: {result}"

--- a/tests/unit/test_tag_service.py
+++ b/tests/unit/test_tag_service.py
@@ -2,18 +2,21 @@
 import os
 import tempfile
 import pytest
+import numpy as np
 from src.db import init_database, get_connection
 from src.services.tag_service import (
     parse_tag,
     validate_and_parse_tags,
     ensure_tag_ids,
     resolve_tag_ids,
+    resolve_tags,
     link_tags,
     format_tags,
     get_entity_tags,
     get_effective_tags,
     get_effective_tags_batch,
 )
+import src.services.embedding_service as emb
 
 
 @pytest.fixture
@@ -392,5 +395,359 @@ class TestGetEffectiveTagsBatch:
             assert "domain:test" in result[log1["log_id"]]
             assert "domain:test" in result[log2["log_id"]]
             assert "extra" in result[log2["log_id"]]
+        finally:
+            conn.close()
+
+
+# ========================================
+# resolve_tags テスト
+# ========================================
+
+EMBEDDING_DIM = 384
+
+
+@pytest.fixture
+def mock_embedding_server(monkeypatch):
+    """embedding_serverへのHTTPリクエストをモック化"""
+
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            np.random.seed(hash(prefix_str + text) % (2**32))
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    yield
+
+
+@pytest.fixture
+def mock_embedding_server_down(monkeypatch):
+    """embeddingサーバーダウン状態をシミュレート"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+    yield
+
+
+class TestResolveTags:
+    """resolve_tagsのテスト"""
+
+    def test_exact_match(self, temp_db, mock_embedding_server):
+        """完全一致 → 既存IDを使用、merged_tagsなし"""
+        # まずタグを作成
+        conn = get_connection()
+        try:
+            ensure_tag_ids(conn, [("", "hook")])
+            conn.commit()
+        finally:
+            conn.close()
+        # embeddingも生成
+        emb.generate_and_store_tag_embedding(1, "hook")
+
+        result = resolve_tags(["hook"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert merged_tags == []
+
+    def test_brand_new_tag(self, temp_db, mock_embedding_server):
+        """新規タグ → 新規作成、merged_tags空"""
+        result = resolve_tags(["brand-new-tag"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert merged_tags == []
+
+        # DBにタグが存在する
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id, name FROM tags WHERE namespace = '' AND name = 'brand-new-tag'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_fuzzy_match_merges(self, temp_db, monkeypatch):
+        """類似タグ → 既存タグにマージ → merged_tagsに情報あり"""
+        # "hook"(document)と"hooks"(query)で同一ベクトルを返すモック
+        # → distance=0 で確実にMERGE_THRESHOLD(0.15)未満になる
+        fixed_vector = np.ones(EMBEDDING_DIM, dtype=np.float32) / np.sqrt(EMBEDDING_DIM)
+        fixed_vector = fixed_vector.tolist()
+
+        def mock_encode_batch(texts, prefix):
+            return [fixed_vector for _ in texts]
+
+        monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+        monkeypatch.setattr(emb, '_server_initialized', True)
+        monkeypatch.setattr(emb, '_backfill_done', True)
+
+        # "hook" タグを作成 + embedding格納
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "hook")])
+            conn.commit()
+        finally:
+            conn.close()
+        emb.generate_and_store_tag_embedding(ids[0], "hook")
+
+        # "hooks" を解決 → "hook" にマージされるべき
+        result = resolve_tags(["hooks"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert len(merged_tags) == 1
+        assert merged_tags[0]["input"] == "hooks"
+        assert merged_tags[0]["merged_to"] == "hook"
+        assert merged_tags[0]["distance"] < 0.15
+
+    def test_force_new_tags_skips_knn(self, temp_db, mock_embedding_server):
+        """force_new_tags=True + 完全一致なし → 新規作成、マージされない"""
+        # "hook" タグを作成 + embedding格納
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "hook")])
+            conn.commit()
+        finally:
+            conn.close()
+        emb.generate_and_store_tag_embedding(ids[0], "hook")
+
+        result = resolve_tags(["hooks"], force_new_tags=True)
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert merged_tags == []  # マージされない
+
+        # "hooks" が新規タグとして作成されている
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id FROM tags WHERE namespace = '' AND name = 'hooks'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_force_new_tags_exact_match_uses_existing(self, temp_db, mock_embedding_server):
+        """force_new_tags=True + 完全一致 "hook" → 既存ID使用（新規作成しない）"""
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "hook")])
+            conn.commit()
+            original_id = ids[0]
+        finally:
+            conn.close()
+
+        result = resolve_tags(["hook"], force_new_tags=True)
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert tag_ids[0] == original_id
+        assert merged_tags == []
+
+    def test_namespace_normalization(self, temp_db, mock_embedding_server):
+        """"Domain:CC-Memory" → 正規化 → namespace="domain", name="cc-memory" で解決"""
+        result = resolve_tags(["Domain:CC-Memory"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+
+        # 正規化されたタグがDBに存在
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT namespace, name FROM tags WHERE id = ?",
+                (tag_ids[0],),
+            ).fetchone()
+            assert row["namespace"] == "domain"
+            assert row["name"] == "cc-memory"
+        finally:
+            conn.close()
+
+    def test_empty_tag_error(self, temp_db, mock_embedding_server):
+        """空文字列タグ → 空リスト（validate_and_parse_tagsが空文字をスキップ）"""
+        result = resolve_tags([""])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert tag_ids == []
+        assert merged_tags == []
+
+    def test_invalid_namespace_error(self, temp_db, mock_embedding_server):
+        """不正namespace → バリデーションエラー"""
+        result = resolve_tags(["unknown:foo"])
+        assert isinstance(result, dict)
+        assert result["error"]["code"] == "INVALID_TAG_NAMESPACE"
+
+    def test_duplicate_input_deduplication(self, temp_db, mock_embedding_server):
+        """["hooks", "hooks"] → IDリストに1つだけ"""
+        result = resolve_tags(["hooks", "hooks"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+
+    def test_embedding_server_down_exact_match_works(self, temp_db, mock_embedding_server_down):
+        """embeddingサーバーダウン → 完全一致のみで動作、エラーにならない"""
+        # まず完全一致用のタグを作成（サーバーダウン前に作れないのでSQLで直接）
+        conn = get_connection()
+        try:
+            conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'hook')")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = resolve_tags(["hook"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert merged_tags == []
+
+    def test_embedding_server_down_new_tag_created(self, temp_db, mock_embedding_server_down):
+        """embeddingサーバーダウン → 完全一致なしの場合は新規作成（KNN空結果）"""
+        result = resolve_tags(["brand-new"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 1
+        assert merged_tags == []
+
+    def test_empty_tag_vec_creates_new(self, temp_db, mock_embedding_server):
+        """空のtag_vec → 全て新規作成"""
+        result = resolve_tags(["alpha", "beta", "gamma"])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert len(tag_ids) == 3
+        assert len(set(tag_ids)) == 3  # 全て異なるID
+
+    def test_empty_input_list(self, temp_db, mock_embedding_server):
+        """空リスト入力 → 空リストが返る"""
+        result = resolve_tags([])
+        assert not isinstance(result, dict), f"Expected tuple, got error: {result}"
+        tag_ids, merged_tags = result
+        assert tag_ids == []
+        assert merged_tags == []
+
+
+# ========================================
+# embedding_service tag ヘルパーのテスト
+# ========================================
+
+
+class TestTagEmbeddingHelpers:
+    """embedding_serviceのtag embeddingヘルパーのテスト"""
+
+    def test_generate_and_store_tag_embedding(self, temp_db, mock_embedding_server):
+        """generate_and_store_tag_embedding: tag_vecにembeddingが格納される"""
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "test-tag")])
+            conn.commit()
+            tag_id = ids[0]
+        finally:
+            conn.close()
+
+        emb.generate_and_store_tag_embedding(tag_id, "test-tag")
+
+        conn = get_connection()
+        try:
+            cursor = conn.execute("SELECT count(*) FROM tag_vec WHERE rowid = ?", (tag_id,))
+            count = cursor.fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_search_similar_tags(self, temp_db, mock_embedding_server):
+        """search_similar_tags: 格納済みtagのKNN検索ができる"""
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "hook"), ("", "design"), ("", "testing")])
+            conn.commit()
+        finally:
+            conn.close()
+
+        for tag_id, name in zip(ids, ["hook", "design", "testing"]):
+            emb.generate_and_store_tag_embedding(tag_id, name)
+
+        results = emb.search_similar_tags("hooks", k=3)
+        assert isinstance(results, list)
+        assert len(results) > 0
+        # 各結果は (tag_id, distance) のタプル
+        for tag_id, distance in results:
+            assert isinstance(tag_id, int)
+            assert isinstance(distance, float)
+
+    def test_search_similar_tags_server_down(self, temp_db, mock_embedding_server_down):
+        """search_similar_tags: サーバーダウン時は空リストを返す"""
+        results = emb.search_similar_tags("hooks")
+        assert results == []
+
+    def test_backfill_tag_embeddings(self, temp_db, mock_embedding_server, monkeypatch):
+        """backfill_tag_embeddings: tag_vecが空のタグにembeddingを一括生成"""
+        monkeypatch.setattr(emb, '_is_server_running', lambda: True)
+
+        # タグを作成（embeddingは生成しない）
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "alpha"), ("", "beta")])
+            conn.commit()
+        finally:
+            conn.close()
+
+        # init_database由来のタグも含めてバックフィル
+        filled = emb.backfill_tag_embeddings()
+        assert filled >= 2  # 少なくともalpha, betaの2つ
+
+        # tag_vecにembeddingが存在する
+        conn = get_connection()
+        try:
+            for tag_id in ids:
+                cursor = conn.execute("SELECT count(*) FROM tag_vec WHERE rowid = ?", (tag_id,))
+                count = cursor.fetchone()[0]
+                assert count == 1
+        finally:
+            conn.close()
+
+    def test_backfill_tag_embeddings_noop(self, temp_db, mock_embedding_server, monkeypatch):
+        """backfill_tag_embeddings: 全タグにembeddingがある場合は0を返す"""
+        monkeypatch.setattr(emb, '_is_server_running', lambda: True)
+
+        # init_database由来のタグを先にバックフィル
+        emb.backfill_tag_embeddings()
+
+        # タグ作成＋embedding生成
+        conn = get_connection()
+        try:
+            ids = ensure_tag_ids(conn, [("", "gamma")])
+            conn.commit()
+        finally:
+            conn.close()
+        emb.generate_and_store_tag_embedding(ids[0], "gamma")
+
+        # 再バックフィルで0を返す
+        filled = emb.backfill_tag_embeddings()
+        assert filled == 0
+
+    def test_generate_and_store_tag_embedding_server_down(self, temp_db, mock_embedding_server_down):
+        """generate_and_store_tag_embedding: サーバーダウン時は何もしない"""
+        conn = get_connection()
+        try:
+            conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'test-tag')")
+            conn.commit()
+            row = conn.execute("SELECT id FROM tags WHERE name = 'test-tag'").fetchone()
+            tag_id = row["id"]
+        finally:
+            conn.close()
+
+        # エラーにならない
+        emb.generate_and_store_tag_embedding(tag_id, "test-tag")
+
+        # tag_vecにはembeddingがない
+        conn = get_connection()
+        try:
+            cursor = conn.execute("SELECT count(*) FROM tag_vec WHERE rowid = ?", (tag_id,))
+            count = cursor.fetchone()[0]
+            assert count == 0
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

- `tag_service.py` に `resolve_tags()` を追加。パース→正規化→完全一致チェック→KNN検索(tag_vec)→閾値判定(distance<0.15)のフローで、表記揺れタグを既存タグに自動統合する
- `embedding_service.py` に tag embedding ヘルパー関数群を追加（`insert_tag_embedding`, `generate_and_store_tag_embedding`, `search_similar_tags`, `backfill_tag_embeddings`）
- 19テストケースを追加（正常系・異常系・エッジケース・embedding ヘルパー）

## Test plan

- [x] `resolve_tags()` の正常系テスト（完全一致、fuzzy match、新規作成、force_new_tags、namespace正規化）
- [x] 異常系テスト（空文字、不正namespace、embeddingサーバーダウン）
- [x] エッジケーステスト（重複入力、空tag_vec、force_new_tags+完全一致）
- [x] embedding ヘルパーのユニットテスト（格納、KNN検索、バックフィル、サーバーダウン）
- [x] 全テスト pass（444 passed, 8 skipped, 0 failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)