### PR TITLE
feat: add_activityにcheck_in統合とtopic_id復活

### DIFF
--- a/migrations/0016_add_activity_topic_id.sql
+++ b/migrations/0016_add_activity_topic_id.sql
@@ -1,0 +1,3 @@
+-- depends: 0015_tag_canonical
+ALTER TABLE activities ADD COLUMN topic_id INTEGER REFERENCES discussion_topics(id) ON DELETE SET NULL;
+CREATE INDEX idx_activities_topic_id ON activities(topic_id);

--- a/src/main.py
+++ b/src/main.py
@@ -264,6 +264,7 @@ decisions・logs（議論の詳細な経緯はlogsに入っていることが多
 アクティブコンテキストのアクティビティ一覧やユーザーの発言から、
 どのアクティビティに取り組もうとしているか判断できるはずです。
 ぴったりなアクティビティがなければそこで`add_activity`をしてください。
+`add_activity`はデフォルトでcheck-inも同時に実行します（check_in=True）。topic_idを指定するとrecent_decisionsも取得できます。
 check-inするとtag_notes・資材・関連decisionsが一括で返り、statusも自動更新されます。
 返ってきたsummaryフィールドはそのまま出力してください。
 
@@ -570,24 +571,32 @@ def add_activity(
     title: str,
     description: str,
     tags: list[str],
+    topic_id: Optional[int] = None,
+    check_in: bool = True,
 ) -> dict:
     """
-    新しいアクティビティを追加する。
+    新しいアクティビティを追加する。check_in=True（デフォルト）で自動的にcheck-inも実行する。
 
     典型的な使い方:
-    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search", "ranking"])
+    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search", "ranking"], topic_id=123)
 
     Args:
         title: アクティビティのタイトル
         description: アクティビティの詳細説明（必須）
         tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
+        topic_id: 紐づけるトピックID（optional）。指定するとcheck-in時にそのトピックのrecent_decisionsが返る
+        check_in: True（デフォルト）で作成直後にcheck-inを実行し、tag_notes・materials・recent_decisionsを一括取得する。Falseで従来動作（status=pending、check_in_resultなし）
 
     Returns:
-        作成されたアクティビティ情報
+        作成されたアクティビティ情報。check_in=Trueの場合はcheck_in_resultフィールドにcheck-in結果がネストされる
     """
-    result = activity_service.add_activity(title, description, tags)
+    result = activity_service.add_activity(title, description, tags, topic_id)
     if "error" not in result:
         _maybe_inject_tag_notes(result, tags)
+        if check_in:
+            checkin_result = _check_in(result["activity_id"])
+            if "error" not in checkin_result:
+                result["check_in_result"] = checkin_result
     return result
 
 

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -37,7 +37,7 @@ def _activity_to_response(activity: dict, tags: list[str]) -> dict:
     }
 
 
-def add_activity(title: str, description: str, tags: list[str]) -> dict:
+def add_activity(title: str, description: str, tags: list[str], topic_id: int | None = None) -> dict:
     """
     アクティビティを作成してIDを返す
 
@@ -45,6 +45,7 @@ def add_activity(title: str, description: str, tags: list[str]) -> dict:
         title: アクティビティのタイトル
         description: アクティビティの説明
         tags: タグ配列（必須、1個以上）
+        topic_id: 紐づけるトピックID（optional）
 
     Returns:
         作成されたアクティビティ情報
@@ -58,8 +59,8 @@ def add_activity(title: str, description: str, tags: list[str]) -> dict:
     try:
         # アクティビティをINSERT
         cursor = conn.execute(
-            "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
-            (title, description, 'pending'),
+            "INSERT INTO activities (title, description, status, topic_id) VALUES (?, ?, ?, ?)",
+            (title, description, 'pending', topic_id),
         )
         activity_id = cursor.lastrowid
 

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -1,6 +1,5 @@
 """check-inサービス"""
 import logging
-import sqlite3
 
 from src.db import get_connection, row_to_dict
 from src.services import activity_service, decision_service
@@ -16,19 +15,15 @@ logger = logging.getLogger(__name__)
 def _get_topic_id(conn, activity_id: int) -> int | None:
     """activitiesテーブルからtopic_idを取得する。
 
