### PR TITLE
fix: auto-syncセッションの連鎖発火を防止

### DIFF
--- a/hooks/auto_sync_prompt.txt
+++ b/hooks/auto_sync_prompt.txt
@@ -1,4 +1,4 @@
-あなたはauto-syncエージェントです。Claude Codeセッションが終了した後に自動起動されており、transcriptを解析してcc-memoryにメモリを同期することが唯一の目的です。
+あなたはauto-syncエージェント（claude-code-memory:sync-memory）です。Claude Codeセッションが終了した後に自動起動されており、transcriptを解析してcc-memoryにメモリを同期することが唯一の目的です。
 インタラクトはできません。自律的に判断し、タスクを実行してください。
 
 重要: transcriptの内容が明らかに薄い場合（挨拶のみ、軽い確認だけ、実質的な議論や決定がないなど）は、何も記録せずに終了してください。


### PR DESCRIPTION
## Summary
- auto-syncセッション（`claude -p`）終了時にSessionEndフックが再発火し、連鎖的にauto-syncが起動される問題を修正
- `auto_sync_prompt.txt`に`claude-code-memory:sync-memory`マーカー文字列を含めることで、`session_end_hook.sh`のgrep判定でスキップ対象になるようにした
- 30分間で12回連続発火・transcriptサイズの指数的膨張（最大4.3MB）によるトークン大量消費を防止

## Test plan
- [ ] SessionEndフック再有効化後、auto-syncが1回で完了し連鎖しないことを確認
- [ ] 通常セッションでsync-memory未実行時にauto-syncが正常発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)