### PR TITLE
docs: activityのintent:タグをdomain:と同等に必須化

### DIFF
--- a/hooks/auto_sync_prompt.txt
+++ b/hooks/auto_sync_prompt.txt
@@ -105,7 +105,7 @@ transcriptを解析し、議論されたテーマを特定する。
 
 アクティビティの書き方:
 - title: [未完] 〜 のプレフィックスをつける
-- tags に domain:タグ（必須）＋内容を表すタグを付ける
+- tags に domain:タグ（必須）＋intent:タグ（必須）＋内容を表すタグを付ける。intent:はプレフィックスに対応: [未完]議論途中=intent:discuss, [未完]設計途中=intent:design, [未完]実装途中=intent:implement
 - description に文脈を多めに記載する。具体的には:
   - 何について話していたか
   - どこまで進んだか・何が決まったか

--- a/src/main.py
+++ b/src/main.py
@@ -314,7 +314,7 @@ check-inするとtag_notes・資材・関連decisionsが一括で返り、status
 ## タグ
 
 トピック・決定事項・ログ・アクティビティはすべてタグで整理されます。
-記録時には必ずタグを付けてください。`domain:`タグは必須、`intent:`タグや素タグもたくさん付けてください。
+記録時には必ずタグを付けてください。`domain:`タグは必須。アクティビティには`intent:`タグも必須です。素タグも積極的に付けてください。
 namespace: `domain:`（関心領域）/ `intent:`（作業意図）/ 素タグ（キーワード）
 
 ### tag notes
@@ -560,7 +560,7 @@ def add_activity(
     Args:
         title: アクティビティのタイトル
         description: アクティビティの詳細説明（必須）
-        tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
+        tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
 
     Returns:
         作成されたアクティビティ情報


### PR DESCRIPTION
## Summary
- インストラクション(main.py)で、activityにはintent:タグも必須と明記
- add_activityのtags descriptionでintent:必須を明記
- auto_sync_prompt.txtのStep 5でintent:タグ付与を指示追加

## Test plan
- [x] 全テストパス (455 passed, 8 skipped)
- [ ] 新セッションでactivityを作成し、intent:タグが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)