### PR TITLE
feat: スキル実行時にstop_hookを3ターンスキップ

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -1,7 +1,7 @@
 """hook共通: 状態ファイル管理クラス HookState
 
 hookが利用する状態ファイル（prev_topic, block_count, nudge_counter, nudge_pending,
-context_retrieved, approved_turns, activity_checkin）の読み書きを一元管理する。
+context_retrieved, approved_turns, activity_checkin, skill_skip）の読み書きを一元管理する。
 標準ライブラリのみに依存。
 """
 from pathlib import Path
@@ -118,6 +118,19 @@ class HookState:
     def set_activity_checkin(self) -> None:
         """activity check-in済みフラグを設定。以後のcheck-inチェックをスキップする。"""
         self._write(self._path("activity_checkin"), "1")
+
+    # --- skill_skip_remaining ---
+
+    def get_skill_skip_remaining(self) -> int:
+        """スキル実行中のスキップ残りターン数を取得。"""
+        return self._read_int(self._path("skill_skip"), 0)
+
+    def set_skill_skip_remaining(self, n: int) -> None:
+        """スキル実行中のスキップ残りターン数を設定。0以下の場合はファイル削除。"""
+        if n <= 0:
+            self._delete(self._path("skill_skip"))
+        else:
+            self._write(self._path("skill_skip"), str(n))
 
     # --- context_retrieved ---
 

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -166,3 +166,50 @@ _CONTEXT_RETRIEVAL_TOOLS = [
 def has_context_retrieval_calls(entries: list[dict]) -> bool:
     """entriesにget系APIの呼び出しがあるかチェック。"""
     return _has_tool_calls(entries, _CONTEXT_RETRIEVAL_TOOLS)
+
+
+def _extract_user_content_text(entry: dict) -> str:
+    """userエントリからcontent文字列を取得する。"""
+    content = entry.get("message", {}).get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "") if isinstance(b, dict) else str(b)
+            for b in content
+        )
+    return ""
+
+
+def get_transcript_info(transcript_path: str) -> tuple[list[dict], bool]:
+    """transcript全行を1パスで読み、(assistant_entries, has_skill_command)を返す。
+
+    has_skill_commandは直近のuserエントリに<command-name>が含まれるかを示す。
+    """
+    path = Path(transcript_path).expanduser()
+    if not path.exists():
+        return [], False
+
+    entries: list[dict] = []
+    last_user_has_command = False
+
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    entry_type = entry.get("type", "")
+                    if entry_type == "assistant":
+                        entries.append(entry)
+                    elif entry_type in ("user", "human"):
+                        text = _extract_user_content_text(entry)
+                        last_user_has_command = "<command-name>" in text
+                except json.JSONDecodeError:
+                    continue
+    except Exception:
+        return [], False
+
+    return entries, last_user_has_command

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -42,34 +42,6 @@ def _has_text_block(entry: dict) -> bool:
     )
 
 
-def get_assistant_entries(transcript_path: str, last_n: int | None = None) -> list[dict]:
-    """transcriptからassistantエントリを取得する。
-    last_nが指定されていれば直近N件のみ返す。"""
-    path = Path(transcript_path).expanduser()
-    if not path.exists():
-        return []
-
-    entries = []
-    try:
-        with open(path) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                    if entry.get("type") == "assistant":
-                        entries.append(entry)
-                except json.JSONDecodeError:
-                    continue
-    except Exception:
-        return []
-
-    if last_n is not None and entries:
-        return entries[-last_n:]
-    return entries
-
-
 def extract_text_from_entry(entry: dict) -> str:
     """エントリからテキスト内容を抽出する。"""
     message = entry.get("message", {})

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -3,15 +3,16 @@
 処理フロー:
 1. stdin読み込み → JSON parse
 2. ブロック上限チェック（2回で強制approve）
-3. メタタグparse（一次ソース: stdinのlast_assistant_message、フォールバック: transcript）
+3. スキルスキップ判定（<command-name>検出 or 残りターン → 即approve）
+4. メタタグparse（一次ソース: stdinのlast_assistant_message、フォールバック: transcript）
    → 1ターン目（approved_turns == 0）は猶予。2ターン目以降はなければblock
