### PR TITLE
feat: エンティティ間リレーション基盤（テーブル・VIEW・サービス）を追加

### DIFF
--- a/migrations/0020_add_relation_tables.sql
+++ b/migrations/0020_add_relation_tables.sql
@@ -1,0 +1,48 @@
+-- depends: 0019_add_reminders
+
+-- topic-topic リレーション
+CREATE TABLE topic_relations (
+    topic_id_1 INTEGER NOT NULL REFERENCES discussion_topics(id) ON DELETE CASCADE,
+    topic_id_2 INTEGER NOT NULL REFERENCES discussion_topics(id) ON DELETE CASCADE,
+    created_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (topic_id_1, topic_id_2),
+    CHECK (topic_id_1 < topic_id_2)
+);
+
+-- topic-activity リレーション
+CREATE TABLE topic_activity_relations (
+    topic_id INTEGER NOT NULL REFERENCES discussion_topics(id) ON DELETE CASCADE,
+    activity_id INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+    created_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (topic_id, activity_id)
+);
+
+-- activity-activity リレーション
+CREATE TABLE activity_relations (
+    activity_id_1 INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+    activity_id_2 INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+    created_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (activity_id_1, activity_id_2),
+    CHECK (activity_id_1 < activity_id_2)
+);
+
+-- 双方向VIEW
+CREATE VIEW relations_view AS
+  SELECT topic_id_1 AS source_id, 'topic' AS source_type,
+         topic_id_2 AS target_id, 'topic' AS target_type, created_at
+  FROM topic_relations
+  UNION ALL
+  SELECT topic_id_2, 'topic', topic_id_1, 'topic', created_at
+  FROM topic_relations
+  UNION ALL
+  SELECT topic_id, 'topic', activity_id, 'activity', created_at
+  FROM topic_activity_relations
+  UNION ALL
+  SELECT activity_id, 'activity', topic_id, 'topic', created_at
+  FROM topic_activity_relations
+  UNION ALL
+  SELECT activity_id_1, 'activity', activity_id_2, 'activity', created_at
+  FROM activity_relations
+  UNION ALL
+  SELECT activity_id_2, 'activity', activity_id_1, 'activity', created_at
+  FROM activity_relations;

--- a/migrations/0020_add_relation_tables.sql
+++ b/migrations/0020_add_relation_tables.sql
@@ -26,6 +26,11 @@ CREATE TABLE activity_relations (
     CHECK (activity_id_1 < activity_id_2)
 );
 
