### PR TITLE
fix: stop hookのapprove後例外でstdoutが二重出力される問題を修正

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -86,9 +86,12 @@ def is_user_message(entry: dict) -> bool:
 
     User Message = ユーザーが実際に送信したuserエントリ。
     tool_resultやsystem-reminderを含むuser/humanエントリは除外する。
+    isMeta=trueのエントリ（スキル内容注入等）も除外する。
     string形式のsystem-reminderの誤判定は許容（発生率0.02%）。
     """
     if entry.get("type") not in ("user", "human"):
+        return False
+    if entry.get("isMeta"):
         return False
     content = entry.get("message", {}).get("content")
     if isinstance(content, str):

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -117,7 +117,7 @@ def main() -> None:
         if in_skill_span:
             state.reset_block_count()
             _output("approve", "Skill Span中のためチェックをスキップします。")
-            _update_state_on_approve(state, all_events, transcript_path)
+            _safe_post_approve(state, all_events, transcript_path)
             return
 
         # 6. メタタグ判定
@@ -126,7 +126,7 @@ def main() -> None:
             if current_turn <= 1:
                 state.reset_block_count()
                 _output("approve", "1ターン目のためメタタグチェックを猶予します。")
-                _update_state_on_approve(state, all_events, transcript_path)
+                _safe_post_approve(state, all_events, transcript_path)
                 return
             # フォールバック: last_assistant_messageが無い場合transcriptから取得
             # NOTE: get_last_assistant_entryは全行逆順走査（Phase 3で廃止予定）
@@ -212,8 +212,7 @@ def main() -> None:
         # 10. nudge判定 + 状態更新 + approve
         state.reset_block_count()
         _output("approve")
-        _update_state_on_approve(state, all_events, transcript_path)
-        _handle_nudges(state, all_events, current_turn)
+        _safe_post_approve(state, all_events, transcript_path, current_turn)
 
     except Exception as e:
         # フェイルオープン: 例外時はapprove
@@ -265,6 +264,19 @@ def _update_checked_in_activity(
     aid = extract_last_activity_id(transcript_path)
     if aid is not None:
         state.set_checked_in_activity(aid)
+
+
+def _safe_post_approve(
+    state: HookState, events: list[dict], transcript_path: str,
+    current_turn: int | None = None,
+) -> None:
+    """approve出力後の状態更新。例外はstderrログのみ（double-output防止）。"""
+    try:
+        _update_state_on_approve(state, events, transcript_path)
+        if current_turn is not None:
+            _handle_nudges(state, events, current_turn)
+    except Exception as e:
+        print(f"stop_hook.py post-approve error: {e}", file=sys.stderr)
 
 
 def _update_state_on_approve(

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -15,6 +15,7 @@
 import json
 import os
 import sys
+import traceback
 from pathlib import Path
 
 # プロジェクトルートをパスに追加（src.db等の参照用）
@@ -212,7 +213,10 @@ def main() -> None:
         # 10. nudge判定 + 状態更新 + approve
         state.reset_block_count()
         _output("approve")
-        _safe_post_approve(state, all_events, transcript_path, current_turn)
+        _safe_post_approve(
+            state, all_events, transcript_path, current_turn,
+            run_nudges=True,
+        )
 
     except Exception as e:
         # フェイルオープン: 例外時はapprove
@@ -268,15 +272,20 @@ def _update_checked_in_activity(
 
 def _safe_post_approve(
     state: HookState, events: list[dict], transcript_path: str,
-    current_turn: int | None = None,
+    current_turn: int = 0,
+    *,
+    run_nudges: bool = False,
 ) -> None:
     """approve出力後の状態更新。例外はstderrログのみ（double-output防止）。"""
     try:
         _update_state_on_approve(state, events, transcript_path)
-        if current_turn is not None:
+        if run_nudges:
             _handle_nudges(state, events, current_turn)
     except Exception as e:
-        print(f"stop_hook.py post-approve error: {e}", file=sys.stderr)
+        print(
+            f"stop_hook.py post-approve error: {e}\n{traceback.format_exc()}",
+            file=sys.stderr,
+        )
 
 
 def _update_state_on_approve(

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -621,6 +621,28 @@ class TestSkillSpan:
         assert result["decision"] == "approve"
         assert "Skill Span" in result["reason"]
 
+    def test_skill_span_with_is_meta_entry(self, env_setup):
+        """スキル内容注入（isMeta=true）がturnを進めずSkill Spanが維持される"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            # スキル呼び出し
+            _make_skill_user_entry("check-in"),
+            # スキル内容注入（isMeta=true）— turnを進めてはいけない
+            {"type": "user", "isMeta": True, "message": {"role": "user", "content": [
+                {"type": "text", "text": "Base directory for this skill: ...\n# check-in\n..."},
+            ]}},
+            _make_assistant_entry(
+                tool_calls=["mcp__plugin_claude-code-memory_cc-memory__get_activities"],
+            ),
+            _make_assistant_entry(text="activity list here"),
+        ], transcript)
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+        assert "Skill Span" in result["reason"]
+
     def test_skill_span_continues_on_next_skill_turn(self, env_setup):
         """連続するSkill turnでもSpan継続"""
         state_dir = env_setup["state_dir"]

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -382,6 +382,49 @@ class TestExceptionFailOpen:
         assert result["decision"] == "approve"
         assert "error" in result.get("reason", "").lower()
 
