### PR TITLE
feat: update_tagにrenameパラメータを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -494,11 +494,12 @@ def update_tag(
     tag: str,
     notes: Optional[str] = None,
     canonical: Optional[str] = None,
+    rename: Optional[str] = None,
 ) -> dict:
     """
-    既存タグの notes（教訓・運用ルール）またはcanonical（エイリアス先）を更新する。
+    既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、またはname（リネーム）を更新する。
 
-    notesとcanonicalは排他（同時指定不可）。少なくとも1つを指定する。
+    notes / canonical / rename は相互排他（1つだけ指定可能）。少なくとも1つを指定する。
 
     notes: タグに紐づく教訓や運用ルールを記録する。CLAUDE.mdのタグ版として機能し、
     そのタグの文脈で作業するときに自動的にAIに注入される。上書き方式（全文置換）。
@@ -510,15 +511,20 @@ def update_tag(
     canonical=""で解除。連鎖（エイリアスのエイリアス）は禁止。
     notes付きタグはエイリアスにできない（先にnotesを除去すること）。
 
+    rename: 新しいタグ名。namespace変更も可能（例: "hooks" → "domain:hooks"）。
+    IDベースの参照なので紐付けはそのまま維持される。
+    新名が既存タグと衝突する場合はエラー。
+
     Args:
         tag: 対象タグ（例: "domain:cc-memory", "hooks"）
         notes: 教訓・運用ルールのテキスト（全文置換）
         canonical: エイリアス先タグ（""で解除）
+        rename: 新しいタグ名（例: "domain:hooks"）
 
     Returns:
         更新結果
     """
