### PR TITLE
feat: embeddingタグ含有・タグLIKE検索・RRF 3ソース化

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -98,7 +98,8 @@ def add_activity(
         activity = row_to_dict(row)
 
         # embedding生成（失敗してもactivity作成には影響しない）
-        generate_and_store_embedding("activity", activity_id, build_embedding_text(title, description))
+        tag_text = " ".join(tag_strings) if tag_strings else ""
+        generate_and_store_embedding("activity", activity_id, build_embedding_text(title, description, tag_text))
 
         result = _activity_to_response(activity, tag_strings)
 
@@ -381,16 +382,17 @@ def update_activity(
         if not row:
             raise Exception("Failed to retrieve updated activity")
 
-        # title/descriptionが変更された場合、embeddingを再生成
-        if title is not None or description is not None:
-            updated = row_to_dict(row)
-            generate_and_store_embedding(
-                "activity", activity_id,
-                build_embedding_text(updated["title"], updated["description"]),
-            )
-
         # タグを取得
         tag_strings = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+
+        # title/description/tagsが変更された場合、embeddingを再生成
+        if title is not None or description is not None or parsed_tags is not None:
+            updated = row_to_dict(row)
+            tag_text = " ".join(tag_strings) if tag_strings else ""
+            generate_and_store_embedding(
+                "activity", activity_id,
+                build_embedding_text(updated["title"], updated["description"], tag_text),
+            )
 
         return _activity_to_response(row_to_dict(row), tag_strings)
 

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -57,7 +57,8 @@ def add_decision(
         effective_tags = get_effective_tags(conn, "decision", decision_id)
 
         # embedding生成（失敗してもdecision作成には影響しない）
-        generate_and_store_embedding("decision", decision_id, build_embedding_text(decision, reason))
+        tag_text = " ".join(effective_tags) if effective_tags else ""
+        generate_and_store_embedding("decision", decision_id, build_embedding_text(decision, reason, tag_text))
 
         return {
             "decision_id": decision_id,

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -70,7 +70,8 @@ def add_log(
         effective_tags = get_effective_tags(conn, "log", log_id)
 
         # embedding生成（失敗してもlog作成には影響しない）
-        generate_and_store_embedding("log", log_id, build_embedding_text(title, content))
+        tag_text = " ".join(effective_tags) if effective_tags else ""
+        generate_and_store_embedding("log", log_id, build_embedding_text(title, content, tag_text))
 
         return {
             "log_id": log_id,

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -201,6 +201,82 @@ def update_embedding(search_index_id: int, embedding: list[float]) -> None:
         conn.close()
 
 
+_ENTITY_TEXT_QUERIES = {
+    "topic": (
+        "SELECT title, description FROM discussion_topics WHERE id = ?",
+        ("title", "description"),
+    ),
+    "decision": (
+        "SELECT decision, reason FROM decisions WHERE id = ?",
+        ("decision", "reason"),
+    ),
+    "activity": (
+        "SELECT title, description FROM activities WHERE id = ?",
+        ("title", "description"),
+    ),
+    "log": (
+        "SELECT title, content FROM discussion_logs WHERE id = ?",
+        ("title", "content"),
+    ),
+    "material": (
+        "SELECT title, content FROM materials WHERE id = ?",
+        ("title", "content"),
+    ),
+}
+
+
+def regenerate_embedding(source_type: str, source_id: int) -> None:
+    """エンティティのembeddingをタグ含有テキストで再生成する。
+
+    タグ変更時に呼び出される。失敗してもraiseしない。
+    """
+    if source_type not in _ENTITY_TEXT_QUERIES:
+        return
+    try:
+        conn = get_connection()
+        try:
+            query_def = _ENTITY_TEXT_QUERIES[source_type]
+            row = conn.execute(query_def[0], (source_id,)).fetchone()
+            if not row:
+                return
+            field1 = row[query_def[1][0]]
+            field2 = row[query_def[1][1]]
+            tag_text = _get_entity_tag_text(conn, source_type, source_id)
+            text = build_embedding_text(field1, field2, tag_text)
+            if text:
+                generate_and_store_embedding(source_type, source_id, text)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning(f"Failed to regenerate embedding for {source_type} {source_id}: {e}")
+
+
+def _get_entity_tag_text(conn, source_type: str, source_id: int) -> str:
+    """エンティティに紐づくタグ文字列をスペース結合で返す（embedding生成・再生成・backfill共通）。"""
+    from src.services.tag_service import get_entity_tags, get_effective_tags
+
+    if source_type == "topic":
+        tags = get_entity_tags(conn, "topic_tags", "topic_id", source_id)
+    elif source_type == "activity":
+        tags = get_entity_tags(conn, "activity_tags", "activity_id", source_id)
+    elif source_type == "decision":
+        tags = get_effective_tags(conn, "decision", source_id)
+    elif source_type == "log":
+        tags = get_effective_tags(conn, "log", source_id)
+    elif source_type == "material":
+        # materialはactivity_idを取得してactivityのタグを継承
+        row = conn.execute(
+            "SELECT activity_id FROM materials WHERE id = ?", (source_id,)
+        ).fetchone()
+        if row:
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", row["activity_id"])
+        else:
+            tags = []
+    else:
+        tags = []
+    return " ".join(tags) if tags else ""
+
+
 def backfill_embeddings() -> int:
     """search_indexにあってvec_indexにないレコードのembeddingを一括生成する。
 
@@ -212,35 +288,35 @@ def backfill_embeddings() -> int:
     # リソースタイプごとのクエリ（バッチ推論のためにグループ化）
     type_queries = {
         "topic": """
-            SELECT si.id, dt.title, dt.description
+            SELECT si.id, si.source_id, dt.title, dt.description
             FROM search_index si
             INNER JOIN discussion_topics dt ON si.source_id = dt.id
             LEFT JOIN vec_index vi ON si.id = vi.rowid
             WHERE si.source_type = 'topic' AND vi.rowid IS NULL
         """,
         "decision": """
-            SELECT si.id, d.decision, d.reason
+            SELECT si.id, si.source_id, d.decision, d.reason
             FROM search_index si
             INNER JOIN decisions d ON si.source_id = d.id
             LEFT JOIN vec_index vi ON si.id = vi.rowid
             WHERE si.source_type = 'decision' AND vi.rowid IS NULL
         """,
         "activity": """
-            SELECT si.id, a.title, a.description
+            SELECT si.id, si.source_id, a.title, a.description
             FROM search_index si
             INNER JOIN activities a ON si.source_id = a.id
             LEFT JOIN vec_index vi ON si.id = vi.rowid
             WHERE si.source_type = 'activity' AND vi.rowid IS NULL
         """,
         "log": """
-            SELECT si.id, dl.title, dl.content
+            SELECT si.id, si.source_id, dl.title, dl.content
             FROM search_index si
             INNER JOIN discussion_logs dl ON si.source_id = dl.id
             LEFT JOIN vec_index vi ON si.id = vi.rowid
             WHERE si.source_type = 'log' AND vi.rowid IS NULL
         """,
         "material": """
-            SELECT si.id, m.title, m.content
+            SELECT si.id, si.source_id, m.title, m.content
             FROM search_index si
             INNER JOIN materials m ON si.source_id = m.id
             LEFT JOIN vec_index vi ON si.id = vi.rowid
@@ -259,7 +335,8 @@ def backfill_embeddings() -> int:
             ids = []
             texts = []
             for row in rows:
-                text = build_embedding_text(row[1], row[2])
+                tag_text = _get_entity_tag_text(conn, source_type, row[1])
+                text = build_embedding_text(row[2], row[3], tag_text)
                 if text:
                     ids.append(row[0])
                     texts.append(text)  # prefix付与はサーバー側で行う

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -4,6 +4,7 @@ import sqlite3
 
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
+from src.services.tag_service import get_entity_tags
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,10 @@ def add_material(activity_id: int, title: str, content: str) -> dict:
 
         conn.commit()
 
-        generate_and_store_embedding("material", material_id, build_embedding_text(title, content))
+        # materialはactivityのタグを継承
+        tag_strings = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+        tag_text = " ".join(tag_strings) if tag_strings else ""
+        generate_and_store_embedding("material", material_id, build_embedding_text(title, content, tag_text))
 
         return _material_to_response(row_to_dict(row))
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -40,6 +40,10 @@ SNIPPET_SOURCE = {
 
 SNIPPET_MAX_LEN = 200
 
+# _tag_like_search: SQLiteパラメータ上限(999)超過を防ぐためのtag_id数制限
+# パラメータ数 = 2 + 7 * len(matched_tag_ids) + 1 なので、100件で最大703パラメータ
+TAG_LIKE_MAX_TAG_IDS = 100
+
 # RRFパラメータ
 RRF_K = 60
 RRF_W_FTS = 1.0
@@ -601,6 +605,9 @@ def _tag_like_search(
         return []
 
     matched_tag_ids = [r["id"] for r in matching_tags]
+
+    # SQLiteパラメータ上限(999)超過を防止
+    matched_tag_ids = matched_tag_ids[:TAG_LIKE_MAX_TAG_IDS]
 
     # tag_idsフィルタ: 指定がある場合は交差を取る
     if tag_ids:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -44,6 +44,7 @@ SNIPPET_MAX_LEN = 200
 RRF_K = 60
 RRF_W_FTS = 1.0
 RRF_W_VEC = 1.0
+RRF_W_TAG = 0.5
 
 # Recency boost パラメータ
 # 半年(182日)で約0.80倍、1年(365日)で約0.66倍
@@ -552,6 +553,132 @@ def find_similar_topics(
         return []
 
 
+def _tag_like_search(
+    keywords: list[str],
+    tag_ids: Optional[list[int]],
+    type_filter: Optional[str],
+    limit: int,
+    keyword_mode: str = "and",
+) -> list[dict]:
+    """タグ名のLIKE検索。キーワードにマッチするタグを持つエンティティを返す。
+
+    entity_tagsの各中間テーブルからタグ名LIKE検索し、
+    search_index経由で結果を返す。
+
+    ANDモードでは「全キーワードを名前に含む単一タグ」を探す。
+    FTS/ベクトルのAND（複数語を含む文書）とは異なる意味論であり、
+    マッチするのは "domain:api-design" のような複合タグ名に限られる。
+    """
+    # LIKEワイルドカード文字をエスケープ
+    def _escape_like(s: str) -> str:
+        return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    # 全キーワードのLIKEパターンを作成
+    like_patterns = [f"%{_escape_like(kw)}%" for kw in keywords]
+
+    # タグテーブルからキーワードにマッチするtag_idsを取得
+    # name単体 or namespace:name の結合文字列に対してLIKE検索する
+    tag_full_expr = "CASE WHEN namespace != '' THEN namespace || ':' || name ELSE name END"
+    single_cond = f"(name LIKE ? ESCAPE '\\' OR {tag_full_expr} LIKE ? ESCAPE '\\')"
+    if keyword_mode == "or":
+        # OR: いずれかのキーワードにマッチするタグ
+        conditions = " OR ".join([single_cond] * len(like_patterns))
+        params: list = []
+        for p in like_patterns:
+            params.extend([p, p])
+    else:
+        # AND: すべてのキーワードにマッチするタグ（1つのタグ名が全キーワードを含む）
+        conditions = " AND ".join([single_cond] * len(like_patterns))
+        params = []
+        for p in like_patterns:
+            params.extend([p, p])
+
+    matching_tags = execute_query(
+        f"SELECT id FROM tags WHERE {conditions}",
+        tuple(params),
+    )
+    if not matching_tags:
+        return []
+
+    matched_tag_ids = [r["id"] for r in matching_tags]
+
+    # tag_idsフィルタ: 指定がある場合は交差を取る
+    if tag_ids:
+        matched_tag_ids = [tid for tid in matched_tag_ids if tid in tag_ids]
+        if not matched_tag_ids:
+            return []
+
+    # マッチしたタグを持つエンティティをsearch_index経由で取得
+    tag_placeholders = ",".join("?" * len(matched_tag_ids))
+
+    # 各中間テーブルからエンティティを収集（UNION ALL）
+    query = f"""
+    SELECT DISTINCT si.source_type AS type, si.source_id AS id, si.title
+    FROM search_index si
+    WHERE
+      (? IS NULL OR si.source_type = ?)
+      AND (
+        EXISTS (
+            SELECT 1 FROM topic_tags tt
+            WHERE tt.topic_id = si.source_id AND si.source_type = 'topic'
+              AND tt.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM activity_tags at
+            WHERE at.activity_id = si.source_id AND si.source_type = 'activity'
+              AND at.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM decision_tags dt
+            WHERE dt.decision_id = si.source_id AND si.source_type = 'decision'
+              AND dt.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM log_tags lt
+            WHERE lt.log_id = si.source_id AND si.source_type = 'log'
+              AND lt.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM materials m
+            JOIN activity_tags at2 ON at2.activity_id = m.activity_id
+            WHERE m.id = si.source_id AND si.source_type = 'material'
+              AND at2.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM decisions d
+            JOIN topic_tags tt2 ON tt2.topic_id = d.topic_id
+            WHERE d.id = si.source_id AND si.source_type = 'decision'
+              AND tt2.tag_id IN ({tag_placeholders})
+        )
+        OR EXISTS (
+            SELECT 1 FROM discussion_logs dl
+            JOIN topic_tags tt3 ON tt3.topic_id = dl.topic_id
+            WHERE dl.id = si.source_id AND si.source_type = 'log'
+              AND tt3.tag_id IN ({tag_placeholders})
+        )
+      )
+    ORDER BY si.id DESC
+    LIMIT ?
+    """
+    # パラメータ: type_filter × 2 + matched_tag_ids × 7 + limit
+    query_params = [type_filter, type_filter]
+    for _ in range(7):
+        query_params.extend(matched_tag_ids)
+    query_params.append(limit)
+
+    rows = execute_query(query, tuple(query_params))
+    results = []
+    for row in rows:
+        r = row_to_dict(row)
+        results.append({
+            "type": r["type"],
+            "id": r["id"],
+            "title": r["title"],
+        })
+    return results
+
+
+
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:
     """RRFスコアにrecency boost（時間減衰）を適用する（in-place）。
 
@@ -596,8 +723,9 @@ def _rrf_merge(
     fts_results: list[dict],
     vec_results: list[dict],
     limit: int,
+    tag_results: Optional[list[dict]] = None,
 ) -> list[dict]:
-    """RRF（Reciprocal Rank Fusion）でFTS5結果とベクトル結果を統合する。"""
+    """RRF（Reciprocal Rank Fusion）でFTS5・ベクトル・タグLIKE結果を統合する。"""
     scores: dict[tuple, dict] = {}  # key: (type, id)
 
     # FTS5結果にRRFスコアを付与（1始まりランク）
@@ -623,6 +751,21 @@ def _rrf_merge(
                 "title": item["title"],
                 "score": vec_score,
             }
+
+    # タグLIKE結果のRRFスコアを加算（1始まりランク）
+    if tag_results:
+        for rank, item in enumerate(tag_results, start=1):
+            key = (item["type"], item["id"])
+            tag_score = RRF_W_TAG / (RRF_K + rank)
+            if key in scores:
+                scores[key]["score"] += tag_score
+            else:
+                scores[key] = {
+                    "type": item["type"],
+                    "id": item["id"],
+                    "title": item["title"],
+                    "score": tag_score,
+                }
 
     # RRFスコア降順でソートし、上位limit件を返す
     merged = sorted(scores.values(), key=lambda x: x["score"], reverse=True)
@@ -745,13 +888,19 @@ def search(
         if vec_results is not None:
             methods_used.append("vector")
 
+        # タグLIKE検索（キーワード長の制限なし）
+        tag_like_results = _tag_like_search(keywords, tag_ids, type_filter, fetch_limit, keyword_mode)
+        if tag_like_results:
+            methods_used.append("tag_like")
+
         # 2文字キーワード + ベクトル検索無効 → エラー
         # OR時: 3文字以上が1つでもあればFTSで検索できるのでエラーにしない
+        # タグLIKE検索結果がある場合もエラーにしない
         fts_available = (
             any(len(kw) >= 3 for kw in keywords) if keyword_mode == "or"
             else min_len >= 3
         )
-        if not fts_available and vec_results is None:
+        if not fts_available and vec_results is None and not tag_like_results:
             return {
                 "error": {
                     "code": "KEYWORD_TOO_SHORT",
@@ -761,7 +910,7 @@ def search(
 
         # RRF統合（recency boost前なのでfetch_limitで多めに保持）
         effective_vec = vec_results if vec_results is not None else []
-        results = _rrf_merge(fts_results, effective_vec, fetch_limit)
+        results = _rrf_merge(fts_results, effective_vec, fetch_limit, tag_results=tag_like_results)
 
         _apply_recency_boost(results)
 

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -819,10 +819,18 @@ def update_tag(
 
         conn.commit()
 
-        # タグ変更に伴うembedding再生成（コミット後に非同期的に実行）
+        # タグ変更に伴うembedding再生成（コミット後に同期的に実行）
         from src.services.embedding_service import regenerate_embedding
         for etype, eid in affected_entities:
             regenerate_embedding(etype, eid)
+            # activityに紐づくmaterialのembeddingも再生成
+            if etype == "activity":
+                mat_rows = conn.execute(
+                    "SELECT id FROM materials WHERE activity_id = ?",
+                    (eid,),
+                ).fetchall()
+                for mat_row in mat_rows:
+                    regenerate_embedding("material", mat_row["id"])
 
         c_tag_str = f"{c_namespace}:{c_name}" if c_namespace else c_name
         return {"tag": tag_str, "canonical": c_tag_str, "updated": True}

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -780,6 +780,24 @@ def update_tag(
             (canonical_id, tag_id),
         )
 
+        # 影響を受けるエンティティを収集（embedding再生成用）
+        _entity_col_to_type = {
+            "topic_id": "topic",
+            "activity_id": "activity",
+            "decision_id": "decision",
+            "log_id": "log",
+        }
+        affected_entities: list[tuple[str, int]] = []
+        for table, entity_col in JUNCTION_TABLES:
+            rows = conn.execute(
+                f"SELECT {entity_col} FROM {table} WHERE tag_id = ?",
+                (tag_id,),
+            ).fetchall()
+            etype = _entity_col_to_type.get(entity_col)
+            if etype:
+                for r in rows:
+                    affected_entities.append((etype, r[entity_col]))
+
         # 紐付け付け替え: 中間テーブル4つ
         for table, entity_col in JUNCTION_TABLES:
             # 1. 重複する行を削除（canonical側IDが既に存在する場合）
@@ -800,6 +818,11 @@ def update_tag(
             )
 
         conn.commit()
+
+        # タグ変更に伴うembedding再生成（コミット後に非同期的に実行）
+        from src.services.embedding_service import regenerate_embedding
+        for etype, eid in affected_entities:
+            regenerate_embedding(etype, eid)
 
         c_tag_str = f"{c_namespace}:{c_name}" if c_namespace else c_name
         return {"tag": tag_str, "canonical": c_tag_str, "updated": True}

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -64,7 +64,8 @@ def add_topic(
         topic = row_to_dict(row)
 
         # embedding生成（失敗してもtopic作成には影響しない）
-        embedding_text = build_embedding_text(title, description)
+        tag_text = " ".join(tag_strings) if tag_strings else ""
+        embedding_text = build_embedding_text(title, description, tag_text)
         embedding_vec = generate_and_store_embedding("topic", topic_id, embedding_text)
 
         # 類似トピックをサジェスト（生成済みembeddingを再利用しHTTPリクエストを削減）

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -516,3 +516,118 @@ def test_ensure_server_running_handles_start_failure(temp_db, monkeypatch):
 
     result = emb._ensure_server_running()
     assert result is False
+
+
+# ========================================
+# embedding生成にタグ含有テスト
+# ========================================
+
+
+def test_embedding_text_includes_tags(temp_db, monkeypatch):
+    """embedding生成テキストにタグ文字列が含まれる"""
+    captured_texts = []
+
+    def capturing_encode_batch(texts, prefix):
+        captured_texts.extend(texts)
+        return [np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist() for _ in texts]
+
+    monkeypatch.setattr(emb, '_encode_batch', capturing_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+    add_topic(
+        title="タグ含有テストトピック",
+        description="テスト説明",
+        tags=["domain:cc-memory", "intent:design"],
+    )
+
+    # embedding生成テキストにタグ文字列が含まれている
+    assert len(captured_texts) >= 1
+    # 最後のencode_batch呼び出しがtopic用
+    topic_text = captured_texts[-1]
+    assert "domain:cc-memory" in topic_text
+    assert "intent:design" in topic_text
+
+
+def test_regenerate_embedding(temp_db, monkeypatch):
+    """regenerate_embedding: エンティティのembeddingがタグ付きで再生成される"""
+    captured_texts = []
+
+    def capturing_encode_batch(texts, prefix):
+        captured_texts.extend(texts)
+        return [np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist() for _ in texts]
+
+    monkeypatch.setattr(emb, '_encode_batch', capturing_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+    topic = add_topic(
+        title="再生成テストトピック",
+        description="再生成テスト説明",
+        tags=["domain:test"],
+    )
+
+    captured_texts.clear()
+
+    # regenerate_embeddingを呼び出す
+    emb.regenerate_embedding("topic", topic["topic_id"])
+
+    # 再生成されたテキストにもタグが含まれる
+    assert len(captured_texts) >= 1
+    regen_text = captured_texts[-1]
+    assert "再生成テストトピック" in regen_text
+    assert "domain:test" in regen_text
+
+
+def test_regenerate_embedding_nonexistent_entity(temp_db, monkeypatch):
+    """regenerate_embedding: 存在しないエンティティでもエラーにならない"""
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+    def mock_encode_batch(texts, prefix):
+        return [np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist() for _ in texts]
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+
+    # 存在しないエンティティでもエラーにならない（graceful degradation）
+    emb.regenerate_embedding("topic", 999999)
+    emb.regenerate_embedding("invalid_type", 1)
+
+
+def test_update_tag_canonical_regenerates_embedding(temp_db, monkeypatch):
+    """update_tag canonical設定時に影響エンティティのembeddingが再生成される（E2E）"""
+    captured_texts = []
+
+    def capturing_encode_batch(texts, prefix):
+        captured_texts.extend(texts)
+        return [np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist() for _ in texts]
+
+    monkeypatch.setattr(emb, '_encode_batch', capturing_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+    # canonical先のタグを持つトピックと、エイリアス元のタグを持つトピックを作成
+    # canonical先（new-tag）を先に作っておく必要がある
+    add_topic(
+        title="canonical先トピック",
+        description="new-tagを持つ",
+        tags=["domain:test", "new-tag"],
+    )
+    topic = add_topic(
+        title="canonical再生成テスト",
+        description="テスト説明",
+        tags=["domain:test", "old-tag"],
+    )
+
+    captured_texts.clear()
+
+    # old-tagをnew-tagのcanonicalに設定（old-tag → new-tagに付け替え）
+    from src.services.tag_service import update_tag
+    result = update_tag("old-tag", canonical="new-tag")
+    assert "error" not in result, f"update_tag failed: {result}"
+
+    # 影響エンティティのembeddingが再生成されたことを確認
+    assert len(captured_texts) >= 1
+    # 再生成テキストに元のトピックのタイトルが含まれる
+    all_regen_text = " ".join(captured_texts)
+    assert "canonical再生成テスト" in all_regen_text

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -1005,3 +1005,71 @@ def test_get_by_ids_single_material(temp_db):
     assert item["data"]["title"] == "詳細取得テスト素材"
     assert "tags" in item["data"]
     assert "domain:test" in item["data"]["tags"]
+
+
+# ========================================
+# タグLIKE検索テスト（FTS5テスト内）
+# ========================================
+
+
+def test_search_tag_like_topic_direct_tag(temp_db):
+    """タグLIKE検索: topicの直接タグにマッチ"""
+    add_topic(
+        title="タグLIKEトピック直接テスト",
+        description="テスト",
+        tags=["domain:fts-tag-like-test"],
+    )
+    result = search_service.search(keyword="fts-tag-like-test")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    assert "tag_like" in result["search_methods_used"]
+    titles = [r["title"] for r in result["results"]]
+    assert any("タグLIKEトピック直接テスト" in t for t in titles)
+
+
+def test_search_tag_like_activity_direct_tag(temp_db):
+    """タグLIKE検索: activityの直接タグにマッチ"""
+    add_activity(
+        title="タグLIKEアクティビティ直接テスト",
+        description="テスト",
+        tags=["domain:fts-activity-tag-test"],
+        check_in=False,
+    )
+    result = search_service.search(keyword="fts-activity-tag-test")
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    types = [r["type"] for r in result["results"]]
+    assert "activity" in types
+
+
+def test_search_tag_like_decision_inherited_tag(temp_db):
+    """タグLIKE検索: decisionがtopicのタグを継承してマッチ"""
+    topic = add_topic(
+        title="トピック",
+        description="テスト",
+        tags=["domain:fts-decision-inherit-test"],
+    )
+    add_decision(
+        topic_id=topic["topic_id"],
+        decision="タグLIKE決定継承テスト",
+        reason="テスト",
+    )
+    result = search_service.search(keyword="fts-decision-inherit-test")
+    assert "error" not in result
+    types = [r["type"] for r in result["results"]]
+    assert "decision" in types
+
+
+def test_search_tag_like_2char_keyword(temp_db):
+    """タグLIKE検索: 2文字キーワードでもタグにマッチすればヒット"""
+    add_topic(
+        title="2文字タグマッチテスト",
+        description="テスト",
+        tags=["domain:ab"],
+    )
+    # "ab"は2文字だが、タグ名"ab"にLIKEマッチするのでヒットする
+    result = search_service.search(keyword="ab")
+    assert "error" not in result
+    # tag_like結果がある場合はKEYWORD_TOO_SHORTエラーにならない
+    assert len(result["results"]) >= 1
+    assert "tag_like" in result["search_methods_used"]

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -12,7 +12,7 @@ import numpy as np
 from src.db import init_database, get_connection
 from src.services.search_service import (
     _rrf_merge, _apply_recency_boost, find_similar_topics,
-    RRF_K, RRF_W_FTS, RRF_W_VEC, RECENCY_DECAY_RATE,
+    RRF_K, RRF_W_FTS, RRF_W_VEC, RRF_W_TAG, RECENCY_DECAY_RATE,
 )
 from src.services import search_service
 from src.services.topic_service import add_topic
@@ -741,6 +741,7 @@ def test_search_methods_used_fts_only_vec_disabled(temp_db, disable_embedding):
     assert result["search_methods_used"] == ["fts5"]
 
 
+
 # ========================================
 # find_similar_topics テスト
 # ========================================
@@ -855,3 +856,173 @@ def test_add_topic_no_similar_when_embedding_disabled(temp_db, disable_embedding
 
     assert "error" not in result
     assert "similar_topics" not in result
+
+
+# ========================================
+# _rrf_merge 3ソース（タグLIKE）テスト
+# ========================================
+
+
+def test_rrf_merge_with_tag_results():
+    """RRF統合: 3ソース（FTS + ベクトル + タグLIKE）でスコアが加算される"""
+    fts = [
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+    vec = [
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+    tag = [
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+
+    results = _rrf_merge(fts, vec, limit=10, tag_results=tag)
+
+    assert len(results) == 1
+    expected_score = (
+        RRF_W_FTS / (RRF_K + 1) +
+        RRF_W_VEC / (RRF_K + 1) +
+        RRF_W_TAG / (RRF_K + 1)
+    )
+    assert results[0]["score"] == pytest.approx(expected_score)
+
+
+def test_rrf_merge_tag_only():
+    """RRF統合: タグLIKEのみの結果"""
+    tag = [
+        {"type": "topic", "id": 10, "title": "Tag only"},
+        {"type": "activity", "id": 20, "title": "Tag only 2"},
+    ]
+
+    results = _rrf_merge([], [], limit=10, tag_results=tag)
+
+    assert len(results) == 2
+    assert results[0]["id"] == 10
+    assert results[0]["score"] == pytest.approx(RRF_W_TAG / (RRF_K + 1))
+    assert results[1]["id"] == 20
+    assert results[1]["score"] == pytest.approx(RRF_W_TAG / (RRF_K + 2))
+
+
+def test_rrf_merge_tag_boosts_existing():
+    """RRF統合: タグLIKE結果がFTS/ベクトルのスコアに加算される"""
+    fts = [
+        {"type": "topic", "id": 1, "title": "Both"},
+        {"type": "topic", "id": 2, "title": "FTS only"},
+    ]
+    tag = [
+        {"type": "topic", "id": 1, "title": "Both"},
+        {"type": "topic", "id": 3, "title": "Tag only"},
+    ]
+
+    results = _rrf_merge(fts, [], limit=10, tag_results=tag)
+
+    score_both = next(r["score"] for r in results if r["id"] == 1)
+    score_fts = next(r["score"] for r in results if r["id"] == 2)
+    score_tag = next(r["score"] for r in results if r["id"] == 3)
+
+    # 両方にヒット > 片方のみ
+    assert score_both > score_fts
+    assert score_both > score_tag
+
+
+def test_rrf_merge_no_tag_results():
+    """RRF統合: tag_results=Noneで従来通りの動作"""
+    fts = [
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+    vec = [
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+
+    results = _rrf_merge(fts, vec, limit=10, tag_results=None)
+
+    assert len(results) == 1
+    expected_score = RRF_W_FTS / (RRF_K + 1) + RRF_W_VEC / (RRF_K + 1)
+    assert results[0]["score"] == pytest.approx(expected_score)
+
+
+# ========================================
+# タグLIKE検索 統合テスト
+# ========================================
+
+
+def test_search_tag_like_basic(temp_db, disable_embedding):
+    """タグLIKE検索: タグ名にマッチするキーワードでエンティティがヒットする"""
+    add_topic(
+        title="タグLIKE検索テスト用トピック",
+        description="タグ名でのマッチを確認",
+        tags=["domain:test"],
+    )
+
+    result = search_service.search(keyword="domain:test")
+
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    assert "tag_like" in result["search_methods_used"]
+
+
+def test_search_tag_like_partial_match(temp_db, disable_embedding):
+    """タグLIKE検索: タグ名の部分一致でヒットする"""
+    add_topic(
+        title="タグ部分一致テスト用トピック",
+        description="テスト",
+        tags=["domain:cc-memory"],
+    )
+
+    result = search_service.search(keyword="cc-memory")
+
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    assert "tag_like" in result["search_methods_used"]
+
+
+def test_search_tag_like_methods_used(temp_db, mock_embedding_model):
+    """タグLIKE検索: search_methods_usedにtag_likeが含まれる"""
+    add_topic(
+        title="メソッド確認タグLIKEテスト用",
+        description="テスト",
+        tags=["domain:test"],
+    )
+
+    result = search_service.search(keyword="domain:test")
+
+    assert "error" not in result
+    assert "tag_like" in result["search_methods_used"]
+
+
+def test_search_tag_like_with_type_filter(temp_db, disable_embedding):
+    """タグLIKE検索: type_filterとの組み合わせ"""
+    topic = add_topic(
+        title="タグLIKEフィルタテスト用トピック",
+        description="テスト",
+        tags=["domain:unique-tag-filter-test"],
+    )
+    add_activity(
+        title="タグLIKEフィルタテスト用アクティビティ",
+        description="テスト",
+        tags=["domain:unique-tag-filter-test"],
+        check_in=False,
+    )
+
+    result = search_service.search(
+        keyword="unique-tag-filter-test",
+        type_filter="topic",
+    )
+
+    assert "error" not in result
+    for item in result["results"]:
+        assert item["type"] == "topic"
+
+
+def test_search_tag_like_no_match(temp_db, disable_embedding):
+    """タグLIKE検索: マッチなしで空結果"""
+    add_topic(
+        title="タグLIKE不一致テスト",
+        description="テスト",
+        tags=["domain:test"],
+    )
+
+    # 全くマッチしないタグ名で検索
+    result = search_service.search(keyword="zzz存在しないタグ名zzz")
+
+    assert "error" not in result
+    assert "tag_like" not in result.get("search_methods_used", [])


### PR DESCRIPTION
## Summary
- embedding生成時にエンティティのタグ文字列を含め、ベクトル検索でのタグ情報活用を実現
- タグ名LIKE検索を3つ目のRRFソースとして追加（重み0.5）、タグ名キーワードでの検索精度向上
- `_rrf_merge`を後方互換で3ソース対応に拡張

## 関連
- cc-memory Activity: #524
- Decision: #1304

## 変更内容

### embedding生成にタグ含有
- 全5エンティティタイプ（topic, activity, decision, log, material）のembedding生成にタグ文字列を追加
- `regenerate_embedding()`関数を追加し、タグ変更時（canonical設定、activity更新）にembeddingを再生成

### タグLIKE検索
- `_tag_like_search()`メソッドを新設。タグ名・namespace:name結合文字列に対してLIKE検索
- decision/logのtopic継承タグも検索対象
- LIKEワイルドカード(`%`, `_`)のエスケープ対応
- 2文字キーワードでもタグLIKE結果があればエラーにしない救済ロジック

### RRF 3ソース化
- `_rrf_merge()`に`tag_results`引数をOptionalで追加（後方互換）
- RRF重み: FTS=1.0, ベクトル=1.0, タグLIKE=0.5
- `search_methods_used`に`"tag_like"`を追加

## Test plan
- [x] RRF 3ソース統合テスト4件（tag_results有無、既存スコアへのブースト）
- [x] タグLIKE検索統合テスト9件（基本、部分マッチ、type_filter、継承タグ、2文字KW）
- [x] embedding再生成テスト4件（単体、E2E canonical、存在しないエンティティ）
- [x] 全680テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)