-    topic_idカラムが存在しない場合やNULLの場合はNoneを返す。
+    NULLの場合はNoneを返す。
     """
-    try:
-        row = conn.execute(
-            "SELECT topic_id FROM activities WHERE id = ?",
-            (activity_id,),
-        ).fetchone()
-        if row is None:
-            return None
-        return row["topic_id"]
-    except sqlite3.OperationalError:
-        # topic_idカラムが存在しない場合（migration 0010で削除済み）
+    row = conn.execute(
+        "SELECT topic_id FROM activities WHERE id = ?",
+        (activity_id,),
+    ).fetchone()
+    if row is None:
         return None
+    return row["topic_id"]
 
 
 def _get_topic_info(conn, topic_id: int) -> dict | None:

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database, execute_query, get_connection
 from src.services.activity_service import add_activity, get_activities, update_activity
+from src.services.topic_service import add_topic
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -72,6 +73,53 @@ class TestAddActivity:
 
         assert "error" not in result
         assert sorted(result["tags"]) == ["domain:cc-memory", "hooks"]
+
+    def test_add_activity_with_topic_id(self, temp_db):
+        """topic_id付きでアクティビティが作成できる"""
+        topic = add_topic(
+            title="Test Topic",
+            description="Topic for testing",
+            tags=DEFAULT_TAGS,
+        )
+        topic_id = topic["topic_id"]
+
+        result = add_activity(
+            title="Activity with topic",
+            description="Linked to a topic",
+            tags=DEFAULT_TAGS,
+            topic_id=topic_id,
+        )
+
+        assert "error" not in result
+        assert result["activity_id"] > 0
+
+        # DBに正しくtopic_idが保存されている
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT topic_id FROM activities WHERE id = ?",
+            (result["activity_id"],),
+        ).fetchone()
+        conn.close()
+        assert row["topic_id"] == topic_id
+
+    def test_add_activity_without_topic_id(self, temp_db):
+        """topic_id未指定でNULLとして作成される"""
+        result = add_activity(
+            title="Activity without topic",
+            description="No topic link",
+            tags=DEFAULT_TAGS,
+        )
+
+        assert "error" not in result
+
+        # DBにtopic_id=NULLで保存されている
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT topic_id FROM activities WHERE id = ?",
+            (result["activity_id"],),
+        ).fetchone()
+        conn.close()
+        assert row["topic_id"] is None
 
 
 class TestGetActivities:

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -4,7 +4,9 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
+from src.services.decision_service import add_decision
 from src.services.material_service import add_material
+from src.services.topic_service import add_topic
 from src.services.checkin_service import check_in
 from src.services.tag_service import _injected_tags
 
@@ -106,7 +108,7 @@ class TestCheckIn:
         result = check_in(activity_id)
 
         assert "error" not in result
-        # activitiesテーブルにtopic_idカラムがないため、topicは省略される
+        # topic_idがNULLなので、topicは省略される
         assert "topic" not in result
 
     def test_check_in_materials_empty(self, activity_id):
@@ -303,3 +305,66 @@ class TestCheckInTagNotes:
         assert "error" not in result2
         domain_notes2 = [n for n in result2["tag_notes"] if n["tag"] == "domain:once"]
         assert len(domain_notes2) == 0
+
+
+class TestCheckInWithTopicId:
+    """topic_id付きアクティビティのcheck-inテスト"""
+
+    def test_check_in_with_topic_returns_topic_info(self, temp_db):
+        """topic_id付きアクティビティのcheck-inでtopicフィールドが返る"""
+        topic = add_topic(
+            title="Design Topic",
+            description="Topic for design discussion",
+            tags=["domain:test"],
+        )
+        topic_id = topic["topic_id"]
+
+        activity = add_activity(
+            title="Activity with topic",
+            description="Linked to topic",
+            tags=["domain:test"],
+            topic_id=topic_id,
+        )
+
+        result = check_in(activity["activity_id"])
+
+        assert "error" not in result
+        assert "topic" in result
+        assert result["topic"]["id"] == topic_id
+        assert result["topic"]["title"] == "Design Topic"
+
+    def test_check_in_with_topic_returns_recent_decisions(self, temp_db):
+        """topic_id付きアクティビティのcheck-inでrecent_decisionsが取得できる"""
+        topic = add_topic(
+            title="Decision Topic",
+            description="Topic with decisions",
+            tags=["domain:test"],
+        )
+        topic_id = topic["topic_id"]
+
+        # トピックに決定事項を追加
+        add_decision(
+            decision="Use JSON format",
+            reason="For compatibility",
+            topic_id=topic_id,
+        )
+        add_decision(
+            decision="Add validation",
+            reason="For safety",
+            topic_id=topic_id,
+        )
+
+        activity = add_activity(
+            title="Activity with decisions",
+            description="Linked to topic with decisions",
+            tags=["domain:test"],
+            topic_id=topic_id,
+        )
+
+        result = check_in(activity["activity_id"])
+
+        assert "error" not in result
+        assert len(result["recent_decisions"]) == 2
+        decision_titles = {d["title"] for d in result["recent_decisions"]}
+        assert "Use JSON format" in decision_titles
+        assert "Add validation" in decision_titles


### PR DESCRIPTION
## Summary
- `add_activity` に `check_in` パラメータ（bool、デフォルトTrue）を追加。作成直後にcheck-inも同時実行し、tag_notes・materials・recent_decisionsを一括取得
- `add_activity` に `topic_id` パラメータ（optional）を追加。activitiesテーブルにtopic_idカラムを復活させ、check-in時のrecent_decisions取得経路を復旧
- `checkin_service._get_topic_id()` の死んだコード（OperationalErrorキャッチ）をクリーンアップ

## Test plan
- [ ] `add_activity(topic_id=N)` でactivities.topic_idが正しく保存される
- [ ] `add_activity(check_in=True)` でcheck_in_resultがネストされて返る
- [ ] `add_activity(check_in=False)` で従来通りの返り値（check_in_resultなし、status=pending）
- [ ] topic_id付きアクティビティのcheck_inでrecent_decisionsが取得できる
- [ ] 既存テスト489件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)