### PR TITLE
feat: materialをsearch対象に含める

### DIFF
--- a/migrations/0018_add_material_search_index.sql
+++ b/migrations/0018_add_material_search_index.sql
@@ -1,0 +1,59 @@
+-- Migration 018: materialsをsearch_indexに登録し検索可能にする
+--
+-- depends: 0017_add_heartbeat
+--
+-- 変更内容:
+--   - 既存materialレコードのsearch_index一括登録
+--   - INSERT/UPDATE/DELETEトリガー作成
+
+-- 1. 既存レコードのsearch_index一括登録
+INSERT INTO search_index (source_type, source_id, title)
+SELECT 'material', m.id, m.title
+FROM materials m;
+
+-- 対応するsearch_index_ftsへの登録
+INSERT INTO search_index_fts (rowid, title, body)
+SELECT si.id, si.title, m.content
+FROM search_index si
+INNER JOIN materials m ON si.source_id = m.id
+WHERE si.source_type = 'material';
+
+-- 2. トリガー
+
+-- INSERT トリガー
+CREATE TRIGGER IF NOT EXISTS trg_search_materials_insert
+AFTER INSERT ON materials
+BEGIN
+  INSERT INTO search_index (source_type, source_id, title)
+  VALUES ('material', NEW.id, NEW.title);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.title, NEW.content);
+END;
+
+-- UPDATE トリガー
+CREATE TRIGGER IF NOT EXISTS trg_search_materials_update
+AFTER UPDATE ON materials
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'material' AND source_id = OLD.id),
+    OLD.title, OLD.content);
+  UPDATE search_index
+  SET title = NEW.title
+  WHERE source_type = 'material' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'material' AND source_id = NEW.id),
+    NEW.title, NEW.content);
+END;
+
+-- DELETE トリガー
+CREATE TRIGGER IF NOT EXISTS trg_search_materials_delete
+AFTER DELETE ON materials
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'material' AND source_id = OLD.id),
+    OLD.title, OLD.content);
+  DELETE FROM search_index WHERE source_type = 'material' AND source_id = OLD.id;
+END;

--- a/src/db.py
+++ b/src/db.py
@@ -152,6 +152,13 @@ def _migrate_fts5_search_index(conn: sqlite3.Connection) -> None:
         FROM activities
     """)
 
+    # materials
+    conn.execute("""
+        INSERT OR IGNORE INTO search_index (source_type, source_id, title)
+        SELECT 'material', id, title
+        FROM materials
+    """)
+
     # FTS5インデックスにデータを投入（contentless方式ではrebuildが使えない）
     conn.execute("""
         INSERT INTO search_index_fts (rowid, title, body)
@@ -161,6 +168,7 @@ def _migrate_fts5_search_index(conn: sqlite3.Connection) -> None:
               WHEN 'topic' THEN (SELECT description FROM discussion_topics WHERE id = si.source_id)
               WHEN 'decision' THEN (SELECT reason FROM decisions WHERE id = si.source_id)
               WHEN 'activity' THEN (SELECT description FROM activities WHERE id = si.source_id)
+              WHEN 'material' THEN (SELECT content FROM materials WHERE id = si.source_id)
             END,
             ''
           )

--- a/src/main.py
+++ b/src/main.py
@@ -424,14 +424,14 @@ def search(
     Args:
         keyword: 検索キーワード（2文字以上）。配列で複数指定時はAND検索
         tags: タグフィルタ（AND条件。未指定=全件検索）
-        type_filter: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log'。未指定で全種類）
+        type_filter: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log', 'material'。未指定で全種類）
         limit: 取得件数上限（デフォルト10件、最大50件）
         offset: スキップ件数（デフォルト0）。ページネーション用
         keyword_mode: キーワード結合モード（"and" または "or"。デフォルト "and"）
 
     Returns:
         検索結果一覧（type, id, title, score, snippet, tags）
-        snippetは各typeの対応するソースカラムの先頭200文字。
+        snippetは各typeの対応するソースカラムの先頭200文字（materialはtitle優先表示）。
         tagsはエンティティに紐づくタグ文字列のリスト。
     """
     result = search_service.search(keyword, tags, type_filter, limit, offset, keyword_mode)

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -233,6 +233,13 @@ def backfill_embeddings() -> int:
             LEFT JOIN vec_index vi ON si.id = vi.rowid
             WHERE si.source_type = 'log' AND vi.rowid IS NULL
         """,
+        "material": """
+            SELECT si.id, m.title, m.content
+            FROM search_index si
+            INNER JOIN materials m ON si.source_id = m.id
+            LEFT JOIN vec_index vi ON si.id = vi.rowid
+            WHERE si.source_type = 'material' AND vi.rowid IS NULL
+        """,
     }
 
     conn = get_connection()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -3,6 +3,7 @@ import logging
 import sqlite3
 
 from src.db import get_connection, row_to_dict
