### PR TITLE
feat: ダイスロール用MCPツール(roll_dice)を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 """MCPサーバーのメインエントリーポイント"""
 import logging
+import random
 from fastmcp import FastMCP
 from typing import Literal, Optional
 from src.services import (
@@ -770,6 +771,12 @@ def add_knowledge(
         保存結果（file_path, title, category, tags）
     """
     return knowledge_service.add_knowledge(title, content, tags, category)
+
+
+@mcp.tool()
+def roll_dice(sides: int = 10) -> dict:
+    """指定面数のダイスを振る。デフォルト1d10。"""
+    return {"result": random.randint(1, sides)}
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_roll_dice.py
+++ b/tests/unit/test_roll_dice.py
@@ -1,0 +1,27 @@
+"""roll_dice MCPツールのユニットテスト"""
+from src.main import roll_dice
+
+
+# @mcp.tool()デコレータがFunctionToolオブジェクトを返すため、.fnで元の関数を取得
+_roll = roll_dice.fn
+
+
+class TestRollDice:
+    """roll_diceの基本動作テスト"""
+
+    def test_default_sides_range(self):
+        """デフォルト（10面）で1〜10の範囲の値が返ること"""
+        for _ in range(100):
+            result = _roll()
+            assert 1 <= result["result"] <= 10
+
+    def test_six_sided_range(self):
+        """sides=6で1〜6の範囲の値が返ること"""
+        for _ in range(100):
+            result = _roll(sides=6)
+            assert 1 <= result["result"] <= 6
+
+    def test_one_sided(self):
+        """sides=1で1が返ること"""
+        result = _roll(sides=1)
+        assert result["result"] == 1


### PR DESCRIPTION
## Summary
- 指定面数のダイスを振る `roll_dice` MCPツールを追加
- パラメータ `sides`（デフォルト10）で面数を指定、`{"result": N}` を返す
- sync-memoryのふりかえり演出で使用していたbashダイスロール（`$((RANDOM % 10 + 1))`）のMCPツール版

## Test plan
- [x] デフォルト（10面）で1〜10の範囲の値が返ること
- [x] sides=6で1〜6の範囲の値が返ること
- [x] sides=1で1が返ること