### PR TITLE
fix: launcherのヘルスチェック406対応とstale lock検出を追加

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -55,8 +55,8 @@ def _is_server_running() -> bool:
         with urllib.request.urlopen(req, timeout=2) as resp:
             return resp.status == 200
     except urllib.error.HTTPError as e:
-        # 405 等のHTTPエラーは「サーバー起動済み」を意味する
-        return e.code in (405, 400)
+        # 4xx系HTTPエラーは「サーバー起動済み」を意味する
+        return e.code in (405, 406, 400)
     except Exception:
         return False
 
@@ -88,9 +88,16 @@ def _ensure_server_running() -> bool:
         return True
     # ロックファイルが存在する場合、別のランチャーが起動中の可能性がある。
     # 二重起動を避けてサーバーの準備完了を待つだけにする。
-    from src.services.lock_file import read as read_lock
+    # ただしプロセスが死んでいる場合はstale lockとして削除し、新規起動する。
+    from src.services.lock_file import read as read_lock, is_process_alive
+    from src.services.lock_file import LOCK_FILE
 
-    if read_lock() is None:
+    lock_info = read_lock()
+    if lock_info is not None and not is_process_alive(lock_info["pid"]):
+        logger.info(f"Removing stale lock file: pid={lock_info['pid']}")
+        LOCK_FILE.unlink(missing_ok=True)
+        lock_info = None
+    if lock_info is None:
         if not _start_http_server():
             return False
     # 最大30秒待機（0.5秒間隔 x 60回）

--- a/src/services/lock_file.py
+++ b/src/services/lock_file.py
@@ -44,7 +44,7 @@ def acquire(port: int) -> bool:
 
     # ファイルが既に存在する場合、stale判定
     existing = read()
-    if existing is not None and _is_process_alive(existing["pid"]):
+    if existing is not None and is_process_alive(existing["pid"]):
         logger.warning(
             f"Server already running: pid={existing['pid']}, port={existing['port']}"
         )
@@ -114,7 +114,7 @@ def release() -> None:
         logger.warning(f"Failed to release lock file: {e}")
 
 
-def _is_process_alive(pid: int) -> bool:
+def is_process_alive(pid: int) -> bool:
     """指定PIDのプロセスが生存しているか確認する。"""
     try:
         os.kill(pid, 0)

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -86,7 +86,7 @@ class TestSessionLifecycle:
 
     def test_stale_lock_recovery_and_new_session(self, monkeypatch):
         """staleロック回収後に新しいセッションが動作する"""
-        monkeypatch.setattr(lock_file, "_is_process_alive", lambda pid: False)
+        monkeypatch.setattr(lock_file, "is_process_alive", lambda pid: False)
         lock_file.LOCK_FILE.write_text(
             json.dumps({"pid": 99999999, "port": 52837}), encoding="utf-8"
         )

--- a/tests/unit/test_lock_file.py
+++ b/tests/unit/test_lock_file.py
@@ -34,7 +34,7 @@ class TestAcquire:
         """死んだプロセスのロックファイルは上書きされる"""
         # 存在しないPIDでロックファイルを手動作成
         stale_pid = 99999999
-        monkeypatch.setattr(lock_file, "_is_process_alive", lambda pid: False)
+        monkeypatch.setattr(lock_file, "is_process_alive", lambda pid: False)
         lock_file.LOCK_FILE.write_text(
             json.dumps({"pid": stale_pid, "port": 52837}), encoding="utf-8"
         )
@@ -100,8 +100,8 @@ class TestRelease:
 class TestIsProcessAlive:
     def test_current_process_is_alive(self):
         """自プロセスは生存している"""
-        assert lock_file._is_process_alive(os.getpid()) is True
+        assert lock_file.is_process_alive(os.getpid()) is True
 
     def test_nonexistent_process(self):
         """存在しないPIDはFalse"""
-        assert lock_file._is_process_alive(99999999) is False
+        assert lock_file.is_process_alive(99999999) is False


### PR DESCRIPTION
FastMCP 2.14.1がGET /mcpに406を返すようになり、ヘルスチェックが
起動済みサーバーを検出できなくなっていた。また、プロセス異常終了後の
stale lockファイルが残った場合に新規起動がブロックされていた。