### PR TITLE
fix: remind_activity hookのmatcher文字列を修正

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -39,7 +39,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__cc-memory__add_decision",
+        "matcher": "mcp__plugin_claude-code-memory_cc-memory__add_decision",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- `hooks/hooks.json` の `PostToolUse` で定義されている `remind_activity_on_decision` hookのmatcher文字列が、実際のMCPツール名と一致していなかったため発火していなかった
- `mcp__cc-memory__add_decision` → `mcp__plugin_claude-code-memory_cc-memory__add_decision` に修正

## Test plan
- [ ] `add_decision` 呼び出し後に `remind_activity_on_decision.sh` が発火することを確認