### PR TITLE
feat: Query Expansion（タグKNN経由FTSクエリ拡張）

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -54,12 +54,81 @@ RRF_W_TAG = 0.5
 # 半年(182日)で約0.80倍、1年(365日)で約0.66倍
 RECENCY_DECAY_RATE = 0.0014
 
+# Query Expansion パラメータ
+QE_DISTANCE_THRESHOLD = 0.3   # コサイン距離。これ未満のタグを拡張候補とする
+QE_MAX_EXPANSIONS = 5          # キーワードあたりの最大拡張タグ数
+QE_EXCLUDE_NAMESPACES = True   # namespace付きタグを除外するか
+
 
 def _escape_fts5_query(keyword: str) -> str:
     """FTS5クエリ用のエスケープ処理。ダブルクォートで囲む。"""
     # ダブルクォート内のダブルクォートは2つ重ねてエスケープ
     escaped = keyword.replace('"', '""')
     return f'"{escaped}"'
+
+
+def _expand_query_with_tags(keywords: list[str]) -> list[str]:
+    """キーワードをtag_vec KNN検索で拡張する。
+
+    各キーワードでtag_vecをKNN検索し、距離がQE_DISTANCE_THRESHOLD未満の
+    素タグ（QE_EXCLUDE_NAMESPACES=True時はnamespace付きを除外）を
+    FTSクエリに追加する拡張キーワードリストを返す。
+
+    拡張されたキーワードは元のキーワードの末尾に追加される。
+    元のキーワードと重複するタグは除外される。
+
+    Args:
+        keywords: 元のキーワードリスト
+
+    Returns:
+        拡張後のキーワードリスト（元のキーワード + 拡張タグ名）
+    """
+    expanded = list(keywords)
+    existing = {kw.lower() for kw in keywords}
+    expansion_count = 0
+
+    conn = get_connection()
+    try:
+        for kw in keywords:
+            if expansion_count >= QE_MAX_EXPANSIONS:
+                break
+
+            similar = embedding_service.search_similar_tags(kw, k=10)
+
+            for tag_id, distance in similar:
+                if expansion_count >= QE_MAX_EXPANSIONS:
+                    break
+                if distance >= QE_DISTANCE_THRESHOLD:
+                    continue
+
+                # タグ情報を取得
+                row = conn.execute(
+                    "SELECT namespace, name FROM tags WHERE id = ?",
+                    (tag_id,),
+                ).fetchone()
+                if not row:
+                    continue
+
+                namespace = row["namespace"]
+                name = row["name"]
+
+                # namespace付きタグを除外
+                if QE_EXCLUDE_NAMESPACES and namespace:
+                    continue
+
+                # 元のキーワードとの重複チェック
+                if name.lower() in existing:
+                    continue
+
+                expanded.append(name)
+                existing.add(name.lower())
+                expansion_count += 1
+    except Exception:
+        logger.warning("Query expansion failed, using original keywords", exc_info=True)
+    finally:
+        conn.close()
+
+    return expanded
 
 
 def _attach_snippets(results: list[dict]) -> None:
@@ -283,8 +352,19 @@ def _fts_search(
     type_filter: Optional[str],
     limit: int,
     keyword_mode: str = "and",
+    original_keyword_count: Optional[int] = None,
 ) -> list[dict]:
-    """FTS5検索。結果はBM25ランク順のリスト。"""
+    """FTS5検索。結果はBM25ランク順のリスト。
+
+    Args:
+        keywords: 検索キーワードリスト（QE拡張分を含む場合がある）
+        tag_ids: タグフィルタ用のtag_idリスト
+        type_filter: 検索対象の絞り込み
+        limit: 取得件数上限
+        keyword_mode: キーワード結合モード（"and" / "or"）
+        original_keyword_count: 元のキーワード数。指定時、先頭N個をAND結合し
+            残りをOR追加する（Query Expansion用）。未指定時は従来通り。
+    """
     # OR時: 3文字以上のキーワードだけでFTS5クエリを組む（2文字はフィルタ除外）
     if keyword_mode == "or":
         fts_keywords = [kw for kw in keywords if len(kw) >= 3]
