### PR TITLE
feat: get_activitiesのdescription切り詰めを200文字に変更

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -16,6 +16,8 @@ from src.services.tag_service import (
 
 logger = logging.getLogger(__name__)
 
+# get_activitiesでdescriptionを切り詰める上限文字数
+ACTIVITY_DESC_MAX_LEN = 200
 # DB格納可能なステータス値
 REAL_STATUSES = {"pending", "in_progress", "completed"}
 # "active"エイリアスが展開されるステータス
@@ -218,7 +220,7 @@ def get_activities(tags: list[str] | None = None, status: str = "active", limit:
             activities.append({
                 "id": activity["id"],
                 "title": activity["title"],
-                "description": (activity["description"] or "")[:200],
+                "description": (activity["description"] or "")[:ACTIVITY_DESC_MAX_LEN],
                 "status": activity["status"],
                 "tags": tags_map.get(activity["id"], []),
                 "created_at": activity["created_at"],

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -218,7 +218,7 @@ def get_activities(tags: list[str] | None = None, status: str = "active", limit:
             activities.append({
                 "id": activity["id"],
                 "title": activity["title"],
-                "description": (activity["description"] or "")[:100],
+                "description": (activity["description"] or "")[:200],
                 "status": activity["status"],
                 "tags": tags_map.get(activity["id"], []),
                 "created_at": activity["created_at"],

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import pytest
 from src.db import init_database, execute_query
-from src.services.activity_service import add_activity, get_activities, update_activity
+from src.services.activity_service import add_activity, get_activities, update_activity, ACTIVITY_DESC_MAX_LEN
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -122,6 +122,16 @@ class TestGetActivities:
         assert result["total_count"] == 1
         assert result["activities"][0]["title"] == "Activity A"
 
+    def test_get_activities_truncates_description_at_max_len(self, temp_db):
+        """descriptionがACTIVITY_DESC_MAX_LEN文字に切り詰められること"""
+        long_desc = "a" * (ACTIVITY_DESC_MAX_LEN + 50)
+        add_activity(title="Long Desc", description=long_desc, tags=["domain:test"])
+
+        result = get_activities(tags=["domain:test"])
+
+        assert "error" not in result
+        activity = result["activities"][0]
+        assert len(activity["description"]) == ACTIVITY_DESC_MAX_LEN
 
 
 class TestUpdateActivity:


### PR DESCRIPTION
## Summary
- get_activitiesで返されるdescriptionの切り詰め文字数を100文字から200文字に変更

## Test plan
- [x] 既存テスト全483件がパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)