### PR TITLE
fix: grep -cの0マッチ時にshort sessionチェックがバイパスされる問題を修正

### DIFF
--- a/hooks/session_end_hook.sh
+++ b/hooks/session_end_hook.sh
@@ -48,7 +48,7 @@ if grep -q 'claude-code-memory:sync-memory' "$TRANSCRIPT_PATH" 2>/dev/null; then
 fi
 
 # ターン数チェック: assistantメッセージが2件以下の短いセッションはスキップ
-ASSISTANT_COUNT=$(grep -c '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+ASSISTANT_COUNT=$(grep -c '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null || true)
 if [ "$ASSISTANT_COUNT" -le 2 ]; then
     log "Short session (assistant_count=$ASSISTANT_COUNT). Skipping auto-sync."
     echo '{"decision": "approve"}'


### PR DESCRIPTION
## Summary
- `session_end_hook.sh` の `grep -c` + `|| echo "0"` の組み合わせで、0マッチ時に `ASSISTANT_COUNT` が `"0\n0"` になり整数比較が失敗していた
- assistantメッセージ0件の空セッションでもauto-syncが無駄に発火する原因になっていた
- `|| echo "0"` → `|| true` に変更して修正

## Test plan
- [x] `grep -c` が0マッチ時に正しく `ASSISTANT_COUNT=0` になることを確認済み
- [x] 既存の正常ケース（マッチあり）に影響がないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)