### PR TITLE
feat: get_activitiesのcompleted/pendingソート順をupdated_at DESCに変更

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -183,7 +183,7 @@ def get_activities(tags: list[str] | None = None, status: str = "active", limit:
         else:
             conditions.append("status = ?")
             where_params.append(status)
-            order_clause = "created_at ASC, id ASC"
+            order_clause = "updated_at DESC, id DESC"
 
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -2,7 +2,7 @@
 import os
 import tempfile
 import pytest
-from src.db import init_database, execute_query
+from src.db import init_database, execute_query, get_connection
 from src.services.activity_service import add_activity, get_activities, update_activity
 
 
@@ -121,6 +121,50 @@ class TestGetActivities:
         assert "error" not in result
         assert result["total_count"] == 1
         assert result["activities"][0]["title"] == "Activity A"
+
+    def test_get_activities_completed_sorted_by_updated_at_desc(self, temp_db):
+        """completedのソート順がupdated_at DESCになっている"""
+        a1 = add_activity(title="Old completed", description="Desc", tags=DEFAULT_TAGS)
+        a2 = add_activity(title="New completed", description="Desc", tags=DEFAULT_TAGS)
+        update_activity(a1["activity_id"], new_status="completed")
+        update_activity(a2["activity_id"], new_status="completed")
+
+        # a1のupdated_atを古い値に書き換えてソート順を明確にする
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2000-01-01 00:00:00' WHERE id = ?",
+            (a1["activity_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(status="completed", limit=10)
+
+        assert "error" not in result
+        assert result["total_count"] == 2
+        titles = [a["title"] for a in result["activities"]]
+        assert titles == ["New completed", "Old completed"]
+
+    def test_get_activities_pending_sorted_by_updated_at_desc(self, temp_db):
+        """pendingのソート順がupdated_at DESCになっている"""
+        a1 = add_activity(title="Old pending", description="Desc", tags=DEFAULT_TAGS)
+        a2 = add_activity(title="New pending", description="Desc", tags=DEFAULT_TAGS)
+
+        # a1のupdated_atを古い値に書き換えてソート順を明確にする
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2000-01-01 00:00:00' WHERE id = ?",
+            (a1["activity_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(status="pending", limit=10)
+
+        assert "error" not in result
+        assert result["total_count"] == 2
+        titles = [a["title"] for a in result["activities"]]
+        assert titles == ["New pending", "Old pending"]
 
 
 


### PR DESCRIPTION
## Summary
- `get_activities`でstatus="completed"またはstatus="pending"を指定した場合のソート順を`created_at ASC`から`updated_at DESC`に変更
- 最近完了/更新されたアクティビティが先頭に来るようになり、status="active"のソート（updated_at DESC）との一貫性も向上
- completed/pendingそれぞれのソート順を検証する統合テストを追加

## Test plan
- [x] completedステータスのソート順がupdated_at DESCであることを検証するテスト
- [x] pendingステータスのソート順がupdated_at DESCであることを検証するテスト
- [x] 全485テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)