### PR TITLE
fix: skill_skipがtool_resultエントリに上書きされる問題を修正

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -177,6 +177,10 @@ def get_transcript_info(transcript_path: str) -> tuple[list[dict], bool]:
                     if entry_type == "assistant":
                         entries.append(entry)
                     elif entry_type in ("user", "human"):
+                        # tool_resultエントリはスキップ（skill検出を上書きしないため）
+                        content = entry.get("message", {}).get("content", "")
+                        if isinstance(content, list) and content and isinstance(content[0], dict) and content[0].get("type") == "tool_result":
+                            continue
                         text = _extract_user_content_text(entry)
                         last_user_has_command = "<command-name>" in text
                 except json.JSONDecodeError:

--- a/tests/unit/test_hook_transcript.py
+++ b/tests/unit/test_hook_transcript.py
@@ -319,6 +319,47 @@ class TestGetTranscriptInfo:
         entries, has_skill = get_transcript_info(str(path))
         assert has_skill is True
 
+    def test_tool_result_does_not_overwrite_skill_detection(self, tmp_path):
+        """tool_resultエントリがskill検出を上書きしない"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry_real(
+                '<command-message>sync-memory</command-message>\n'
+                '<command-name>/claude-code-memory:sync-memory</command-name>'
+            ),
+            _make_assistant_entry(text="calling tools"),
+            # tool_result: type="user"だがskill検出を上書きしてはいけない
+            {"type": "user", "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_123", "content": "result"},
+            ]}},
+            _make_assistant_entry(text="more tools"),
+            {"type": "user", "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_456", "content": "result2"},
+            ]}},
+            _make_assistant_entry(text="final response"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert len(entries) == 3
+        assert has_skill is True
+
+    def test_real_user_message_after_tool_result_overrides_skill(self, tmp_path):
+        """tool_result後の本物のuserメッセージはskill検出を上書きする"""
+        path = tmp_path / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry_real(
+                '<command-name>/sync-memory</command-name>'
+            ),
+            _make_assistant_entry(text="skill response"),
+            {"type": "user", "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_123", "content": "result"},
+            ]}},
+            _make_assistant_entry(text="more response"),
+            _make_user_entry_real("normal follow-up message"),
+            _make_assistant_entry(text="normal response"),
+        ], path)
+        entries, has_skill = get_transcript_info(str(path))
+        assert has_skill is False
+
     def test_file_not_found(self, tmp_path):
         """ファイルが存在しない場合"""
         path = tmp_path / "nonexistent.jsonl"


### PR DESCRIPTION
## Summary
- `get_transcript_info`の`has_skill_cmd`判定がtool_resultエントリに上書きされ、スキル実行時のstop_hookスキップが途中で切れるバグを修正
- transcriptではtool_resultも`type: "user"`として記録されるため、`last_user_has_command`がfalseで上書きされていた
- tool_resultエントリ（`content[0].type == "tool_result"`）をスキップすることで、スキル検出の再トリガーが正しく動作するようにした

## Test plan
- [x] 新規テスト: tool_resultがskill検出を上書きしないことを確認
- [x] 新規テスト: tool_result後の本物のuserメッセージはskill検出を正しく上書きすることを確認
- [x] 全544テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)