### PR TITLE
feat: stdio↔HTTPブリッジランチャーを追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
     "cc-memory": {
       "command": "uv",
-      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "python", "-m", "src.main"]
+      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "python", "-m", "src.launcher"]
     }
   }

--- a/src/http_config.py
+++ b/src/http_config.py
@@ -1,0 +1,7 @@
+"""HTTP transport 共通設定
+
+launcher.py と main.py の両方から参照される定数を集約する。
+"""
+
+HTTP_HOST = "localhost"
+HTTP_PORT = 52837

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -20,9 +20,9 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# サーバー接続設定
-HTTP_HOST = "localhost"
-HTTP_PORT = 52837
+# サーバー接続設定（HTTP_HOST, HTTP_PORTはmain.pyと共有）
+from src.http_config import HTTP_HOST, HTTP_PORT
+
 MCP_ENDPOINT = f"http://{HTTP_HOST}:{HTTP_PORT}/mcp"
 SESSION_REGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/register"
 SESSION_UNREGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/unregister"
@@ -62,7 +62,11 @@ def _is_server_running() -> bool:
 
 
 def _start_http_server() -> bool:
-    """HTTPサーバーをデーモンとして起動する。"""
+    """HTTPサーバーをデーモンとして起動する。
+
+    sys.executableは.mcp.jsonの「uv run python -m src.launcher」経由で
+    起動されることを前提とし、uv仮想環境のPython（.venv/bin/python）を使用する。
+    """
     try:
         subprocess.Popen(
             [sys.executable, "-m", "src.main", "--transport", "http"],
@@ -82,8 +86,13 @@ def _ensure_server_running() -> bool:
     """ヘルスチェック -> 起動 -> 待機のフロー。成功でTrue、タイムアウトでFalse。"""
     if _is_server_running():
         return True
-    if not _start_http_server():
-        return False
+    # ロックファイルが存在する場合、別のランチャーが起動中の可能性がある。
+    # 二重起動を避けてサーバーの準備完了を待つだけにする。
+    from src.services.lock_file import read as read_lock
+
+    if read_lock() is None:
+        if not _start_http_server():
+            return False
     # 最大30秒待機（0.5秒間隔 x 60回）
     for _ in range(60):
         time.sleep(0.5)
@@ -195,6 +204,10 @@ async def _bridge() -> None:
             except Exception:
                 logger.debug("stdin reader ended")
             finally:
+                if buffer.strip():
+                    logger.warning(
+                        f"Discarding {len(buffer)} bytes of incomplete data in stdin buffer"
+                    )
                 transport.close()
                 await write_stream.aclose()
 
@@ -214,7 +227,7 @@ async def _bridge() -> None:
             except anyio.ClosedResourceError:
                 pass
             except Exception:
-                logger.debug("stdout writer ended")
+                logger.debug("stdout writer ended", exc_info=True)
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(stdin_to_server)

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -1,0 +1,257 @@
+"""stdio <-> HTTP ブリッジ + デーモン起動ランチャー
+
+Claude Code が stdio プロトコルで接続してくるエントリーポイント。
+HTTPサーバーが未起動なら自動でデーモン起動し、
+stdinからのJSON-RPCメッセージをStreamable HTTP経由で転送する。
+終了時にセッション解除を行う。
+"""
+import asyncio
+import atexit
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# サーバー接続設定
+HTTP_HOST = "localhost"
+HTTP_PORT = 52837
+MCP_ENDPOINT = f"http://{HTTP_HOST}:{HTTP_PORT}/mcp"
+SESSION_REGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/register"
+SESSION_UNREGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/unregister"
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+
+# セッションID（プロセスごとにユニーク）
+_session_id = str(uuid.uuid4())
+
+# クリーンアップ状態
+_cleanup_done = False
+
+
+# =============================================
+# デーモン起動ロジック（embedding_serviceパターン踏襲）
+# =============================================
+
+
+def _is_server_running() -> bool:
+    """HTTPサーバーの生存確認を行う。
+
+    MCP Streamable HTTP の POST /mcp にアクセスしてステータスコードで判定する。
+    405 (Method Not Allowed for GET) も「起動済み」と見なす。
+    """
+    try:
+        req = urllib.request.Request(
+            MCP_ENDPOINT,
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            return resp.status == 200
+    except urllib.error.HTTPError as e:
+        # 405 等のHTTPエラーは「サーバー起動済み」を意味する
+        return e.code in (405, 400)
+    except Exception:
+        return False
+
+
+def _start_http_server() -> bool:
+    """HTTPサーバーをデーモンとして起動する。"""
+    try:
+        subprocess.Popen(
+            [sys.executable, "-m", "src.main", "--transport", "http"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            cwd=_PROJECT_ROOT,
+        )
+    except OSError as e:
+        logger.warning(f"Failed to start HTTP server: {e}")
+        return False
+    logger.info("HTTP server process started")
+    return True
+
+
+def _ensure_server_running() -> bool:
+    """ヘルスチェック -> 起動 -> 待機のフロー。成功でTrue、タイムアウトでFalse。"""
+    if _is_server_running():
+        return True
+    if not _start_http_server():
+        return False
+    # 最大30秒待機（0.5秒間隔 x 60回）
+    for _ in range(60):
+        time.sleep(0.5)
+        if _is_server_running():
+            logger.info("HTTP server is ready")
+            return True
+    logger.warning("HTTP server failed to start within 30 seconds")
+    return False
+
+
+# =============================================
+# セッションライフサイクル管理
+# =============================================
+
+
+def _register_session() -> bool:
+    """セッション登録（POST /session/register）"""
+    try:
+        data = json.dumps({"session_id": _session_id}).encode("utf-8")
+        req = urllib.request.Request(
+            SESSION_REGISTER_URL,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            result = json.loads(resp.read())
+            logger.info(f"Session registered: {result}")
+            return True
+    except Exception as e:
+        logger.warning(f"Session register failed: {e}")
+        return False
+
+
+def _unregister_session() -> bool:
+    """セッション解除（POST /session/unregister）"""
+    try:
+        data = json.dumps({"session_id": _session_id}).encode("utf-8")
+        req = urllib.request.Request(
+            SESSION_UNREGISTER_URL,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            result = json.loads(resp.read())
+            logger.info(f"Session unregistered: {result}")
+            return True
+    except Exception as e:
+        logger.warning(f"Session unregister failed: {e}")
+        return False
+
+
+def _cleanup():
+    """セッション解除 + ログ出力"""
+    global _cleanup_done
+    if _cleanup_done:
+        return
+    _cleanup_done = True
+    _unregister_session()
+
+
+# =============================================
+# stdio <-> HTTP ブリッジ
+# =============================================
+
+
+async def _bridge() -> None:
+    """stdinからJSON-RPCメッセージを読み、HTTP POST /mcpに転送し、レスポンスをstdoutに書く。
+
+    MCP SDK の streamable_http_client を利用し、ストリーム間のブリッジを行う。
+    """
+    # 遅延import: デーモン起動ロジックはMCP SDKに依存しないため、
+    # ブリッジ実行時まで重いimportを遅延させて起動速度を確保する
+    import anyio
+    from mcp import types
+    from mcp.client.streamable_http import streamable_http_client
+    from mcp.shared.message import SessionMessage
+
+    async with streamable_http_client(
+        url=MCP_ENDPOINT,
+        terminate_on_close=False,
+    ) as (read_stream, write_stream, _get_session_id):
+
+        async def stdin_to_server() -> None:
+            """stdinから1行ずつ読み、write_streamに送る。"""
+            loop = asyncio.get_running_loop()
+            reader = asyncio.StreamReader()
+            transport, _ = await loop.connect_read_pipe(
+                lambda: asyncio.StreamReaderProtocol(reader),
+                sys.stdin.buffer,
+            )
+            try:
+                buffer = b""
+                while True:
+                    chunk = await reader.read(65536)
+                    if not chunk:
+                        break
+                    buffer += chunk
+                    while b"\n" in buffer:
+                        line, buffer = buffer.split(b"\n", 1)
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            message = types.JSONRPCMessage.model_validate_json(line)
+                            session_msg = SessionMessage(message)
+                            await write_stream.send(session_msg)
+                        except Exception:
+                            logger.exception("Failed to parse stdin message")
+            except Exception:
+                logger.debug("stdin reader ended")
+            finally:
+                transport.close()
+                await write_stream.aclose()
+
+        async def server_to_stdout() -> None:
+            """read_streamからメッセージを受信し、stdoutに書く。"""
+            try:
+                async for session_msg_or_exc in read_stream:
+                    if isinstance(session_msg_or_exc, Exception):
+                        logger.warning(f"Received exception from server: {session_msg_or_exc}")
+                        continue
+                    message = session_msg_or_exc.message
+                    json_bytes = message.model_dump_json(
+                        by_alias=True, exclude_none=True
+                    ).encode("utf-8")
+                    sys.stdout.buffer.write(json_bytes + b"\n")
+                    sys.stdout.buffer.flush()
+            except anyio.ClosedResourceError:
+                pass
+            except Exception:
+                logger.debug("stdout writer ended")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(stdin_to_server)
+            tg.start_soon(server_to_stdout)
+
+
+def main() -> None:
+    """ランチャーのメインエントリーポイント"""
+    # ログ設定（stderrへ出力、stdoutはMCPプロトコル用）
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [launcher] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+
+    # 1. HTTPサーバーの起動確認
+    if not _ensure_server_running():
+        logger.error("Failed to ensure HTTP server is running")
+        sys.exit(1)
+
+    # 2. セッション登録
+    if not _register_session():
+        logger.error("Failed to register session")
+        sys.exit(1)
+
+    # 3. クリーンアップ登録
+    atexit.register(_cleanup)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))  # atexitが発火する
+
+    # 4. stdio <-> HTTP ブリッジ起動
+    try:
+        asyncio.run(_bridge())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        _cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -881,8 +881,7 @@ async def session_unregister(request: Request) -> JSONResponse:
 
 
 # サーバー起動
-HTTP_HOST = "localhost"
-HTTP_PORT = 52837
+from src.http_config import HTTP_HOST, HTTP_PORT
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1,0 +1,255 @@
+"""launcher.pyのユニットテスト
+
+デーモン起動ロジック、セッションライフサイクル管理、ヘルスチェックを検証する。
+stdio <-> HTTP ブリッジは統合テストで検証する。
+"""
+import json
+import subprocess
+import urllib.error
+import urllib.request
+
+import pytest
+
+from src import launcher
+
+
+class TestIsServerRunning:
+    def test_returns_true_when_server_responds_200(self, monkeypatch):
+        """サーバーが200を返す場合はTrueを返す"""
+
+        class FakeResponse:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeResponse(),
+        )
+        assert launcher._is_server_running() is True
+
+    def test_returns_true_on_405(self, monkeypatch):
+        """405 (Method Not Allowed) もサーバー起動済みと見なす"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=405, msg="Method Not Allowed",
+                hdrs={}, fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._is_server_running() is True
+
+    def test_returns_true_on_400(self, monkeypatch):
+        """400 (Bad Request) もサーバー起動済みと見なす"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=400, msg="Bad Request",
+                hdrs={}, fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._is_server_running() is True
+
+    def test_returns_false_on_connection_error(self, monkeypatch):
+        """接続エラーの場合はFalseを返す"""
+
+        def fake_urlopen(req, timeout=None):
+            raise ConnectionRefusedError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._is_server_running() is False
+
+    def test_returns_false_on_500(self, monkeypatch):
+        """500エラーの場合はFalseを返す"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=500, msg="Internal Server Error",
+                hdrs={}, fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._is_server_running() is False
+
+
+class TestStartHttpServer:
+    def test_calls_popen_with_correct_args(self, monkeypatch):
+        """正しい引数でsubprocess.Popenが呼ばれる"""
+        called_with = {}
+
+        class FakePopen:
+            def __init__(self, args, **kwargs):
+                called_with["args"] = args
+                called_with["kwargs"] = kwargs
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        result = launcher._start_http_server()
+
+        assert result is True
+        assert called_with["args"][1:] == ["-m", "src.main", "--transport", "http"]
+        assert called_with["kwargs"]["start_new_session"] is True
+        assert called_with["kwargs"]["stdout"] == subprocess.DEVNULL
+        assert called_with["kwargs"]["stderr"] == subprocess.DEVNULL
+        assert called_with["kwargs"]["cwd"] == launcher._PROJECT_ROOT
+
+    def test_returns_false_on_oserror(self, monkeypatch):
+        """OSErrorの場合はFalseを返す"""
+
+        def fake_popen(*args, **kwargs):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        assert launcher._start_http_server() is False
+
+
+class TestEnsureServerRunning:
+    def test_returns_true_if_already_running(self, monkeypatch):
+        """既にサーバーが起動している場合はTrueを即座に返す"""
+        monkeypatch.setattr(launcher, "_is_server_running", lambda: True)
+        assert launcher._ensure_server_running() is True
+
+    def test_starts_server_and_waits(self, monkeypatch):
+        """サーバーを起動し、起動確認を待つ"""
+        call_count = {"check": 0}
+
+        def fake_is_running():
+            call_count["check"] += 1
+            # 最初の呼び出し（_ensure_server_running冒頭）はFalse
+            # 3回目の呼び出し（待機ループ2回目）でTrue
+            return call_count["check"] >= 3
+
+        monkeypatch.setattr(launcher, "_is_server_running", fake_is_running)
+        monkeypatch.setattr(launcher, "_start_http_server", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+        assert launcher._ensure_server_running() is True
+
+    def test_returns_false_on_start_failure(self, monkeypatch):
+        """起動失敗でFalseを返す"""
+        monkeypatch.setattr(launcher, "_is_server_running", lambda: False)
+        monkeypatch.setattr(launcher, "_start_http_server", lambda: False)
+        assert launcher._ensure_server_running() is False
+
+    def test_returns_false_on_timeout(self, monkeypatch):
+        """タイムアウトでFalseを返す"""
+        monkeypatch.setattr(launcher, "_is_server_running", lambda: False)
+        monkeypatch.setattr(launcher, "_start_http_server", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+        assert launcher._ensure_server_running() is False
+
+
+class TestSessionRegistration:
+    def test_register_success(self, monkeypatch):
+        """セッション登録が成功する"""
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return json.dumps({"registered": True, "active_sessions": 1}).encode()
+
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeResponse(),
+        )
+        assert launcher._register_session() is True
+
+    def test_register_failure(self, monkeypatch):
+        """セッション登録が失敗する"""
+
+        def fake_urlopen(req, timeout=None):
+            raise ConnectionRefusedError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._register_session() is False
+
+    def test_unregister_success(self, monkeypatch):
+        """セッション解除が成功する"""
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return json.dumps({"unregistered": True, "active_sessions": 0}).encode()
+
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeResponse(),
+        )
+        assert launcher._unregister_session() is True
+
+    def test_unregister_failure(self, monkeypatch):
+        """セッション解除が失敗する"""
+
+        def fake_urlopen(req, timeout=None):
+            raise ConnectionRefusedError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert launcher._unregister_session() is False
+
+
+class TestCleanup:
+    def test_cleanup_calls_unregister(self, monkeypatch):
+        """クリーンアップでunregisterが呼ばれる"""
+        called = {"unregister": False}
+
+        def fake_unregister():
+            called["unregister"] = True
+            return True
+
+        monkeypatch.setattr(launcher, "_unregister_session", fake_unregister)
+        # _cleanup_doneをリセット
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        launcher._cleanup()
+        assert called["unregister"] is True
+
+    def test_cleanup_idempotent(self, monkeypatch):
+        """クリーンアップは2回呼んでも1回しか実行されない"""
+        call_count = {"unregister": 0}
+
+        def fake_unregister():
+            call_count["unregister"] += 1
+            return True
+
+        monkeypatch.setattr(launcher, "_unregister_session", fake_unregister)
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        launcher._cleanup()
+        launcher._cleanup()
+        assert call_count["unregister"] == 1
+
+
+class TestSessionId:
+    def test_session_id_is_valid_uuid(self):
+        """セッションIDが有効なUUIDである"""
+        import uuid
+        # ValueError が出なければOK
+        uuid.UUID(launcher._session_id)
+
+    def test_session_id_is_string(self):
+        """セッションIDが文字列である"""
+        assert isinstance(launcher._session_id, str)
+
+
+class TestProjectRoot:
+    def test_project_root_points_to_package_root(self):
+        """_PROJECT_ROOTがパッケージルートを指している"""
+        import os
+        assert os.path.isdir(launcher._PROJECT_ROOT)
+        assert os.path.isfile(os.path.join(launcher._PROJECT_ROOT, "pyproject.toml"))


### PR DESCRIPTION
## Summary
- `src/launcher.py` を新規作成: デーモン起動 + セッション登録 + stdio↔HTTPブリッジ
- MCP SDK `streamable_http_client` を利用し、stdinのJSON-RPCメッセージをStreamable HTTP経由で転送
- `.mcp.json` のエントリーポイントを `src.main` → `src.launcher` に変更
- ユニットテスト20件追加（723 passed）

## Background
PR #251 で追加したHTTPサーバーモードに対して、Claude Code側のエントリーポイントとなるstdioブリッジを実装。これにより複数セッションが1つのHTTPサーバーを共有し、メモリ消費を削減する（35MB×N → 5MB×N + 35MB×1）。

## Architecture
```
Claude Code session
  └── launcher.py (stdio bridge, ~5MB)
        ├── ポートチェック → 未起動ならHTTPサーバーをデーモン起動
        ├── セッション登録 (POST /session/register)
        ├── stdio ↔ HTTP ブリッジ (MCP SDK streamable_http_client)
        └── 終了時 → セッション解除 (POST /session/unregister)

HTTP MCP Server (daemon, ~35MB, shared)
  └── src/main.py --transport http
```

## Test plan
- [x] ユニットテスト20件全PASS
- [x] 既存テスト703件に影響なし（計723 passed）
- [ ] 統合テスト: 実際のClaude Codeセッションでの動作確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)