+from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,9 @@ def add_material(activity_id: int, title: str, content: str) -> dict:
             }
 
         conn.commit()
+
+        generate_and_store_embedding("material", material_id, build_embedding_text(title, content))
+
         return _material_to_response(row_to_dict(row))
 
     except sqlite3.IntegrityError as e:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -17,8 +17,8 @@ from src.services.tag_service import (
 
 logger = logging.getLogger(__name__)
 
-SEARCHABLE_TYPES = {'topic', 'decision', 'activity', 'log'}
-VALID_TYPES = SEARCHABLE_TYPES | {'material'}
+SEARCHABLE_TYPES = {'topic', 'decision', 'activity', 'log', 'material'}
+VALID_TYPES = SEARCHABLE_TYPES
 
 GET_BY_IDS_MAX = 20
 
@@ -70,6 +70,25 @@ def _attach_snippets(results: list[dict]) -> None:
         by_type.setdefault(item["type"], []).append(item)
 
     for type_name, items in by_type.items():
+        if type_name == "material":
+            # material: title優先snippet ("title: content[:残り]" 形式)
+            ids = [item["id"] for item in items]
+            placeholders = ",".join("?" * len(ids))
+            rows = execute_query(
+                f"SELECT id, title, content FROM materials WHERE id IN ({placeholders})",
+                tuple(ids),
+            )
+            snippet_map: dict[int, str] = {}
+            for r in rows:
+                title = r["title"] or ""
+                content = r["content"] or ""
+                prefix = f"{title}: "
+                remaining = max(0, SNIPPET_MAX_LEN - len(prefix))
+                snippet_map[r["id"]] = prefix + content[:remaining]
+            for item in items:
+                item["snippet"] = snippet_map.get(item["id"], "")
+            continue
+
         if type_name not in SNIPPET_SOURCE:
             for item in items:
                 item["snippet"] = ""
@@ -124,6 +143,27 @@ def _attach_tags(results: list[dict]) -> None:
                 tags_map = get_effective_tags_batch_by_ids(conn, type_name, ids)
                 for item in items:
                     item["tags"] = tags_map.get(item["id"], [])
+            elif type_name == "material":
+                # material: activityのタグを継承
+                ids = [item["id"] for item in items]
+                placeholders = ",".join("?" * len(ids))
+                rows = conn.execute(f"""
+                    SELECT m.id AS material_id, t.namespace, t.name
+                    FROM materials m
+                    JOIN activity_tags at ON at.activity_id = m.activity_id
+                    JOIN tags t ON t.id = at.tag_id
+                    WHERE m.id IN ({placeholders})
+                """, ids).fetchall()
+                # material_id → tags のマップ構築
+                mat_tag_map: dict[int, list[str]] = {}
+                for r in rows:
+                    mid = r["material_id"]
+                    ns = r["namespace"]
+                    name = r["name"]
+                    tag_str = f"{ns}:{name}" if ns else name
+                    mat_tag_map.setdefault(mid, []).append(tag_str)
+                for item in items:
+                    item["tags"] = mat_tag_map.get(item["id"], [])
             else:
                 for item in items:
                     item["tags"] = []
@@ -198,6 +238,14 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
             SELECT lt.log_id, lt.tag_id
             FROM log_tags lt WHERE lt.tag_id IN ({placeholders})
         ) GROUP BY log_id HAVING COUNT(DISTINCT tag_id) = ?
