### PR TITLE
feat: check_inの返り値にactivityのdescription全文を含める

### DIFF
--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -172,6 +172,7 @@ def check_in(activity_id: int) -> dict:
             "activity": {
                 "id": activity["id"],
                 "title": activity["title"],
+                "description": activity["description"],
                 "status": activity["status"],
                 "tags": tags,
             },

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -59,6 +59,7 @@ class TestCheckIn:
         assert "activity" in result
         assert result["activity"]["id"] == activity_id
         assert result["activity"]["title"] == "[作業] タグnotesカラム追加"
+        assert result["activity"]["description"] == "タグnotesカラムを追加する作業"
         assert result["activity"]["status"] == "in_progress"
         assert "tags" in result["activity"]
         assert "tag_notes" in result


### PR DESCRIPTION
## Summary
- check_inの返り値に含まれるactivityオブジェクトにdescriptionフィールドを追加
- 既存テストにdescriptionのアサーションを追加

## Test plan
- [x] check_in統合テスト（18件）がパスすること
- [x] 全テスト（483件）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)