### PR TITLE
fix: メタタグの初回トピック遷移を許容する

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -146,6 +146,16 @@ class HookState:
         else:
             self._write(self._path("skill_skip"), str(n))
 
+    # --- topic_transitioned ---
+
+    def has_topic_transitioned(self) -> bool:
+        """セッション内で初回のトピック遷移が発生済みかチェック。"""
+        return self._path("topic_transitioned").exists()
+
+    def set_topic_transitioned(self) -> None:
+        """初回トピック遷移済みフラグを設定。"""
+        self._write(self._path("topic_transitioned"), "1")
+
     # --- checked_in_activity ---
 
     def get_checked_in_activity(self) -> int | None:

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -158,18 +158,22 @@ def main() -> None:
                 )
                 return
 
-        # 7. トピック変更チェック → 記録がなければblock
+        # 7. トピック変更チェック → 記録がなければblock（初回遷移は許容）
         prev_topic = state.get_prev_topic()
         if prev_topic is not None and prev_topic != current_topic_name:
-            recent_entries = all_entries[-5:] if all_entries else []
-            if not has_recent_recording(recent_entries):
-                state.increment_block_count()
-                _output(
-                    "block",
-                    "トピックが変わりました。移動前に記録（add_decision / add_log / add_topic）を"
-                    "行ってください。",
-                )
-                return
+            if not state.has_topic_transitioned():
+                # 初回のトピック遷移は許容（check-in→実トピックへの着地等）
+                state.set_topic_transitioned()
+            else:
+                recent_entries = all_entries[-5:] if all_entries else []
+                if not has_recent_recording(recent_entries):
+                    state.increment_block_count()
+                    _output(
+                        "block",
+                        "トピックが変わりました。移動前に記録（add_decision / add_log / add_topic）を"
+                        "行ってください。",
+                    )
+                    return
 
         # 8. nudgeカウンター
         nudge_count = state.increment_nudge_counter()

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -10,7 +10,7 @@
    → なければblock
 6. activity check-inチェック（_CHECKIN_DEFER_TURNSターン後、one-shot block）
    → check-in/add_activity未呼出 → block
-7. トピック変更チェック → 直近に記録系ツール呼び出しがなければblock
+7. トピック変更チェック → 初回遷移は許容、2回目以降は記録がなければblock
 8. nudgeカウンター管理
 9. 状態更新 → approve
 """

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -202,20 +202,51 @@ class TestMetaTagApproves:
 
 
 class TestTopicChangeNoRecord:
-    """3. トピック変更 + 記録なし → block"""
+    """3. トピック変更 + 記録なし → block（2回目以降）/ approve（初回遷移）"""
 
-    def test_topic_change_without_record_blocks(self, env_setup):
+    def test_first_topic_transition_approves(self, env_setup):
+        """初回のトピック遷移は記録なしでもapprove"""
         state_dir = Path(env_setup["state_dir"])
 
-        # prev_topic をトピック名で設定
         prev_file = state_dir / "prev_topic_test-session"
         prev_file.write_text("test-topic")
 
-        # context_retrieved フラグを設定（既にコンテキスト取得済み）
         context_file = state_dir / "context_retrieved_test-session"
         context_file.write_text("1")
 
-        # 別トピックに変更するtranscript（記録なし）
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                _make_assistant_entry(text=f"{META_TAG_TOPIC_B}\nresponse"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG_TOPIC_B}",
+        )
+        assert result["decision"] == "approve"
+
+        # topic_transitioned フラグが設定される
+        transitioned_file = state_dir / "topic_transitioned_test-session"
+        assert transitioned_file.exists()
+
+    def test_topic_change_without_record_blocks(self, env_setup):
+        """2回目以降のトピック遷移で記録なし → block"""
+        state_dir = Path(env_setup["state_dir"])
+
+        prev_file = state_dir / "prev_topic_test-session"
+        prev_file.write_text("test-topic")
+
+        context_file = state_dir / "context_retrieved_test-session"
+        context_file.write_text("1")
+
+        # 初回遷移済みフラグを設定（2回目の遷移をシミュレート）
+        transitioned_file = state_dir / "topic_transitioned_test-session"
+        transitioned_file.write_text("1")
+
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -246,6 +277,10 @@ class TestTopicChangeWithRecord:
         # context_retrieved フラグを設定
         context_file = state_dir / "context_retrieved_test-session"
         context_file.write_text("1")
+
+        # 初回遷移済みフラグを設定（2回目の遷移をシミュレート）
+        transitioned_file = state_dir / "topic_transitioned_test-session"
+        transitioned_file.write_text("1")
 
         # 別トピックに変更するtranscript（add_decision記録あり）
         transcript = env_setup["tmp_path"] / "transcript.jsonl"

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -120,6 +120,15 @@ class TestActivityCheckin:
         assert hook_state.has_activity_checkin() is True
 
 
+class TestTopicTransitioned:
+    def test_has_returns_false_when_no_file(self, hook_state):
+        assert hook_state.has_topic_transitioned() is False
+
+    def test_set_then_has(self, hook_state):
+        hook_state.set_topic_transitioned()
+        assert hook_state.has_topic_transitioned() is True
+
+
 class TestSkillSkipRemaining:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_skill_skip_remaining() == 0
@@ -159,6 +168,7 @@ class TestClearSession:
         state.increment_approved_turns()
         state.set_activity_checkin()
         state.set_skill_skip_remaining(3)
+        state.set_topic_transitioned()
 
         # clear
         HookState.clear_session("sess-abc")
@@ -172,6 +182,7 @@ class TestClearSession:
         assert state.get_approved_turns() == 0
         assert state.has_activity_checkin() is False
         assert state.get_skill_skip_remaining() == 0
+        assert state.has_topic_transitioned() is False
 
 
 class TestSessionIdSlash:


### PR DESCRIPTION
## Summary
- セッション内で初めてトピックが変わった場合（check-in→実トピックへの着地等）は記録なしでもblockしない
- 2回目以降のトピック変更は従来通りblock
- `hook_state.py`に`topic_transitioned`フラグを追加し、`stop_hook.py`のステップ7で初回遷移を判定

## Test plan
- [x] 初回トピック遷移がapproveされることを確認（新規テスト）
- [x] 2回目以降のトピック遷移が記録なしでblockされることを確認（既存テスト更新）
- [x] 記録ありのトピック遷移がapproveされることを確認（既存テスト更新）
- [x] `clear_session`で`topic_transitioned`フラグも削除されることを確認
- [x] 全72テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)