### PR TITLE
fix: activity check-inテストの閾値を2ターン目に合わせて修正

### DIFF
--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -608,14 +608,14 @@ class TestActivityCheckinBlock:
         )
         assert result["decision"] == "approve"
 
-    def test_before_3_turns_no_block(self, env_setup):
-        """2ターン目ではblockしない（approved_turns=1）"""
+    def test_before_2_turns_no_block(self, env_setup):
+        """1ターン目ではblockしない（approved_turns=0）"""
         state_dir = Path(env_setup["state_dir"])
         turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("1")
+        turns_file.write_text("0")
         context_file = state_dir / "context_retrieved_test-session"
         context_file.write_text("1")
-        # check-in未呼出だが、まだ3ターン目未満
+        # check-in未呼出だが、まだ2ターン目未満
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript([
             _make_user_entry("hi"),


### PR DESCRIPTION
## Summary
- PR #191でactivity check-inのblock閾値を3ターン目→2ターン目に変更した際、テスト側の更新が漏れていた
- `test_before_3_turns_no_block` を `test_before_2_turns_no_block` にリネームし、`approved_turns` を1→0に修正

## Test plan
- [x] `TestActivityCheckinBlock` 全6テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)