### PR TITLE
feat: intent:タグnotesの初期投入 + check-in時の常時注入

### DIFF
--- a/migrations/0015_intent_tag_notes.sql
+++ b/migrations/0015_intent_tag_notes.sql
@@ -1,0 +1,59 @@
+-- Migration 015: intent:タグに notes（振る舞いガイド）を投入
+--
+-- depends: 0014_intent_namespace
+
+-- Step 1: 不足しているintent:タグを追加（既存なら無視）
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'discuss');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'design');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'investigate');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'implement');
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'review');
+
+-- Step 2: notesを投入
+UPDATE tags SET notes = '境界: 設計・実装に入らない。
+
+目的: ユーザーの要件から曖昧さを取り除き、決定事項として記録する。
+完了条件: What / Why / Scope / Acceptance が明確になっていること。
+
+振る舞い:
+- ユーザーに言語化させることがゴール。エージェントが勝手に決めない
+- 矛盾を指摘する。必要性を問う。代替案を出す。「なんで？」「具体的には？」で深掘りする
+- 根拠は1次情報ベース（公式ドキュメント、コードベース等）。「一般的には〜」はNG
+- 発散優先。本題から逸れなければどんどん広げていい。収束は急がない
+- 先回りで関連情報を調べるのはOK。趣味ベースで調べ始めてもOK
+- 成果物: decisionとして記録。設計フェーズは自動で開始しない'
+WHERE namespace = 'intent' AND name = 'discuss';
+
+UPDATE tags SET notes = '前提: 議論フェーズのdecision（What/Why/Scope）が揃っていること。なければ議論に戻す。
+境界: 実装に入らない。
+
+目的: How / Interface / Edge cases を決定し、実装に必要な決定事項を揃える。
+完了条件: How / Interface / Edge cases / Verification が明確になっていること。
+
+振る舞い:
+- トレードオフを明示して、ユーザーに選ばせる。エージェントが勝手に決めない
+- 代替案を提示する。影響範囲を確認する。抜け漏れを指摘する
+- 根拠は1次情報ベース
+- 成果物: decisionと[作業]アクティビティ。作業アクティビティには背景を詳しく書く
+  （特にEdge casesは実装者が判断に迷わないレベルまで網羅）
+- 作業フェーズは自動で開始しない'
+WHERE namespace = 'intent' AND name = 'design';
+
+UPDATE tags SET notes = '境界: 実装しない。
+
+目的: 調査・情報収集に専念する。
+振る舞い:
+- 事実と推測を明確に分ける
+- 調査結果はmaterialとして保存する'
+WHERE namespace = 'intent' AND name = 'investigate';
+
+UPDATE tags SET notes = '振る舞い:
+- 着手前にアクティビティの仕様と関連decisionを確認する
+- 完了したらユーザーの承認を得てからアクティビティを閉じる'
+WHERE namespace = 'intent' AND name = 'implement';
+
+UPDATE tags SET notes = '境界: 変更しない。指摘のみ。
+
+振る舞い:
+- diffだけ見て推測で指摘しない。実コードで呼び出し関係を確認してから指摘する'
+WHERE namespace = 'intent' AND name = 'review';

--- a/src/main.py
+++ b/src/main.py
@@ -346,7 +346,12 @@ def build_instructions() -> str:
 
 
 def _maybe_inject_tag_notes(result: dict, tag_strings: list[str]) -> dict:
-    """結果dictにtag_notesを注入する（notes があれば）"""
+    """結果dictにtag_notesを注入する（notes があれば）
+
+    Note: always_inject_namespacesは渡さない（意図的）。
+    intent:タグがこの経路で_injected_tagsに登録されるが、
+    check_in経路はalways_inject_namespacesで常時注入が保証されるため問題ない。
+    """
     conn = get_connection()
     try:
         notes = collect_tag_notes_for_injection(conn, tag_strings)

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -91,9 +91,12 @@ def check_in(activity_id: int) -> dict:
     statusがin_progress以外（pending, completed含む）の場合はin_progressに自動更新する。
     completedのアクティビティも再オープンされる（追加作業が発生したケースに対応）。
 
