### PR TITLE
fix: add_logのtitle自動生成でリテラル\nも分割対象にする

### DIFF
--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -1,4 +1,5 @@
 """議論ログ管理サービス"""
+import re
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
@@ -32,7 +33,7 @@ def add_log(
     """
     if not title or not title.strip():
         # titleが未指定・空の場合、contentから自動生成を試みる
-        first_line = content.strip().split('\n', 1)[0].strip()
+        first_line = re.split(r'\n|\\n', content.strip(), maxsplit=1)[0].strip()
         title = first_line[:50] if len(first_line) > 50 else first_line
         if not title:
             return {

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -264,6 +264,19 @@ def test_add_log_title_auto_uses_first_line_only(temp_db):
     assert result["title"] == "1行目のタイトル"
 
 
+def test_add_log_title_auto_splits_on_literal_backslash_n(temp_db):
+    """contentにリテラルな\\nが含まれる場合もそこでtitleを分割する"""
+    topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)
+
+    result = add_log(
+        topic_id=topic["topic_id"],
+        content="1行目のタイトル\\n2行目の内容",
+    )
+
+    assert "error" not in result
+    assert result["title"] == "1行目のタイトル"
+
+
 def test_add_log_title_none_content_empty_error(temp_db):
     """title=Noneかつcontent=""の場合にエラーが返る"""
     topic = add_topic(title="テストトピック", description="Test description", tags=DEFAULT_TAGS)


### PR DESCRIPTION
## Summary
- `add_log`のtitle自動生成で、リテラルな`\n`文字列（バックスラッシュ+n）でも先頭行を分割するように修正
- AIがcontentにリテラル`\n`を書いてくるケースで、titleに`\n`以降の文字列が含まれてしまう問題を解決

## Changes
- `str.split('\n')` → `re.split(r'\n|\\n')` に変更
- リテラル`\n`での分割テストを追加

## Test plan
- [x] 既存の title 自動生成テスト 3件がパス
- [x] 新規テスト `test_add_log_title_auto_splits_on_literal_backslash_n` がパス
- [x] 全505テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)