### PR TITLE
feat: stophookを1ターンに緩和

### DIFF
--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -35,7 +35,7 @@ from hooks.hook_transcript import (
     parse_meta_tag,
 )
 
-_BLOCK_LIMIT = 2
+_BLOCK_LIMIT = 1
 _NUDGE_INTERVAL = 2
 _CHECKIN_DEFER_TURNS = 2
 _SKILL_SKIP_TURNS = 3


### PR DESCRIPTION
## 概要

stophookがスキップされるターン数を2ターンで様子見をしていたが、特にメリットを感じなかったため、これを1ターンに変更