+    def test_post_approve_exception_no_double_output(self, env_setup):
+        """approve後の状態更新で例外 → stdoutは1行のみ（double-output防止の回帰テスト）"""
+        state_dir = env_setup["state_dir"]
+
+        # checked_in_activityを設定 → update_heartbeatが呼ばれる
+        Path(state_dir, "checked_in_activity_test-session").write_text("999")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript([
+            _make_user_entry("hi"),
+            CONTEXT_RETRIEVAL_ENTRY,
+            _make_assistant_entry(text=f"{META_TAG}\nresponse"),
+        ], transcript)
+
+        # DB pathを空ファイルに向ける → activitiesテーブルがないのでsqlite3.OperationalError
+        empty_db = env_setup["tmp_path"] / "empty.db"
+        empty_db.touch()
+
+        env = {**os.environ, **env_setup["env_override"], "DISCUSSION_DB_PATH": str(empty_db)}
+        input_data = json.dumps({
+            "transcript_path": str(transcript),
+            "session_id": "test-session",
+            "last_assistant_message": f"response\n{META_TAG}",
+        })
+
+        result = subprocess.run(
+            [sys.executable, "hooks/stop_hook.py"],
+            input=input_data,
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+        )
+
+        # stdoutは1行のJSONのみ（double-outputなし）
+        stdout_lines = result.stdout.strip().split("\n")
+        assert len(stdout_lines) == 1, f"Expected 1 stdout line, got {len(stdout_lines)}: {result.stdout}"
+        parsed = json.loads(stdout_lines[0])
+        assert parsed["decision"] == "approve"
+
+        # stderrにpost-approve errorログが出ている
+        assert "post-approve error" in result.stderr
+
 
 class TestContextRetrievalCheck:
     """コンテキスト取得ツール呼び出しチェック"""

--- a/tests/unit/test_hook_transcript.py
+++ b/tests/unit/test_hook_transcript.py
@@ -5,11 +5,13 @@ from pathlib import Path
 import pytest
 
 from hooks.hook_transcript import (
+    extract_events,
     extract_text_from_entry,
     get_last_assistant_entry,
     get_transcript_info,
     has_context_retrieval_calls,
     has_recent_recording,
+    is_user_message,
     parse_meta_tag,
 )
 
@@ -374,3 +376,75 @@ class TestGetTranscriptInfo:
         entries, has_skill = get_transcript_info(str(path))
         assert entries == []
         assert has_skill is False
+
+
+# --- is_user_message ---
+
+
+class TestIsUserMessage:
+    def test_string_content_is_user_message(self):
+        entry = {"type": "user", "message": {"content": "hello"}}
+        assert is_user_message(entry) is True
+
+    def test_list_content_without_tool_result_is_user_message(self):
+        entry = {"type": "user", "message": {"content": [
+            {"type": "text", "text": "hello"},
+        ]}}
+        assert is_user_message(entry) is True
+
+    def test_tool_result_is_not_user_message(self):
+        entry = {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "toolu_123", "content": "result"},
+        ]}}
+        assert is_user_message(entry) is False
+
+    def test_assistant_is_not_user_message(self):
+        entry = {"type": "assistant", "message": {"content": "hello"}}
+        assert is_user_message(entry) is False
+
+    def test_is_meta_entry_is_not_user_message(self):
+        """isMeta=trueのエントリ（スキル内容注入等）はUser Messageではない"""
+        entry = {
+            "type": "user",
+            "isMeta": True,
+            "message": {"content": [
+                {"type": "text", "text": "Base directory for this skill: ..."},
+            ]},
+        }
+        assert is_user_message(entry) is False
+
+    def test_is_meta_false_is_user_message(self):
+        """isMeta=falseは通常のUser Message"""
+        entry = {
+            "type": "user",
+            "isMeta": False,
+            "message": {"content": "hello"},
+        }
+        assert is_user_message(entry) is True
+
+
+# --- extract_events: isMeta handling ---
+
+
+class TestExtractEventsIsMeta:
+    def test_is_meta_does_not_advance_turn(self):
+        """isMeta=trueのエントリはturnを進めない"""
+        entries = [
+            # ユーザーのスキル呼び出し
+            {"type": "user", "message": {"content":
+                "<command-name>/check-in</command-name>"}},
+            # スキル内容注入（isMeta=true）
+            {"type": "user", "isMeta": True, "message": {"content": [
+                {"type": "text", "text": "Base directory for this skill..."},
+            ]}},
+            # アシスタント応答
+            {"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "response"},
+            ]}},
+        ]
+        events, current_turn = extract_events(entries, 0)
+        # turn 1のみ（isMeta=trueでturn 2にならない）
+        assert current_turn == 1
+        skill_events = [e for e in events if e["e"] == "skill"]
+        assert len(skill_events) == 1
+        assert skill_events[0]["turn"] == 1


### PR DESCRIPTION
## Summary
### 1. double-output bug（CI 6テスト失敗の原因）
- `_output("approve")`呼出後に`_update_state_on_approve`/`_handle_nudges`で例外が発生すると、外側のexceptブロックで再度`_output`が呼ばれstdoutに2行のJSON出力が生じていた
- CIではDBが存在しないため`update_heartbeat`が`sqlite3.OperationalError`を投げてこの経路に入る
- `_safe_post_approve()`でapprove後の状態更新を独立したtry/exceptに隔離し、例外時はstderrログのみに変更

### 2. isMeta=trueのturn誤カウント（Skill Span破壊）
- Claude Codeはスキル呼び出し時にuserエントリを2つ書く: (1) `<command-name>`タグ (2) スキル内容注入（`isMeta=true`）
- `is_user_message()`が2つ目をUser Messageと判定し、turnが不正に進みSkill Spanが壊れていた
- `isMeta=true`のエントリを除外することで修正

## Test plan
- [x] `tests/e2e/test_stop_hook.py` 31テスト全Pass（新規1件追加）
- [x] `tests/unit/test_hook_transcript.py` 45テスト全Pass（新規8件追加）
- [ ] CIでテストがPassすることを確認


🤖 Generated with [Claude Code](https://claude.com/claude-code)