### PR TITLE
feat: stop hookをイベント駆動アーキテクチャに移行（Phase 1）

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -113,7 +113,7 @@ class HookState:
         """events.jsonl にイベントを追記する"""
         if not events:
             return
-        with open(self.events_path, "a") as f:
+        with open(self.events_path, "a", encoding="utf-8") as f:
             for event in events:
                 f.write(json.dumps(event, ensure_ascii=False) + "\n")
 
@@ -123,7 +123,7 @@ class HookState:
             return []
         events = []
         try:
-            with open(self.events_path) as f:
+            with open(self.events_path, encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line:

--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -1,9 +1,10 @@
 """hook共通: 状態ファイル管理クラス HookState
 
-hookが利用する状態ファイル（prev_topic, block_count, nudge_counter, nudge_pending,
-context_retrieved, approved_turns, activity_checkin, skill_skip）の読み書きを一元管理する。
+hookが利用する状態ファイル（prev_topic, block_count, transcript_offset, current_turn,
+checked_in_activity）とイベントファイル（events_{session_id}.jsonl）の読み書きを一元管理する。
 標準ライブラリのみに依存。
 """
+import json
 from pathlib import Path
 
 
@@ -66,95 +67,25 @@ class HookState:
         """ファイル削除（missing_ok=True）"""
         self._delete(self._path("block_count"))
 
-    # --- nudge_counter ---
+    # --- transcript_offset ---
 
-    def get_nudge_counter(self) -> int:
-        """state/nudge_counter_{session_id_safe} を読む。
-        ファイルなし or 内容が不正 -> 0"""
-        return self._read_int(self._path("nudge_counter"), 0)
+    def get_transcript_offset(self) -> int:
+        """transcript差分読みのバイトオフセットを取得。未設定 -> 0"""
+        return self._read_int(self._path("transcript_offset"), 0)
 
-    def increment_nudge_counter(self) -> int:
-        """インクリメントして書き込み、新しい値を返す"""
-        new_val = self.get_nudge_counter() + 1
-        self._write(self._path("nudge_counter"), str(new_val))
-        return new_val
+    def set_transcript_offset(self, offset: int) -> None:
+        """transcript差分読みのバイトオフセットを保存"""
+        self._write(self._path("transcript_offset"), str(offset))
 
-    def reset_nudge_counter(self) -> None:
-        """ファイル削除（missing_ok=True）"""
-        self._delete(self._path("nudge_counter"))
+    # --- current_turn ---
 
-    # --- nudge_pending ---
+    def get_current_turn(self) -> int:
+        """現在のturn番号を取得。未設定 -> 0"""
+        return self._read_int(self._path("current_turn"), 0)
 
-    def set_nudge_pending(self) -> None:
-        """state/nudge_pending_{session_id_safe} に '1' を書く"""
-        self._write(self._path("nudge_pending"), "1")
-
-    def pop_nudge_pending(self) -> bool:
-        """ファイルが存在すれば削除して True、なければ False"""
-        try:
-            self._path("nudge_pending").unlink()
-            return True
-        except FileNotFoundError:
-            return False
-
-    # --- activity_nudge_pending ---
-
-    def set_activity_nudge_pending(self) -> None:
-        """state/activity_nudge_pending_{session_id_safe} に '1' を書く"""
-        self._write(self._path("activity_nudge_pending"), "1")
-
-    def pop_activity_nudge_pending(self) -> bool:
-        """ファイルが存在すれば削除して True、なければ False"""
-        try:
-            self._path("activity_nudge_pending").unlink()
-            return True
-        except FileNotFoundError:
-            return False
-
-    # --- approved_turns ---
-
-    def get_approved_turns(self) -> int:
-        """approve済みターン数を取得。block時はインクリメントされない。"""
-        return self._read_int(self._path("approved_turns"), 0)
-
-    def increment_approved_turns(self) -> int:
-        """approve済みターン数を+1して返す。ステップ7(approve)でのみ呼ばれる。"""
-        new_val = self.get_approved_turns() + 1
-        self._write(self._path("approved_turns"), str(new_val))
-        return new_val
-
-    # --- activity_checkin ---
-
-    def has_activity_checkin(self) -> bool:
-        """activity check-in済みフラグを確認。one-shot block制御に使用。"""
-        return self._path("activity_checkin").exists()
-
-    def set_activity_checkin(self) -> None:
-        """activity check-in済みフラグを設定。以後のcheck-inチェックをスキップする。"""
-        self._write(self._path("activity_checkin"), "1")
-
-    # --- skill_skip_remaining ---
-
-    def get_skill_skip_remaining(self) -> int:
-        """スキル実行中のスキップ残りターン数を取得。"""
-        return self._read_int(self._path("skill_skip"), 0)
-
-    def set_skill_skip_remaining(self, n: int) -> None:
-        """スキル実行中のスキップ残りターン数を設定。0以下の場合はファイル削除。"""
-        if n <= 0:
-            self._delete(self._path("skill_skip"))
-        else:
-            self._write(self._path("skill_skip"), str(n))
-
-    # --- topic_transitioned ---
-
-    def has_topic_transitioned(self) -> bool:
-        """セッション内で初回のトピック遷移が発生済みかチェック。"""
-        return self._path("topic_transitioned").exists()
-
-    def set_topic_transitioned(self) -> None:
-        """初回トピック遷移済みフラグを設定。"""
-        self._write(self._path("topic_transitioned"), "1")
+    def set_current_turn(self, turn: int) -> None:
+        """現在のturn番号を保存"""
+        self._write(self._path("current_turn"), str(turn))
 
     # --- checked_in_activity ---
 
@@ -171,27 +102,53 @@ class HookState:
         """checked_in_activity_{session_id} に書く"""
         self._write(self._path("checked_in_activity"), str(activity_id))
 
-    # --- context_retrieved ---
+    # --- events.jsonl ---
 
-    def has_context_retrieval(self) -> bool:
-        """context_retrieved フラグファイルが存在するかチェック。
-        セッション中に一度でもget系APIを呼んだらTrue。"""
-        return self._path("context_retrieved").exists()
+    @property
+    def events_path(self) -> Path:
+        """events_{session_id_safe}.jsonl のパスを返す"""
+        return self.BASE_DIR / f"events_{self._session_id_safe}.jsonl"
 
-    def set_context_retrieved(self) -> None:
-        """context_retrieved フラグファイルを作成する。"""
-        self._write(self._path("context_retrieved"), "1")
+    def append_events(self, events: list[dict]) -> None:
+        """events.jsonl にイベントを追記する"""
+        if not events:
+            return
+        with open(self.events_path, "a") as f:
+            for event in events:
+                f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    def read_events(self) -> list[dict]:
+        """events.jsonl から全イベントを読み込む。ファイルなし -> 空リスト"""
+        if not self.events_path.exists():
+            return []
+        events = []
+        try:
+            with open(self.events_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        events.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except FileNotFoundError:
+            return []
+        return events
 
     # --- clear_session ---
 
     @classmethod
     def clear_session(cls, session_id: str) -> None:
-        """BASE_DIR内の全状態ファイルを削除する"""
+        """BASE_DIR内の全状態ファイルとeventsファイルを削除する"""
         session_id_safe = session_id.replace("/", "_")
         if not cls.BASE_DIR.exists():
             return
         for f in cls.BASE_DIR.glob(f"*_{session_id_safe}"):
             f.unlink(missing_ok=True)
+        # events.jsonl は命名規則が異なるので個別削除
+        events_file = cls.BASE_DIR / f"events_{session_id_safe}.jsonl"
+        events_file.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -1,7 +1,215 @@
-"""hook共通: transcript解析ユーティリティ"""
+"""hook共通: transcript解析ユーティリティ
+
+イベント駆動アーキテクチャ用の差分読み・イベント抽出と、
+レガシー関数（Phase 3で廃止予定）を含む。
+"""
 import json
 import re
 from pathlib import Path
+
+# --- cc-memory MCPツールのプレフィックス ---
+
+_CC_MEMORY_PREFIX = "mcp__plugin_claude-code-memory_cc-memory__"
+
+# --- コンテキスト取得ツール ---
+
+_CONTEXT_RETRIEVAL_TOOLS = {
+    "search",
+    "get_topics",
+    "get_decisions",
+    "get_logs",
+    "get_activities",
+    "get_by_ids",
+}
+
+# --- 記録ツール ---
+
+_RECORDING_TOOLS = {
+    "add_decision",
+    "add_topic",
+    "add_log",
+}
+
+# --- check-in系ツール ---
+
+_CHECKIN_TOOLS = {
+    "check_in",
+    "add_activity",
+}
+
+
+# ===================================================================
+# イベント駆動アーキテクチャ: 差分読み + イベント抽出
+# ===================================================================
+
+
+def read_transcript_from_offset(transcript_path: str, offset: int) -> tuple[list[dict], int]:
+    """transcriptをバイトオフセットから読み、(新規エントリ一覧, 新オフセット)を返す。
+
+    transcriptはappend-onlyのJSONL形式。offsetがファイルサイズを超えた場合は
+    0にリセットして全読みする（defensive coding）。
+    """
+    path = Path(transcript_path).expanduser()
+    if not path.exists():
+        return [], 0
+
+    try:
+        file_size = path.stat().st_size
+        if offset > file_size:
+            offset = 0
+
+        entries = []
+        with open(path, "rb") as f:
+            f.seek(offset)
+            data = f.read()
+            new_offset = offset + len(data)
+
+        for line in data.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+        return entries, new_offset
+
+    except Exception:
+        return [], offset
+
+
+def is_user_message(entry: dict) -> bool:
+    """エントリがUser Message（ターン境界）かどうかを判定する。
+
+    User Message = ユーザーが実際に送信したuserエントリ。
+    tool_resultやsystem-reminderを含むuser/humanエントリは除外する。
+    string形式のsystem-reminderの誤判定は許容（発生率0.02%）。
+    """
+    if entry.get("type") not in ("user", "human"):
+        return False
+    content = entry.get("message", {}).get("content")
+    if isinstance(content, str):
+        return True
+    if isinstance(content, list):
+        return not any(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in content
+        )
+    return False
+
+
+def extract_events(entries: list[dict], current_turn: int) -> tuple[list[dict], int]:
+    """transcriptエントリ群からイベントを抽出する。
+
+    3型イベントを抽出:
+    - tool: cc-memoryツール呼び出し（assistantのtool_useブロック）
+    - meta: メタタグ検出（assistantのtextブロック）
+    - skill: スキル開始検出（User Messageの<command-name>タグ）
+
+    Args:
+        entries: transcriptの新規エントリ一覧
+        current_turn: 現在のturn番号
+
+    Returns:
+        (抽出されたイベントのリスト, 更新後のturn番号)
+    """
+    events: list[dict] = []
+
+    for entry in entries:
+        entry_type = entry.get("type", "")
+
+        # Turn境界検出: User Message到着で新turnが始まる
+        if is_user_message(entry):
+            current_turn += 1
+            # skillイベント: User Messageに<command-name>が含まれる場合
+            text = _extract_user_content_text(entry)
+            match = re.search(r"<command-name>/?(.*?)</command-name>", text)
+            if match:
+                events.append({
+                    "e": "skill",
+                    "name": match.group(1).strip(),
+                    "turn": current_turn,
+                })
+            continue
+
+        # assistantエントリからtool/metaイベントを抽出
+        if entry_type == "assistant":
+            message = entry.get("message", {})
+            content = message.get("content", [])
+
+            if isinstance(content, str):
+                meta = parse_meta_tag(content)
+                if meta:
+                    events.append({
+                        "e": "meta",
+                        "topic": meta["topic_name"],
+                        "turn": current_turn,
+                    })
+                continue
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+
+                if block_type == "tool_use":
+                    name = block.get("name", "")
+                    if name.startswith(_CC_MEMORY_PREFIX):
+                        short_name = name[len(_CC_MEMORY_PREFIX):]
+                        event: dict = {
+                            "e": "tool",
+                            "name": short_name,
+                            "turn": current_turn,
+                        }
+                        # check_inのactivity_idを保存
+                        if short_name == "check_in":
+                            aid = block.get("input", {}).get("activity_id")
+                            if aid is not None:
+                                try:
+                                    event["activity_id"] = int(aid)
+                                except (ValueError, TypeError):
+                                    pass
+                        events.append(event)
+
+                elif block_type == "text":
+                    text = block.get("text", "")
+                    meta = parse_meta_tag(text)
+                    if meta:
+                        events.append({
+                            "e": "meta",
+                            "topic": meta["topic_name"],
+                            "turn": current_turn,
+                        })
+
+    return events, current_turn
+
+
+# ===================================================================
+# 共通ユーティリティ（イベント駆動でも使用）
+# ===================================================================
+
+
+def parse_meta_tag(text: str) -> dict | None:
+    """テキストからメタタグをパースする。
+
+    フォーマット:
+    <!-- [meta] topic: xxx -->
+
+    Returns:
+        {"found": True, "topic_name": ...}
+        or None
+    """
+    pattern = r'<!--\s*\[meta\]\s*topic:\s*(.+?)\s*-->'
+    match = re.search(pattern, text)
+
+    if match:
+        return {
+            "found": True,
+            "topic_name": match.group(1).strip(),
+        }
+
+    return None
 
 
 def get_last_assistant_entry(transcript_path: str) -> dict | None:
@@ -31,17 +239,6 @@ def get_last_assistant_entry(transcript_path: str) -> dict | None:
     return None
 
 
-def _has_text_block(entry: dict) -> bool:
-    """エントリにtextブロックが含まれるかチェック。"""
-    content = entry.get("message", {}).get("content", [])
-    if isinstance(content, str):
-        return bool(content.strip())
-    return any(
-        isinstance(block, dict) and block.get("type") == "text"
-        for block in content
-    )
-
-
 def extract_text_from_entry(entry: dict) -> str:
     """エントリからテキスト内容を抽出する。"""
     message = entry.get("message", {})
@@ -60,35 +257,60 @@ def extract_text_from_entry(entry: dict) -> str:
     return "\n".join(texts)
 
 
-def parse_meta_tag(text: str) -> dict | None:
-    """テキストからメタタグをパースする。
-
-    フォーマット:
-    <!-- [meta] topic: xxx -->
-
-    Returns:
-        {"found": True, "topic_name": ...}
-        or None
-    """
-    pattern = r'<!--\s*\[meta\]\s*topic:\s*(.+?)\s*-->'
-    match = re.search(pattern, text)
-
-    if match:
-        return {
-            "found": True,
-            "topic_name": match.group(1).strip(),
-        }
-
-    return None
+def _has_text_block(entry: dict) -> bool:
+    """エントリにtextブロックが含まれるかチェック。"""
+    content = entry.get("message", {}).get("content", [])
+    if isinstance(content, str):
+        return bool(content.strip())
+    return any(
+        isinstance(block, dict) and block.get("type") == "text"
+        for block in content
+    )
 
 
-_RECORDING_TOOLS = [
-    "mcp__plugin_claude-code-memory_cc-memory__add_decision",
-    "mcp__plugin_claude-code-memory_cc-memory__add_topic",
-    "mcp__plugin_claude-code-memory_cc-memory__add_log",
+def _extract_user_content_text(entry: dict) -> str:
+    """userエントリからcontent文字列を取得する。"""
+    content = entry.get("message", {}).get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "") if isinstance(b, dict) else str(b)
+            for b in content
+        )
+    return ""
+
+
+# ===================================================================
+# レガシー関数（Phase 3で廃止予定）
+# 現在はテストからの参照があるため残置
+# ===================================================================
+
+
+_RECORDING_TOOLS_FULL = [
+    f"{_CC_MEMORY_PREFIX}add_decision",
+    f"{_CC_MEMORY_PREFIX}add_topic",
+    f"{_CC_MEMORY_PREFIX}add_log",
 ]
 
-_ADD_DECISION_TOOL = "mcp__plugin_claude-code-memory_cc-memory__add_decision"
+_ADD_DECISION_TOOL = f"{_CC_MEMORY_PREFIX}add_decision"
+
+_ACTIVITY_CHECKIN_TOOLS_FULL = [
+    f"{_CC_MEMORY_PREFIX}check_in",
+    f"{_CC_MEMORY_PREFIX}add_activity",
+]
+
+_CHECKIN_TOOL = f"{_CC_MEMORY_PREFIX}check_in"
+_ADD_ACTIVITY_TOOL = f"{_CC_MEMORY_PREFIX}add_activity"
+
+_CONTEXT_RETRIEVAL_TOOLS_FULL = [
+    f"{_CC_MEMORY_PREFIX}search",
+    f"{_CC_MEMORY_PREFIX}get_topics",
+    f"{_CC_MEMORY_PREFIX}get_decisions",
+    f"{_CC_MEMORY_PREFIX}get_logs",
+    f"{_CC_MEMORY_PREFIX}get_activities",
+    f"{_CC_MEMORY_PREFIX}get_by_ids",
+]
 
 
 def _has_tool_calls(entries: list[dict], tool_names: list[str]) -> bool:
@@ -113,22 +335,12 @@ def _has_tool_calls(entries: list[dict], tool_names: list[str]) -> bool:
 
 def has_recent_recording(entries: list[dict]) -> bool:
     """entriesにadd_decision/add_topic/add_logのツール呼び出しがあるかチェック。"""
-    return _has_tool_calls(entries, _RECORDING_TOOLS)
-
-
-_ACTIVITY_CHECKIN_TOOLS = [
-    "mcp__plugin_claude-code-memory_cc-memory__check_in",
-    "mcp__plugin_claude-code-memory_cc-memory__add_activity",
-]
+    return _has_tool_calls(entries, _RECORDING_TOOLS_FULL)
 
 
 def has_activity_checkin_calls(entries: list[dict]) -> bool:
     """entriesにcheck_in/add_activityのツール呼び出しがあるかチェック。"""
-    return _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS)
-
-
-_CHECKIN_TOOL = "mcp__plugin_claude-code-memory_cc-memory__check_in"
-_ADD_ACTIVITY_TOOL = "mcp__plugin_claude-code-memory_cc-memory__add_activity"
+    return _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS_FULL)
 
 
 def extract_checkin_activity_id(entries: list[dict]) -> int | None:
@@ -219,10 +431,7 @@ def extract_last_activity_id(transcript_path: str) -> int | None:
 
 
 def _parse_activity_id_from_result(result_content) -> int | None:
-    """tool_resultのcontentからactivity_idをパースする。
-
-    contentは文字列（JSON）またはリスト（contentブロック配列）の場合がある。
-    """
+    """tool_resultのcontentからactivity_idをパースする。"""
     if isinstance(result_content, str):
         return _try_parse_activity_id(result_content)
     if isinstance(result_content, list):
@@ -246,19 +455,9 @@ def _try_parse_activity_id(text: str) -> int | None:
     return None
 
 
-_CONTEXT_RETRIEVAL_TOOLS = [
-    "mcp__plugin_claude-code-memory_cc-memory__search",
-    "mcp__plugin_claude-code-memory_cc-memory__get_topics",
-    "mcp__plugin_claude-code-memory_cc-memory__get_decisions",
-    "mcp__plugin_claude-code-memory_cc-memory__get_logs",
-    "mcp__plugin_claude-code-memory_cc-memory__get_activities",
-    "mcp__plugin_claude-code-memory_cc-memory__get_by_ids",
-]
-
-
 def has_context_retrieval_calls(entries: list[dict]) -> bool:
     """entriesにget系APIの呼び出しがあるかチェック。"""
-    return _has_tool_calls(entries, _CONTEXT_RETRIEVAL_TOOLS)
+    return _has_tool_calls(entries, _CONTEXT_RETRIEVAL_TOOLS_FULL)
 
 
 def has_decision_without_activity(entries: list[dict]) -> bool:
@@ -266,21 +465,8 @@ def has_decision_without_activity(entries: list[dict]) -> bool:
     has_decision = _has_tool_calls(entries, [_ADD_DECISION_TOOL])
     if not has_decision:
         return False
-    has_activity = _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS)
+    has_activity = _has_tool_calls(entries, _ACTIVITY_CHECKIN_TOOLS_FULL)
     return not has_activity
-
-
-def _extract_user_content_text(entry: dict) -> str:
-    """userエントリからcontent文字列を取得する。"""
-    content = entry.get("message", {}).get("content", "")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return " ".join(
-            b.get("text", "") if isinstance(b, dict) else str(b)
-            for b in content
-        )
-    return ""
 
 
 def get_transcript_info(transcript_path: str) -> tuple[list[dict], bool]:
@@ -307,7 +493,6 @@ def get_transcript_info(transcript_path: str) -> tuple[list[dict], bool]:
                     if entry_type == "assistant":
                         entries.append(entry)
                     elif entry_type in ("user", "human"):
-                        # tool_resultエントリはスキップ（skill検出を上書きしないため）
                         content = entry.get("message", {}).get("content", "")
                         if isinstance(content, list) and content and isinstance(content[0], dict) and content[0].get("type") == "tool_result":
                             continue