+-- 逆方向参照用インデックス
+CREATE INDEX idx_topic_relations_id2 ON topic_relations(topic_id_2);
+CREATE INDEX idx_topic_activity_relations_activity ON topic_activity_relations(activity_id);
+CREATE INDEX idx_activity_relations_id2 ON activity_relations(activity_id_2);
+
 -- 双方向VIEW
 CREATE VIEW relations_view AS
   SELECT topic_id_1 AS source_id, 'topic' AS source_type,

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -84,11 +84,15 @@ def _get_delete_params(source_type: str, source_id: int, target_type: str, targe
     """source/targetの組み合わせから、適切なテーブルとDELETE条件を返す。
 
     Returns:
-        (table_name, where_clause, values)
+        (table_name, where_clause, values) or None（自己参照の場合）
 
     Raises:
         ValueError: 不正なtype組み合わせ（バリデーション済みなら到達しない）
     """
+    # 自己参照チェック（_get_insert_paramsと対称）
+    if source_type == target_type and source_id == target_id:
+        return None
+
     if source_type == "topic" and target_type == "topic":
         id_1, id_2 = min(source_id, target_id), max(source_id, target_id)
         return ("topic_relations", "topic_id_1 = ? AND topic_id_2 = ?", (id_1, id_2))
@@ -330,6 +334,13 @@ def get_map(entity_type: str, entity_id: int, min_depth: int = 0, max_depth: int
             "error": {
                 "code": "INVALID_PARAMETER",
                 "message": "max_depth must be >= min_depth",
+            }
+        }
+    if max_depth > 10:
+        return {
+            "error": {
+                "code": "INVALID_PARAMETER",
+                "message": "max_depth must be <= 10",
             }
         }
 

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -1,0 +1,352 @@
+"""エンティティ間リレーション管理サービス"""
+import logging
+import sqlite3
+
+from src.db import get_connection
+from src.services.tag_service import (
+    get_entity_tags_batch,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_ENTITY_TYPES = {"topic", "activity"}
+
+
+def _validate_entity_type(entity_type: str) -> dict | None:
+    """エンティティタイプをバリデーションする。不正な場合はエラーdictを返す。"""
+    if entity_type not in VALID_ENTITY_TYPES:
+        return {
+            "error": {
+                "code": "INVALID_ENTITY_TYPE",
+                "message": f"Invalid entity type: '{entity_type}'. Must be one of {sorted(VALID_ENTITY_TYPES)}",
+            }
+        }
+    return None
+
+
+def _validate_targets(targets: list[dict]) -> dict | None:
+    """targetsのバリデーション。不正な場合はエラーdictを返す。"""
+    if not targets:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "targets must not be empty",
+            }
+        }
+    for target in targets:
+        if "type" not in target or "ids" not in target:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": "Each target must have 'type' and 'ids' fields",
+                }
+            }
+        err = _validate_entity_type(target["type"])
+        if err:
+            return err
+        if not isinstance(target["ids"], list) or not target["ids"]:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"'ids' for type '{target['type']}' must be a non-empty list",
+                }
+            }
+    return None
+
+
+def _get_insert_params(source_type: str, source_id: int, target_type: str, target_id: int):
+    """source/targetの組み合わせから、適切なテーブルとINSERTパラメータを返す。
+
+    Returns:
+        (table_name, columns, values) or None（自己参照の場合）
+    """
+    # 自己参照チェック
+    if source_type == target_type and source_id == target_id:
+        return None
+
+    if source_type == "topic" and target_type == "topic":
+        # 正規化: id_1 < id_2
+        id_1, id_2 = min(source_id, target_id), max(source_id, target_id)
+        return ("topic_relations", "(topic_id_1, topic_id_2)", (id_1, id_2))
+    elif source_type == "topic" and target_type == "activity":
+        return ("topic_activity_relations", "(topic_id, activity_id)", (source_id, target_id))
+    elif source_type == "activity" and target_type == "topic":
+        return ("topic_activity_relations", "(topic_id, activity_id)", (target_id, source_id))
+    elif source_type == "activity" and target_type == "activity":
+        # 正規化: id_1 < id_2
+        id_1, id_2 = min(source_id, target_id), max(source_id, target_id)
+        return ("activity_relations", "(activity_id_1, activity_id_2)", (id_1, id_2))
+    else:
+        raise ValueError(f"Unexpected type combination: {source_type}/{target_type}")
+
+
+def _get_delete_params(source_type: str, source_id: int, target_type: str, target_id: int):
+    """source/targetの組み合わせから、適切なテーブルとDELETE条件を返す。
+
+    Returns:
+        (table_name, where_clause, values)
+
+    Raises:
+        ValueError: 不正なtype組み合わせ（バリデーション済みなら到達しない）
+    """
+    if source_type == "topic" and target_type == "topic":
+        id_1, id_2 = min(source_id, target_id), max(source_id, target_id)
+        return ("topic_relations", "topic_id_1 = ? AND topic_id_2 = ?", (id_1, id_2))
+    elif source_type == "topic" and target_type == "activity":
+        return ("topic_activity_relations", "topic_id = ? AND activity_id = ?", (source_id, target_id))
+    elif source_type == "activity" and target_type == "topic":
+        return ("topic_activity_relations", "topic_id = ? AND activity_id = ?", (target_id, source_id))
+    elif source_type == "activity" and target_type == "activity":
+        id_1, id_2 = min(source_id, target_id), max(source_id, target_id)
+        return ("activity_relations", "activity_id_1 = ? AND activity_id_2 = ?", (id_1, id_2))
+    else:
+        raise ValueError(f"Unexpected type combination: {source_type}/{target_type}")
+
+
+def _add_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]) -> int:
+    """conn共有版: リレーションを追加する。追加件数を返す。"""
+    added = 0
+    for target in targets:
+        target_type = target["type"]
+        for target_id in target["ids"]:
+            params = _get_insert_params(source_type, source_id, target_type, target_id)
+            if params is None:
+                # 自己参照はスキップ
+                continue
+            table, columns, values = params
+            placeholders = ", ".join("?" for _ in values)
+            conn.execute(
+                f"INSERT OR IGNORE INTO {table} {columns} VALUES ({placeholders})",
+                values,
+            )
+            # INSERT OR IGNOREの場合、重複時はchanges()=0
+            if conn.execute("SELECT changes()").fetchone()[0] > 0:
+                added += 1
+    return added
+
+
+def _remove_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]) -> int:
+    """conn共有版: リレーションを削除する。削除件数を返す。"""
+    removed = 0
+    for target in targets:
+        target_type = target["type"]
+        for target_id in target["ids"]:
+            params = _get_delete_params(source_type, source_id, target_type, target_id)
+            if params is None:
+                continue
+            table, where_clause, values = params
+            conn.execute(
+                f"DELETE FROM {table} WHERE {where_clause}",
+                values,
+            )
+            removed += conn.execute("SELECT changes()").fetchone()[0]
+    return removed
+
+
+def add_relation(source_type: str, source_id: int, targets: list[dict]) -> dict:
+    """リレーションを追加する。
+
+    Args:
+        source_type: 起点エンティティのタイプ（"topic" or "activity"）
+        source_id: 起点エンティティのID
+        targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
+
+    Returns:
+        成功時: {"added": int}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    err = _validate_entity_type(source_type)
+    if err:
+        return err
+    err = _validate_targets(targets)
+    if err:
+        return err
+
+    conn = get_connection()
+    try:
+        added = _add_relation_with_conn(conn, source_type, source_id, targets)
+        conn.commit()
+        return {"added": added}
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        logger.error(f"add_relation failed: {e}")
+        return {"error": {"code": "CONSTRAINT_VIOLATION", "message": str(e)}}
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"add_relation failed: {e}")
+        return {"error": {"code": "ADD_RELATION_FAILED", "message": str(e)}}
+    finally:
+        conn.close()
+
+
+def remove_relation(source_type: str, source_id: int, targets: list[dict]) -> dict:
+    """リレーションを削除する。
+
+    Args:
+        source_type: 起点エンティティのタイプ（"topic" or "activity"）
+        source_id: 起点エンティティのID
+        targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
+
+    Returns:
+        成功時: {"removed": int}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    err = _validate_entity_type(source_type)
+    if err:
+        return err
+    err = _validate_targets(targets)
+    if err:
+        return err
+
+    conn = get_connection()
+    try:
+        removed = _remove_relation_with_conn(conn, source_type, source_id, targets)
+        conn.commit()
+        return {"removed": removed}
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"remove_relation failed: {e}")
+        return {"error": {"code": "REMOVE_RELATION_FAILED", "message": str(e)}}
+    finally:
+        conn.close()
+
+
+def _get_map_with_conn(
+    conn: sqlite3.Connection,
+    entity_type: str,
+    entity_id: int,
+    min_depth: int = 0,
+    max_depth: int = 2,
+) -> list[dict]:
+    """conn共有版: 再帰CTEでリレーショングラフを走査し、到達可能エンティティを返す。"""
+    rows = conn.execute(
+        """
+        WITH RECURSIVE reachable(entity_type, entity_id, depth) AS (
+            SELECT ?, ?, 0
+            UNION
+            SELECT r.target_type, r.target_id, re.depth + 1
+            FROM reachable re
+            JOIN relations_view r
+              ON r.source_type = re.entity_type AND r.source_id = re.entity_id
+            WHERE re.depth < ?
+        )
+        SELECT DISTINCT entity_type, entity_id, MIN(depth) AS depth
+        FROM reachable
+        WHERE depth >= ?
+        GROUP BY entity_type, entity_id
+        """,
+        (entity_type, entity_id, max_depth, min_depth),
+    ).fetchall()
+
+    # エンティティのタイプ別にIDを収集
+    topic_ids = [row["entity_id"] for row in rows if row["entity_type"] == "topic"]
+    activity_ids = [row["entity_id"] for row in rows if row["entity_type"] == "activity"]
+
+    # タイトルをバッチ取得
+    topic_titles = {}
+    if topic_ids:
+        placeholders = ",".join("?" * len(topic_ids))
+        title_rows = conn.execute(
+            f"SELECT id, title FROM discussion_topics WHERE id IN ({placeholders})",
+            tuple(topic_ids),
+        ).fetchall()
+        topic_titles = {r["id"]: r["title"] for r in title_rows}
+
+    activity_titles = {}
+    if activity_ids:
+        placeholders = ",".join("?" * len(activity_ids))
+        title_rows = conn.execute(
+            f"SELECT id, title FROM activities WHERE id IN ({placeholders})",
+            tuple(activity_ids),
+        ).fetchall()
+        activity_titles = {r["id"]: r["title"] for r in title_rows}
+
+    # タグをバッチ取得
+    topic_tags_map = get_entity_tags_batch(conn, "topic_tags", "topic_id", topic_ids) if topic_ids else {}
+    activity_tags_map = get_entity_tags_batch(conn, "activity_tags", "activity_id", activity_ids) if activity_ids else {}
+
+    # 存在するIDのセットを構築（存在しないIDを除外するため）
+    existing_ids = set()
+    existing_ids.update(("topic", tid) for tid in topic_titles)
+    existing_ids.update(("activity", aid) for aid in activity_titles)
+
+    # カタログ構築（存在しないエンティティは除外）
+    entities = []
+    for row in rows:
+        etype = row["entity_type"]
+        eid = row["entity_id"]
+        depth = row["depth"]
+
+        if (etype, eid) not in existing_ids:
+            continue
+
+        if etype == "topic":
+            title = topic_titles[eid]
+            tags = topic_tags_map.get(eid, [])
+        else:
+            title = activity_titles[eid]
+            tags = activity_tags_map.get(eid, [])
+
+        entities.append({
+            "type": etype,
+            "id": eid,
+            "title": title,
+            "tags": tags,
+            "depth": depth,
+        })
+
+    # depth順、同depth内はtype→id順でソート
+    entities.sort(key=lambda e: (e["depth"], e["type"], e["id"]))
+
+    return entities
+
+
+def get_map(entity_type: str, entity_id: int, min_depth: int = 0, max_depth: int = 2) -> dict:
+    """リレーショングラフを走査し、到達可能エンティティのカタログを返す。
+
+    Args:
+        entity_type: 起点エンティティのタイプ（"topic" or "activity"）
+        entity_id: 起点エンティティのID
+        min_depth: 最小深度（デフォルト: 0）
+        max_depth: 最大深度（デフォルト: 2）
+
+    Returns:
+        成功時: {"entities": [...], "total_count": int}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    err = _validate_entity_type(entity_type)
+    if err:
+        return err
+
+    if min_depth < 0:
+        return {
+            "error": {
+                "code": "INVALID_PARAMETER",
+                "message": "min_depth must be >= 0",
+            }
+        }
+    if max_depth < min_depth:
+        return {
+            "error": {
+                "code": "INVALID_PARAMETER",
+                "message": "max_depth must be >= min_depth",
+            }
+        }
+
+    conn = get_connection()
+    try:
+        entities = _get_map_with_conn(conn, entity_type, entity_id, min_depth, max_depth)
+        return {
+            "entities": entities,
+            "total_count": len(entities),
+        }
+    except Exception as e:
+        logger.error(f"get_map failed: {e}")
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -1,0 +1,510 @@
+"""リレーションサービスの統合テスト"""
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.relation_service import add_relation, get_map, remove_relation
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = [("domain", "test")]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _create_topic(conn, title="Test Topic"):
+    """テスト用トピックを作成する"""
+    from src.services.tag_service import ensure_tag_ids, link_tags
+
+    cursor = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        (title, f"Description for {title}"),
+    )
+    topic_id = cursor.lastrowid
+    tag_ids = ensure_tag_ids(conn, DEFAULT_TAGS)
+    link_tags(conn, "topic_tags", "topic_id", topic_id, tag_ids)
+    return topic_id
+
+
+def _create_activity(conn, title="Test Activity"):
+    """テスト用アクティビティを作成する"""
+    from src.services.tag_service import ensure_tag_ids, link_tags
+
+    cursor = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, f"Description for {title}", "pending"),
+    )
+    activity_id = cursor.lastrowid
+    tag_ids = ensure_tag_ids(conn, DEFAULT_TAGS)
+    link_tags(conn, "activity_tags", "activity_id", activity_id, tag_ids)
+    return activity_id
+
+
+@pytest.fixture
+def sample_entities(temp_db):
+    """テスト用のトピックとアクティビティを作成する"""
+    conn = get_connection()
+    try:
+        t1 = _create_topic(conn, "Topic A")
+        t2 = _create_topic(conn, "Topic B")
+        t3 = _create_topic(conn, "Topic C")
+        a1 = _create_activity(conn, "Activity X")
+        a2 = _create_activity(conn, "Activity Y")
+        a3 = _create_activity(conn, "Activity Z")
+        conn.commit()
+    finally:
+        conn.close()
+    return {"t1": t1, "t2": t2, "t3": t3, "a1": a1, "a2": a2, "a3": a3}
+
+
+class TestAddRelation:
+    """add_relationの統合テスト"""
+
+    def test_add_topic_topic_relation(self, sample_entities):
+        """topic↔topicリレーションが追加できる"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_add_topic_activity_relation(self, sample_entities):
+        """topic↔activityリレーションが追加できる"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_add_activity_topic_relation(self, sample_entities):
+        """activity→topicリレーション（逆方向指定）が追加できる"""
+        e = sample_entities
+        result = add_relation("activity", e["a1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        assert "error" not in result
+        assert result["added"] == 1
+
+        # topic_activity_relationsに正しく格納されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM topic_activity_relations WHERE topic_id = ? AND activity_id = ?",
+                (e["t1"], e["a1"]),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_add_activity_activity_relation(self, sample_entities):
+        """activity↔activityリレーションが追加できる"""
+        e = sample_entities
+        result = add_relation("activity", e["a1"], [{"type": "activity", "ids": [e["a2"]]}])
+
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_add_multiple_targets(self, sample_entities):
+        """複数ターゲットを一度に追加できる"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [
+            {"type": "topic", "ids": [e["t2"], e["t3"]]},
+            {"type": "activity", "ids": [e["a1"]]},
+        ])
+
+        assert "error" not in result
+        assert result["added"] == 3
+
+    def test_add_relation_idempotent(self, sample_entities):
+        """重複追加が冪等（エラーにならず、added=0）"""
+        e = sample_entities
+        result1 = add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+        assert result1["added"] == 1
+
+        result2 = add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+        assert "error" not in result2
+        assert result2["added"] == 0
+
+    def test_add_relation_self_reference_skipped(self, sample_entities):
+        """自己参照はスキップされる（エラーにならない）"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        assert "error" not in result
+        assert result["added"] == 0
+
+    def test_add_relation_invalid_source_type(self, sample_entities):
+        """不正なsource_typeでエラー"""
+        e = sample_entities
+        result = add_relation("invalid", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_ENTITY_TYPE"
+
+    def test_add_relation_invalid_target_type(self, sample_entities):
+        """不正なtarget_typeでエラー"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [{"type": "invalid", "ids": [e["t2"]]}])
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_ENTITY_TYPE"
+
+    def test_add_relation_empty_targets(self, sample_entities):
+        """空のtargetsでエラー"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [])
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_add_relation_nonexistent_id_returns_error(self, sample_entities):
+        """存在しないIDへのリレーション追加はFK違反でエラー"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [{"type": "topic", "ids": [99999]}])
+
+        assert "error" in result
+        assert result["error"]["code"] == "CONSTRAINT_VIOLATION"
+
+    def test_add_relation_partial_fk_violation_rolls_back(self, sample_entities):
+        """複数targets指定時にFK違反が起きると全体がロールバックされる"""
+        e = sample_entities
+        result = add_relation("topic", e["t1"], [
+            {"type": "topic", "ids": [e["t2"], 99999]},
+        ])
+
+        assert "error" in result
+
+        # t2へのリレーションもロールバックされている
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM topic_relations"
+            ).fetchone()
+            assert row["cnt"] == 0
+        finally:
+            conn.close()
+
+    def test_add_relation_normalizes_order(self, sample_entities):
+        """topic_id_1 < topic_id_2に正規化される"""
+        e = sample_entities
+        # t2 > t1 のはずなので、t2からt1への追加でもt1,t2の順に格納される
+        result = add_relation("topic", e["t2"], [{"type": "topic", "ids": [e["t1"]]}])
+        assert result["added"] == 1
+
+        # 正規化済みの順で格納されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM topic_relations WHERE topic_id_1 = ? AND topic_id_2 = ?",
+                (min(e["t1"], e["t2"]), max(e["t1"], e["t2"])),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+
+class TestRemoveRelation:
+    """remove_relationの統合テスト"""
+
+    def test_remove_relation_success(self, sample_entities):
+        """リレーション削除が正常に動作する"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        result = remove_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_remove_nonexistent_relation(self, sample_entities):
+        """存在しないリレーションの削除がエラーにならない"""
+        e = sample_entities
+        result = remove_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 0
+
+    def test_remove_topic_activity_relation(self, sample_entities):
+        """topic↔activityリレーション削除が動作する"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        result = remove_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_remove_activity_activity_relation(self, sample_entities):
+        """activity↔activityリレーション削除が動作する"""
+        e = sample_entities
+        add_relation("activity", e["a1"], [{"type": "activity", "ids": [e["a2"]]}])
+
+        result = remove_relation("activity", e["a1"], [{"type": "activity", "ids": [e["a2"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_remove_activity_topic_relation(self, sample_entities):
+        """activity→topic方向のリレーション削除が動作する"""
+        e = sample_entities
+        add_relation("activity", e["a1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        result = remove_relation("activity", e["a1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_remove_multiple_targets(self, sample_entities):
+        """複数ターゲットの一括削除"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [
+            {"type": "topic", "ids": [e["t2"], e["t3"]]},
+        ])
+
+        result = remove_relation("topic", e["t1"], [
+            {"type": "topic", "ids": [e["t2"], e["t3"]]},
+        ])
+
+        assert "error" not in result
+        assert result["removed"] == 2
+
+
+class TestGetMap:
+    """get_mapの統合テスト"""
+
+    def test_get_map_depth_0_returns_origin(self, sample_entities):
+        """depth=0で起点のみ返る"""
+        e = sample_entities
+        # リレーションを追加（depth=0テストでは結果に含まれない想定）
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=0)
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["entities"][0]["type"] == "topic"
+        assert result["entities"][0]["id"] == e["t1"]
+        assert result["entities"][0]["depth"] == 0
+
+    def test_get_map_depth_1_returns_direct_relations(self, sample_entities):
+        """depth=1で直接関連が返る"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [
+            {"type": "topic", "ids": [e["t2"]]},
+            {"type": "activity", "ids": [e["a1"]]},
+        ])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=1)
+
+        assert "error" not in result
+        # 起点(t1) + t2 + a1 = 3エンティティ
+        assert result["total_count"] == 3
+        types_ids = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", e["t1"]) in types_ids
+        assert ("topic", e["t2"]) in types_ids
+        assert ("activity", e["a1"]) in types_ids
+
+    def test_get_map_min_depth_filters(self, sample_entities):
+        """min_depthで起点を除外できる"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=1, max_depth=1)
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["entities"][0]["id"] == e["t2"]
+
+    def test_get_map_transitive_depth_2(self, sample_entities):
+        """depth=2で間接関連が返る"""
+        e = sample_entities
+        # t1 - t2 - t3 のチェーン
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+        add_relation("topic", e["t2"], [{"type": "topic", "ids": [e["t3"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        # t1(0) + t2(1) + t3(2) = 3エンティティ
+        assert result["total_count"] == 3
+        types_ids = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", e["t3"]) in types_ids
+
+    def test_get_map_no_infinite_loop_on_cycle(self, sample_entities):
+        """循環参照で無限ループしない"""
+        e = sample_entities
+        # t1 - t2 - t3 - t1 の循環
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+        add_relation("topic", e["t2"], [{"type": "topic", "ids": [e["t3"]]}])
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t3"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=5)
+
+        assert "error" not in result
+        # 循環してもt1, t2, t3の3つしかない
+        assert result["total_count"] == 3
+
+    def test_get_map_returns_catalog_with_title_and_tags(self, sample_entities):
+        """カタログにtitleとtagsが含まれる"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=1)
+
+        assert "error" not in result
+        for entity in result["entities"]:
+            assert "title" in entity
+            assert "tags" in entity
+            assert isinstance(entity["tags"], list)
+            assert entity["title"] != ""
+
+    def test_get_map_invalid_entity_type(self, temp_db):
+        """不正なentity_typeでエラー"""
+        result = get_map("invalid", 1, min_depth=0, max_depth=1)
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_ENTITY_TYPE"
+
+    def test_get_map_invalid_min_depth(self, temp_db):
+        """min_depth < 0でエラー"""
+        result = get_map("topic", 1, min_depth=-1, max_depth=1)
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_PARAMETER"
+
+    def test_get_map_max_depth_less_than_min_depth(self, temp_db):
+        """max_depth < min_depthでエラー"""
+        result = get_map("topic", 1, min_depth=2, max_depth=1)
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_PARAMETER"
+
+    def test_get_map_no_relations(self, sample_entities):
+        """リレーションなしの場合、起点のみ返る"""
+        e = sample_entities
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["entities"][0]["id"] == e["t1"]
+
+    def test_get_map_nonexistent_id_returns_empty(self, temp_db):
+        """存在しないIDのget_mapは空結果を返す"""
+        result = get_map("topic", 99999, min_depth=0, max_depth=1)
+
+        assert "error" not in result
+        assert result["total_count"] == 0
+        assert result["entities"] == []
+
+    def test_get_map_multiple_paths_returns_min_depth(self, sample_entities):
+        """同じエンティティに異なるdepthで到達する場合、MIN(depth)が返る"""
+        e = sample_entities
+        # t1 - t2 - t3 (depth 2 for t3)
+        # t1 - t3        (depth 1 for t3)
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"], e["t3"]]}])
+        add_relation("topic", e["t2"], [{"type": "topic", "ids": [e["t3"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        t3_entry = next(ent for ent in result["entities"] if ent["id"] == e["t3"])
+        assert t3_entry["depth"] == 1  # 直接到達の方が浅い
+
+    def test_get_map_sorted_by_depth(self, sample_entities):
+        """結果がdepth順でソートされている"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+        add_relation("topic", e["t2"], [{"type": "topic", "ids": [e["t3"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        depths = [ent["depth"] for ent in result["entities"]]
+        assert depths == sorted(depths)
+
+
+class TestCascadeDelete:
+    """ON DELETE CASCADEの動作テスト"""
+
+    def test_cascade_delete_topic_cleans_topic_relations(self, sample_entities):
+        """トピック削除時にtopic_relationsが消える"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM discussion_topics WHERE id = ?", (e["t1"],))
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM topic_relations WHERE topic_id_1 = ? OR topic_id_2 = ?",
+                (e["t1"], e["t1"]),
+            ).fetchone()
+            assert row["cnt"] == 0
+        finally:
+            conn.close()
+
+    def test_cascade_delete_topic_cleans_topic_activity_relations(self, sample_entities):
+        """トピック削除時にtopic_activity_relationsが消える"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM discussion_topics WHERE id = ?", (e["t1"],))
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM topic_activity_relations WHERE topic_id = ?",
+                (e["t1"],),
+            ).fetchone()
+            assert row["cnt"] == 0
+        finally:
+            conn.close()
+
+    def test_cascade_delete_activity_cleans_topic_activity_relations(self, sample_entities):
+        """アクティビティ削除時にtopic_activity_relationsが消える"""
+        e = sample_entities
+        add_relation("topic", e["t1"], [{"type": "activity", "ids": [e["a1"]]}])
+
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM activities WHERE id = ?", (e["a1"],))
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM topic_activity_relations WHERE activity_id = ?",
+                (e["a1"],),
+            ).fetchone()
+            assert row["cnt"] == 0
+        finally:
+            conn.close()
+
+    def test_cascade_delete_activity_cleans_activity_relations(self, sample_entities):
+        """アクティビティ削除時にactivity_relationsが消える"""
+        e = sample_entities
+        add_relation("activity", e["a1"], [{"type": "activity", "ids": [e["a2"]]}])
+
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM activities WHERE id = ?", (e["a1"],))
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM activity_relations WHERE activity_id_1 = ? OR activity_id_2 = ?",
+                (e["a1"], e["a1"]),
+            ).fetchone()
+            assert row["cnt"] == 0
+        finally:
+            conn.close()

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -391,6 +391,21 @@ class TestGetMap:
         assert "error" in result
         assert result["error"]["code"] == "INVALID_PARAMETER"
 
+    def test_get_map_max_depth_exceeds_limit(self, temp_db):
+        """max_depth > 10でエラー"""
+        result = get_map("topic", 1, min_depth=0, max_depth=11)
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_PARAMETER"
+        assert "10" in result["error"]["message"]
+
+    def test_get_map_max_depth_at_limit(self, sample_entities):
+        """max_depth=10は許可される"""
+        e = sample_entities
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=10)
+
+        assert "error" not in result
+
     def test_get_map_no_relations(self, sample_entities):
         """リレーションなしの場合、起点のみ返る"""
         e = sample_entities


### PR DESCRIPTION
## Summary
- エンティティ間（topic↔topic, topic↔activity, activity↔activity）のN:Nリレーションを管理する基盤を追加
- 3テーブル + 双方向VIEW（relations_view） + relation_service.py（add/remove/get_map）
- 再帰CTEによるグラフ走査でカタログ形式の関連マップを取得可能

## Test plan
- [x] add_relation: 4タイプの組み合わせ + 冪等性 + 自己参照スキップ + FK違反 + 部分ロールバック（13テスト）
- [x] remove_relation: 正常削除 + 存在しない削除 + activity→topic方向（6テスト）
- [x] get_map: depth走査 + 循環参照 + 存在しないID + 複数パスMIN(depth)（13テスト）
- [x] CASCADE: topic/activity削除時の自動クリーンアップ（4テスト）
- [x] 既存642テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)