-    return _update_tag(tag, notes=notes, canonical=canonical)
+    return _update_tag(tag, notes=notes, canonical=canonical, rename=rename)
 
 
 @mcp.tool()

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -652,6 +652,13 @@ def update_tag(
             parsed_new = validate_and_parse_tags([rename])
             if isinstance(parsed_new, dict):
                 return parsed_new
+            if not parsed_new:
+                return {
+                    "error": {
+                        "code": "INVALID_TAG_NAME",
+                        "message": "rename cannot be empty.",
+                    }
+                }
             new_namespace, new_name = parsed_new[0]
 
             # 同一名へのリネームは無意味

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -581,8 +581,13 @@ JUNCTION_TABLES = [
 ]
 
 
-def update_tag(tag: str, notes: str | None = None, canonical: str | None = None) -> dict:
-    """既存タグの notes（教訓・運用ルール）またはcanonical（エイリアス先）を更新する。
+def update_tag(
+    tag: str,
+    notes: str | None = None,
+    canonical: str | None = None,
+    rename: str | None = None,
+) -> dict:
+    """既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、またはname（リネーム）を更新する。
 
     Args:
         tag: タグ文字列（例: "domain:cc-memory", "hooks"）
@@ -590,27 +595,31 @@ def update_tag(tag: str, notes: str | None = None, canonical: str | None = None)
         canonical: エイリアス先タグ文字列。設定するとtagがcanonicalのエイリアスになる。
                    ""（空文字）でエイリアス解除。上書き可能だが、旧canonical先に
                    付け替え済みの紐付けは戻らない。
+        rename: 新しいタグ名。namespace変更も可能（例: "hooks" → "domain:hooks"）。
+                新名が既存タグと衝突する場合はエラー。
 
     Returns:
         成功時: {"tag": str, "notes": str, "updated": True} (notes更新時)
                 {"tag": str, "canonical": str | None, "updated": True} (canonical更新時)
+                {"tag": str, "renamed_to": str, "updated": True} (rename時)
         失敗時: {"error": {"code": ..., "message": ...}}
     """
-    # バリデーション: 同時指定禁止
-    if notes is not None and canonical is not None:
+    # バリデーション: 相互排他（notes, canonical, rename は1つだけ指定可能）
+    specified = [p for p in (notes, canonical, rename) if p is not None]
+    if len(specified) > 1:
         return {
             "error": {
                 "code": "CONFLICTING_PARAMS",
-                "message": "Cannot specify both 'notes' and 'canonical'. Use separate calls.",
+                "message": "Only one of 'notes', 'canonical', or 'rename' can be specified. Use separate calls.",
             }
         }
 
     # 少なくとも1つは指定必須
-    if notes is None and canonical is None:
+    if not specified:
         return {
             "error": {
                 "code": "MISSING_PARAMS",
-                "message": "At least one of 'notes' or 'canonical' must be specified.",
+                "message": "At least one of 'notes', 'canonical', or 'rename' must be specified.",
             }
         }
 
@@ -637,6 +646,44 @@ def update_tag(tag: str, notes: str | None = None, canonical: str | None = None)
 
         tag_id = row["id"]
         tag_str = f"{namespace}:{name}" if namespace else name
+
+        # --- rename ---
+        if rename is not None:
+            parsed_new = validate_and_parse_tags([rename])
+            if isinstance(parsed_new, dict):
+                return parsed_new
+            new_namespace, new_name = parsed_new[0]
+
+            # 同一名へのリネームは無意味
+            if new_namespace == namespace and new_name == name:
+                return {
+                    "error": {
+                        "code": "SAME_NAME",
+                        "message": f"New name is the same as current name: '{tag_str}'",
+                    }
+                }
+
+            # 新名が既存タグと衝突するかチェック
+            existing = conn.execute(
+                "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                (new_namespace, new_name),
+            ).fetchone()
+            if existing:
+                new_display = f"{new_namespace}:{new_name}" if new_namespace else new_name
+                return {
+                    "error": {
+                        "code": "ALREADY_EXISTS",
+                        "message": f"Tag '{new_display}' already exists.",
+                    }
+                }
+
+            conn.execute(
+                "UPDATE tags SET namespace = ?, name = ? WHERE id = ?",
+                (new_namespace, new_name, tag_id),
+            )
+            conn.commit()
+            new_tag_str = f"{new_namespace}:{new_name}" if new_namespace else new_name
+            return {"tag": tag_str, "renamed_to": new_tag_str, "updated": True}
 
         # --- notes 更新 ---
         if notes is not None:

--- a/tests/unit/test_tag_rename.py
+++ b/tests/unit/test_tag_rename.py
@@ -1,0 +1,155 @@
+"""タグリネーム機能のユニットテスト
+
+- update_tag(rename=...): 基本リネーム、namespace変更、衝突エラー、同名エラー
+- リネーム後の紐付け維持確認
+- バリデーション: 他パラメータとの排他
+"""
+import os
+import tempfile
+import pytest
+from src.db import init_database, get_connection
+from src.services.tag_service import update_tag
+from src.services.topic_service import add_topic
+import src.services.embedding_service as emb
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+class TestRenameBasic:
+    """rename基本動作テスト"""
+
+    def test_rename_bare_tag(self, temp_db):
+        """素タグのリネーム"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="hook-system")
+        assert result["updated"] is True
+        assert result["tag"] == "hooks"
+        assert result["renamed_to"] == "hook-system"
+
+    def test_rename_namespaced_tag(self, temp_db):
+        """namespace付きタグのリネーム"""
+        add_topic(title="T", description="D", tags=["domain:test"])
+
+        result = update_tag("domain:test", rename="domain:testing")
+        assert result["updated"] is True
+        assert result["renamed_to"] == "domain:testing"
+
+    def test_rename_change_namespace(self, temp_db):
+        """素タグからnamespace付きへの変更"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="domain:hooks")
+        assert result["updated"] is True
+        assert result["tag"] == "hooks"
+        assert result["renamed_to"] == "domain:hooks"
+
+    def test_rename_remove_namespace(self, temp_db):
+        """namespace付きから素タグへの変更"""
+        add_topic(title="T", description="D", tags=["domain:hooks"])
+
+        result = update_tag("domain:hooks", rename="hooks")
+        assert result["updated"] is True
+        assert result["renamed_to"] == "hooks"
+
+
+class TestRenamePreservesLinks:
+    """リネーム後の紐付け維持テスト"""
+
+    def test_topic_link_preserved(self, temp_db):
+        """リネーム後もtopicとの紐付けが維持される"""
+        result = add_topic(title="T", description="D", tags=["old-name"])
+        topic_id = result["topic_id"]
+
+        # リネーム
+        update_tag("old-name", rename="new-name")
+
+        # 紐付けが維持されていることを確認
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT t.namespace, t.name FROM tags t
+                JOIN topic_tags tt ON t.id = tt.tag_id
+                WHERE tt.topic_id = ?
+                """,
+                (topic_id,),
+            ).fetchall()
+            tag_names = [r["name"] for r in rows]
+            assert "new-name" in tag_names
+            assert "old-name" not in tag_names
+        finally:
+            conn.close()
+
+
+class TestRenameValidation:
+    """renameのバリデーションテスト"""
+
+    def test_rename_same_name_error(self, temp_db):
+        """同一名へのリネームでエラー"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="hooks")
+        assert "error" in result
+        assert result["error"]["code"] == "SAME_NAME"
+
+    def test_rename_collision_error(self, temp_db):
+        """既存タグとの衝突でエラー"""
+        add_topic(title="T", description="D", tags=["old-tag", "existing-tag"])
+
+        result = update_tag("old-tag", rename="existing-tag")
+        assert "error" in result
+        assert result["error"]["code"] == "ALREADY_EXISTS"
+
+    def test_rename_not_found_error(self, temp_db):
+        """存在しないタグのリネームでエラー"""
+        result = update_tag("nonexistent", rename="new-name")
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_rename_invalid_namespace_error(self, temp_db):
+        """無効なnamespaceへのリネームでエラー"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="invalid:hooks")
+        assert "error" in result
+
+    def test_conflicting_rename_and_notes(self, temp_db):
+        """renameとnotesの同時指定でエラー"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="hook-system", notes="some note")
+        assert "error" in result
+        assert result["error"]["code"] == "CONFLICTING_PARAMS"
+
+    def test_conflicting_rename_and_canonical(self, temp_db):
+        """renameとcanonicalの同時指定でエラー"""
+        add_topic(title="T", description="D", tags=["hooks", "domain:test"])
+
+        result = update_tag("hooks", rename="hook-system", canonical="domain:test")
+        assert "error" in result
+        assert result["error"]["code"] == "CONFLICTING_PARAMS"
+
+    def test_missing_all_params(self, temp_db):
+        """全パラメータ未指定でエラー"""
+        result = update_tag("hooks")
+        assert "error" in result
+        assert result["error"]["code"] == "MISSING_PARAMS"

--- a/tests/unit/test_tag_rename.py
+++ b/tests/unit/test_tag_rename.py
@@ -103,6 +103,42 @@ class TestRenamePreservesLinks:
 class TestRenameValidation:
     """renameのバリデーションテスト"""
 
+    def test_rename_empty_string_error(self, temp_db):
+        """空文字でのリネームでエラー"""
+        add_topic(title="T", description="D", tags=["hooks"])
+
+        result = update_tag("hooks", rename="")
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_TAG_NAME"
+
+    def test_rename_alias_tag(self, temp_db):
+        """エイリアスタグ（canonical_id設定済み）のリネーム"""
+        add_topic(title="T", description="D", tags=["old-alias", "canonical-target"])
+        update_tag("old-alias", canonical="canonical-target")
+
+        result = update_tag("old-alias", rename="new-alias")
+        assert result["updated"] is True
+        assert result["renamed_to"] == "new-alias"
+
+    def test_rename_tag_with_notes(self, temp_db):
+        """notes付きタグのリネーム（notes維持）"""
+        add_topic(title="T", description="D", tags=["hooks"])
+        update_tag("hooks", notes="重要な教訓")
+
+        result = update_tag("hooks", rename="hook-system")
+        assert result["updated"] is True
+        assert result["renamed_to"] == "hook-system"
+
+        # notesが維持されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT notes FROM tags WHERE namespace = '' AND name = 'hook-system'",
+            ).fetchone()
+            assert row["notes"] == "重要な教訓"
+        finally:
+            conn.close()
+
     def test_rename_same_name_error(self, temp_db):
         """同一名へのリネームでエラー"""
         add_topic(title="T", description="D", tags=["hooks"])


### PR DESCRIPTION
## Summary
- `update_tag` ツールに `rename` パラメータを追加
- タグ名のリネームとnamespace変更（例: 素タグ → `domain:` 付き）に対応
- IDベースの参照のため、リネーム後も既存の紐付け（topic_tags等4テーブル）はそのまま維持
- notes / canonical / rename の3パラメータは相互排他（1つだけ指定可能）

Closes: activity #492 (タグ整理フローの設計 topic #320)
Related: decision #1237

## Test plan
- [x] 素タグのリネーム
- [x] namespace付きタグのリネーム
- [x] 素タグ → namespace付きへの変更
- [x] namespace付き → 素タグへの変更
- [x] リネーム後のtopic紐付け維持
- [x] 同名リネームエラー (SAME_NAME)
- [x] 既存タグとの衝突エラー (ALREADY_EXISTS)
- [x] 存在しないタグのリネームエラー (NOT_FOUND)
- [x] 無効なnamespaceでのリネームエラー
- [x] rename + notes 同時指定エラー (CONFLICTING_PARAMS)
- [x] rename + canonical 同時指定エラー (CONFLICTING_PARAMS)
- [x] 全パラメータ未指定エラー (MISSING_PARAMS)
- [x] 既存テスト53件の通過確認（tag_alias, tag_notes, list_tags）

🤖 Generated with [Claude Code](https://claude.com/claude-code)