--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -43,19 +43,21 @@ _CHECKIN_TOOLS = {
 # ===================================================================
 
 
-def read_transcript_from_offset(transcript_path: str, offset: int) -> tuple[list[dict], int]:
-    """transcriptをバイトオフセットから読み、(新規エントリ一覧, 新オフセット)を返す。
+def read_transcript_from_offset(transcript_path: str, offset: int) -> tuple[list[dict], int, bool]:
+    """transcriptをバイトオフセットから読み、(新規エントリ一覧, 新オフセット, リセット発生)を返す。
 
     transcriptはappend-onlyのJSONL形式。offsetがファイルサイズを超えた場合は
     0にリセットして全読みする（defensive coding）。
+    リセット発生時は呼び出し側でcurrent_turnやevents.jsonlもリセットすべき。
     """
     path = Path(transcript_path).expanduser()
     if not path.exists():
-        return [], 0
+        return [], 0, False
 
     try:
         file_size = path.stat().st_size
-        if offset > file_size:
+        offset_reset = offset > file_size
+        if offset_reset:
             offset = 0
 
         entries = []
@@ -73,10 +75,10 @@ def read_transcript_from_offset(transcript_path: str, offset: int) -> tuple[list
             except json.JSONDecodeError:
                 continue
 
-        return entries, new_offset
+        return entries, new_offset, offset_reset
 
     except Exception:
-        return [], offset
+        return [], offset, False
 
 
 def is_user_message(entry: dict) -> bool:

--- a/hooks/pretooluse_hook.py
+++ b/hooks/pretooluse_hook.py
@@ -1,12 +1,11 @@
-"""PreToolUse hook: nudgeリマインダー注入
+"""PreToolUse hook: nudgeリマインダー注入（イベント駆動版）
 
 処理フロー:
 1. stdin読み込み → JSON parse（session_id取得）
 2. session_idが空/null → 空JSON出力して終了
-3. HookState(session_id)を生成
-4. アクティビティ作成nudge → system-reminder注入
-5. 記録リマインダーnudge → system-reminder注入
-6. 何もなし → 空JSON出力
+3. events.jsonl全読み
+4. 未消費のnudgeイベント判定 → system-reminder注入
+5. 何もなし → 空JSON出力
 """
 import json
 import os
@@ -73,26 +72,47 @@ def main() -> None:
             print("{}")
             return
 
-        # 3. HookState生成
+        # 3. events.jsonl全読み
         state = HookState(session_id)
+        events = state.read_events()
 
-        # 4. アクティビティ作成nudge
-        if state.pop_activity_nudge_pending():
-            print(json.dumps(_make_hook_output(_ACTIVITY_NUDGE_MESSAGE), ensure_ascii=False))
+        if not events:
+            print("{}")
             return
 
-        # 5. 記録リマインダーnudge
-        if state.pop_nudge_pending():
-            print(json.dumps(_make_hook_output(_RECORD_NUDGE_MESSAGE), ensure_ascii=False))
-            return
+        # 4. 未消費のnudgeイベント判定
+        # 最新のnudgeイベントを探す（consumed=Trueでないもの）
+        for e in reversed(events):
+            if e.get("e") != "nudge":
+                continue
+            if e.get("consumed"):
+                continue
 
-        # 6. 何もなし
+            # nudgeを消費済みにマーク
+            e["consumed"] = True
+            _rewrite_events(state, events)
+
+            if e.get("type") == "activity":
+                print(json.dumps(_make_hook_output(_ACTIVITY_NUDGE_MESSAGE), ensure_ascii=False))
+                return
+            elif e.get("type") == "record":
+                print(json.dumps(_make_hook_output(_RECORD_NUDGE_MESSAGE), ensure_ascii=False))
+                return
+
+        # 5. 何もなし
         print("{}")
 
     except Exception as e:
         # フェイルオープン: 例外時は空JSON + stderrログ
         print(f"pretooluse_hook.py error: {e}", file=sys.stderr)
         print("{}")
+
+
+def _rewrite_events(state: HookState, events: list[dict]) -> None:
+    """events.jsonlを全書き換えする（nudge消費マーク用）。"""
+    with open(state.events_path, "w") as f:
+        for event in events:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
 
 
 if __name__ == "__main__":

--- a/hooks/pretooluse_hook.py
+++ b/hooks/pretooluse_hook.py
@@ -109,10 +109,17 @@ def main() -> None:
 
 
 def _rewrite_events(state: HookState, events: list[dict]) -> None:
-    """events.jsonlを全書き換えする（nudge消費マーク用）。"""
-    with open(state.events_path, "w") as f:
+    """events.jsonlを全書き換えする（nudge消費マーク用）。
+    tempfile + os.replace()でアトミックに書き換える。"""
+    import os
+    import tempfile
+
+    dir_ = state.events_path.parent
+    with tempfile.NamedTemporaryFile("w", dir=dir_, delete=False, suffix=".tmp", encoding="utf-8") as f:
+        tmp = f.name
         for event in events:
             f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    os.replace(tmp, state.events_path)
 
 
 if __name__ == "__main__":

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -1,18 +1,16 @@
-"""Stop hook: メタタグ強制 + コンテキスト取得チェック + activity check-in + 記録強制 + nudgeカウンター
+"""Stop hook: イベント駆動アーキテクチャ Phase 1
 
 処理フロー:
 1. stdin読み込み → JSON parse
-2. ブロック上限チェック（1回で強制approve）
-3. スキルスキップ判定（<command-name>検出 or 残りターン → 即approve）
-4. メタタグparse（一次ソース: stdinのlast_assistant_message、フォールバック: transcript）
-   → 1ターン目（approved_turns == 0）は猶予。2ターン目以降はなければblock
-5. get系API呼び出しチェック（セッション中1回以上）
-   → なければblock
-6. activity check-inチェック（_CHECKIN_DEFER_TURNSターン後、one-shot block）
-   → check-in/add_activity未呼出 → block
-7. トピック変更チェック → 初回遷移は許容、2回目以降は記録がなければblock
-8. nudgeカウンター管理
-9. 状態更新 → approve
+2. ブロック上限チェック（_BLOCK_LIMIT回で強制approve）
+3. transcript差分読み → イベント抽出 → events.jsonl追記
+4. events.jsonl全読み
+5. Skill Span判定 → Span中なら即approve（安全弁: MAX_SKILL_SPAN_TURNS）
+6. メタタグ判定（最新e:metaイベント、初期ターン猶予あり）
+7. context retrieval判定（e:toolで取得系ツールが1件でもあるか）
+8. check-in判定（e:toolでcheck_in/add_activityが1件でもあるか、猶予あり）
+9. トピック変更 → 記録チェック（prev_topic比較 + 初回遷移許容 + e:toolで直近N turn）
+10. nudge判定 + 状態更新 → approve
 """
 import json
 import os
@@ -27,22 +25,22 @@ if str(_project_root) not in sys.path:
 from hooks.heartbeat import update_heartbeat
 from hooks.hook_state import HookState
 from hooks.hook_transcript import (
-    extract_checkin_activity_id,
+    _CHECKIN_TOOLS,
+    _CONTEXT_RETRIEVAL_TOOLS,
+    _RECORDING_TOOLS,
+    extract_events,
     extract_last_activity_id,
     extract_text_from_entry,
     get_last_assistant_entry,
-    get_transcript_info,
-    has_activity_checkin_calls,
-    has_context_retrieval_calls,
-    has_decision_without_activity,
-    has_recent_recording,
     parse_meta_tag,
+    read_transcript_from_offset,
 )
 
 _BLOCK_LIMIT = 1
-_NUDGE_INTERVAL = 2
 _CHECKIN_DEFER_TURNS = 2
-_SKILL_SKIP_TURNS = 3
+_MAX_SKILL_SPAN_TURNS = 20
+_NUDGE_INTERVAL = 2
+_RECENT_TURNS_WINDOW = 3
 
 
 def _output(decision: str, reason: str = "") -> None:
@@ -76,97 +74,124 @@ def main() -> None:
             _output("approve", f"ブロック上限（{_BLOCK_LIMIT}回）に達しました。強制的に通します。")
             return
 
-        # 3. スキルスキップ判定
-        skill_skip = state.get_skill_skip_remaining()
-        if skill_skip > 0:
-            state.set_skill_skip_remaining(skill_skip - 1)
-            state.reset_block_count()
-            state.increment_approved_turns()
-            _output("approve", f"スキル実行中（残り{skill_skip - 1}ターン）")
-            return
+        # 3. transcript差分読み → イベント抽出 → events.jsonl追記
+        offset = state.get_transcript_offset()
+        current_turn = state.get_current_turn()
+        new_entries, new_offset = read_transcript_from_offset(transcript_path, offset)
+        new_events, current_turn = extract_events(new_entries, current_turn)
 
-        all_entries, has_skill_cmd = get_transcript_info(transcript_path)
-        if has_skill_cmd:
-            state.set_skill_skip_remaining(_SKILL_SKIP_TURNS - 1)
-            state.reset_block_count()
-            state.increment_approved_turns()
-            _output("approve", "スキル実行を検出。チェックをスキップします。")
-            return
-
-        # 4. メタタグparse
-        # 一次ソース: stdinのlast_assistant_message
+        # stdinのlast_assistant_messageからメタタグを補完（レースコンディション対策）
         last_msg = data.get("last_assistant_message", "")
-        meta = parse_meta_tag(last_msg) if last_msg else None
+        if last_msg:
+            meta = parse_meta_tag(last_msg)
+            if meta:
+                # 同一turnで同じtopicのmetaイベントがなければ追加
+                has_same_meta = any(
+                    e["e"] == "meta" and e["turn"] == current_turn and e["topic"] == meta["topic_name"]
+                    for e in new_events
+                )
+                if not has_same_meta:
+                    new_events.append({
+                        "e": "meta",
+                        "topic": meta["topic_name"],
+                        "turn": current_turn,
+                    })
 
-        # フォールバック: transcriptから取得
-        if meta is None:
-            last_entry = get_last_assistant_entry(transcript_path)
-            if last_entry is not None:
-                text = extract_text_from_entry(last_entry)
-                meta = parse_meta_tag(text)
+        state.append_events(new_events)
+        state.set_transcript_offset(new_offset)
+        state.set_current_turn(current_turn)
 
-        if meta is None:
-            # 1ターン目（approved_turns == 0）はメタタグなしでも猶予
-            if state.get_approved_turns() == 0:
-                # メタタグなしでもapproveして次に進む（ステップ5以降はスキップ）
+        # 4. events.jsonl全読み
+        all_events = state.read_events()
+
+        # 5. Skill Span判定
+        in_skill_span = _is_in_skill_span(all_events, current_turn)
+        if in_skill_span:
+            state.reset_block_count()
+            _output("approve", "Skill Span中のためチェックをスキップします。")
+            _update_state_on_approve(state, all_events, transcript_path)
+            return
+
+        # 6. メタタグ判定
+        latest_meta = _get_latest_meta(all_events)
+        if latest_meta is None:
+            if current_turn <= 1:
                 state.reset_block_count()
-                state.increment_approved_turns()
                 _output("approve", "1ターン目のためメタタグチェックを猶予します。")
+                _update_state_on_approve(state, all_events, transcript_path)
                 return
+            # stdinフォールバック: last_assistant_messageが無い場合transcriptから
+            if not last_msg:
+                last_entry = get_last_assistant_entry(transcript_path)
+                if last_entry is not None:
+                    text = extract_text_from_entry(last_entry)
+                    meta_fb = parse_meta_tag(text)
+                    if meta_fb:
+                        latest_meta = meta_fb["topic_name"]
+            if latest_meta is None:
+                state.increment_block_count()
+                _output(
+                    "block",
+                    "応答の最後にメタタグを出力してください。フォーマット: "
+                    "<!-- [meta] topic: xxx -->",
+                )
+                return
+
+        current_topic_name = latest_meta
+
+        # 7. context retrieval判定
+        has_retrieval = any(
+            e["e"] == "tool" and e.get("name") in _CONTEXT_RETRIEVAL_TOOLS
+            for e in all_events
+        )
+        if not has_retrieval:
             state.increment_block_count()
             _output(
                 "block",
-                "応答の最後にメタタグを出力してください。フォーマット: "
-                "<!-- [meta] topic: xxx -->",
+                "応答の前に過去のコンテキストを取得してください。"
+                "search / get_topics / get_decisions / get_logs / get_activities / get_by_ids "
+                "のいずれかを使ってください。",
             )
             return
 
-        current_topic_name = meta["topic_name"]
+        # 8. check-in判定
+        has_checkin = any(
+            e["e"] == "tool" and e.get("name") in _CHECKIN_TOOLS
+            for e in all_events
+        )
+        if has_checkin:
+            # activity_idを抽出して保存
+            _update_checked_in_activity(state, all_events, transcript_path)
+        elif current_turn == _CHECKIN_DEFER_TURNS:
+            # one-shot block: 正確にdefer turnで1回だけblock
+            state.increment_block_count()
+            _output(
+                "block",
+                "アクティビティにcheck-inしてください。"
+                "該当するものがなければadd_activityで作成してください。",
+            )
+            return
 
-        # 5. get系API呼び出しチェック（セッション中1回以上）
-
-        if not state.has_context_retrieval():
-            if has_context_retrieval_calls(all_entries):
-                state.set_context_retrieved()
-            else:
-                state.increment_block_count()
-                _output(
-                    "block",
-                    "応答の前に過去のコンテキストを取得してください。"
-                    "search / get_topics / get_decisions / get_logs / get_activities / get_by_ids "
-                    "のいずれかを使ってください。",
-                )
-                return
-
-        # 6. Activity check-in チェック（2ターン目）
-        if not state.has_activity_checkin():
-            has_checkin = has_activity_checkin_calls(all_entries)
-            if has_checkin:
-                state.set_activity_checkin()
-                activity_id = extract_checkin_activity_id(all_entries)
-                if activity_id is None:
-                    activity_id = extract_last_activity_id(transcript_path)
-                if activity_id is not None:
-                    state.set_checked_in_activity(activity_id)
-            elif state.get_approved_turns() >= _CHECKIN_DEFER_TURNS:
-                state.set_activity_checkin()  # one-shot: 次回はスキップ
-                state.increment_block_count()
-                _output(
-                    "block",
-                    "アクティビティにcheck-inしてください。"
-                    "該当するものがなければadd_activityで作成してください。",
-                )
-                return
-
-        # 7. トピック変更チェック → 記録がなければblock（初回遷移は許容）
+        # 9. トピック変更チェック
         prev_topic = state.get_prev_topic()
         if prev_topic is not None and prev_topic != current_topic_name:
-            if not state.has_topic_transitioned():
-                # 初回のトピック遷移は許容（check-in→実トピックへの着地等）
-                state.set_topic_transitioned()
-            else:
-                recent_entries = all_entries[-5:] if all_entries else []
-                if not has_recent_recording(recent_entries):
+            # 初回遷移判定: 過去turnのmetaイベントに異なるtopicが2つ以上あるか
+            # current_turnのmetaは「今まさに遷移した」ものなので除外
+            prev_meta_topics = {
+                e["topic"] for e in all_events
+                if e["e"] == "meta" and e.get("turn", 0) < current_turn
+            }
+            is_first_transition = len(prev_meta_topics) <= 1
+            if not is_first_transition:
+                # 直近N turnに記録ツール呼び出しがあるか
+                recent_turn_threshold = current_turn - _RECENT_TURNS_WINDOW
+                has_recent_record = any(
+                    e["e"] == "tool"
+                    and e.get("name") in _RECORDING_TOOLS
+                    and e.get("turn", 0) >= recent_turn_threshold
+                    for e in all_events
+                )
+                if not has_recent_record:
                     state.increment_block_count()
                     _output(
                         "block",
@@ -175,35 +200,121 @@ def main() -> None:
                     )
                     return
 
-        # 8. nudgeカウンター
-        nudge_count = state.increment_nudge_counter()
-
-        if nudge_count % _NUDGE_INTERVAL == 0:
-            recent_entries = all_entries[-10:] if all_entries else []
-            if has_recent_recording(recent_entries):
-                state.reset_nudge_counter()
-            else:
-                state.set_nudge_pending()
-
-        # 8b. decision後のアクティビティ作成nudge
-        recent_entries_short = all_entries[-2:] if all_entries else []
-        if has_decision_without_activity(recent_entries_short):
-            state.set_activity_nudge_pending()
-
-        # 9. 状態更新 + approve
-        activity_id = state.get_checked_in_activity()
-        if activity_id is not None:
-            update_heartbeat(activity_id)
-
-        state.set_prev_topic(current_topic_name)
+        # 10. nudge判定 + 状態更新 + approve
         state.reset_block_count()
-        state.increment_approved_turns()
         _output("approve")
+        _update_state_on_approve(state, all_events, transcript_path)
+        _handle_nudges(state, all_events, current_turn)
 
     except Exception as e:
         # フェイルオープン: 例外時はapprove
         print(f"stop_hook.py error: {e}", file=sys.stderr)
         _output("approve", f"stop_hook.py internal error: {e}")
+
+
+def _is_in_skill_span(events: list[dict], current_turn: int) -> bool:
+    """Skill Span中かどうかを判定する。
+
+    最後のskillイベントのturnから現在のturnまでの距離が
+    MAX_SKILL_SPAN_TURNS以内で、かつ直近のturnにskillイベントがある場合。
+    """
+    last_skill_turn = None
+    for e in events:
+        if e["e"] == "skill":
+            last_skill_turn = e.get("turn", 0)
+
+    if last_skill_turn is None:
+        return False
+
+    # 安全弁: MAX_SKILL_SPAN_TURNS超過で強制終了
+    if current_turn - last_skill_turn > _MAX_SKILL_SPAN_TURNS:
+        return False
+
+    # 直近turnにskillイベントがあるか（= skillイベントがないturnが来たらSpan終了）
+    return last_skill_turn >= current_turn
+
+
+def _get_latest_meta(events: list[dict]) -> str | None:
+    """events内の最新metaイベントからtopic名を取得する。"""
+    for e in reversed(events):
+        if e["e"] == "meta":
+            return e.get("topic")
+    return None
+
+
+def _update_checked_in_activity(
+    state: HookState, events: list[dict], transcript_path: str
+) -> None:
+    """check_inイベントからactivity_idを抽出し、checked_in_activityを更新する。"""
+    # check_inイベントからactivity_idを取得
+    for e in reversed(events):
+        if e["e"] == "tool" and e.get("name") == "check_in" and "activity_id" in e:
+            state.set_checked_in_activity(e["activity_id"])
+            return
+
+    # フォールバック: transcript全走査（add_activityのtool_result対応）
+    aid = extract_last_activity_id(transcript_path)
+    if aid is not None:
+        state.set_checked_in_activity(aid)
+
+
+def _update_state_on_approve(
+    state: HookState, events: list[dict], transcript_path: str
+) -> None:
+    """approve時の状態更新（prev_topic, heartbeat）"""
+    # prev_topic更新
+    latest_meta = _get_latest_meta(events)
+    if latest_meta:
+        state.set_prev_topic(latest_meta)
+
+    # heartbeat更新
+    activity_id = state.get_checked_in_activity()
+    if activity_id is not None:
+        update_heartbeat(activity_id)
+
+
+def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> None:
+    """nudge判定: events.jsonlから直接判定してnudgeイベントを追記する。
+
+    pretooluse_hookがevents.jsonlを読んでnudge注入を判定するため、
+    nudgeフラグの代わりにnudgeイベントをevents.jsonlに追記する。
+    """
+    nudge_events: list[dict] = []
+
+    # record nudge: _NUDGE_INTERVAL turnごとに記録がなければ発火
+    if current_turn > 0 and current_turn % _NUDGE_INTERVAL == 0:
+        recent_turn_threshold = current_turn - _NUDGE_INTERVAL
+        has_recent_record = any(
+            e["e"] == "tool"
+            and e.get("name") in _RECORDING_TOOLS
+            and e.get("turn", 0) > recent_turn_threshold
+            for e in events
+        )
+        if not has_recent_record:
+            nudge_events.append({
+                "e": "nudge",
+                "type": "record",
+                "turn": current_turn,
+            })
+
+    # activity nudge: 直近turnにadd_decisionあり & add_activity/check_inなし
+    recent_events = [e for e in events if e.get("turn", 0) == current_turn]
+    has_decision = any(
+        e["e"] == "tool" and e.get("name") == "add_decision" for e in recent_events
+    )
+    if has_decision:
+        has_activity = any(
+            e["e"] == "tool" and e.get("name") in _CHECKIN_TOOLS for e in recent_events
+        )
+        if not has_activity:
+            nudge_events.append({
+                "e": "nudge",
+                "type": "activity",
+                "turn": current_turn,
+            })
+
+    if nudge_events:
+        state.append_events(nudge_events)
 
 
 if __name__ == "__main__":

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -77,7 +77,15 @@ def main() -> None:
         # 3. transcript差分読み → イベント抽出 → events.jsonl追記
         offset = state.get_transcript_offset()
         current_turn = state.get_current_turn()
-        new_entries, new_offset = read_transcript_from_offset(transcript_path, offset)
+        new_entries, new_offset, offset_was_reset = read_transcript_from_offset(transcript_path, offset)
+
+        # オフセットリセット時はcurrent_turnとevents.jsonlもリセット
+        if offset_was_reset:
+            current_turn = 0
+            # events.jsonlを空にする（古いイベントは無効）
+            if state.events_path.exists():
+                state.events_path.unlink()
+
         new_events, current_turn = extract_events(new_entries, current_turn)
 
         # stdinのlast_assistant_messageからメタタグを補完（レースコンディション対策）
@@ -120,7 +128,8 @@ def main() -> None:
                 _output("approve", "1ターン目のためメタタグチェックを猶予します。")
                 _update_state_on_approve(state, all_events, transcript_path)
                 return
-            # stdinフォールバック: last_assistant_messageが無い場合transcriptから
+            # フォールバック: last_assistant_messageが無い場合transcriptから取得
+            # NOTE: get_last_assistant_entryは全行逆順走査（Phase 3で廃止予定）
             if not last_msg:
                 last_entry = get_last_assistant_entry(transcript_path)
                 if last_entry is not None:

--- a/tests/e2e/test_pretooluse_hook.py
+++ b/tests/e2e/test_pretooluse_hook.py
@@ -1,7 +1,7 @@
-"""hooks/pretooluse_hook.py のE2Eテスト
+"""hooks/pretooluse_hook.py のE2Eテスト（イベント駆動アーキテクチャ版）
 
 subprocess.runでpretooluse_hook.pyを呼び出し、stdin→stdoutの入出力をテスト。
-テスト用にtmpディレクトリのstateを使う（HOOK_STATE_DIR環境変数）。
+nudge判定はevents.jsonl内のnudgeイベントに基づく。
 """
 import json
 import os
@@ -36,21 +36,41 @@ def _run_hook(input_data: dict, state_dir: Path) -> subprocess.CompletedProcess:
     )
 
 