-4. get系API呼び出しチェック（セッション中1回以上）
+5. get系API呼び出しチェック（セッション中1回以上）
    → なければblock
-5. activity check-inチェック（_CHECKIN_DEFER_TURNSターン後、one-shot block）
+6. activity check-inチェック（_CHECKIN_DEFER_TURNSターン後、one-shot block）
    → check-in/add_activity未呼出 → block
-6. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
-7. nudgeカウンター管理
-8. 状態更新 → approve
+7. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
+8. nudgeカウンター管理
+9. 状態更新 → approve
 """
 import json
 import os
@@ -26,8 +27,8 @@ if str(_project_root) not in sys.path:
 from hooks.hook_state import HookState
 from hooks.hook_transcript import (
     extract_text_from_entry,
-    get_assistant_entries,
     get_last_assistant_entry,
+    get_transcript_info,
     has_activity_checkin_calls,
     has_context_retrieval_calls,
     has_recent_recording,
@@ -37,6 +38,7 @@ from hooks.hook_transcript import (
 _BLOCK_LIMIT = 2
 _NUDGE_INTERVAL = 2
 _CHECKIN_DEFER_TURNS = 2
+_SKILL_SKIP_TURNS = 3
 
 
 def _output(decision: str, reason: str = "") -> None:
@@ -70,7 +72,24 @@ def main() -> None:
             _output("approve", "ブロック上限（2回）に達しました。強制的に通します。")
             return
 
-        # 3. メタタグparse
+        # 3. スキルスキップ判定
+        skill_skip = state.get_skill_skip_remaining()
+        if skill_skip > 0:
+            state.set_skill_skip_remaining(skill_skip - 1)
+            state.reset_block_count()
+            state.increment_approved_turns()
+            _output("approve", f"スキル実行中（残り{skill_skip - 1}ターン）")
+            return
+
+        all_entries, has_skill_cmd = get_transcript_info(transcript_path)
+        if has_skill_cmd:
+            state.set_skill_skip_remaining(_SKILL_SKIP_TURNS - 1)
+            state.reset_block_count()
+            state.increment_approved_turns()
+            _output("approve", "スキル実行を検出。チェックをスキップします。")
+            return
+
+        # 4. メタタグparse
         # 一次ソース: stdinのlast_assistant_message
         last_msg = data.get("last_assistant_message", "")
         meta = parse_meta_tag(last_msg) if last_msg else None
@@ -85,7 +104,7 @@ def main() -> None:
         if meta is None:
             # 1ターン目（approved_turns == 0）はメタタグなしでも猶予
             if state.get_approved_turns() == 0:
-                # メタタグなしでもapproveして次に進む（ステップ4以降はスキップ）
+                # メタタグなしでもapproveして次に進む（ステップ5以降はスキップ）
                 state.reset_block_count()
                 state.increment_approved_turns()
                 _output("approve", "1ターン目のためメタタグチェックを猶予します。")
@@ -100,8 +119,7 @@ def main() -> None:
 
         current_topic_name = meta["topic_name"]
 
-        # 4. get系API呼び出しチェック（セッション中1回以上）
-        all_entries = get_assistant_entries(transcript_path)
+        # 5. get系API呼び出しチェック（セッション中1回以上）
 
         if not state.has_context_retrieval():
             if has_context_retrieval_calls(all_entries):
@@ -116,7 +134,7 @@ def main() -> None:
                 )
                 return
 
-        # 5. Activity check-in チェック（2ターン目）
+        # 6. Activity check-in チェック（2ターン目）
         if not state.has_activity_checkin():
             if has_activity_checkin_calls(all_entries):
                 state.set_activity_checkin()
@@ -130,7 +148,7 @@ def main() -> None:
                 )
                 return
 
-        # 6. トピック変更チェック → 記録がなければblock
+        # 7. トピック変更チェック → 記録がなければblock
         prev_topic = state.get_prev_topic()
         if prev_topic is not None and prev_topic != current_topic_name:
             recent_entries = all_entries[-5:] if all_entries else []
@@ -143,7 +161,7 @@ def main() -> None:
                 )
                 return
 
-        # 7. nudgeカウンター
+        # 8. nudgeカウンター
         nudge_count = state.increment_nudge_counter()
 
         if nudge_count % _NUDGE_INTERVAL == 0:
@@ -153,7 +171,7 @@ def main() -> None:
             else:
                 state.set_nudge_pending()
 
-        # 8. 状態更新 + approve
+        # 9. 状態更新 + approve
         state.set_prev_topic(current_topic_name)
         state.reset_block_count()
         state.increment_approved_turns()

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -837,3 +837,133 @@ class TestContextRetrievalCheck:
         )
         # フラグがあるのでblockされない
         assert result["decision"] == "approve"
+
+
+def _make_skill_user_entry(skill_name: str = "sync-memory") -> dict:
+    """スキル発動時のuserエントリ（実際のtranscript形式）"""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": (
+                f"<command-message>{skill_name}</command-message>\n"
+                f"<command-name>/{skill_name}</command-name>"
+            ),
+        },
+    }
+
+
+class TestSkillSkip:
+    """スキル実行時のスキップ機能"""
+
+    def test_skill_command_approves_without_meta_tag(self, env_setup):
+        """スキル発動ターン: メタタグなし・コンテキスト取得なしでもapprove"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_skill_user_entry("sync-memory"),
+            _make_assistant_entry(text="processing skill..."),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+        assert "スキル" in result["reason"]
+
+    def test_skill_skip_remaining_approves(self, env_setup):
+        """スキップ残りがある場合: 即approve"""
+        state_dir = Path(env_setup["state_dir"])
+        skip_file = state_dir / "skill_skip_test-session"
+        skip_file.write_text("2")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("normal message"),
+            _make_assistant_entry(text="response without meta tag"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+        assert "スキル" in result["reason"]
+
+        # スキップ残りが1にデクリメント
+        assert skip_file.read_text().strip() == "1"
+
+    def test_skill_skip_decrements_to_zero(self, env_setup):
+        """スキップ残り1 → 0でファイル削除"""
+        state_dir = Path(env_setup["state_dir"])
+        skip_file = state_dir / "skill_skip_test-session"
+        skip_file.write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("normal message"),
+            _make_assistant_entry(text="response"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+
+        # 0になったのでファイル削除
+        assert not skip_file.exists()
+
+    def test_skill_skip_sets_remaining_turns(self, env_setup):
+        """スキル検出時にskill_skipファイルが作成される"""
+        state_dir = Path(env_setup["state_dir"])
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_skill_user_entry("sync-memory"),
+            _make_assistant_entry(text="processing"),
+        ], transcript)
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+
+        # skill_skip = 2 (3ターン中、検出ターンで1消費)
+        skip_file = state_dir / "skill_skip_test-session"
+        assert skip_file.exists()
+        assert skip_file.read_text().strip() == "2"
+
+    def test_normal_checks_resume_after_skip(self, env_setup):
+        """スキップ終了後は通常チェック再開（メタタグなし→block）"""
+        state_dir = Path(env_setup["state_dir"])
+        # approved_turns=1にして1ターン目猶予を使い切る
+        turns_file = state_dir / "approved_turns_test-session"
+        turns_file.write_text("5")
+
+        # skill_skipは0（スキップ終了済み）
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("normal message"),
+            _make_assistant_entry(text="no meta tag"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "block"
+        assert "メタタグ" in result["reason"]
+
+    def test_skill_skip_increments_approved_turns(self, env_setup):
+        """スキル検出ターンでapproved_turnsがインクリメントされる"""
+        state_dir = Path(env_setup["state_dir"])
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_skill_user_entry("sync-memory"),
+            _make_assistant_entry(text="processing"),
+        ], transcript)
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+
+        turns_file = state_dir / "approved_turns_test-session"
+        assert turns_file.exists()
+        assert turns_file.read_text().strip() == "1"

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -106,6 +106,31 @@ class TestActivityCheckin:
         assert hook_state.has_activity_checkin() is True
 
 