+
+        UNION ALL
+        -- material (activity_tags経由で継承)
+        SELECT 'material', material_id FROM (
+            SELECT m.id AS material_id, at.tag_id
+            FROM materials m JOIN activity_tags at ON at.activity_id = m.activity_id
+            WHERE at.tag_id IN ({placeholders})
+        ) GROUP BY material_id HAVING COUNT(DISTINCT tag_id) = ?
     )
     """
 
@@ -215,6 +263,9 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
     params.append(n_tags)
     # log (2つのIN句)
     params.extend(tag_ids)
+    params.extend(tag_ids)
+    params.append(n_tags)
+    # material (1つのIN句)
     params.extend(tag_ids)
     params.append(n_tags)
 
@@ -531,14 +582,14 @@ def search(
     Args:
         keyword: 検索キーワード（2文字以上）。配列で複数指定時はAND検索
         tags: タグフィルタ（AND条件。未指定=全件検索）
-        type_filter: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log'。未指定で全種類）
+        type_filter: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log', 'material'。未指定で全種類）
         limit: 取得件数上限（デフォルト10件、最大50件）
         offset: スキップ件数（デフォルト0）。ページネーション用
         keyword_mode: キーワード結合モード（"and" または "or"。デフォルト "and"）
 
     Returns:
         検索結果一覧（type, id, title, score, snippet, tags）
-        snippetは各typeの対応するソースカラムの先頭200文字。
+        snippetは各typeの対応するソースカラムの先頭200文字（materialはtitle優先表示）。
         tagsはエンティティに紐づくタグ文字列のリスト。
     """
     # keyword_modeバリデーション
@@ -756,7 +807,7 @@ def get_by_id(type: str, id: int, conn=None) -> dict:
                 }
             }
 
-        # タグ取得: topic/activityはget_entity_tags、decision/logはget_effective_tags、materialはタグなし
+        # タグ取得: topic/activityはget_entity_tags、decision/logはget_effective_tags、materialはactivity_tags継承
         if type == 'topic':
             tags = get_entity_tags(conn, "topic_tags", "topic_id", id)
         elif type == 'activity':
@@ -766,7 +817,12 @@ def get_by_id(type: str, id: int, conn=None) -> dict:
         elif type == 'log':
             tags = get_effective_tags(conn, "log", id)
         elif type == 'material':
-            tags = []
+            # material: activityのタグを継承
+            activity_id = row_to_dict(row).get("activity_id")
+            if activity_id:
+                tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+            else:
+                tags = []
         else:
             tags = []
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -153,7 +153,7 @@ def _attach_tags(results: list[dict]) -> None:
                     JOIN activity_tags at ON at.activity_id = m.activity_id
                     JOIN tags t ON t.id = at.tag_id
                     WHERE m.id IN ({placeholders})
-                """, ids).fetchall()
+                """, tuple(ids)).fetchall()
                 # material_id → tags のマップ構築
                 mat_tag_map: dict[int, list[str]] = {}
                 for r in rows:
@@ -817,12 +817,9 @@ def get_by_id(type: str, id: int, conn=None) -> dict:
         elif type == 'log':
             tags = get_effective_tags(conn, "log", id)
         elif type == 'material':
-            # material: activityのタグを継承
+            # material: activityのタグを継承 (activity_idはNOT NULL制約あり)
             activity_id = row_to_dict(row).get("activity_id")
-            if activity_id:
-                tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
-            else:
-                tags = []
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
         else:
             tags = []
 

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -179,7 +179,7 @@ class TestGetByIdMaterial:
         assert result["data"]["activity_id"] == activity_id
         assert result["data"]["title"] == "ById Test"
         assert "content" not in result["data"]  # カタログ形式: 全文なし
-        assert result["data"]["tags"] == []
+        assert result["data"]["tags"] == ["domain:test"]  # activityのタグを継承
 
     def test_get_by_id_material_not_found(self, temp_db):
         """存在しないmaterial_idでNOT_FOUNDエラーになる"""

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -7,6 +7,7 @@ from src.services.topic_service import add_topic
 from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
 from src.services.discussion_log_service import add_log as add_log_entry