-class TestNoFlags:
-    """フラグなし → 空JSON"""
+def _write_events(events: list[dict], state_dir: Path) -> None:
+    """events.jsonlをpre-seedする"""
+    state = HookState(_SESSION_ID)
+    state.append_events(events)
 
-    def test_empty_json_when_no_flags(self, state_dir):
+
+class TestNoNudge:
+    """nudgeイベントなし → 空JSON"""
+
+    def test_empty_json_when_no_events(self, state_dir):
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+
+    def test_empty_json_when_no_nudge_events(self, state_dir):
+        _write_events(
+            [
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "meta", "topic": "test", "turn": 1},
+            ],
+            state_dir,
+        )
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         assert result.returncode == 0
         assert json.loads(result.stdout) == {}
 
 
-class TestNudgePending:
-    """nudge_pendingフラグあり → system-reminder注入 + フラグ消去確認"""
+class TestRecordNudge:
+    """record nudgeイベント → system-reminder注入"""
 
     def test_record_nudge_injection(self, state_dir):
-        state = HookState(_SESSION_ID)
-        state.set_nudge_pending()
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 2}],
+            state_dir,
+        )
 
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         assert result.returncode == 0
@@ -64,22 +84,28 @@ class TestNudgePending:
         assert "Self-check before continuing" in ctx
         assert "add_decision" in ctx
 
