### PR TITLE
feat: add_logのtitleを省略可能にし、contentから自動生成

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -386,12 +386,13 @@ def add_topic(
 @mcp.tool()
 def add_log(
     topic_id: int,
-    title: str,
-    content: str,
+    title: Optional[str] = None,
+    content: str = "",
     tags: Optional[list[str]] = None,
 ) -> dict:
     """トピックに議論ログを追加する。
 
+    title: ログのタイトル。省略するとcontentの先頭行から自動生成される。
     tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
     """
     result = discussion_log_service.add_log(topic_id, title, content, tags)

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -14,8 +14,8 @@ from src.services.tag_service import (
 
 def add_log(
     topic_id: int,
-    title: str,
-    content: str,
+    title: Optional[str] = None,
+    content: str = "",
     tags: Optional[list[str]] = None,
 ) -> dict:
     """
@@ -23,7 +23,7 @@ def add_log(
 
     Args:
         topic_id: 対象トピックのID
-        title: ログのタイトル（必須、空文字不可）
+        title: ログのタイトル。省略時はcontentの先頭行から自動生成される
         content: 議論内容（マークダウン可）
         tags: 追加タグ（optional）。省略時はtopicのタグを継承
 
@@ -31,12 +31,16 @@ def add_log(
         作成されたログ情報
     """
     if not title or not title.strip():
-        return {
-            "error": {
-                "code": "VALIDATION_ERROR",
-                "message": "title must not be empty"
+        # titleが未指定・空の場合、contentから自動生成を試みる
+        first_line = content.strip().split('\n', 1)[0].strip()
+        title = first_line[:50] if len(first_line) > 50 else first_line
+        if not title:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": "title and content cannot both be empty"
+                }
             }
-        }
 
     # タグのバリデーション（tagsが指定された場合のみ）
     parsed_tags = None

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -376,8 +376,8 @@ def test_search_log_title_fallback(temp_db):
     assert item["data"]["title"] == "フォールバックテスト"
 
 
-def test_add_log_empty_title_error(temp_db):
-    """バリデーション: title空文字でadd_logするとバリデーションエラー"""
+def test_add_log_empty_title_auto_generates_from_content(temp_db):
+    """title空文字でcontentありの場合、contentの先頭行からtitleを自動生成する"""
     topic = add_topic(
         title="バリデーションテスト用トピック",
         description="テスト用",
@@ -387,12 +387,11 @@ def test_add_log_empty_title_error(temp_db):
     result = add_log_entry(
         topic_id=topic["topic_id"],
         title="",
-        content="内容があってもtitleが空ならエラー",
+        content="内容があればtitleが自動生成される",
     )
 
-    assert "error" in result
-    assert result["error"]["code"] == "VALIDATION_ERROR"
-    assert "title must not be empty" in result["error"]["message"]
+    assert "error" not in result
+    assert result["title"] == "内容があればtitleが自動生成される"
 
 
 # ========================================

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -207,6 +207,92 @@ def test_add_log_invalid_topic(temp_db):
     assert result["error"]["code"] == "CONSTRAINT_VIOLATION"
 
 
+def test_add_log_title_none_auto_generates(temp_db):
+    """title=Noneでcontentの先頭行からtitleが自動生成される"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        title=None,
+        content="自動生成されるタイトル\nこれは本文の2行目です",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "自動生成されるタイトル"
+    assert result["log_id"] > 0
+
+
+def test_add_log_title_empty_auto_generates(temp_db):
+    """title=""でcontentの先頭行からtitleが自動生成される"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        title="",
+        content="空文字titleの自動生成テスト",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "空文字titleの自動生成テスト"
+
+
+def test_add_log_title_auto_truncate_at_50(temp_db):
+    """contentの最初の行が50文字を超える場合に50文字で切り詰められる"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    long_first_line = "あ" * 60  # 60文字
+    result = add_log(
+        topic_id=topic["topic_id"],
+        content=long_first_line + "\n2行目",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "あ" * 50
+    assert len(result["title"]) == 50
+
+
+def test_add_log_title_auto_uses_first_line_only(temp_db):
+    """contentが改行を含む場合に最初の行だけがtitleになる"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        content="1行目のタイトル\n2行目の内容\n3行目の内容",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "1行目のタイトル"
+
+
+def test_add_log_title_none_content_empty_error(temp_db):
+    """title=Noneかつcontent=""の場合にエラーが返る"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        title=None,
+        content="",
+    )
+
+    assert "error" in result
+    assert result["error"]["code"] == "VALIDATION_ERROR"
+    assert "title and content cannot both be empty" in result["error"]["message"]
+
+
+def test_add_log_explicit_title_unchanged(temp_db):
+    """title指定時は従来通り動作する（自動生成されない）"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        title="明示的なタイトル",
+        content="contentの先頭行とは異なる",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "明示的なタイトル"
+
+
 def test_add_decision_success(temp_db):
     """決定事項の追加が成功する"""
     # トピックを作成


### PR DESCRIPTION
## Summary

- `add_log` の `title` パラメータを必須から省略可能（`Optional[str] = None`）に変更
- title未指定時はcontentの先頭行（最大50文字）からtitleを自動生成する
- titleもcontentも空の場合はバリデーションエラーを返す

## Test plan

- [x] title=None でcontentから自動生成されること
- [x] title="" でcontentから自動生成されること
- [x] contentの最初の行が50文字を超える場合に切り詰められること
- [x] contentが改行を含む場合に最初の行だけがtitleになること
- [x] title=None かつ content="" の場合にエラーが返ること
- [x] title指定時は従来通り動作すること
- [x] 全491テストPASS、リグレッションなし