### PR TITLE
feat: searchレスポンスにsearch_methods_usedフィールドを追加

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -462,7 +462,7 @@ def search(
                 tag_ids = _resolve_tag_ids_readonly(conn, tags)
                 # 指定タグの一部でもDBに存在しない場合、ANDフィルタは必ず空結果
                 if len(tag_ids) < len(tags):
-                    return {"results": [], "total_count": 0}
+                    return {"results": [], "total_count": 0, "search_methods_used": []}
             finally:
                 conn.close()
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -469,14 +469,20 @@ def search(
         # RRFで両ソースをマージした後にlimitで切るため、各ソースからlimitより多めに取得する
         fetch_limit = limit * 5
 
+        # 使用された検索手法を追跡
+        methods_used: list[str] = []
+
         # FTS5検索: 全キーワードが3文字以上の場合のみ
         min_len = min(len(kw) for kw in keywords)
         fts_results = []
         if min_len >= 3:
             fts_results = _fts_search(keywords, tag_ids, type_filter, fetch_limit)
+            methods_used.append("fts5")
 
         # ベクトル検索
         vec_results = _vector_search(keywords, tag_ids, type_filter, fetch_limit)
+        if vec_results is not None:
+            methods_used.append("vector")
 
         # 2文字キーワード + ベクトル検索無効 → エラー
         if min_len < 3 and vec_results is None:
@@ -498,7 +504,11 @@ def search(
 
         _attach_snippets(results)
 
-        return {"results": results, "total_count": len(results)}
+        return {
+            "results": results,
+            "total_count": len(results),
+            "search_methods_used": methods_used,
+        }
 
     except Exception as e:
         return {

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -48,12 +48,14 @@ def test_search_basic(temp_db):
 
 
 def test_search_response_format(temp_db):
-    """レスポンス形式: results配列とtotal_count"""
+    """レスポンス形式: results配列とtotal_countとsearch_methods_used"""
     add_topic(title="レスポンス形式検索テスト", description="テスト用", tags=DEFAULT_TAGS)
     result = search_service.search(keyword="レスポンス形式検索テスト")
     assert "error" not in result
     assert "results" in result
     assert "total_count" in result
+    assert "search_methods_used" in result
+    assert isinstance(result["search_methods_used"], list)
     assert isinstance(result["results"], list)
     if result["results"]:
         item = result["results"][0]
@@ -613,3 +615,25 @@ def test_get_by_ids_missing_fields(temp_db):
     for r in result["results"]:
         assert "error" in r
         assert r["error"]["code"] == "VALIDATION_ERROR"
+
+
+# ========================================
+# search_methods_used テスト
+# ========================================
+
+
+def test_search_methods_used_fts_only(temp_db):
+    """embedding無効時: FTS5のみが使われる（3文字以上キーワード）"""
+    add_topic(title="メソッド確認用トピック検索テスト", description="テスト", tags=DEFAULT_TAGS)
+    result = search_service.search(keyword="メソッド確認用トピック検索テスト")
+    assert "error" not in result
+    assert "search_methods_used" in result
+    assert result["search_methods_used"] == ["fts5"]
+
+
+def test_search_methods_used_empty_results(temp_db):
+    """結果0件でもsearch_methods_usedは返る"""
+    result = search_service.search(keyword="絶対に存在しないキーワード999999")
+    assert "error" not in result
+    assert "search_methods_used" in result
+    assert result["search_methods_used"] == ["fts5"]

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -574,3 +574,53 @@ def test_search_recency_boost_applied(temp_db, mock_embedding_model):
     idx_new = ids_in_order.index(t_new["topic_id"])
     idx_old = ids_in_order.index(t_old["topic_id"])
     assert idx_new < idx_old, "新しいトピックが古いトピックより上位に来るべき"
+
+
+# ========================================
+# search_methods_used テスト
+# ========================================
+
+
+def test_search_methods_used_hybrid(temp_db, mock_embedding_model):
+    """3文字以上 + ベクトル有効: fts5とvectorの両方が使われる"""
+    add_topic(
+        title="ハイブリッドメソッド確認テスト用",
+        description="FTS5とベクトルの両方が使われることを確認",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="ハイブリッドメソッド確認テスト")
+
+    assert "error" not in result
+    assert "search_methods_used" in result
+    assert result["search_methods_used"] == ["fts5", "vector"]
+
+
+def test_search_methods_used_vector_only(temp_db, mock_embedding_model):
+    """2文字キーワード + ベクトル有効: vectorのみが使われる"""
+    add_topic(
+        title="設計ドキュメント",
+        description="アーキテクチャ設計の詳細",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="設計")
+
+    assert "error" not in result
+    assert "search_methods_used" in result
+    assert result["search_methods_used"] == ["vector"]
+
+
+def test_search_methods_used_fts_only_vec_disabled(temp_db, disable_embedding):
+    """3文字以上 + ベクトル無効: fts5のみが使われる"""
+    add_topic(
+        title="認証フローメソッド確認テスト",
+        description="FTSのみで検索される",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="認証フローメソッド確認テスト")
+
+    assert "error" not in result
+    assert "search_methods_used" in result
+    assert result["search_methods_used"] == ["fts5"]


### PR DESCRIPTION
## Summary
- searchレスポンスに `search_methods_used` フィールド（`list[str]`）を追加。実際に使用された検索手法（`"fts5"`, `"vector"`）を返す
- 2文字キーワードでFTS5がスキップされた場合や、embedding_server未起動でベクトル検索が不可の場合に、どの手法が使われたかを透明にする
- 既存の検索ロジックは変更なし。追跡フィールドの追加のみ

## Test plan
- [x] FTS5のみ（embedding無効、3文字以上キーワード）→ `["fts5"]`
- [x] ベクトルのみ（2文字キーワード、embedding有効）→ `["vector"]`
- [x] ハイブリッド（3文字以上、embedding有効）→ `["fts5", "vector"]`
- [x] FTSのみ（3文字以上、embedding無効）→ `["fts5"]`
- [x] 結果0件でも `search_methods_used` が返ること
- [x] レスポンス形式テストに `search_methods_used` のアサーション追加
- [x] 全488テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)