-    def test_pending_flag_cleared_after_nudge(self, state_dir):
-        state = HookState(_SESSION_ID)
-        state.set_nudge_pending()
+    def test_nudge_consumed_after_injection(self, state_dir):
+        """nudge消費後は空JSON"""
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 2}],
+            state_dir,
+        )
 
         _run_hook({"session_id": _SESSION_ID}, state_dir)
 
-        # フラグが消去されていることを確認
-        assert state.pop_nudge_pending() is False
+        # 2回目は空JSON
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert json.loads(result.stdout) == {}
 
 
-class TestActivityNudgePending:
-    """activity_nudge_pendingフラグあり → system-reminder注入 + フラグ消去確認"""
+class TestActivityNudge:
+    """activity nudgeイベント → system-reminder注入"""
 
     def test_activity_nudge_injection(self, state_dir):
-        state = HookState(_SESSION_ID)
-        state.set_activity_nudge_pending()
+        _write_events(
+            [{"e": "nudge", "type": "activity", "turn": 3}],
+            state_dir,
+        )
 
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         assert result.returncode == 0
@@ -90,27 +116,27 @@ class TestActivityNudgePending:
         assert "decision" in ctx
         assert "activity" in ctx.lower()
 
-    def test_activity_nudge_flag_cleared(self, state_dir):
-        state = HookState(_SESSION_ID)
-        state.set_activity_nudge_pending()
-
-        _run_hook({"session_id": _SESSION_ID}, state_dir)
-        assert state.pop_activity_nudge_pending() is False
-
-    def test_activity_nudge_takes_priority_over_record_nudge(self, state_dir):
-        """両方のフラグがある場合、activity_nudgeが先に消費される"""
-        state = HookState(_SESSION_ID)
-        state.set_activity_nudge_pending()
-        state.set_nudge_pending()
+    def test_activity_nudge_takes_priority(self, state_dir):
+        """activity nudgeが最新なら、record nudgeより優先"""
+        _write_events(
+            [
+                {"e": "nudge", "type": "record", "turn": 2},
+                {"e": "nudge", "type": "activity", "turn": 3},
+            ],
+            state_dir,
+        )
 
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         output = json.loads(result.stdout)
         ctx = output["hookSpecificOutput"]["additionalContext"]
-        # activity nudgeが注入される
+        # activity nudgeが注入される（最新のnudgeが先に消費される）
         assert "activity" in ctx.lower()
 
         # record nudgeはまだ残っている
-        assert state.pop_nudge_pending() is True
+        result2 = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        output2 = json.loads(result2.stdout)
+        ctx2 = output2["hookSpecificOutput"]["additionalContext"]
+        assert "Self-check before continuing" in ctx2
 
 
 class TestEmptySessionId:
@@ -131,7 +157,6 @@ class TestFailOpen:
     """例外→空JSON（フェイルオープン）"""
 
     def test_invalid_json_input(self, state_dir):
-        """不正なJSON入力でもクラッシュせず空JSONを返す"""
         proc = subprocess.run(
             [sys.executable, "hooks/pretooluse_hook.py"],
             input="not valid json",
@@ -142,5 +167,4 @@ class TestFailOpen:
         )
         assert proc.returncode == 0
         assert json.loads(proc.stdout) == {}
-        # stderrにエラーログが出ている
         assert "error" in proc.stderr.lower()

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -1,4 +1,4 @@
-"""hooks/stop_hook.py の E2E テスト
+"""hooks/stop_hook.py の E2E テスト（イベント駆動アーキテクチャ版）
 
 subprocess.run で stop_hook.py を呼び出し、stdin→stdout の入出力をテスト。
 テスト用に tmpdir の state を使う（HOOK_STATE_DIR 環境変数）。
@@ -35,16 +35,52 @@ def _make_assistant_entry(
     if tool_calls:
         for i, tool in enumerate(tool_calls):
             inp = tool_inputs[i] if tool_inputs and i < len(tool_inputs) else {}
-            content.append({"type": "tool_use", "name": tool, "input": inp})
+            content.append({"type": "tool_use", "name": tool, "input": inp, "id": f"tu_{i}"})
     return {"type": "assistant", "message": {"content": content}}
 
 
 def _make_user_entry(text: str = "hello") -> dict:
-    return {"type": "human", "message": {"content": [{"type": "text", "text": text}]}}
+    return {"type": "user", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+def _make_skill_user_entry(skill_name: str = "sync-memory") -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": (
+                f"<command-message>{skill_name}</command-message>\n"
+                f"<command-name>/{skill_name}</command-name>"
+            ),
+        },
+    }
+
+
+def _write_events(events: list[dict], state_dir: str, session_id: str) -> None:
+    """events.jsonl をpre-seedする"""
+    path = Path(state_dir) / f"events_{session_id}.jsonl"
+    with open(path, "w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _read_events(state_dir: str, session_id: str) -> list[dict]:
+    """events.jsonl を読み取る"""
+    path = Path(state_dir) / f"events_{session_id}.jsonl"
+    if not path.exists():
+        return []
+    events = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
 
 
 META_TAG = '<!-- [meta] topic: test-topic -->'
 META_TAG_TOPIC_B = '<!-- [meta] topic: another-topic -->'
+META_TAG_TOPIC_C = '<!-- [meta] topic: third-topic -->'
 CONTEXT_RETRIEVAL_ENTRY = _make_assistant_entry(
     tool_calls=["mcp__plugin_claude-code-memory_cc-memory__get_topics"],
 )
@@ -57,11 +93,6 @@ def _run_stop_hook(
     last_assistant_message: str = "",
     return_stderr: bool = False,
 ) -> dict | tuple[dict, str]:
-    """stop_hook.py を subprocess で実行し、出力 JSON を返す
-
-    Args:
-        return_stderr: True の場合、(json_result, stderr_text) のタプルを返す
-    """
     input_data = json.dumps({
         "transcript_path": transcript_path,
         "session_id": session_id,
@@ -81,7 +112,6 @@ def _run_stop_hook(
         env=env,
     )
 
-    # 標準出力からJSONをパース
     stdout = result.stdout.strip()
     assert stdout, f"stop_hook.py produced no output. stderr: {result.stderr}"
     parsed = json.loads(stdout)
@@ -96,7 +126,6 @@ def _run_stop_hook(
 
 @pytest.fixture
 def env_setup(tmp_path):
-    """テスト用環境をセットアップし、env_override dict を返す"""
     state_dir = str(tmp_path / "state")
     os.makedirs(state_dir, exist_ok=True)
 
@@ -115,20 +144,17 @@ def env_setup(tmp_path):
 
 
 class TestNoMetaTag:
-    """1. メタタグなし → block（2ターン目以降）/ approve（1ターン目猶予）"""
+    """メタタグなし → block（2ターン目以降）/ approve（1ターン目猶予）"""
 
     def test_no_meta_tag_blocks_after_first_turn(self, env_setup):
-        """2ターン目以降（approved_turns>=1）でメタタグなし → block"""
-        state_dir = Path(env_setup["state_dir"])
-        # approved_turns を 1 にセット（2ターン目）
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("1")
-
+        """2ターン目以降でメタタグなし → block"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
                 _make_user_entry("hi"),
-                _make_assistant_entry(text="response without meta tag"),
+                _make_assistant_entry(text="response 1 without meta tag"),
+                _make_user_entry("continue"),
+                _make_assistant_entry(text="response 2 without meta tag"),
             ],
             transcript,
         )
@@ -140,7 +166,7 @@ class TestNoMetaTag:
         assert "メタタグ" in result["reason"]
 
     def test_no_meta_tag_approves_on_first_turn(self, env_setup):
-        """1ターン目（approved_turns=0）でメタタグなし → approve（猶予）"""
+        """1ターン目でメタタグなし → approve（猶予）"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -156,8 +182,8 @@ class TestNoMetaTag:
         assert result["decision"] == "approve"
         assert "猶予" in result["reason"]
 
-    def test_first_turn_grace_increments_approved_turns(self, env_setup):
-        """1ターン目猶予でapproveされた後、approved_turnsが1にインクリメントされる"""
+    def test_first_turn_grace_sets_current_turn(self, env_setup):
+        """1ターン目猶予後、current_turnが1に設定される"""
         state_dir = Path(env_setup["state_dir"])
 
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
@@ -174,14 +200,13 @@ class TestNoMetaTag:
         )
         assert result["decision"] == "approve"
 
-        # approved_turns が 1 にインクリメントされている
-        turns_file = state_dir / "approved_turns_test-session"
+        turns_file = state_dir / "current_turn_test-session"
         assert turns_file.exists()
         assert turns_file.read_text().strip() == "1"
 
 
 class TestMetaTagApproves:
-    """2. メタタグあり + コンテキスト取得済み → approve"""
+    """メタタグあり + コンテキスト取得済み → approve"""
 
     def test_meta_tag_with_context_retrieval_approves(self, env_setup):
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
@@ -201,23 +226,29 @@ class TestMetaTagApproves:
         assert result["decision"] == "approve"
 
 
-class TestTopicChangeNoRecord:
-    """3. トピック変更 + 記録なし → block（2回目以降）/ approve（初回遷移）"""
+class TestTopicChange:
+    """トピック変更チェック"""
 
     def test_first_topic_transition_approves(self, env_setup):
         """初回のトピック遷移は記録なしでもapprove"""
-        state_dir = Path(env_setup["state_dir"])
+        state_dir = env_setup["state_dir"]
 
-        prev_file = state_dir / "prev_topic_test-session"
-        prev_file.write_text("test-topic")
-
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
+        # 前ターンの状態: topic="test-topic", check-in済み
+        _write_events(
+            [
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+                {"e": "meta", "topic": "test-topic", "turn": 1},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "prev_topic_test-session").write_text("test-topic")
+        Path(state_dir, "current_turn_test-session").write_text("1")
 
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
-                _make_user_entry("hi"),
+                _make_user_entry("switching topic"),
                 _make_assistant_entry(text=f"{META_TAG_TOPIC_B}\nresponse"),
             ],
             transcript,
@@ -229,91 +260,83 @@ class TestTopicChangeNoRecord:
         )
         assert result["decision"] == "approve"
 
-        # topic_transitioned フラグが設定される
-        transitioned_file = state_dir / "topic_transitioned_test-session"
-        assert transitioned_file.exists()
-
-    def test_topic_change_without_record_blocks(self, env_setup):
+    def test_second_topic_transition_blocks_without_record(self, env_setup):
         """2回目以降のトピック遷移で記録なし → block"""
-        state_dir = Path(env_setup["state_dir"])
+        state_dir = env_setup["state_dir"]
 
-        prev_file = state_dir / "prev_topic_test-session"
-        prev_file.write_text("test-topic")
-
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        # 初回遷移済みフラグを設定（2回目の遷移をシミュレート）
-        transitioned_file = state_dir / "topic_transitioned_test-session"
-        transitioned_file.write_text("1")
+        # 前ターン: 2つの異なるtopicのmetaイベント（= 既に1回遷移済み）, check-in済み
+        _write_events(
+            [
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+                {"e": "meta", "topic": "test-topic", "turn": 1},
+                {"e": "meta", "topic": "another-topic", "turn": 2},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "prev_topic_test-session").write_text("another-topic")
+        Path(state_dir, "current_turn_test-session").write_text("2")
 
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
-                _make_user_entry("hi"),
-                _make_assistant_entry(text=f"{META_TAG_TOPIC_B}\nresponse"),
+                _make_user_entry("switching again"),
+                _make_assistant_entry(text=f"{META_TAG_TOPIC_C}\nresponse"),
             ],
             transcript,
         )
 
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG_TOPIC_B}",
+            last_assistant_message=f"response\n{META_TAG_TOPIC_C}",
         )
         assert result["decision"] == "block"
         assert "トピックが変わりました" in result["reason"]
 
