### PR TITLE
feat: update_materialツールを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -588,7 +588,7 @@ def update_material(
 
     Args:
         material_id: 資材のID
-        content: 新しい本文（全体置換。optional）
+        content: 新しい本文（全体置換。optional）。先頭1-2文は内容の説明・要約を書くこと（check-inやsearchのsnippetに使われるため）
         title: 新しいタイトル（optional）
 
     Returns:

--- a/src/main.py
+++ b/src/main.py
@@ -570,6 +570,34 @@ def add_material(
 
 
 @mcp.tool()
+def update_material(
+    material_id: int,
+    content: str | None = None,
+    title: str | None = None,
+) -> dict:
+    """
+    既存の資材を更新する。contentとtitleを個別または同時に更新できる。
+
+    contentは全体置換（部分更新やappendではない）。
+    少なくとも1つのパラメータを指定する必要がある。
+
+    典型的な使い方:
+    - 内容を改訂: update_material(material_id=5, content="# 改訂版\n...")
+    - タイトル変更: update_material(material_id=5, title="新しいタイトル")
+    - 両方更新: update_material(material_id=5, content="...", title="...")
+
+    Args:
+        material_id: 資材のID
+        content: 新しい本文（全体置換。optional）
+        title: 新しいタイトル（optional）
+
+    Returns:
+        更新された資材情報（material_id, title, content, tags, created_at）
+    """
+    return material_service.update_material(material_id, content=content, title=title)
+
+
+@mcp.tool()
 def get_material(
     material_id: int,
 ) -> dict:

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -157,6 +157,121 @@ def get_materials_by_relation_with_conn(conn, activity_id: int) -> list[dict]:
     ]
 
 
+def update_material(
+    material_id: int,
+    content: str | None = None,
+    title: str | None = None,
+) -> dict:
+    """
+    Update an existing material's content and/or title.
+
+    Args:
+        material_id: ID of the material to update
+        content: New content (full replace, optional)
+        title: New title (optional)
+
+    Returns:
+        Updated material info
+    """
+    if content is None and title is None:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "At least one of content or title must be provided",
+            }
+        }
+
+    if title is not None and not title.strip():
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "title must not be empty",
+            }
+        }
+
+    if content is not None and not content.strip():
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "content must not be empty",
+            }
+        }
+
+    conn = get_connection()
+    try:
+        # Check existence
+        row = conn.execute(
+            "SELECT * FROM materials WHERE id = ?", (material_id,)
+        ).fetchone()
+        if not row:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"Material with id {material_id} not found",
+                }
+            }
+
+        # Build dynamic SQL
+        set_parts = []
+        values = []
+
+        if title is not None:
+            set_parts.append("title = ?")
+            values.append(title)
+
+        if content is not None:
+            set_parts.append("content = ?")
+            values.append(content)
+
+        set_clause = ", ".join(set_parts)
+        values.append(material_id)
+
+        conn.execute(
+            f"UPDATE materials SET {set_clause} WHERE id = ?",
+            tuple(values),
+        )
+        conn.commit()
+
+        # Retrieve updated material
+        row = conn.execute(
+            "SELECT * FROM materials WHERE id = ?", (material_id,)
+        ).fetchone()
+        if not row:
+            raise Exception("Failed to retrieve updated material")
+
+        # Get tags
+        tag_strings = get_entity_tags(conn, "material_tags", "material_id", material_id)
+
+        # Regenerate embedding
+        updated = row_to_dict(row)
+        tag_text = " ".join(tag_strings) if tag_strings else ""
+        generate_and_store_embedding(
+            "material", material_id,
+            build_embedding_text(updated["title"], updated["content"], tag_text),
+        )
+
+        return _material_to_response(updated, tag_strings)
+
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "CONSTRAINT_VIOLATION",
+                "message": str(e),
+            }
+        }
+    except Exception as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()
+
+
 def get_material(material_id: int) -> dict:
     """
     資材を全文取得する

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -250,7 +250,9 @@ def update_material(
             build_embedding_text(updated["title"], updated["content"], tag_text),
         )
 
-        return _material_to_response(updated, tag_strings)
+        result = _material_to_response(updated, tag_strings)
+        result["hint"] = "contentの先頭1-2文は内容の説明・要約を書いてください。check-inやsearchのsnippetに使われます。"
+        return result
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -251,7 +251,8 @@ def update_material(
         )
 
         result = _material_to_response(updated, tag_strings)
-        result["hint"] = "contentの先頭1-2文は内容の説明・要約を書いてください。check-inやsearchのsnippetに使われます。"
+        if content is not None:
+            result["hint"] = "contentの先頭1-2文は内容の説明・要約を書いてください。check-inやsearchのsnippetに使われます。"
         return result
 
     except sqlite3.IntegrityError as e:

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -270,6 +270,7 @@ class TestUpdateMaterial:
         assert result["material_id"] == material_id
         assert result["content"] == "Updated content"
         assert result["title"] == "Original Title"  # unchanged
+        assert "hint" in result
 
     def test_update_title(self, temp_db):
         """Updating title only succeeds"""
@@ -282,6 +283,7 @@ class TestUpdateMaterial:
         assert result["material_id"] == material_id
         assert result["title"] == "Updated Title"
         assert result["content"] == "Original content"  # unchanged
+        assert "hint" in result
 
     def test_update_both(self, temp_db):
         """Updating both content and title succeeds"""
@@ -294,6 +296,7 @@ class TestUpdateMaterial:
         assert result["material_id"] == material_id
         assert result["title"] == "New Title"
         assert result["content"] == "New content"
+        assert "hint" in result
 
     def test_update_neither_returns_validation_error(self, temp_db):
         """Providing neither content nor title returns VALIDATION_ERROR"""

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database
 from src.services.activity_service import add_activity
-from src.services.material_service import add_material, get_material
+from src.services.material_service import add_material, get_material, update_material
 from src.services.search_service import get_by_id, get_by_ids
 
 
@@ -246,3 +246,91 @@ class TestGetByIdMaterial:
         # activity
         assert result["results"][1]["type"] == "activity"
         assert result["results"][1]["data"]["id"] == activity_id
+
+
+class TestUpdateMaterial:
+    """update_material integration tests"""
+
+    def _create_material(self):
+        """Helper to create a material for update tests"""
+        return add_material(
+            title="Original Title",
+            content="Original content",
+            tags=["domain:test", "design"],
+        )
+
+    def test_update_content(self, temp_db):
+        """Updating content only succeeds"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="Updated content")
+
+        assert "error" not in result
+        assert result["material_id"] == material_id
+        assert result["content"] == "Updated content"
+        assert result["title"] == "Original Title"  # unchanged
+
+    def test_update_title(self, temp_db):
+        """Updating title only succeeds"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, title="Updated Title")
+
+        assert "error" not in result
+        assert result["material_id"] == material_id
+        assert result["title"] == "Updated Title"
+        assert result["content"] == "Original content"  # unchanged
+
+    def test_update_both(self, temp_db):
+        """Updating both content and title succeeds"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="New content", title="New Title")
+
+        assert "error" not in result
+        assert result["material_id"] == material_id
+        assert result["title"] == "New Title"
+        assert result["content"] == "New content"
+
+    def test_update_neither_returns_validation_error(self, temp_db):
+        """Providing neither content nor title returns VALIDATION_ERROR"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "At least one" in result["error"]["message"]
+
+    def test_update_not_found(self, temp_db):
+        """Non-existent material_id returns NOT_FOUND"""
+        result = update_material(9999, content="New content")
+
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_update_empty_title(self, temp_db):
+        """Empty title returns VALIDATION_ERROR"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, title="")
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "title" in result["error"]["message"]
+
+    def test_update_empty_content(self, temp_db):
+        """Empty content returns VALIDATION_ERROR"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="")
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "content" in result["error"]["message"]

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -271,6 +271,7 @@ class TestUpdateMaterial:
         assert result["content"] == "Updated content"
         assert result["title"] == "Original Title"  # unchanged
         assert "hint" in result
+        assert sorted(result["tags"]) == sorted(["design", "domain:test"])
 
     def test_update_title(self, temp_db):
         """Updating title only succeeds"""
@@ -283,7 +284,8 @@ class TestUpdateMaterial:
         assert result["material_id"] == material_id
         assert result["title"] == "Updated Title"
         assert result["content"] == "Original content"  # unchanged
-        assert "hint" in result
+        assert "hint" not in result
+        assert sorted(result["tags"]) == sorted(["design", "domain:test"])
 
     def test_update_both(self, temp_db):
         """Updating both content and title succeeds"""
@@ -326,6 +328,18 @@ class TestUpdateMaterial:
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
         assert "title" in result["error"]["message"]
+
+    def test_update_persists_via_get_material(self, temp_db):
+        """get_materialで更新が永続化されていることを確認"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        update_material(material_id, content="Persisted content", title="Persisted Title")
+
+        fetched = get_material(material_id)
+        assert fetched["title"] == "Persisted Title"
+        assert fetched["content"] == "Persisted content"
+        assert sorted(fetched["tags"]) == sorted(["design", "domain:test"])
 
     def test_update_empty_content(self, temp_db):
         """Empty content returns VALIDATION_ERROR"""


### PR DESCRIPTION
## Summary
- 既存materialのcontent/titleを更新する `update_material` MCPツールを追加
- `update_reminder` パターンを踏襲したシンプルな実装（動的SQL + embedding再生成）
- テスト7ケース追加、全827テストパス

## 関連
- cc-memory activity: #534
- decision: #1358

## 変更内容
- `src/services/material_service.py`: `update_material` 関数追加
- `src/main.py`: MCPツール登録
- `tests/integration/test_material_service.py`: `TestUpdateMaterial` クラス追加（7ケース）

## Test plan
- [x] content のみ更新
- [x] title のみ更新
- [x] 両方同時更新
- [x] 両方未指定 → VALIDATION_ERROR
- [x] 存在しないID → NOT_FOUND
- [x] 空文字title → VALIDATION_ERROR
- [x] 空文字content → VALIDATION_ERROR
- [x] 既存テスト827件リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)