-    tag_notesはセッション内初回遭遇時のみ注入される（_injected_tags管理）。
-    同一セッションで同じタグを持つアクティビティに2回check-inすると、
-    2回目のtag_notesは空になる。これはtag_service側の設計による意図的な動作。
+    tag_notesの注入ルール:
+    - 通常タグ: セッション内初回遭遇時のみ注入される（_injected_tags管理）。
+      同一セッションで同じタグを持つアクティビティに2回check-inすると、
+      2回目のtag_notesは空になる。
+    - always_inject_namespaces対象タグ（例: intent:）: 毎回注入される。
+      _injected_tagsによるフィルタをスキップし、check-inのたびにnotesを返す。
 
     Args:
         activity_id: アクティビティID

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -126,7 +126,7 @@ def check_in(activity_id: int) -> dict:
             topic_info = _get_topic_info(conn, topic_id)
 
         # 3. tag_notes収集
-        tag_notes = collect_tag_notes_for_injection(conn, tags) or []
+        tag_notes = collect_tag_notes_for_injection(conn, tags, always_inject_namespaces=["intent"]) or []
 
         # 4. materials取得（カタログ形式、共有コネクション使用）
         materials = get_materials_by_activity_with_conn(conn, activity_id)

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -391,26 +391,49 @@ def update_tag(tag: str, notes: str) -> dict:
 _injected_tags: set[str] = set()
 
 
-def collect_tag_notes_for_injection(conn: sqlite3.Connection, tag_strings: list[str]) -> list[dict] | None:
+def collect_tag_notes_for_injection(
+    conn: sqlite3.Connection,
+    tag_strings: list[str],
+    always_inject_namespaces: list[str] | None = None,
+) -> list[dict] | None:
     """未注入タグの notes を収集し、注入済みとしてマークする。
 
     Args:
         conn: DB接続
         tag_strings: タグ文字列リスト（例: ["domain:cc-memory", "intent:design"]）
+        always_inject_namespaces: 常時注入するnamespaceのリスト（例: ["intent"]）。
+            このnamespaceに属するタグは _injected_tags チェックをスキップし、
+            毎回 notes を返す。_injected_tags には登録しない。
 
     Returns:
         notes があるタグの一覧。なければ None
         [{"tag": "domain:cc-memory", "notes": "..."}, ...]
     """
-    new_tags = [t for t in tag_strings if t not in _injected_tags]
-    if not new_tags:
+    always_ns = set(always_inject_namespaces) if always_inject_namespaces else set()
+
+    # always_inject対象とそれ以外を分離
+    always_tags = []
+    normal_tags = []
+    for t in tag_strings:
+        ns, _ = parse_tag(t)
+        if ns in always_ns:
+            always_tags.append(t)
+        else:
+            normal_tags.append(t)
+
+    # 通常タグ: 未注入のもののみ
+    new_normal_tags = [t for t in normal_tags if t not in _injected_tags]
+
+    # 通常タグをすべてマーク（notes の有無に関わらず）
+    _injected_tags.update(new_normal_tags)
+
+    # クエリ対象: new_normal_tags + always_tags（always_tagsは毎回クエリ）
+    query_tags = new_normal_tags + always_tags
+    if not query_tags:
         return None
 
-    # 新規遭遇タグをすべてマーク（notes の有無に関わらず）
-    _injected_tags.update(new_tags)
-
     # notes がある分だけ取得（バッチクエリ）
