### PR TITLE
feat: get_topics/get_activitiesにsince/untilパラメータを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -226,12 +226,16 @@ def get_topics(
     tags: list[str] | None = None,
     limit: int = 10,
     offset: int = 0,
+    since: str | None = None,
+    until: str | None = None,
 ) -> dict:
     """トピックを新しい順に取得する（ページネーション付き）。
 
     tags: タグ配列（optional）。指定時はAND条件でフィルタ。未指定時は全件返す。例: ["domain:cc-memory"]
+    since: ISO日付文字列（例: "2026-03-10"）。この日付以降に作成されたトピックのみ返す
+    until: ISO日付文字列。この日付以前に作成されたトピックのみ返す
     """
-    result = topic_service.get_topics(tags, limit, offset)
+    result = topic_service.get_topics(tags, limit, offset, since, until)
     if "error" not in result and tags:
         _maybe_inject_tag_notes(result, tags)
     return result
@@ -453,6 +457,8 @@ def get_activities(
     tags: list[str] | None = None,
     status: str = "active",
     limit: int = 5,
+    since: str | None = None,
+    until: str | None = None,
 ) -> dict:
     """
     アクティビティ一覧を取得する（tagsでフィルタリング、statusでフィルタリング可能）。
@@ -462,6 +468,7 @@ def get_activities(
     - ドメイン指定: get_activities(["domain:cc-memory"])
     - 進行中のみ: get_activities(["domain:cc-memory"], status="in_progress")
     - 完了アクティビティの確認: get_activities(status="completed")
+    - 最近1週間: get_activities(since="2026-03-09")
 
     ワークフロー位置: アクティビティ状況の確認時
 
@@ -470,11 +477,13 @@ def get_activities(
         status: フィルタするステータス（active/pending/in_progress/completed、デフォルト: active）
                 "active"はpending+in_progressの両方を返すエイリアス
         limit: 取得件数上限（デフォルト: 5）
+        since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
+        until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す
 
     Returns:
         アクティビティ一覧（total_countで該当ステータスの全件数を確認可能）
     """
-    result = activity_service.get_activities(tags, status, limit)
+    result = activity_service.get_activities(tags, status, limit, since, until)
     if "error" not in result and tags:
         _maybe_inject_tag_notes(result, tags)
     return result

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -1,5 +1,6 @@
 """アクティビティ管理サービス"""
 import logging
+import re
 import sqlite3
 from typing import Optional
 
@@ -175,6 +176,22 @@ def get_activities(
             }
         }
 
+    date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$")
+    if since is not None and not date_pattern.match(since):
+        return {
+            "error": {
+                "code": "INVALID_PARAMETER",
+                "message": f"since must be ISO date format (YYYY-MM-DD), got '{since}'",
+            }
+        }
+    if until is not None and not date_pattern.match(until):
+        return {
+            "error": {
+                "code": "INVALID_PARAMETER",
+                "message": f"until must be ISO date format (YYYY-MM-DD), got '{until}'",
+            }
+        }
+
     conn = get_connection()
     try:
         # タグフィルタでactivity_idsを絞り込む（tags指定時のみ）
