### PR TITLE
feat: decision作成後にアクティビティ作成を促すnudge追加

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -97,6 +97,20 @@ class HookState:
         except FileNotFoundError:
             return False
 
+    # --- activity_nudge_pending ---
+
+    def set_activity_nudge_pending(self) -> None:
+        """state/activity_nudge_pending_{session_id_safe} に '1' を書く"""
+        self._write(self._path("activity_nudge_pending"), "1")
+
+    def pop_activity_nudge_pending(self) -> bool:
+        """ファイルが存在すれば削除して True、なければ False"""
+        try:
+            self._path("activity_nudge_pending").unlink()
+            return True
+        except FileNotFoundError:
+            return False
+
     # --- approved_turns ---
 
     def get_approved_turns(self) -> int:

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -88,6 +88,8 @@ _RECORDING_TOOLS = [
     "mcp__plugin_claude-code-memory_cc-memory__add_log",
 ]
 
+_ADD_DECISION_TOOL = "mcp__plugin_claude-code-memory_cc-memory__add_decision"
+
 
 def _has_tool_calls(entries: list[dict], tool_names: list[str]) -> bool:
     """entriesに指定ツールの呼び出しがあるかチェック。"""
@@ -138,6 +140,15 @@ _CONTEXT_RETRIEVAL_TOOLS = [
 def has_context_retrieval_calls(entries: list[dict]) -> bool:
     """entriesにget系APIの呼び出しがあるかチェック。"""
     return _has_tool_calls(entries, _CONTEXT_RETRIEVAL_TOOLS)
+
+
+def has_decision_without_activity(entries: list[dict]) -> bool:
+    """entriesにadd_decisionがあり、かつcheck_in/add_activityがない場合True。"""
+    has_decision = _has_tool_calls(entries, [_ADD_DECISION_TOOL])
+    if not has_decision:
+        return False
+    has_activity = _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS)
+    return not has_activity
 
 
 def _extract_user_content_text(entry: dict) -> str:

--- a/hooks/pretooluse_hook.py
+++ b/hooks/pretooluse_hook.py
@@ -4,8 +4,9 @@
 1. stdin読み込み → JSON parse（session_id取得）
 2. session_idが空/null → 空JSON出力して終了
 3. HookState(session_id)を生成