@@ -293,8 +373,17 @@ def _fts_search(
         escaped_parts = [_escape_fts5_query(kw) for kw in fts_keywords]
         escaped_keyword = " OR ".join(escaped_parts)
     else:
-        escaped_parts = [_escape_fts5_query(kw) for kw in keywords]
-        escaped_keyword = " AND ".join(escaped_parts)
+        if original_keyword_count is not None and original_keyword_count < len(keywords):
+            # QE拡張あり: 元キーワードをAND結合し、拡張タグをOR追加
+            original_parts = [_escape_fts5_query(kw) for kw in keywords[:original_keyword_count]]
+            expanded_parts = [_escape_fts5_query(kw) for kw in keywords[original_keyword_count:]]
+            original_query = " AND ".join(original_parts)
+            # (元kw1 AND 元kw2) OR 拡張1 OR 拡張2
+            all_parts = [f"({original_query})"] + expanded_parts
+            escaped_keyword = " OR ".join(all_parts)
+        else:
+            escaped_parts = [_escape_fts5_query(kw) for kw in keywords]
+            escaped_keyword = " AND ".join(escaped_parts)
 
     if tag_ids:
         cte_sql, cte_params = _build_tag_filter_cte(tag_ids)
@@ -876,21 +965,35 @@ def search(
         # 使用された検索手法を追跡
         methods_used: list[str] = []
 
+        # Query Expansion: tag_vec KNN検索でFTSクエリを拡張
+        # ベクトル検索には元のキーワードをそのまま渡す
+        fts_keywords = _expand_query_with_tags(keywords)
+        if len(fts_keywords) > len(keywords):
+            logger.info(
+                "Query expanded: %s -> %s",
+                keywords,
+                fts_keywords[len(keywords):],
+            )
+
         # FTS5検索判定
         min_len = min(len(kw) for kw in keywords)
         fts_results = []
+        # QE拡張がある場合、元のキーワード数を記録
+        original_kw_count = len(keywords) if len(fts_keywords) > len(keywords) else None
+
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
-            if any(len(kw) >= 3 for kw in keywords):
-                fts_results = _fts_search(keywords, tag_ids, type_filter, fetch_limit, keyword_mode)
+            if any(len(kw) >= 3 for kw in fts_keywords):
+                fts_results = _fts_search(fts_keywords, tag_ids, type_filter, fetch_limit, keyword_mode, original_kw_count)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
+            # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
             if min_len >= 3:
-                fts_results = _fts_search(keywords, tag_ids, type_filter, fetch_limit, keyword_mode)
+                fts_results = _fts_search(fts_keywords, tag_ids, type_filter, fetch_limit, keyword_mode, original_kw_count)
                 methods_used.append("fts5")
 
-        # ベクトル検索
+        # ベクトル検索（元のキーワードのまま、拡張なし）
         vec_results = _vector_search(keywords, tag_ids, type_filter, fetch_limit, keyword_mode)
         if vec_results is not None:
             methods_used.append("vector")

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -56,7 +56,7 @@ RECENCY_DECAY_RATE = 0.0014
 
 # Query Expansion パラメータ
 QE_DISTANCE_THRESHOLD = 0.3   # コサイン距離。これ未満のタグを拡張候補とする
-QE_MAX_EXPANSIONS = 5          # キーワードあたりの最大拡張タグ数
+QE_MAX_EXPANSIONS = 5          # 全キーワード合計での最大拡張タグ数
 QE_EXCLUDE_NAMESPACES = True   # namespace付きタグを除外するか
 
 
@@ -87,46 +87,54 @@ def _expand_query_with_tags(keywords: list[str]) -> list[str]:
     existing = {kw.lower() for kw in keywords}
     expansion_count = 0
 
-    conn = get_connection()
     try:
+        # 全キーワードの類似タグ候補を収集
+        candidate_tag_ids: list[tuple[int, float]] = []
         for kw in keywords:
+            similar = embedding_service.search_similar_tags(kw, k=10)
+            for tag_id, distance in similar:
+                if distance < QE_DISTANCE_THRESHOLD:
+                    candidate_tag_ids.append((tag_id, distance))
+
+        if not candidate_tag_ids:
+            return expanded
+
+        # 候補タグのIDを一括で取得
+        unique_ids = list({tid for tid, _ in candidate_tag_ids})
+        placeholders = ",".join("?" * len(unique_ids))
+        rows = execute_query(
+            f"SELECT id, namespace, name FROM tags WHERE id IN ({placeholders})",
+            tuple(unique_ids),
+        )
+        tag_info_map: dict[int, tuple[str, str]] = {}
+        for row in rows:
+            tag_info_map[row["id"]] = (row["namespace"], row["name"])
+
+        # 距離順でソートして拡張タグを選定
+        candidate_tag_ids.sort(key=lambda x: x[1])
+        for tag_id, _distance in candidate_tag_ids:
             if expansion_count >= QE_MAX_EXPANSIONS:
                 break
 
-            similar = embedding_service.search_similar_tags(kw, k=10)
+            info = tag_info_map.get(tag_id)
+            if not info:
+                continue
 
-            for tag_id, distance in similar:
-                if expansion_count >= QE_MAX_EXPANSIONS:
-                    break
-                if distance >= QE_DISTANCE_THRESHOLD:
-                    continue
+            namespace, name = info
 
-                # タグ情報を取得
-                row = conn.execute(
-                    "SELECT namespace, name FROM tags WHERE id = ?",
-                    (tag_id,),
-                ).fetchone()
-                if not row:
-                    continue
+            # namespace付きタグを除外
+            if QE_EXCLUDE_NAMESPACES and namespace:
+                continue
 
-                namespace = row["namespace"]
-                name = row["name"]
+            # 元のキーワードとの重複チェック
+            if name.lower() in existing:
+                continue
 
-                # namespace付きタグを除外
-                if QE_EXCLUDE_NAMESPACES and namespace:
-                    continue
-
-                # 元のキーワードとの重複チェック
-                if name.lower() in existing:
-                    continue
-
-                expanded.append(name)
-                existing.add(name.lower())
-                expansion_count += 1
+            expanded.append(name)
+            existing.add(name.lower())
+            expansion_count += 1
     except Exception:
         logger.warning("Query expansion failed, using original keywords", exc_info=True)
-    finally:
-        conn.close()
 
     return expanded
 
@@ -984,7 +992,7 @@ def search(
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(fts_keywords, tag_ids, type_filter, fetch_limit, keyword_mode, original_kw_count)
+                fts_results = _fts_search(fts_keywords, tag_ids, type_filter, fetch_limit, keyword_mode, None)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -11,8 +11,9 @@ import numpy as np
 
 from src.db import init_database, get_connection
 from src.services.search_service import (
-    _rrf_merge, _apply_recency_boost, find_similar_topics,
+    _rrf_merge, _apply_recency_boost, find_similar_topics, _expand_query_with_tags,
     RRF_K, RRF_W_FTS, RRF_W_VEC, RRF_W_TAG, RECENCY_DECAY_RATE,
+    QE_DISTANCE_THRESHOLD, QE_MAX_EXPANSIONS, QE_EXCLUDE_NAMESPACES,
 )
 from src.services import search_service
 from src.services.topic_service import add_topic
@@ -1026,3 +1027,176 @@ def test_search_tag_like_no_match(temp_db, disable_embedding):
 
     assert "error" not in result
     assert "tag_like" not in result.get("search_methods_used", [])
+
+
+# ========================================
+# Query Expansion テスト
+# ========================================
+
+
+def test_qe_constants():
+    """QE定数が期待値で定義されている"""
+    assert QE_DISTANCE_THRESHOLD == 0.3
+    assert QE_MAX_EXPANSIONS == 5
+    assert QE_EXCLUDE_NAMESPACES is True
+
+
+def test_qe_no_expansion_without_embedding(temp_db, disable_embedding):
+    """embedding無効時: QE拡張は行われず元のキーワードがそのまま返る"""
+    result = _expand_query_with_tags(["テスト"])
+    assert result == ["テスト"]
+
+
+def test_qe_no_expansion_when_no_similar_tags(temp_db, mock_embedding_model):
+    """類似タグなし: QE拡張は行われず元のキーワードがそのまま返る"""
+    # タグが存在しないDBではKNN検索結果が空
+    result = _expand_query_with_tags(["存在しないキーワード"])
+    assert result == ["存在しないキーワード"]
+
+
+def test_qe_expansion_with_similar_tags(temp_db, mock_embedding_model):
+    """類似タグあり: 距離閾値未満のタグが拡張される"""
+    # タグを作成してIDを取得
+    conn = get_connection()
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-search')")
+    search_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-search'").fetchone()["id"]
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-query')")
+    query_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-query'").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    # search_similar_tagsをモックして距離をコントロール
+    def mock_search_similar(query_text, k=10):
+        return [(query_id, 0.1)]  # qe-queryタグが距離0.1で類似
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        result = _expand_query_with_tags(["qe-search"])
+        assert "qe-search" in result
+        assert "qe-query" in result
+        assert len(result) == 2
+    finally:
+        emb.search_similar_tags = original
+
+
+def test_qe_excludes_namespace_tags(temp_db, mock_embedding_model):
+    """QE_EXCLUDE_NAMESPACES=True: namespace付きタグは拡張に含まれない"""
+    conn = get_connection()
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('domain', 'qe-ns-test')")
+    ns_id = conn.execute("SELECT id FROM tags WHERE namespace = 'domain' AND name = 'qe-ns-test'").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    def mock_search_similar(query_text, k=10):
+        # domain:qe-ns-testが距離0.1で類似
+        return [(ns_id, 0.1)]
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        result = _expand_query_with_tags(["test"])
+        # namespace付きタグは除外されるため、元のキーワードのみ
+        assert result == ["test"]
+    finally:
+        emb.search_similar_tags = original
+
+
+def test_qe_respects_distance_threshold(temp_db, mock_embedding_model):
+    """距離閾値以上のタグは拡張に含まれない"""
+    conn = get_connection()
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-near')")
+    near_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-near'").fetchone()["id"]
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-far')")
+    far_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-far'").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    def mock_search_similar(query_text, k=10):
+        return [
+            (near_id, 0.1),   # 閾値未満 → 拡張される
+            (far_id, 0.5),    # 閾値以上 → 除外
+        ]
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        result = _expand_query_with_tags(["test"])
+        assert "qe-near" in result
+        assert "qe-far" not in result
+    finally:
+        emb.search_similar_tags = original
+
+
+def test_qe_max_expansions_limit(temp_db, mock_embedding_model):
+    """最大拡張数QE_MAX_EXPANSIONSを超えない"""
+    conn = get_connection()
+    tag_ids = []
+    for i in range(10):
+        conn.execute(f"INSERT INTO tags (namespace, name) VALUES ('', 'qe-max-{i}')")
+        tid = conn.execute(f"SELECT id FROM tags WHERE namespace = '' AND name = 'qe-max-{i}'").fetchone()["id"]
+        tag_ids.append(tid)
+    conn.commit()
+    conn.close()
+
+    def mock_search_similar(query_text, k=10):
+        # 全て距離0.1で類似
+        return [(tid, 0.1) for tid in tag_ids]
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        result = _expand_query_with_tags(["test"])
+        # 元のキーワード(1) + 拡張(最大5) = 6
+        assert len(result) <= 1 + QE_MAX_EXPANSIONS
+    finally:
+        emb.search_similar_tags = original
+
+
+def test_qe_dedup_with_original_keyword(temp_db, mock_embedding_model):
+    """元のキーワードと同名のタグは拡張に含まれない"""
+    conn = get_connection()
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-dedup')")
+    dedup_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-dedup'").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    def mock_search_similar(query_text, k=10):
+        return [(dedup_id, 0.05)]  # 元キーワードと同名のタグ
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        result = _expand_query_with_tags(["qe-dedup"])
+        # 重複除外で元のキーワードのみ
+        assert result == ["qe-dedup"]
+    finally:
+        emb.search_similar_tags = original
+
+
+def test_qe_vector_search_not_expanded(temp_db, mock_embedding_model):
+    """search()でベクトル検索には元のキーワードのまま渡される"""
+    conn = get_connection()
+    conn.execute("INSERT INTO tags (namespace, name) VALUES ('', 'qe-expanded')")
+    expanded_id = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'qe-expanded'").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    add_topic(
+        title="QEベクトル分離テスト用トピック",
+        description="QEが適用されないことを確認",
+        tags=DEFAULT_TAGS,
+    )
+
+    def mock_search_similar(query_text, k=10):
+        return [(expanded_id, 0.1)]
+
+    original = emb.search_similar_tags
+    emb.search_similar_tags = mock_search_similar
+    try:
+        # search()が正常に動作すれば、ベクトル検索は元キーワードで呼ばれている
+        result = search_service.search(keyword="QEベクトル分離テスト")
+        assert "error" not in result
+        assert len(result["results"]) >= 1
+    finally:
+        emb.search_similar_tags = original


### PR DESCRIPTION
## Summary
- FTS検索前にtag_vecでKNN検索し、コサイン距離0.3未満の素タグをFTSクエリにOR追加
- namespace付きタグは除外、最大拡張数5、ベクトル検索には拡張適用なし
- AND+QE拡張時は `(元kw1 AND 元kw2) OR 拡張1 OR 拡張2` の構文で検索意図を保持

## 関連
- cc-memory Activity: #524
- Decision: #1306

## 変更内容

### Query Expansionロジック
- `_expand_query_with_tags(keywords)`: 各キーワードでtag_vecをKNN検索、距離0.3未満の素タグを収集
- namespace付きタグ除外（`QE_EXCLUDE_NAMESPACES=True`）
- 元キーワードとの重複はcase-insensitiveで排除
- 全キーワード合計で最大5拡張

### FTS検索への統合
- `_fts_search()`に`original_keyword_count`パラメータ追加
- AND検索+QE拡張時: `(元キーワードAND部分) OR 拡張タグ1 OR 拡張タグ2`
- OR検索時: 既存のOR結合に拡張タグが自然に追加

### 定数（search_service.py先頭に集約）
- `QE_DISTANCE_THRESHOLD = 0.3`
- `QE_MAX_EXPANSIONS = 5`
- `QE_EXCLUDE_NAMESPACES = True`

## Test plan
- [x] QE定数検証
- [x] embedding無効時の挙動
- [x] 類似タグなし時の挙動
- [x] 距離閾値未満タグの拡張
- [x] namespace付きタグの除外
- [x] 距離閾値によるフィルタ
- [x] 最大拡張数制限
- [x] 元キーワードとの重複除外
- [x] ベクトル検索への拡張非適用
- [x] 全672テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)