+class TestSkillSkipRemaining:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_skill_skip_remaining() == 0
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_skill_skip_remaining(3)
+        assert hook_state.get_skill_skip_remaining() == 3
+
+    def test_set_zero_deletes_file(self, hook_state):
+        hook_state.set_skill_skip_remaining(3)
+        hook_state.set_skill_skip_remaining(0)
+        assert hook_state.get_skill_skip_remaining() == 0
+        assert not hook_state._path("skill_skip").exists()
+
+    def test_set_negative_deletes_file(self, hook_state):
+        hook_state.set_skill_skip_remaining(3)
+        hook_state.set_skill_skip_remaining(-1)
+        assert hook_state.get_skill_skip_remaining() == 0
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("skill_skip")
+        path.write_text("abc")
+        assert hook_state.get_skill_skip_remaining() == 0
+
+
 class TestClearSession:
     def test_clears_all_state_files(self, tmp_path, monkeypatch):
         monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
@@ -118,6 +143,7 @@ class TestClearSession:
         state.set_nudge_pending()
         state.increment_approved_turns()
         state.set_activity_checkin()
+        state.set_skill_skip_remaining(3)
 
         # clear
         HookState.clear_session("sess-abc")
@@ -129,6 +155,7 @@ class TestClearSession:
         assert state.pop_nudge_pending() is False
         assert state.get_approved_turns() == 0
         assert state.has_activity_checkin() is False