-4. 記録リマインダーnudge → system-reminder注入
-5. 何もなし → 空JSON出力
+4. アクティビティ作成nudge → system-reminder注入
+5. 記録リマインダーnudge → system-reminder注入
+6. 何もなし → 空JSON出力
 """
 import json
 import os
@@ -29,6 +30,15 @@ def _make_hook_output(message: str) -> dict:
         }
     }
 
+
+_ACTIVITY_NUDGE_MESSAGE = (
+    "<system-reminder>"
+    "You just recorded a decision. Consider whether it implies follow-up work "
+    "(design discussion, implementation, investigation) that should be tracked "
+    "as a new activity. If so, create one with add_activity. "
+    "Ignore if not applicable."
+    "</system-reminder>"
+)
 
 _RECORD_NUDGE_MESSAGE = (
     "<system-reminder>"
@@ -66,12 +76,17 @@ def main() -> None:
         # 3. HookState生成
         state = HookState(session_id)
 
-        # 4. 記録リマインダーnudge
+        # 4. アクティビティ作成nudge
+        if state.pop_activity_nudge_pending():
+            print(json.dumps(_make_hook_output(_ACTIVITY_NUDGE_MESSAGE), ensure_ascii=False))
+            return
+
+        # 5. 記録リマインダーnudge
         if state.pop_nudge_pending():
             print(json.dumps(_make_hook_output(_RECORD_NUDGE_MESSAGE), ensure_ascii=False))
             return
 
-        # 5. 何もなし
+        # 6. 何もなし
         print("{}")
 
     except Exception as e:

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -31,6 +31,7 @@ from hooks.hook_transcript import (
     get_transcript_info,
     has_activity_checkin_calls,
     has_context_retrieval_calls,
+    has_decision_without_activity,
     has_recent_recording,
     parse_meta_tag,
 )
@@ -170,6 +171,11 @@ def main() -> None:
                 state.reset_nudge_counter()
             else:
                 state.set_nudge_pending()
+
+        # 8b. decision後のアクティビティ作成nudge
+        recent_entries_short = all_entries[-2:] if all_entries else []
+        if has_decision_without_activity(recent_entries_short):
+            state.set_activity_nudge_pending()
 
         # 9. 状態更新 + approve
         state.set_prev_topic(current_topic_name)

--- a/skills/sync-memory/SKILL.md
+++ b/skills/sync-memory/SKILL.md
@@ -105,6 +105,7 @@ transcriptを解析し、議論されたテーマを特定する。
 - log には Step 3 で保存した material ID を参照として含める（例: 「SA出力（material #NNN）を踏まえてA案を採用」）
 - `topic_id` は関連するトピックを指定
 - `tags` で内容を表すタグを付ける（省略時はtopicのタグを継承）
+- **記録したdecisionの中に、今後の作業や継続議論を伴うものがあれば、対応するアクティビティを `add_activity` で作成する**（Step 2で未登録の場合）
 
 ### 5. 未決定の論点を記録 (add_decision)
 

--- a/tests/e2e/test_pretooluse_hook.py
+++ b/tests/e2e/test_pretooluse_hook.py
@@ -74,6 +74,45 @@ class TestNudgePending:
         assert state.pop_nudge_pending() is False
 
 
+class TestActivityNudgePending:
+    """activity_nudge_pendingフラグあり → system-reminder注入 + フラグ消去確認"""
+
+    def test_activity_nudge_injection(self, state_dir):
+        state = HookState(_SESSION_ID)
+        state.set_activity_nudge_pending()
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        assert "hookSpecificOutput" in output
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "decision" in ctx
+        assert "activity" in ctx.lower()
+
+    def test_activity_nudge_flag_cleared(self, state_dir):
+        state = HookState(_SESSION_ID)
+        state.set_activity_nudge_pending()
+
+        _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert state.pop_activity_nudge_pending() is False
+
+    def test_activity_nudge_takes_priority_over_record_nudge(self, state_dir):
+        """両方のフラグがある場合、activity_nudgeが先に消費される"""
+        state = HookState(_SESSION_ID)
+        state.set_activity_nudge_pending()
+        state.set_nudge_pending()
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        # activity nudgeが注入される
+        assert "activity" in ctx.lower()
+
+        # record nudgeはまだ残っている
+        assert state.pop_nudge_pending() is True
+
+
 class TestEmptySessionId:
     """session_id空 → 空JSON"""
 

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -427,6 +427,82 @@ class TestNudgeCounter:
         assert not counter_file.exists()
 
 
+class TestActivityNudge:
+    """decision作成後のアクティビティ作成nudge"""
+
+    def test_decision_without_activity_sets_nudge(self, env_setup):
+        """add_decisionあり + add_activityなし → activity_nudge_pending設定"""
+        state_dir = Path(env_setup["state_dir"])
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(
+                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
+                text=f"{META_TAG}\nrecorded",
+            ),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"recorded\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+        pending_file = state_dir / "activity_nudge_pending_test-session"
+        assert pending_file.exists()
+
+    def test_decision_with_activity_no_nudge(self, env_setup):
+        """add_decision + add_activity両方あり → activity_nudge_pending設定されない"""
+        state_dir = Path(env_setup["state_dir"])
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(
+                tool_calls=[
+                    "mcp__plugin_claude-code-memory_cc-memory__add_decision",
+                    "mcp__plugin_claude-code-memory_cc-memory__add_activity",
+                ],
+                text=f"{META_TAG}\nrecorded",
+            ),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"recorded\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+        pending_file = state_dir / "activity_nudge_pending_test-session"
+        assert not pending_file.exists()
+
+    def test_no_decision_no_nudge(self, env_setup):
+        """add_decisionなし → activity_nudge_pending設定されない"""
+        state_dir = Path(env_setup["state_dir"])
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+        pending_file = state_dir / "activity_nudge_pending_test-session"
+        assert not pending_file.exists()
+
+
 class TestStateUpdatedOnApprove:
     """approve時の状態更新"""
 

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -83,6 +83,20 @@ class TestNudgePending:
         assert hook_state.pop_nudge_pending() is False
 
 
+class TestActivityNudgePending:
+    def test_pop_returns_false_when_no_file(self, hook_state):
+        assert hook_state.pop_activity_nudge_pending() is False
+
+    def test_set_then_pop(self, hook_state):
+        hook_state.set_activity_nudge_pending()
+        assert hook_state.pop_activity_nudge_pending() is True
+
+    def test_pop_after_pop_returns_false(self, hook_state):
+        hook_state.set_activity_nudge_pending()
+        hook_state.pop_activity_nudge_pending()
+        assert hook_state.pop_activity_nudge_pending() is False
+
+
 class TestApprovedTurns:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_approved_turns() == 0
@@ -141,6 +155,7 @@ class TestClearSession:
         state.increment_block_count()
         state.increment_nudge_counter()
         state.set_nudge_pending()
+        state.set_activity_nudge_pending()
         state.increment_approved_turns()
         state.set_activity_checkin()
         state.set_skill_skip_remaining(3)
@@ -153,6 +168,7 @@ class TestClearSession:
         assert state.get_block_count() == 0
         assert state.get_nudge_counter() == 0
         assert state.pop_nudge_pending() is False
+        assert state.pop_activity_nudge_pending() is False
         assert state.get_approved_turns() == 0
         assert state.has_activity_checkin() is False
         assert state.get_skill_skip_remaining() == 0


### PR DESCRIPTION
## Summary
- decision記録後にフォローアップのアクティビティ作成を促すnudgeを追加
- sync-memoryスキルにdecisionからのアクティビティ作成ステップを追加
- decisionが記録されたのにactivityが作られないケースを防止

## 変更内容
- `hook_state.py`: `activity_nudge_pending`のset/pop追加
- `hook_transcript.py`: `has_decision_without_activity()`関数追加
- `stop_hook.py`: add_decision検知→フラグ設定（Step 8b）
- `pretooluse_hook.py`: フラグ検知→system-reminder注入（record nudgeより優先）
- `sync-memory/SKILL.md`: Step 4にフォローアップのアクティビティ作成を追記

## Test plan
- [x] unit: TestActivityNudgePending（3件）
- [x] e2e stop_hook: TestActivityNudge（3件 — decision_without_activity, decision_with_activity, no_decision）
- [x] e2e pretooluse: TestActivityNudgePending（3件 — injection, flag_cleared, priority）
- [x] 全514テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)