+from src.services.material_service import add_material
 from src.services import search_service
 import src.services.embedding_service as emb
 
@@ -313,7 +314,7 @@ def test_get_by_ids_single_log(temp_db):
     assert "domain:test" in item["data"]["tags"]
 
 
-def test_get_by_ids_not_found(temp_db):
+def test_get_by_ids_single_not_found(temp_db):
     """get_by_ids: 存在しないIDでNOT_FOUNDエラー"""
     result = search_service.get_by_ids([{"type": "topic", "id": 999999}])
     assert len(result["results"]) == 1
@@ -848,3 +849,159 @@ def test_search_methods_used_empty_results(temp_db):
     assert "error" not in result
     assert "search_methods_used" in result
     assert result["search_methods_used"] == ["fts5"]
+
+
+# ========================================
+# material 検索テスト
+# ========================================
+
+
+def test_search_trigger_sync_material(temp_db):
+    """materialがsearch_indexに同期される"""
+    activity = add_activity(title="素材テスト用アクティビティ", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    add_material(activity_id=activity["activity_id"], title="トリガー同期素材検索テスト", content="素材の内容テスト")
+    result = search_service.search(keyword="トリガー同期素材検索テスト")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    types = [r["type"] for r in result["results"]]
+    assert "material" in types
+
+
+def test_search_type_filter_material(temp_db):
+    """type_filter=materialでmaterialのみ取得"""
+    activity = add_activity(title="素材フィルタテスト用", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    add_material(activity_id=activity["activity_id"], title="素材フィルタ対象テスト", content="素材の内容")
+    result = search_service.search(keyword="素材フィルタ対象テスト", type_filter="material")
+    assert "error" not in result
+    for item in result["results"]:
+        assert item["type"] == "material"
+
+
+def test_search_cross_type_includes_material(temp_db):
+    """横断検索にmaterialも含まれる"""
+    topic = add_topic(title="横断素材検索テスト用", description="テスト", tags=DEFAULT_TAGS)
+    activity = add_activity(title="横断素材検索テスト用アクティビティ", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    add_material(activity_id=activity["activity_id"], title="横断素材検索テスト対象素材", content="素材内容")
+    add_decision(topic_id=topic["topic_id"], decision="横断素材検索テスト決定", reason="テスト")
+    result = search_service.search(keyword="横断素材検索テスト")
+    assert "error" not in result
+    types_found = {r["type"] for r in result["results"]}
+    assert "material" in types_found
+
+
+def test_search_material_by_content(temp_db):
+    """materialのcontentでも検索がヒットする"""
+    activity = add_activity(title="コンテンツ検索テスト用", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    add_material(activity_id=activity["activity_id"], title="タイトル", content="素材コンテンツ検索対象のユニーク文字列")
+    result = search_service.search(keyword="素材コンテンツ検索対象のユニーク文字列")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    types = [r["type"] for r in result["results"]]
+    assert "material" in types
+
+
+# ========================================
+# material snippet テスト
+# ========================================
+
+
+def test_search_snippet_material_title_priority(temp_db):
+    """materialのsnippetはtitle優先表示（"title: content..." 形式）"""
+    activity = add_activity(title="スニペットテスト用", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    add_material(activity_id=activity["activity_id"], title="設計書", content="ここに設計の内容が入ります")
+    result = search_service.search(keyword="設計書", type_filter="material")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    item = next(r for r in result["results"] if r["type"] == "material")
+    assert "snippet" in item
+    assert item["snippet"].startswith("設計書: ")
+    assert "ここに設計の内容が入ります" in item["snippet"]
+
+
+def test_search_snippet_material_max_length(temp_db):
+    """materialのsnippetはSNIPPET_MAX_LEN以下に収まる"""
+    activity = add_activity(title="スニペット長テスト用", description="テスト", tags=DEFAULT_TAGS, check_in=False)
+    long_content = "あ" * 300
+    add_material(activity_id=activity["activity_id"], title="長コンテンツテスト素材", content=long_content)
+    result = search_service.search(keyword="長コンテンツテスト素材", type_filter="material")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    item = next(r for r in result["results"] if r["type"] == "material")
+    assert len(item["snippet"]) <= 200
+
+
+# ========================================
+# material タグフィルタテスト
+# ========================================
+
+
+def test_search_material_tag_filter_inherited(temp_db):
+    """materialはactivityのタグを継承してタグフィルタされる"""
+    activity = add_activity(
+        title="タグ継承テスト用アクティビティ",
+        description="テスト",
+        tags=["domain:test", "intent:design"],
+        check_in=False,
+    )
+    add_material(activity_id=activity["activity_id"], title="タグ継承テスト素材対象", content="素材の内容")
+    result = search_service.search(keyword="タグ継承テスト素材対象", tags=["intent:design"])
+    assert "error" not in result
+    types = [r["type"] for r in result["results"]]
+    assert "material" in types
+
+
+def test_search_material_tag_filter_excludes(temp_db):
+    """materialはactivityにないタグでフィルタすると除外される"""
+    activity = add_activity(
+        title="タグ除外テスト用アクティビティ",
+        description="テスト",
+        tags=["domain:test"],
+        check_in=False,
+    )
+    add_material(activity_id=activity["activity_id"], title="タグ除外テスト素材対象", content="素材の内容")
+    result = search_service.search(keyword="タグ除外テスト素材対象", tags=["domain:other"])
+    assert "error" not in result
+    # domain:other は存在しないのでヒットしない
+    assert result["results"] == []
+
+
+def test_search_material_tags_in_results(temp_db):
+    """search結果のmaterialにactivity継承のtagsが含まれること"""
+    activity = add_activity(
+        title="素材タグ表示テスト用",
+        description="テスト",
+        tags=["domain:test", "intent:implement"],
+        check_in=False,
+    )
+    add_material(activity_id=activity["activity_id"], title="素材タグ表示テスト対象", content="素材の内容")
+    result = search_service.search(keyword="素材タグ表示テスト対象")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    item = next(r for r in result["results"] if r["type"] == "material")
+    assert "tags" in item
+    assert "domain:test" in item["tags"]
+    assert "intent:implement" in item["tags"]
+
+
+# ========================================
+# material get_by_ids テスト
+# ========================================
+
+
+def test_get_by_ids_single_material(temp_db):
+    """get_by_ids: materialの詳細取得（1件）"""
+    activity = add_activity(
+        title="素材詳細テスト用アクティビティ",
+        description="テスト",
+        tags=["domain:test"],
+        check_in=False,
+    )
+    material = add_material(activity_id=activity["activity_id"], title="詳細取得テスト素材", content="素材本文テスト")
+    result = search_service.get_by_ids([{"type": "material", "id": material["material_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "material"
+    assert item["data"]["title"] == "詳細取得テスト素材"
+    assert "tags" in item["data"]
+    assert "domain:test" in item["data"]["tags"]


### PR DESCRIPTION
## Summary
- FTS5インデックスにmaterialのcontent/titleを追加し、searchで発見可能にした
- タグフィルタはactivityのタグを継承する方式（activity_id経由）
- snippetはtitle優先表示（`"title: content[:残り文字数]"` 形式）
- get_by_idのmaterialタグ取得もactivity_tags継承に統一

## Changes
- `migrations/0018_add_material_search_index.sql`: INSERT/UPDATE/DELETEトリガー + 既存material一括登録
- `src/db.py`: バックフィル処理にmaterial追加
- `src/services/search_service.py`: SEARCHABLE_TYPES, snippet, タグフィルタCTE, タグ継承, get_by_id対応
- `src/main.py`: searchツールのdocstring更新
- テスト: 11テスト追加（558 passed）

## Related
- cc-memory activity #491, topic #322
- decisions: #1247, #1252, #1253, #1256

## Test plan
- [x] `search(keyword=...)`でmaterialがヒットする
- [x] `search(type_filter="material")`でmaterialのみ返る
- [x] materialのsnippetが`"title: content..."` 形式
- [x] `search(tags=["domain:xxx"])`でactivityのタグを持つmaterialがヒットする
- [x] 既存のtopic/decision/activity/logの検索が壊れていない
- [x] 全558テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)