### PR TITLE
fix: hooks.jsonのhook設定を復元

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,1 +1,63 @@
-{}
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/hook_state.py clear"
+          },
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/session_start_hook.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/stop_hook.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/pretooluse_hook.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__cc-memory__add_decision",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/remind_task_on_decision.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session_end_hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- #181で古いフック残留バグ修正のため`hooks.json`を`{}`に上書きしたが、その後のPR(#188等)でstop_hook.pyにロジック追加した際に`hooks.json`の復元が漏れていた
- 全hook設定（SessionStart, Stop, PreToolUse, PostToolUse, SessionEnd）を復元

## Test plan
- [x] キャッシュに直接配置して動作確認済み（stop hookのactivity check-inブロックが正常に発火）

🤖 Generated with [Claude Code](https://claude.com/claude-code)