-
-class TestTopicChangeWithRecord:
-    """4. トピック変更 + 記録あり → approve"""
-
     def test_topic_change_with_record_approves(self, env_setup):
-        state_dir = Path(env_setup["state_dir"])
+        """トピック遷移 + 記録あり → approve"""
+        state_dir = env_setup["state_dir"]
 
-        # prev_topic をトピック名で設定
-        prev_file = state_dir / "prev_topic_test-session"
-        prev_file.write_text("test-topic")
+        _write_events(
+            [
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+                {"e": "meta", "topic": "test-topic", "turn": 1},
+                {"e": "meta", "topic": "another-topic", "turn": 2},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "prev_topic_test-session").write_text("another-topic")
+        Path(state_dir, "current_turn_test-session").write_text("2")
 
-        # context_retrieved フラグを設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        # 初回遷移済みフラグを設定（2回目の遷移をシミュレート）
-        transitioned_file = state_dir / "topic_transitioned_test-session"
-        transitioned_file.write_text("1")
-
-        # 別トピックに変更するtranscript（add_decision記録あり）
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
-                _make_user_entry("hi"),
+                _make_user_entry("switching with record"),
                 _make_assistant_entry(
                     tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
                 ),
-                _make_user_entry("continue"),
-                _make_assistant_entry(text=f"{META_TAG_TOPIC_B}\nresponse"),
+                _make_assistant_entry(text=f"{META_TAG_TOPIC_C}\nresponse"),
             ],
             transcript,
         )
 
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG_TOPIC_B}",
+            last_assistant_message=f"response\n{META_TAG_TOPIC_C}",
         )
         assert result["decision"] == "approve"
 
 
 class TestBlockLimitForceApprove:
-    """5. ブロック上限2回 → force approve"""
+    """ブロック上限 → force approve"""
 
     def test_block_limit_force_approves(self, env_setup):
         state_dir = Path(env_setup["state_dir"])
 
-        # block_count を 2 にセット（上限到達）
         block_file = state_dir / "block_count_test-session"
         block_file.write_text("2")
 
-        # メタタグなしtranscript（通常ならblock）
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -329,15 +352,13 @@ class TestBlockLimitForceApprove:
         assert result["decision"] == "approve"
         assert "ブロック上限" in result["reason"]
 
-        # block_count がリセットされている
         assert not block_file.exists()
 
 
 class TestExceptionFailOpen:
-    """6. 例外発生時 → approve（フェイルオープン）"""
+    """例外発生時 → approve（フェイルオープン）"""
 
     def test_exception_causes_approve(self, env_setup):
-        # state_dir をファイルにして HookState.__init__ の mkdir を失敗させる
         state_as_file = env_setup["tmp_path"] / "state_as_file"
         state_as_file.write_text("not a directory")
 
@@ -362,468 +383,6 @@ class TestExceptionFailOpen:
         assert "error" in result.get("reason", "").lower()
 
 
-class TestNudgeCounter:
-    """nudgeカウンターの動作確認"""
-
-    def test_nudge_pending_set_on_interval_without_recording(self, env_setup):
-        """インターバル到達で記録なし → nudge_pending が設定される"""
-        state_dir = Path(env_setup["state_dir"])
-
-        # nudge_counter を 1 にセット（次が2の倍数）
-        counter_file = state_dir / "nudge_counter_test-session"
-        counter_file.write_text("1")
-
-        # context_retrieved フラグを設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-            ],
-            transcript,
-        )
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        # nudge_pending が設定されている
-        pending_file = state_dir / "nudge_pending_test-session"
-        assert pending_file.exists()
-
-    def test_nudge_counter_resets_on_recent_recording(self, env_setup):
-        """インターバル到達で記録あり → nudge_counter がリセットされる"""
-        state_dir = Path(env_setup["state_dir"])
-
-        # nudge_counter を 1 にセット
-        counter_file = state_dir / "nudge_counter_test-session"
-        counter_file.write_text("1")
-
-        # context_retrieved フラグを設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                _make_assistant_entry(
-                    tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
-                    text=f"{META_TAG}\nrecorded",
-                ),
-            ],
-            transcript,
-        )
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"recorded\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        # nudge_counter がリセットされている（ファイル削除）
-        assert not counter_file.exists()
-
-    def test_nudge_counter_resets_on_add_log(self, env_setup):
-        """インターバル到達でadd_log記録あり → nudge_counter がリセットされる"""
-        state_dir = Path(env_setup["state_dir"])
-
-        counter_file = state_dir / "nudge_counter_test-session"
-        counter_file.write_text("1")
-
-        # context_retrieved フラグを設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                _make_assistant_entry(
-                    tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_log"],
-                    text=f"logged\n{META_TAG}",
-                ),
-            ],
-            transcript,
-        )
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"logged\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        # add_logでもnudge_counterがリセットされる
-        assert not counter_file.exists()
-
-
-class TestActivityNudge:
-    """decision作成後のアクティビティ作成nudge"""
-
-    def test_decision_without_activity_sets_nudge(self, env_setup):
-        """add_decisionあり + add_activityなし → activity_nudge_pending設定"""
-        state_dir = Path(env_setup["state_dir"])
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(
-                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
-                text=f"{META_TAG}\nrecorded",
-            ),
-        ], transcript)
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"recorded\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        pending_file = state_dir / "activity_nudge_pending_test-session"
-        assert pending_file.exists()
-
-    def test_decision_with_activity_no_nudge(self, env_setup):
-        """add_decision + add_activity両方あり → activity_nudge_pending設定されない"""
-        state_dir = Path(env_setup["state_dir"])
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(
-                tool_calls=[
-                    "mcp__plugin_claude-code-memory_cc-memory__add_decision",
-                    "mcp__plugin_claude-code-memory_cc-memory__add_activity",
-                ],
-                text=f"{META_TAG}\nrecorded",
-            ),
-        ], transcript)
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"recorded\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        pending_file = state_dir / "activity_nudge_pending_test-session"
-        assert not pending_file.exists()
-
-    def test_no_decision_no_nudge(self, env_setup):
-        """add_decisionなし → activity_nudge_pending設定されない"""
-        state_dir = Path(env_setup["state_dir"])
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-        pending_file = state_dir / "activity_nudge_pending_test-session"
-        assert not pending_file.exists()
-
-
-class TestStateUpdatedOnApprove:
-    """approve時の状態更新"""
-
-    def test_prev_topic_updated(self, env_setup):
-        """approve後に prev_topic が更新される"""
-        state_dir = Path(env_setup["state_dir"])
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-            ],
-            transcript,
-        )
-
-        _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-
-        prev_file = state_dir / "prev_topic_test-session"
-        assert prev_file.exists()
-        assert prev_file.read_text().strip() == "test-topic"
-
-    def test_block_count_reset_on_approve(self, env_setup):
-        """approve後に block_count がリセットされる"""
-        state_dir = Path(env_setup["state_dir"])
-
-        # block_count を 1 にセット
-        block_file = state_dir / "block_count_test-session"
-        block_file.write_text("1")
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-            ],
-            transcript,
-        )
-
-        _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-
-        # block_count がリセットされている
-        assert not block_file.exists()
-
-
-class TestSplitEntries:
-    """エントリ分割パターン: text+meta と tool_use が別エントリ"""
-
-    def test_split_entry_with_last_assistant_message(self, env_setup):
-        """分割エントリでもlast_assistant_messageで検出できる"""
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        # text+meta と tool_use を別エントリに分割
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-                _make_assistant_entry(text=f"{META_TAG}\nresponse"),  # textのみ
-                _make_assistant_entry(tool_calls=["Bash"]),  # tool_useのみ
-            ],
-            transcript,
-        )
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"{META_TAG}\nresponse",
-        )
-        assert result["decision"] == "approve"
-
-    def test_split_entry_fallback_to_transcript(self, env_setup):
-        """last_assistant_messageなしでもtranscriptフォールバックで検出"""
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-                _make_assistant_entry(tool_calls=["Bash"]),
-            ],
-            transcript,
-        )
-
-        # last_assistant_message なし → transcriptフォールバック
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-        )
-        assert result["decision"] == "approve"
-
-
-class TestLastAssistantMessage:
-    """last_assistant_message あり/なしの両パターン"""
-
-    def test_meta_tag_via_last_assistant_message(self, env_setup):
-        """last_assistant_messageからメタタグを検出（レースコンディション模擬）"""
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        # transcriptにはメタタグなし（レースコンディション模擬）だが
-        # コンテキスト取得ツールの呼び出しは含める
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-            ],
-            transcript,
-        )
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"{META_TAG}\nresponse",
-        )
-        assert result["decision"] == "approve"
-
-    def test_no_last_assistant_message_falls_back_to_transcript(self, env_setup):
-        """last_assistant_messageなし → transcriptから検出"""
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript(
-            [
-                _make_user_entry("hi"),
-                CONTEXT_RETRIEVAL_ENTRY,
-                _make_assistant_entry(text=f"response\n{META_TAG}"),
-            ],
-            transcript,
-        )
-
-        # last_assistant_message なし
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-        )
-        assert result["decision"] == "approve"
-
-
-class TestActivityCheckinBlock:
-    """activity check-in チェック"""
-
-    def test_no_checkin_after_defer_turns_blocks(self, env_setup):
-        """猶予期間後（approved_turns=2）でcheck-in未呼出 → block"""
-        state_dir = Path(env_setup["state_dir"])
-        # approved_turns を 2 にセット（3ターン目）
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("2")
-        # context_retrieved フラグを設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        # transcript（check-in呼出なし）
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            CONTEXT_RETRIEVAL_ENTRY,
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "block"
-        assert "check-in" in result["reason"]
-        # block時にapproved_turnsがインクリメントされていないことを確認
-        assert turns_file.read_text().strip() == "2"
-
-    def test_checkin_called_approves(self, env_setup):
-        """check_in呼出済み → approve"""
-        state_dir = Path(env_setup["state_dir"])
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("2")
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(
-                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__check_in"],
-            ),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-    def test_add_activity_called_approves(self, env_setup):
-        """add_activity呼出済み → approve"""
-        state_dir = Path(env_setup["state_dir"])
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("2")
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(
-                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_activity"],
-            ),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-    def test_block_only_once(self, env_setup):
-        """activity_checkinフラグ設定済み → 2回目はblockしない"""
-        state_dir = Path(env_setup["state_dir"])
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("5")
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        checkin_file = state_dir / "activity_checkin_test-session"
-        checkin_file.write_text("1")
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-    def test_before_defer_turns_no_block(self, env_setup):
-        """猶予期間中（approved_turns=0）ではblockしない"""
-        state_dir = Path(env_setup["state_dir"])
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("0")
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        # check-in未呼出だが、まだ猶予期間中
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-    def test_checkin_grace_at_turn_1(self, env_setup):
-        """猶予期間中（approved_turns=1）でもblockしない"""
-        state_dir = Path(env_setup["state_dir"])
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("1")
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        # check-in未呼出だが、まだ猶予期間中（< _CHECKIN_DEFER_TURNS=2）
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-
-    def test_approved_turns_incremented_on_approve(self, env_setup):
-        """approve時にapproved_turnsがインクリメントされる"""
-        state_dir = Path(env_setup["state_dir"])
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("hi"),
-            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
-        ], transcript)
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-            last_assistant_message=f"response\n{META_TAG}",
-        )
-        assert result["decision"] == "approve"
-        # approved_turns が 1 にインクリメントされている
-        turns_file = state_dir / "approved_turns_test-session"
-        assert turns_file.exists()
-        assert turns_file.read_text().strip() == "1"
-
-
 class TestContextRetrievalCheck:
     """コンテキスト取得ツール呼び出しチェック"""
 
