### PR TITLE
fix: stop hookのメタタグ初手猶予とcheck-in猶予拡大

### DIFF
--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -4,11 +4,11 @@
 1. stdin読み込み → JSON parse
 2. ブロック上限チェック（2回で強制approve）
 3. メタタグparse（一次ソース: stdinのlast_assistant_message、フォールバック: transcript）
-   → なければblock
+   → 1ターン目（approved_turns == 0）は猶予。2ターン目以降はなければblock
 4. get系API呼び出しチェック（セッション中1回以上）
    → なければblock
-5. activity check-inチェック（2ターン目、one-shot block）
-   → 2ターン目 + check-in/add_activity未呼出 → block
+5. activity check-inチェック（_CHECKIN_DEFER_TURNSターン後、one-shot block）
+   → check-in/add_activity未呼出 → block
 6. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
 7. nudgeカウンター管理
 8. 状態更新 → approve
@@ -36,6 +36,7 @@ from hooks.hook_transcript import (
 
 _BLOCK_LIMIT = 2
 _NUDGE_INTERVAL = 2
+_CHECKIN_DEFER_TURNS = 2
 
 
 def _output(decision: str, reason: str = "") -> None:
@@ -82,6 +83,13 @@ def main() -> None:
                 meta = parse_meta_tag(text)
 
         if meta is None:
+            # 1ターン目（approved_turns == 0）はメタタグなしでも猶予
+            if state.get_approved_turns() == 0:
+                # メタタグなしでもapproveして次に進む（ステップ4以降はスキップ）
+                state.reset_block_count()
+                state.increment_approved_turns()
+                _output("approve", "1ターン目のためメタタグチェックを猶予します。")
+                return
             state.increment_block_count()
             _output(
                 "block",
@@ -112,7 +120,7 @@ def main() -> None:
         if not state.has_activity_checkin():
             if has_activity_checkin_calls(all_entries):
                 state.set_activity_checkin()
-            elif state.get_approved_turns() >= 1:
+            elif state.get_approved_turns() >= _CHECKIN_DEFER_TURNS:
                 state.set_activity_checkin()  # one-shot: 次回はスキップ
                 state.increment_block_count()
                 _output(

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -115,9 +115,15 @@ def env_setup(tmp_path):
 
 
 class TestNoMetaTag:
-    """1. メタタグなし → block"""
+    """1. メタタグなし → block（2ターン目以降）/ approve（1ターン目猶予）"""
 
-    def test_no_meta_tag_blocks(self, env_setup):
+    def test_no_meta_tag_blocks_after_first_turn(self, env_setup):
+        """2ターン目以降（approved_turns>=1）でメタタグなし → block"""
+        state_dir = Path(env_setup["state_dir"])
+        # approved_turns を 1 にセット（2ターン目）
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("1")
+
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -132,6 +138,46 @@ class TestNoMetaTag:
         )
         assert result["decision"] == "block"
         assert "メタタグ" in result["reason"]
+
+    def test_no_meta_tag_approves_on_first_turn(self, env_setup):
+        """1ターン目（approved_turns=0）でメタタグなし → approve（猶予）"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                _make_assistant_entry(text="response without meta tag"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"]
+        )
+        assert result["decision"] == "approve"
+        assert "猶予" in result["reason"]
+
+    def test_first_turn_grace_increments_approved_turns(self, env_setup):
+        """1ターン目猶予でapproveされた後、approved_turnsが1にインクリメントされる"""
+        state_dir = Path(env_setup["state_dir"])
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                _make_assistant_entry(text="response without meta tag"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"]
+        )
+        assert result["decision"] == "approve"
+
+        # approved_turns が 1 にインクリメントされている
+        turns_file = state_dir / "approved_turns_test-session"
+        assert turns_file.exists()
+        assert turns_file.read_text().strip() == "1"
 
 
 class TestMetaTagApproves:
@@ -521,8 +567,8 @@ class TestLastAssistantMessage:
 class TestActivityCheckinBlock:
     """activity check-in チェック"""
 
-    def test_no_checkin_after_3_turns_blocks(self, env_setup):
-        """3ターン目でcheck-in未呼出 → block"""
+    def test_no_checkin_after_defer_turns_blocks(self, env_setup):
+        """猶予期間後（approved_turns=2）でcheck-in未呼出 → block"""
         state_dir = Path(env_setup["state_dir"])
         # approved_turns を 2 にセット（3ターン目）
         turns_file = state_dir / "approved_turns_test-session"
@@ -608,14 +654,33 @@ class TestActivityCheckinBlock:
         )
         assert result["decision"] == "approve"
 
-    def test_before_2_turns_no_block(self, env_setup):
-        """1ターン目ではblockしない（approved_turns=0）"""
+    def test_before_defer_turns_no_block(self, env_setup):
+        """猶予期間中（approved_turns=0）ではblockしない"""
         state_dir = Path(env_setup["state_dir"])
         turns_file = state_dir / "approved_turns_test-session"
         turns_file.write_text("0")
         context_file = state_dir / "context_retrieved_test-session"
         context_file.write_text("1")
-        # check-in未呼出だが、まだ2ターン目未満
+        # check-in未呼出だが、まだ猶予期間中
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_checkin_grace_at_turn_1(self, env_setup):
+        """猶予期間中（approved_turns=1）でもblockしない"""
+        state_dir = Path(env_setup["state_dir"])
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("1")
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+        # check-in未呼出だが、まだ猶予期間中（< _CHECKIN_DEFER_TURNS=2）
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript([
             _make_user_entry("hi"),


### PR DESCRIPTION
## Summary
- **Meta tag grace period**: Skip meta tag enforcement on the first turn (approved_turns == 0). From the second turn onward, meta tags are required as before.
- **Check-in grace period expansion**: Extend the check-in enforcement deferral from 2 turns to 3 turns by introducing `_CHECKIN_DEFER_TURNS = 2` constant (block triggers at `approved_turns >= 2` instead of `>= 1`).

## Test plan
- [x] Meta tag: first turn (approved_turns=0) without meta tag approves with grace message
- [x] Meta tag: second turn (approved_turns=1) without meta tag blocks as expected
- [x] Meta tag: first turn grace increments approved_turns correctly
- [x] Check-in: approved_turns=1 does not block (within grace period)
- [x] Check-in: approved_turns=2 blocks as expected (grace period expired)
- [x] All 30 existing E2E tests pass