-    parsed = [parse_tag(t) for t in new_tags]
+    parsed = [parse_tag(t) for t in query_tags]
     placeholders = " OR ".join(["(namespace = ? AND name = ?)"] * len(parsed))
     params = [v for pair in parsed for v in pair]
     rows = conn.execute(

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -411,29 +411,31 @@ def collect_tag_notes_for_injection(
     """
     always_ns = set(always_inject_namespaces) if always_inject_namespaces else set()
 
-    # always_inject対象とそれ以外を分離
-    always_tags = []
+    # always_inject対象とそれ以外を分離（パース結果も保持）
+    always_parsed = []
     normal_tags = []
+    normal_parsed = []
     for t in tag_strings:
-        ns, _ = parse_tag(t)
+        ns, name = parse_tag(t)
         if ns in always_ns:
-            always_tags.append(t)
+            always_parsed.append((ns, name))
         else:
             normal_tags.append(t)
+            normal_parsed.append((ns, name))
 
     # 通常タグ: 未注入のもののみ
-    new_normal_tags = [t for t in normal_tags if t not in _injected_tags]
+    new_normal = [
+        (t, p) for t, p in zip(normal_tags, normal_parsed)
+        if t not in _injected_tags
+    ]
 
     # 通常タグをすべてマーク（notes の有無に関わらず）
-    _injected_tags.update(new_normal_tags)
+    _injected_tags.update(t for t, _ in new_normal)
 
-    # クエリ対象: new_normal_tags + always_tags（always_tagsは毎回クエリ）
-    query_tags = new_normal_tags + always_tags
-    if not query_tags:
+    # クエリ対象: new_normal + always（always_tagsは毎回クエリ）
+    parsed = [p for _, p in new_normal] + always_parsed
+    if not parsed:
         return None
-
-    # notes がある分だけ取得（バッチクエリ）
-    parsed = [parse_tag(t) for t in query_tags]
     placeholders = " OR ".join(["(namespace = ? AND name = ?)"] * len(parsed))
     params = [v for pair in parsed for v in pair]
     rows = conn.execute(

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -240,3 +240,65 @@ class TestCheckInTagNotes:
 
         assert "error" not in result
         assert result["tag_notes"] == []
+
+    def test_intent_tag_notes_injected_every_time(self, temp_db):
+        """intent:タグのnotesは毎回注入される（常時注入）"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE tags SET notes = ? WHERE namespace = 'intent' AND name = 'design'",
+                ("設計の教訓",),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        activity = add_activity(
+            title="Design task",
+            description="Desc",
+            tags=["intent:design"],
+        )
+        aid = activity["activity_id"]
+
+        # 1回目
+        result1 = check_in(aid)
+        assert "error" not in result1
+        intent_notes1 = [n for n in result1["tag_notes"] if n["tag"] == "intent:design"]
+        assert len(intent_notes1) == 1
+
+        # 2回目: intent: は常時注入なので再度返る
+        result2 = check_in(aid)
+        assert "error" not in result2
+        intent_notes2 = [n for n in result2["tag_notes"] if n["tag"] == "intent:design"]
+        assert len(intent_notes2) == 1
+
+    def test_non_intent_tag_notes_injected_once(self, temp_db):
+        """intent:以外のタグのnotesはセッション初回のみ注入される"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "once", "1回だけの教訓"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        activity = add_activity(
+            title="Domain task",
+            description="Desc",
+            tags=["domain:once"],
+        )
+        aid = activity["activity_id"]
+
+        # 1回目: 注入される
+        result1 = check_in(aid)
+        assert "error" not in result1
+        domain_notes1 = [n for n in result1["tag_notes"] if n["tag"] == "domain:once"]
+        assert len(domain_notes1) == 1
+
+        # 2回目: domain: は通常タグなので注入されない
+        result2 = check_in(aid)
+        assert "error" not in result2
+        domain_notes2 = [n for n in result2["tag_notes"] if n["tag"] == "domain:once"]
+        assert len(domain_notes2) == 0

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -176,13 +176,13 @@ class TestTagNotesInjection:
 
     def test_mixed_tags_with_and_without_notes(self, temp_db):
         """notes があるタグとないタグの混在"""
-        add_topic(title="Test", description="Desc", tags=["domain:test", "intent:design"])
+        add_topic(title="Test", description="Desc", tags=["domain:test", "domain:empty"])
         update_tag("domain:test", "テスト教訓")
-        # intent:design には notes を設定しない
+        # domain:empty には notes を設定しない
 
         conn = get_connection()
         try:
-            result = collect_tag_notes_for_injection(conn, ["domain:test", "intent:design"])
+            result = collect_tag_notes_for_injection(conn, ["domain:test", "domain:empty"])
             assert result is not None
             assert len(result) == 1
             assert result[0]["tag"] == "domain:test"
@@ -231,6 +231,138 @@ class TestTagNotesInjection:
         try:
             result = collect_tag_notes_for_injection(conn, ["domain:nonexistent"])
             assert result is None
+        finally:
+            conn.close()
+
+
+# ========================================
+# 常時注入（always_inject_namespaces）テスト
+# ========================================
+
+
+class TestAlwaysInjectNamespaces:
+    """always_inject_namespaces パラメータのテスト"""
+
+    def test_always_inject_returns_notes_every_time(self, temp_db):
+        """always_inject_namespaces 対象のタグは毎回 notes を返す"""
+        add_topic(title="Test", description="Desc", tags=["intent:design"])
+        update_tag("intent:design", "設計の教訓")
+
+        conn = get_connection()
+        try:
+            # 1回目
+            result1 = collect_tag_notes_for_injection(
+                conn, ["intent:design"], always_inject_namespaces=["intent"]
+            )
+            assert result1 is not None
+            assert len(result1) == 1
+            assert result1[0]["tag"] == "intent:design"
+
+            # 2回目: 通常なら None だが、always_inject なので返る
+            result2 = collect_tag_notes_for_injection(
+                conn, ["intent:design"], always_inject_namespaces=["intent"]
+            )
+            assert result2 is not None
+            assert len(result2) == 1
+            assert result2[0]["tag"] == "intent:design"
+        finally:
+            conn.close()
+
+    def test_always_inject_does_not_register_in_injected_tags(self, temp_db):
+        """always_inject 対象のタグは _injected_tags に登録されない"""
+        add_topic(title="Test", description="Desc", tags=["intent:design"])
+        update_tag("intent:design", "設計の教訓")
+
+        conn = get_connection()
+        try:
+            collect_tag_notes_for_injection(
+                conn, ["intent:design"], always_inject_namespaces=["intent"]
+            )
+            assert "intent:design" not in _injected_tags
+        finally:
+            conn.close()
+
+    def test_normal_tags_still_deduplicated(self, temp_db):
+        """always_inject_namespaces を使っても通常タグは従来通り重複防止される"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "intent:design"])
+        update_tag("domain:test", "テスト教訓")
+        update_tag("intent:design", "設計の教訓")
+
+        conn = get_connection()
+        try:
+            # 1回目: 両方返る
+            result1 = collect_tag_notes_for_injection(
+                conn, ["domain:test", "intent:design"],
+                always_inject_namespaces=["intent"],
+            )
+            assert result1 is not None
+            assert len(result1) == 2
+
+            # 2回目: domain:test は既に注入済みなので intent:design だけ
+            result2 = collect_tag_notes_for_injection(
+                conn, ["domain:test", "intent:design"],
+                always_inject_namespaces=["intent"],
+            )
+            assert result2 is not None
+            assert len(result2) == 1
+            assert result2[0]["tag"] == "intent:design"
+        finally:
+            conn.close()
+
+    def test_always_inject_no_notes_returns_none(self, temp_db):
+        """always_inject 対象でも notes がなければ None が返る"""
+        # domain:nonotes に notes を設定しない
+        add_topic(title="Test", description="Desc", tags=["domain:nonotes"])
+
+        conn = get_connection()
+        try:
+            result = collect_tag_notes_for_injection(
+                conn, ["domain:nonotes"], always_inject_namespaces=["domain"]
+            )
+            assert result is None
+        finally:
+            conn.close()
+
+    def test_always_inject_with_no_parameter(self, temp_db):
+        """always_inject_namespaces 未指定の場合、従来通りの動作"""
+        add_topic(title="Test", description="Desc", tags=["intent:design"])
+        update_tag("intent:design", "設計の教訓")
+
+        conn = get_connection()
+        try:
+            # 1回目
+            result1 = collect_tag_notes_for_injection(conn, ["intent:design"])
+            assert result1 is not None
+
+            # 2回目: 従来通り None
+            result2 = collect_tag_notes_for_injection(conn, ["intent:design"])
+            assert result2 is None
+        finally:
+            conn.close()
+
+    def test_multiple_always_inject_namespaces(self, temp_db):
+        """複数の namespace を always_inject に指定できる"""
+        add_topic(title="Test", description="Desc", tags=["intent:design", "domain:test"])
+        update_tag("intent:design", "設計の教訓")
+        update_tag("domain:test", "テスト教訓")
+
+        conn = get_connection()
+        try:
+            # 1回目
+            result1 = collect_tag_notes_for_injection(
+                conn, ["intent:design", "domain:test"],
+                always_inject_namespaces=["intent", "domain"],
+            )
+            assert result1 is not None
+            assert len(result1) == 2
+
+            # 2回目: 両方 always なので両方返る
+            result2 = collect_tag_notes_for_injection(
+                conn, ["intent:design", "domain:test"],
+                always_inject_namespaces=["intent", "domain"],
+            )
+            assert result2 is not None
+            assert len(result2) == 2
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

- intent:タグ5種（discuss / design / investigate / implement / review）にnotes（振る舞いガイド）を初期投入するマイグレーション追加
- `collect_tag_notes_for_injection` に `always_inject_namespaces` パラメータを追加し、check-in時にintent:タグのnotesを `_injected_tags` に関係なく毎回返すように変更
- ユニットテスト6件 + 統合テスト2件を追加

## Test plan

- [ ] `python -m pytest tests/unit/test_tag_notes.py -v` — 常時注入テスト（TestAlwaysInjectNamespaces）がパスすること
- [ ] `python -m pytest tests/integration/test_checkin_service.py -v` — check-in時のintent:タグ常時注入テストがパスすること
- [ ] `python -m pytest tests/ -v` — 全テストがパスすること
- [ ] check-inを2回呼んでintent:タグのnotesが毎回返ることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)