@@ -224,8 +241,10 @@ def get_activities(
             where_params.append(since)
 
         if until is not None:
+            # 日付のみ指定時は当日を含めるため末尾に時刻を付与
+            until_value = until if " " in until else until + " 23:59:59"
             conditions.append("updated_at <= ?")
-            where_params.append(until)
+            where_params.append(until_value)
 
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -131,7 +131,13 @@ def add_activity(
     return result
 
 
-def get_activities(tags: list[str] | None = None, status: str = "active", limit: int = 5) -> dict:
+def get_activities(
+    tags: list[str] | None = None,
+    status: str = "active",
+    limit: int = 5,
+    since: str | None = None,
+    until: str | None = None,
+) -> dict:
     """
     アクティビティ一覧を取得（tagsでフィルタリング、statusでフィルタリング）
 
@@ -140,6 +146,8 @@ def get_activities(tags: list[str] | None = None, status: str = "active", limit:
         status: フィルタするステータス（active/pending/in_progress/completed、デフォルト: active）
                 "active"はpending+in_progressの両方を返すエイリアス
         limit: 取得件数上限（デフォルト: 5）
+        since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
+        until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す
 
     Returns:
         アクティビティ一覧とtotal_count
@@ -210,6 +218,14 @@ def get_activities(tags: list[str] | None = None, status: str = "active", limit:
             conditions.append("status = ?")
             where_params.append(status)
             order_clause = "updated_at DESC, id DESC"
+
+        if since is not None:
+            conditions.append("updated_at >= ?")
+            where_params.append(since)
+
+        if until is not None:
+            conditions.append("updated_at <= ?")
+            where_params.append(until)
 
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -1,4 +1,5 @@
 """議論トピック管理サービス"""
+import re
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
@@ -158,6 +159,22 @@ def get_topics(
                 }
             }
 
+        date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$")
+        if since is not None and not date_pattern.match(since):
+            return {
+                "error": {
+                    "code": "INVALID_PARAMETER",
+                    "message": f"since must be ISO date format (YYYY-MM-DD), got '{since}'",
+                }
+            }
+        if until is not None and not date_pattern.match(until):
+            return {
+                "error": {
+                    "code": "INVALID_PARAMETER",
+                    "message": f"until must be ISO date format (YYYY-MM-DD), got '{until}'",
+                }
+            }
+
         conn = get_connection()
         try:
             # タグフィルタでtopic_idsを絞り込む（tags指定時のみ）
@@ -197,8 +214,10 @@ def get_topics(
                 where_params.append(since)
 
             if until is not None:
+                # 日付のみ指定時は当日を含めるため末尾に時刻を付与
+                until_value = until if " " in until else until + " 23:59:59"
                 conditions.append("created_at <= ?")
-                where_params.append(until)
+                where_params.append(until_value)
 
             if conditions:
                 where_clause = "WHERE " + " AND ".join(conditions)

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -119,6 +119,8 @@ def get_topics(
     tags: list[str] | None = None,
     limit: int = 10,
     offset: int = 0,
+    since: str | None = None,
+    until: str | None = None,
 ) -> dict:
     """
     トピックを新しい順に取得する（ページネーション付き）。
@@ -127,6 +129,8 @@ def get_topics(
         tags: タグ配列（optional。指定時はAND条件でフィルタ、未指定時は全件）
         limit: 取得件数（デフォルト10）
         offset: スキップ件数（デフォルト0）
+        since: ISO日付文字列（例: "2026-03-10"）。この日付以降に作成されたトピックのみ返す
+        until: ISO日付文字列。この日付以前に作成されたトピックのみ返す
 
     Returns:
         トピック一覧（total_count付き）
@@ -180,13 +184,26 @@ def get_topics(
                     return {"topics": [], "total_count": 0}
 
             # クエリ組み立て
+            conditions = []
+            where_params = []
+
             if topic_ids is not None:
                 id_placeholders = ",".join("?" * len(topic_ids))
-                where_clause = f"WHERE id IN ({id_placeholders})"
-                where_params = list(topic_ids)
+                conditions.append(f"id IN ({id_placeholders})")
+                where_params.extend(topic_ids)
+
+            if since is not None:
+                conditions.append("created_at >= ?")
+                where_params.append(since)
+
+            if until is not None:
+                conditions.append("created_at <= ?")
+                where_params.append(until)
+
+            if conditions:
+                where_clause = "WHERE " + " AND ".join(conditions)
             else:
                 where_clause = ""
-                where_params = []
 
             count_row = conn.execute(
                 f"SELECT COUNT(*) as count FROM discussion_topics {where_clause}",

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -358,6 +358,8 @@ class TestGetActivities:
         a2 = add_activity(title="New Pending", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         update_activity(a1["activity_id"], new_status="completed")
 
+        # update_activityが内部でupdated_at=CURRENT_TIMESTAMPを設定するため、
+        # テスト用に手動で上書きしてsince条件の検証を可能にする
         conn = get_connection()
         conn.execute(
             "UPDATE activities SET updated_at = '2026-01-01 00:00:00' WHERE id = ?",
@@ -375,6 +377,37 @@ class TestGetActivities:
         assert "error" not in result
         assert result["total_count"] == 0
         assert result["activities"] == []
+
+    def test_get_activities_until_includes_same_day(self, temp_db):
+        """until指定日と同日のレコードが含まれる（境界テスト）"""
+        add_activity(title="Same Day", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-03-15 18:00:00' WHERE title = 'Same Day'"
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(tags=DEFAULT_TAGS, until="2026-03-15")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["activities"][0]["title"] == "Same Day"
+
+    def test_get_activities_invalid_since_format(self, temp_db):
+        """不正なsince形式でINVALID_PARAMETERエラー"""
+        result = get_activities(tags=DEFAULT_TAGS, since="not-a-date")
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_PARAMETER"
+
+    def test_get_activities_invalid_until_format(self, temp_db):
+        """不正なuntil形式でINVALID_PARAMETERエラー"""
+        result = get_activities(tags=DEFAULT_TAGS, until="2026/03/15")
+
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_PARAMETER"
 
     def test_get_activities_truncates_description_at_max_len(self, temp_db):
         """descriptionがACTIVITY_DESC_MAX_LEN文字に切り詰められること"""

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -291,6 +291,91 @@ class TestGetActivities:
         titles = [a["title"] for a in result["activities"]]
         assert titles == ["New pending", "Old pending"]
 
+    def test_get_activities_since_filter(self, temp_db):
+        """since指定でupdated_at以降のアクティビティのみ返す"""
+        add_activity(title="Old Activity", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_activity(title="New Activity", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-01-01 00:00:00' WHERE title = 'Old Activity'"
+        )
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-03-15 00:00:00' WHERE title = 'New Activity'"
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(tags=DEFAULT_TAGS, since="2026-03-01")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["activities"][0]["title"] == "New Activity"
+
+    def test_get_activities_until_filter(self, temp_db):
+        """until指定でupdated_at以前のアクティビティのみ返す"""
+        add_activity(title="Old Activity", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_activity(title="New Activity", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-01-01 00:00:00' WHERE title = 'Old Activity'"
+        )
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-03-15 00:00:00' WHERE title = 'New Activity'"
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(tags=DEFAULT_TAGS, until="2026-02-01")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["activities"][0]["title"] == "Old Activity"
+
+    def test_get_activities_since_and_until_combined(self, temp_db):
+        """since+until指定で範囲内のアクティビティのみ返す"""
+        add_activity(title="Jan", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_activity(title="Feb", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_activity(title="Mar", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+
+        conn = get_connection()
+        conn.execute("UPDATE activities SET updated_at = '2026-01-15 00:00:00' WHERE title = 'Jan'")
+        conn.execute("UPDATE activities SET updated_at = '2026-02-15 00:00:00' WHERE title = 'Feb'")
+        conn.execute("UPDATE activities SET updated_at = '2026-03-15 00:00:00' WHERE title = 'Mar'")
+        conn.commit()
+        conn.close()
+
+        result = get_activities(tags=DEFAULT_TAGS, since="2026-02-01", until="2026-02-28")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["activities"][0]["title"] == "Feb"
+
+    def test_get_activities_since_with_status_filter(self, temp_db):
+        """since + status組み合わせ"""
+        a1 = add_activity(title="Old Completed", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        a2 = add_activity(title="New Pending", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        update_activity(a1["activity_id"], new_status="completed")
+
+        conn = get_connection()
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-01-01 00:00:00' WHERE id = ?",
+            (a1["activity_id"],),
+        )
+        conn.execute(
+            "UPDATE activities SET updated_at = '2026-03-15 00:00:00' WHERE id = ?",
+            (a2["activity_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        result = get_activities(status="completed", since="2026-03-01")
+
+        assert "error" not in result
+        assert result["total_count"] == 0
+        assert result["activities"] == []
+
     def test_get_activities_truncates_description_at_max_len(self, temp_db):
         """descriptionがACTIVITY_DESC_MAX_LEN文字に切り詰められること"""
         long_desc = "a" * (ACTIVITY_DESC_MAX_LEN + 50)

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -300,6 +300,41 @@ def test_get_topics_since_without_tags(temp_db):
     assert result["topics"][0]["title"] == "New"
 
 
+def test_get_topics_until_includes_same_day(temp_db):
+    """until指定日と同日のレコードが含まれる（境界テスト）"""
+    t1 = add_topic(title="Same Day", description="Desc", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-03-15 12:30:00' WHERE id = ?",
+        (t1["topic_id"],),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_topics(tags=DEFAULT_TAGS, until="2026-03-15")
+
+    assert "error" not in result
+    assert result["total_count"] == 1
+    assert result["topics"][0]["title"] == "Same Day"
+
+
+def test_get_topics_invalid_since_format(temp_db):
+    """不正なsince形式でINVALID_PARAMETERエラー"""
+    result = get_topics(tags=DEFAULT_TAGS, since="not-a-date")
+
+    assert "error" in result
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+
+
+def test_get_topics_invalid_until_format(temp_db):
+    """不正なuntil形式でINVALID_PARAMETERエラー"""
+    result = get_topics(tags=DEFAULT_TAGS, until="2026/03/15")
+
+    assert "error" in result
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+
+
 def test_get_topics_has_tags_field(temp_db):
     """各topicにtags付き"""
     add_topic(title="Tagged Topic", description="Desc", tags=["domain:test", "intent:design"])

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -6,7 +6,7 @@ get_logs/get_decisionsは各アイテムにtagsフィールドを含む。
 import os
 import tempfile
 import pytest
-from src.db import init_database
+from src.db import init_database, get_connection
 from src.services.topic_service import (
     add_topic,
     get_topics,
@@ -176,6 +176,128 @@ def test_get_topics_and_filter(temp_db):
     assert "error" not in result
     assert result["total_count"] == 1
     assert result["topics"][0]["title"] == "Both Tags"
+
+
+def test_get_topics_since_filter(temp_db):
+    """since指定でcreated_at以降のトピックのみ返す"""
+    t1 = add_topic(title="Old Topic", description="Desc", tags=DEFAULT_TAGS)
+    t2 = add_topic(title="New Topic", description="Desc", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-01-01 00:00:00' WHERE id = ?",
+        (t1["topic_id"],),
+    )
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-03-15 00:00:00' WHERE id = ?",
+        (t2["topic_id"],),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_topics(tags=DEFAULT_TAGS, since="2026-03-01")
+
+    assert "error" not in result
+    assert result["total_count"] == 1
+    assert result["topics"][0]["title"] == "New Topic"
+
+
+def test_get_topics_until_filter(temp_db):
+    """until指定でcreated_at以前のトピックのみ返す"""
+    t1 = add_topic(title="Old Topic", description="Desc", tags=DEFAULT_TAGS)
+    t2 = add_topic(title="New Topic", description="Desc", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-01-01 00:00:00' WHERE id = ?",
+        (t1["topic_id"],),
+    )
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-03-15 00:00:00' WHERE id = ?",
+        (t2["topic_id"],),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_topics(tags=DEFAULT_TAGS, until="2026-02-01")
+
+    assert "error" not in result
+    assert result["total_count"] == 1
+    assert result["topics"][0]["title"] == "Old Topic"
+
+
+def test_get_topics_since_and_until_combined(temp_db):
+    """since+until指定で範囲内のトピックのみ返す"""
+    t1 = add_topic(title="Jan Topic", description="Desc", tags=DEFAULT_TAGS)
+    t2 = add_topic(title="Feb Topic", description="Desc", tags=DEFAULT_TAGS)
+    t3 = add_topic(title="Mar Topic", description="Desc", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-01-15 00:00:00' WHERE id = ?",
+        (t1["topic_id"],),
+    )
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-02-15 00:00:00' WHERE id = ?",
+        (t2["topic_id"],),
+    )
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-03-15 00:00:00' WHERE id = ?",
+        (t3["topic_id"],),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_topics(tags=DEFAULT_TAGS, since="2026-02-01", until="2026-02-28")
+
+    assert "error" not in result
+    assert result["total_count"] == 1
+    assert result["topics"][0]["title"] == "Feb Topic"
+
+
+def test_get_topics_since_no_match(temp_db):
+    """sinceが未来日で0件"""
+    add_topic(title="Topic", description="Desc", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    conn.execute("UPDATE discussion_topics SET created_at = '2026-01-01 00:00:00'")
+    conn.commit()
+    conn.close()
+
+    result = get_topics(tags=DEFAULT_TAGS, since="2099-01-01")
+
+    assert "error" not in result
+    assert result["total_count"] == 0
+    assert result["topics"] == []
+
+
+def test_get_topics_since_without_tags(temp_db):
+    """tags未指定 + sinceで全トピックから日付フィルタ"""
+    t1 = add_topic(title="Old", description="Desc", tags=["domain:a"])
+    t2 = add_topic(title="New", description="Desc", tags=["domain:b"])
+
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-01-01 00:00:00' WHERE id = ?",
+        (t1["topic_id"],),
+    )
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2026-03-15 00:00:00' WHERE id = ?",
+        (t2["topic_id"],),
+    )
+    # init_databaseのfirst_topicも古い日付にする
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = '2025-01-01 00:00:00' WHERE id NOT IN (?, ?)",
+        (t1["topic_id"], t2["topic_id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_topics(since="2026-03-01")
+
+    assert "error" not in result
+    assert result["total_count"] == 1
+    assert result["topics"][0]["title"] == "New"
 
 
 def test_get_topics_has_tags_field(temp_db):


### PR DESCRIPTION
## Summary
- `get_topics`に`since`/`until`パラメータを追加（`created_at`で比較）
- `get_activities`に`since`/`until`パラメータを追加（`updated_at`で比較）
- ISO日付文字列の辞書順比較で実装（decision #1346準拠）
- テスト10件追加（topics 6件 + activities 4件）

## Test plan
- [x] 既存テスト全パス（29 + 12）
- [x] since単体フィルタ
- [x] until単体フィルタ
- [x] since + until範囲指定
- [x] tags未指定 + since
- [x] status + since組み合わせ
- [x] マッチなしで空配列

🤖 Generated with [Claude Code](https://claude.com/claude-code)