@@ -846,7 +405,7 @@ class TestContextRetrievalCheck:
         assert "コンテキスト" in result["reason"]
 
     def test_get_topics_call_approves(self, env_setup):
-        """get_topics呼出済み + メタタグあり → approve"""
+        """get_topics呼出済み → approve"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -864,7 +423,7 @@ class TestContextRetrievalCheck:
         assert result["decision"] == "approve"
 
     def test_search_call_approves(self, env_setup):
-        """search呼出済み + メタタグあり → approve"""
+        """search呼出済み → approve"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -884,7 +443,7 @@ class TestContextRetrievalCheck:
         assert result["decision"] == "approve"
 
     def test_get_by_ids_call_approves(self, env_setup):
-        """get_by_ids呼出済み + メタタグあり → approve"""
+        """get_by_ids呼出済み → approve"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -924,15 +483,21 @@ class TestContextRetrievalCheck:
         assert result["decision"] == "block"
         assert "コンテキスト" in result["reason"]
 
-    def test_context_retrieval_flag_persists(self, env_setup):
-        """一度コンテキスト取得したらフラグで記憶される"""
-        state_dir = Path(env_setup["state_dir"])
+    def test_context_retrieval_persists_in_events(self, env_setup):
+        """過去turnでコンテキスト取得済み → 新turnでも有効"""
+        state_dir = env_setup["state_dir"]
 
-        # context_retrieved フラグを事前設定
-        context_file = state_dir / "context_retrieved_test-session"
-        context_file.write_text("1")
+        _write_events(
+            [
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+                {"e": "meta", "topic": "test-topic", "turn": 1},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "prev_topic_test-session").write_text("test-topic")
 
-        # transcriptにはコンテキスト取得ツールなし
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -946,29 +511,104 @@ class TestContextRetrievalCheck:
             str(transcript), "test-session", env_setup["env_override"],
             last_assistant_message=f"response\n{META_TAG}",
         )
-        # フラグがあるのでblockされない
         assert result["decision"] == "approve"
 
 
-def _make_skill_user_entry(skill_name: str = "sync-memory") -> dict:
-    """スキル発動時のuserエントリ（実際のtranscript形式）"""
-    return {
-        "type": "user",
-        "message": {
-            "role": "user",
-            "content": (
-                f"<command-message>{skill_name}</command-message>\n"
-                f"<command-name>/{skill_name}</command-name>"
-            ),
-        },
-    }
+class TestActivityCheckinBlock:
+    """activity check-in チェック"""
+
+    def test_no_checkin_after_defer_turns_blocks(self, env_setup):
+        """猶予期間後（turn>=2）でcheck-in未呼出 → block"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 1"),
+                _make_user_entry("continue"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 2"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response 2\n{META_TAG}",
+        )
+        assert result["decision"] == "block"
+        assert "check-in" in result["reason"]
+
+    def test_checkin_called_approves(self, env_setup):
+        """check_in呼出済み → approve"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(
+                    tool_calls=["mcp__plugin_claude-code-memory_cc-memory__check_in"],
+                    tool_inputs=[{"activity_id": 42}],
+                ),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 1"),
+                _make_user_entry("continue"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 2"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response 2\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_add_activity_called_approves(self, env_setup):
+        """add_activity呼出済み → approve"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(
+                    tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_activity"],
+                ),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 1"),
+                _make_user_entry("continue"),
+                _make_assistant_entry(text=f"{META_TAG}\nresponse 2"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response 2\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+    def test_before_defer_turns_no_block(self, env_setup):
+        """猶予期間中（turn<2）ではcheck-in未呼出でもblockしない"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
 
 
-class TestSkillSkip:
-    """スキル実行時のスキップ機能"""
+class TestSkillSpan:
+    """Skill Span中のスキップ機能"""
 
-    def test_skill_command_approves_without_meta_tag(self, env_setup):
-        """スキル発動ターン: メタタグなし・コンテキスト取得なしでもapprove"""
+    def test_skill_span_approves_without_checks(self, env_setup):
+        """Skill Span中: メタタグなし・コンテキスト取得なしでもapprove"""
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript([
             _make_skill_user_entry("sync-memory"),
@@ -979,102 +619,254 @@ class TestSkillSkip:
             str(transcript), "test-session", env_setup["env_override"],
         )
         assert result["decision"] == "approve"
-        assert "スキル" in result["reason"]
+        assert "Skill Span" in result["reason"]
 
-    def test_skill_skip_remaining_approves(self, env_setup):
-        """スキップ残りがある場合: 即approve"""
-        state_dir = Path(env_setup["state_dir"])
-        skip_file = state_dir / "skill_skip_test-session"
-        skip_file.write_text("2")
+    def test_skill_span_continues_on_next_skill_turn(self, env_setup):
+        """連続するSkill turnでもSpan継続"""
+        state_dir = env_setup["state_dir"]
+
+        _write_events(
+            [{"e": "skill", "name": "sync-memory", "turn": 1}],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
 
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript([
-            _make_user_entry("normal message"),
-            _make_assistant_entry(text="response without meta tag"),
+            _make_skill_user_entry("sync-memory"),
+            _make_assistant_entry(text="still processing"),
         ], transcript)
 
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
         )
         assert result["decision"] == "approve"
-        assert "スキル" in result["reason"]
+        assert "Skill Span" in result["reason"]
 
-        # スキップ残りが1にデクリメント
-        assert skip_file.read_text().strip() == "1"
+    def test_skill_span_ends_when_no_skill_event(self, env_setup):
+        """Skill Span終了: skillイベントがないturnで通常チェック再開"""
+        state_dir = env_setup["state_dir"]
 
-    def test_skill_skip_decrements_to_zero(self, env_setup):
-        """スキップ残り1 → 0でファイル削除"""
-        state_dir = Path(env_setup["state_dir"])
-        skip_file = state_dir / "skill_skip_test-session"
-        skip_file.write_text("1")
+        _write_events(
+            [
+                {"e": "skill", "name": "sync-memory", "turn": 1},
+                {"e": "tool", "name": "get_topics", "turn": 1},
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+                {"e": "meta", "topic": "test-topic", "turn": 1},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "prev_topic_test-session").write_text("test-topic")
 
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript([
-            _make_user_entry("normal message"),
-            _make_assistant_entry(text="response"),
+            _make_user_entry("normal message after skill"),
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
         ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+        # Skill Spanが終了し通常チェックが動く → approve（条件を満たしている）
+        assert result["decision"] == "approve"
+        assert "Skill Span" not in result.get("reason", "")
+
+
+class TestNudge:
+    """nudgeイベントの生成"""
+
+    def test_activity_nudge_on_decision_without_activity(self, env_setup):
+        """add_decision + add_activityなし → activity nudgeイベント"""
+        state_dir = env_setup["state_dir"]
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            CONTEXT_RETRIEVAL_ENTRY,
+            _make_assistant_entry(
+                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__add_decision"],
+                text=f"{META_TAG}\nrecorded",
+            ),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"recorded\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        nudge_events = [e for e in events if e.get("e") == "nudge"]
+        activity_nudges = [e for e in nudge_events if e.get("type") == "activity"]
+        assert len(activity_nudges) >= 1
+
+    def test_no_activity_nudge_when_checkin_present(self, env_setup):
+        """add_decision + check_in → activity nudge不発"""
+        state_dir = env_setup["state_dir"]
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            CONTEXT_RETRIEVAL_ENTRY,
+            _make_assistant_entry(
+                tool_calls=[
+                    "mcp__plugin_claude-code-memory_cc-memory__add_decision",
+                    "mcp__plugin_claude-code-memory_cc-memory__check_in",
+                ],
+                tool_inputs=[{}, {"activity_id": 1}],
+            ),
+            _make_assistant_entry(text=f"{META_TAG}\nrecorded"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"recorded\n{META_TAG}",
+        )
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        activity_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "activity"]
+        assert len(activity_nudges) == 0
+
+
+class TestStateUpdatedOnApprove:
+    """approve時の状態更新"""
+
+    def test_prev_topic_updated(self, env_setup):
+        """approve後に prev_topic が更新される"""
+        state_dir = Path(env_setup["state_dir"])
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+            ],
+            transcript,
+        )
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+
+        prev_file = state_dir / "prev_topic_test-session"
+        assert prev_file.exists()
+        assert prev_file.read_text().strip() == "test-topic"
+
+    def test_block_count_reset_on_approve(self, env_setup):
+        """approve後に block_count がリセットされる"""
+        state_dir = Path(env_setup["state_dir"])
+
+        block_file = state_dir / "block_count_test-session"
+        block_file.write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+            ],
+            transcript,
+        )
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+
+        assert not block_file.exists()
+
+    def test_events_file_created(self, env_setup):
+        """初回実行後にevents.jsonlが作成される"""
+        state_dir = env_setup["state_dir"]
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+            ],
+            transcript,
+        )
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+
+        events = _read_events(state_dir, "test-session")
+        assert len(events) > 0
+        # get_topicsのtoolイベントがある
+        tool_events = [e for e in events if e.get("e") == "tool"]
+        assert any(e["name"] == "get_topics" for e in tool_events)
+        # metaイベントがある
+        meta_events = [e for e in events if e.get("e") == "meta"]
+        assert any(e["topic"] == "test-topic" for e in meta_events)
+
+    def test_transcript_offset_updated(self, env_setup):
+        """approve後にtranscript_offsetが更新される"""
+        state_dir = Path(env_setup["state_dir"])
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+            ],
+            transcript,
+        )
+
+        _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"response\n{META_TAG}",
+        )
+
+        offset_file = state_dir / "transcript_offset_test-session"
+        assert offset_file.exists()
+        offset_val = int(offset_file.read_text().strip())
+        assert offset_val == transcript.stat().st_size
+
+
+class TestLastAssistantMessage:
+    """last_assistant_message あり/なしの両パターン"""
+
+    def test_meta_tag_via_last_assistant_message(self, env_setup):
+        """last_assistant_messageからメタタグを検出"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+            last_assistant_message=f"{META_TAG}\nresponse",
+        )
+        assert result["decision"] == "approve"
+
+    def test_no_last_assistant_message_falls_back_to_transcript(self, env_setup):
+        """last_assistant_messageなし → transcriptから検出"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text=f"response\n{META_TAG}"),
+            ],
+            transcript,
+        )
 
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
         )
         assert result["decision"] == "approve"
-
-        # 0になったのでファイル削除
-        assert not skip_file.exists()
-
-    def test_skill_skip_sets_remaining_turns(self, env_setup):
-        """スキル検出時にskill_skipファイルが作成される"""
-        state_dir = Path(env_setup["state_dir"])
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_skill_user_entry("sync-memory"),
-            _make_assistant_entry(text="processing"),
-        ], transcript)
-
-        _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-        )
-
-        # skill_skip = 2 (3ターン中、検出ターンで1消費)
-        skip_file = state_dir / "skill_skip_test-session"
-        assert skip_file.exists()
-        assert skip_file.read_text().strip() == "2"
-
-    def test_normal_checks_resume_after_skip(self, env_setup):
-        """スキップ終了後は通常チェック再開（メタタグなし→block）"""
-        state_dir = Path(env_setup["state_dir"])
-        # approved_turns=1にして1ターン目猶予を使い切る
-        turns_file = state_dir / "approved_turns_test-session"
-        turns_file.write_text("5")
-
-        # skill_skipは0（スキップ終了済み）
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_user_entry("normal message"),
-            _make_assistant_entry(text="no meta tag"),
-        ], transcript)
-
-        result = _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-        )
-        assert result["decision"] == "block"
-        assert "メタタグ" in result["reason"]
-
-    def test_skill_skip_increments_approved_turns(self, env_setup):
-        """スキル検出ターンでapproved_turnsがインクリメントされる"""
-        state_dir = Path(env_setup["state_dir"])
-
-        transcript = env_setup["tmp_path"] / "transcript.jsonl"
-        _write_transcript([
-            _make_skill_user_entry("sync-memory"),
-            _make_assistant_entry(text="processing"),
-        ], transcript)
-
-        _run_stop_hook(
-            str(transcript), "test-session", env_setup["env_override"],
-        )
-
-        turns_file = state_dir / "approved_turns_test-session"
-        assert turns_file.exists()
-        assert turns_file.read_text().strip() == "1"

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -50,108 +50,78 @@ class TestBlockCount:
         assert hook_state.get_block_count() == 0
 
 
-class TestNudgeCounter:
+class TestTranscriptOffset:
     def test_get_returns_zero_when_no_file(self, hook_state):
-        assert hook_state.get_nudge_counter() == 0
-
-    def test_increment(self, hook_state):
-        assert hook_state.increment_nudge_counter() == 1
-        assert hook_state.increment_nudge_counter() == 2
-
-    def test_reset(self, hook_state):
-        hook_state.increment_nudge_counter()
-        hook_state.reset_nudge_counter()
-        assert hook_state.get_nudge_counter() == 0
-
-    def test_corrupted_file_returns_zero(self, hook_state):
-        path = hook_state._path("nudge_counter")
-        path.write_text("xyz")
-        assert hook_state.get_nudge_counter() == 0
-
-
-class TestNudgePending:
-    def test_pop_returns_false_when_no_file(self, hook_state):
-        assert hook_state.pop_nudge_pending() is False
-
-    def test_set_then_pop(self, hook_state):
-        hook_state.set_nudge_pending()
-        assert hook_state.pop_nudge_pending() is True
-
-    def test_pop_after_pop_returns_false(self, hook_state):
-        hook_state.set_nudge_pending()
-        hook_state.pop_nudge_pending()
-        assert hook_state.pop_nudge_pending() is False
-
-
-class TestActivityNudgePending:
-    def test_pop_returns_false_when_no_file(self, hook_state):
-        assert hook_state.pop_activity_nudge_pending() is False
-
-    def test_set_then_pop(self, hook_state):
-        hook_state.set_activity_nudge_pending()
-        assert hook_state.pop_activity_nudge_pending() is True
-
-    def test_pop_after_pop_returns_false(self, hook_state):
-        hook_state.set_activity_nudge_pending()
-        hook_state.pop_activity_nudge_pending()
-        assert hook_state.pop_activity_nudge_pending() is False
-
-
-class TestApprovedTurns:
-    def test_get_returns_zero_when_no_file(self, hook_state):
-        assert hook_state.get_approved_turns() == 0
-
-    def test_increment(self, hook_state):
-        assert hook_state.increment_approved_turns() == 1
-        assert hook_state.increment_approved_turns() == 2
-
-    def test_corrupted_file_returns_zero(self, hook_state):
-        path = hook_state._path("approved_turns")
-        path.write_text("abc")
-        assert hook_state.get_approved_turns() == 0
-
-
-class TestActivityCheckin:
-    def test_has_returns_false_when_no_file(self, hook_state):
-        assert hook_state.has_activity_checkin() is False
-
-    def test_set_then_has(self, hook_state):
-        hook_state.set_activity_checkin()
-        assert hook_state.has_activity_checkin() is True
-
-
-class TestTopicTransitioned:
-    def test_has_returns_false_when_no_file(self, hook_state):
-        assert hook_state.has_topic_transitioned() is False
-
-    def test_set_then_has(self, hook_state):
-        hook_state.set_topic_transitioned()
-        assert hook_state.has_topic_transitioned() is True
-
-
-class TestSkillSkipRemaining:
-    def test_get_returns_zero_when_no_file(self, hook_state):
-        assert hook_state.get_skill_skip_remaining() == 0
+        assert hook_state.get_transcript_offset() == 0
 
     def test_set_then_get(self, hook_state):
-        hook_state.set_skill_skip_remaining(3)
-        assert hook_state.get_skill_skip_remaining() == 3
-
-    def test_set_zero_deletes_file(self, hook_state):
-        hook_state.set_skill_skip_remaining(3)
-        hook_state.set_skill_skip_remaining(0)
-        assert hook_state.get_skill_skip_remaining() == 0
-        assert not hook_state._path("skill_skip").exists()
-
-    def test_set_negative_deletes_file(self, hook_state):
-        hook_state.set_skill_skip_remaining(3)
-        hook_state.set_skill_skip_remaining(-1)
-        assert hook_state.get_skill_skip_remaining() == 0
+        hook_state.set_transcript_offset(12345)
+        assert hook_state.get_transcript_offset() == 12345
 
     def test_corrupted_file_returns_zero(self, hook_state):
-        path = hook_state._path("skill_skip")
+        path = hook_state._path("transcript_offset")
         path.write_text("abc")
-        assert hook_state.get_skill_skip_remaining() == 0
+        assert hook_state.get_transcript_offset() == 0
+
+
+class TestCurrentTurn:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_current_turn() == 0
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_current_turn(5)
+        assert hook_state.get_current_turn() == 5
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("current_turn")
+        path.write_text("abc")
+        assert hook_state.get_current_turn() == 0
+
+
+class TestCheckedInActivity:
+    def test_get_returns_none_when_no_file(self, hook_state):
+        assert hook_state.get_checked_in_activity() is None
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_checked_in_activity(42)
+        assert hook_state.get_checked_in_activity() == 42
+
+
+class TestEventsJsonl:
+    def test_read_returns_empty_when_no_file(self, hook_state):
+        assert hook_state.read_events() == []
+
+    def test_append_then_read(self, hook_state):
+        events = [
+            {"e": "tool", "name": "add_decision", "turn": 1},
+            {"e": "meta", "topic": "test-topic", "turn": 1},
+        ]
+        hook_state.append_events(events)
+        result = hook_state.read_events()
+        assert len(result) == 2
+        assert result[0]["e"] == "tool"
+        assert result[1]["e"] == "meta"
+
+    def test_append_is_additive(self, hook_state):
+        hook_state.append_events([{"e": "tool", "name": "search", "turn": 1}])
+        hook_state.append_events([{"e": "meta", "topic": "topic-a", "turn": 2}])
+        result = hook_state.read_events()
+        assert len(result) == 2
+
+    def test_empty_list_does_not_create_file(self, hook_state):
+        hook_state.append_events([])
+        assert not hook_state.events_path.exists()
+
+    def test_malformed_json_line_skipped(self, hook_state):
+        with open(hook_state.events_path, "w") as f:
+            f.write('{"e": "tool", "name": "search", "turn": 1}\n')
+            f.write("not json\n")
+            f.write('{"e": "meta", "topic": "t", "turn": 2}\n')
+        result = hook_state.read_events()
+        assert len(result) == 2
+
+    def test_events_path(self, hook_state):
+        assert hook_state.events_path.name == "events_test-session-123.jsonl"
 
 
 class TestClearSession:
@@ -162,13 +132,10 @@ class TestClearSession:
         # 全種類の状態ファイルを作成
         state.set_prev_topic("topic-10")
         state.increment_block_count()
-        state.increment_nudge_counter()
-        state.set_nudge_pending()
-        state.set_activity_nudge_pending()
-        state.increment_approved_turns()
-        state.set_activity_checkin()
-        state.set_skill_skip_remaining(3)
-        state.set_topic_transitioned()
+        state.set_transcript_offset(100)
+        state.set_current_turn(3)
+        state.set_checked_in_activity(42)
+        state.append_events([{"e": "tool", "name": "search", "turn": 1}])
 
         # clear
         HookState.clear_session("sess-abc")
@@ -176,13 +143,19 @@ class TestClearSession:
         # 全ファイルが消えている
         assert state.get_prev_topic() is None
         assert state.get_block_count() == 0
-        assert state.get_nudge_counter() == 0
-        assert state.pop_nudge_pending() is False
-        assert state.pop_activity_nudge_pending() is False
-        assert state.get_approved_turns() == 0
-        assert state.has_activity_checkin() is False
-        assert state.get_skill_skip_remaining() == 0
-        assert state.has_topic_transitioned() is False
+        assert state.get_transcript_offset() == 0
+        assert state.get_current_turn() == 0
+        assert state.get_checked_in_activity() is None
+        assert state.read_events() == []
+
+    def test_clears_events_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
+        state = HookState("sess-events")
+        state.append_events([{"e": "meta", "topic": "t", "turn": 1}])
+        assert state.events_path.exists()
+
+        HookState.clear_session("sess-events")
+        assert not state.events_path.exists()
 
 
 class TestSessionIdSlash:
@@ -204,7 +177,7 @@ class TestMainCli:
         # 状態ファイルを作成
         state = HookState("cli-test-sess")
         state.set_prev_topic("topic-1")
-        state.increment_nudge_counter()
+        state.set_current_turn(3)
 
         # ファイルが存在する
         assert state.get_prev_topic() == "topic-1"
@@ -224,4 +197,4 @@ class TestMainCli:
 
         # CLIで実際にファイルが削除されたことを確認
         assert state.get_prev_topic() is None
-        assert state.get_nudge_counter() == 0
+        assert state.get_current_turn() == 0


### PR DESCRIPTION
## Summary
- transcript全走査を廃止し、バイトオフセットによる差分読み → events.jsonlへのイベント追記 → events.jsonlベースの判定に移行
- 状態ファイルを10個から5個に削減（nudge系4個 + approved_turns + activity_checkin + skill_skip + context_retrieved + topic_transitioned を廃止）
- pretooluse_hookのフラグファイル通信をevents.jsonl直読みに置き換え

## Changes
- `hooks/hook_state.py`: transcript_offset, current_turn, events.jsonl I/O追加。廃止フラグ/カウンター削除
- `hooks/hook_transcript.py`: is_user_message(), extract_events(), read_transcript_from_offset()追加
- `hooks/stop_hook.py`: 10ステップフローに全面改修（差分読み→イベント抽出→events.jsonl判定）
- `hooks/pretooluse_hook.py`: events.jsonlからnudgeイベントを直接読み取り・消費
- テスト3ファイルを新アーキテクチャに合わせて書き直し（全591テストパス）

## Design decisions
- D#1231: イベントスキーマ（3型: tool/meta/skill + turn）
- D#1232: 差分読みオフセット（hook_stateに保存）
- D#1235: pretooluse hookは注入プロキシとして存続
- D#1236: events.jsonlはセッションごとにリセット
- D#1260: Phase 1実装設計

## Test plan
- [x] 全591テストパス（unit + integration + e2e）
- [ ] 実環境でのセッション動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)