+        assert state.get_skill_skip_remaining() == 0
 
 
 class TestSessionIdSlash:

--- a/tests/unit/test_hook_transcript.py
+++ b/tests/unit/test_hook_transcript.py
@@ -8,6 +8,7 @@ from hooks.hook_transcript import (
     extract_text_from_entry,
     get_assistant_entries,
     get_last_assistant_entry,
+    get_transcript_info,
     has_context_retrieval_calls,
     has_recent_recording,
     parse_meta_tag,
@@ -297,3 +298,92 @@ class TestHasContextRetrievalCalls:
         """記録ツールはコンテキスト取得とみなさない"""
         entries = [_make_assistant_entry(tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"])]
         assert has_context_retrieval_calls(entries) is False
+
+
+# --- get_transcript_info ---
+
+
+def _make_user_entry_real(text: str = "hello") -> dict:
+    """実際のtranscript形式（type: "user"）でuserエントリを作成する。"""
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+class TestGetTranscriptInfo:
+    def test_returns_assistant_entries_and_no_skill(self, tmp_path):
+        """通常のtranscript: assistant entriesを返し、skill commandなし"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry_real("hi"),
+            _make_assistant_entry(text="response"),
+            _make_user_entry_real("more"),
+            _make_assistant_entry(text="response2"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert len(entries) == 2
+        assert has_skill is False
+
+    def test_detects_skill_command(self, tmp_path):
+        """<command-name>を含むuserエントリでskill検出"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry_real(
+                '<command-message>sync-memory</command-message>\n'
+                '<command-name>/claude-code-memory:sync-memory</command-name>'
+            ),
+            _make_assistant_entry(text="processing skill"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert len(entries) == 1
+        assert has_skill is True
+
+    def test_only_last_user_entry_matters(self, tmp_path):
+        """直近のuserエントリのみが判定対象"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry_real(
+                '<command-name>/sync-memory</command-name>'
+            ),
+            _make_assistant_entry(text="skill response"),
+            _make_user_entry_real("normal message"),
+            _make_assistant_entry(text="normal response"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert len(entries) == 2
+        assert has_skill is False
+
+    def test_handles_human_type(self, tmp_path):
+        """type: humanのエントリでもskill検出可能"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            {"type": "human", "message": {"content": "<command-name>/test</command-name>"}},
+            _make_assistant_entry(text="response"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert has_skill is True
+
+    def test_handles_list_content(self, tmp_path):
+        """contentがリスト形式でもskill検出可能"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            {"type": "user", "message": {"content": [
+                {"type": "text", "text": "<command-name>/test</command-name>"},
+            ]}},
+            _make_assistant_entry(text="response"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert has_skill is True
+
+    def test_file_not_found(self, tmp_path):
+        """ファイルが存在しない場合"""
+        path = tmp_path / "nonexistent.jsonl"
+        entries, has_skill = get_transcript_info(str(path))
+        assert entries == []
+        assert has_skill is False
+
+    def test_empty_file(self, tmp_path):
+        """空ファイルの場合"""
+        path = tmp_path / "transcript.jsonl"
+        path.write_text("")
+        entries, has_skill = get_transcript_info(str(path))
+        assert entries == []
+        assert has_skill is False

--- a/tests/unit/test_hook_transcript.py
+++ b/tests/unit/test_hook_transcript.py
@@ -6,7 +6,6 @@ import pytest
 
 from hooks.hook_transcript import (
     extract_text_from_entry,
-    get_assistant_entries,
     get_last_assistant_entry,
     get_transcript_info,
     has_context_retrieval_calls,
@@ -182,59 +181,6 @@ class TestGetLastAssistantEntry:
         """ファイルが存在しない場合はNoneを返す"""
         path = tmp_path / "nonexistent.jsonl"
         assert get_last_assistant_entry(str(path)) is None
-
-
-# --- get_assistant_entries ---
-
-
-class TestGetAssistantEntries:
-    def test_get_all(self, tmp_path):
-        """全件取得"""
-        path = tmp_path / "transcript.jsonl"
-        lines = [
-            _make_user_entry(),
-            _make_assistant_entry(text="msg0"),
-            _make_user_entry(),
-            _make_assistant_entry(text="msg1"),
-            _make_user_entry(),
-            _make_assistant_entry(text="msg2"),
-        ]
-        _write_transcript(lines, path)
-        result = get_assistant_entries(str(path))
-        assert len(result) == 3
-
-    def test_get_last_n(self, tmp_path):
-        """last_n指定"""
-        path = tmp_path / "transcript.jsonl"
-        entries = [_make_assistant_entry(text=f"msg{i}") for i in range(5)]
-        lines = []
-        for e in entries:
-            lines.append(_make_user_entry())
-            lines.append(e)
-        _write_transcript(lines, path)
-
-        result = get_assistant_entries(str(path), last_n=3)
-        assert len(result) == 3
-        assert result[0]["message"]["content"][0]["text"] == "msg2"
-        assert result[1]["message"]["content"][0]["text"] == "msg3"
-        assert result[2]["message"]["content"][0]["text"] == "msg4"
-
-    def test_file_not_found(self, tmp_path):
-        """ファイルが存在しない場合は空リストを返す"""
-        path = tmp_path / "nonexistent.jsonl"
-        assert get_assistant_entries(str(path)) == []
-
-    def test_empty_file(self, tmp_path):
-        """空ファイルの場合は空リストを返す"""
-        path = tmp_path / "transcript.jsonl"
-        path.write_text("")
-        assert get_assistant_entries(str(path)) == []
-
-    def test_no_assistant_entries(self, tmp_path):
-        """ユーザーエントリのみの場合は空リストを返す"""
-        path = tmp_path / "transcript.jsonl"
-        _write_transcript([_make_user_entry("only user entries")], path)
-        assert get_assistant_entries(str(path)) == []
 
 
 # --- has_recent_recording ---


### PR DESCRIPTION
## Summary
- スキル（`/sync-memory`等）発動時、transcriptのuserエントリ内の`<command-name>`タグを検出し、検出ターンを含む3ターンの間stop_hookの全チェックをスキップする
- `hook_state.py`に`skill_skip_remaining`状態を追加、`hook_transcript.py`に`get_transcript_info()`を追加し既存のtranscript読み込みに相乗りする形で実装
- スキップ残りが0になると通常チェックが再開される

## Test plan
- [ ] unit: `TestSkillSkipRemaining` — state読み書き・0でファイル削除・破損ファイル耐性
- [ ] unit: `TestGetTranscriptInfo` — skill command検出・直近userエントリのみ判定・type user/human両対応・list content対応
- [ ] e2e: `TestSkillSkip` — skill発動時approve・skip残りデクリメント・0でファイル削除・通常チェック再開・approved_turnsインクリメント
- [ ] 既存104テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)