### PR TITLE
feat: 4ツールにtag_notes結果ベース注入を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -150,16 +150,19 @@ def build_instructions() -> str:
     return RULES
 
 
-def _maybe_inject_tag_notes(result: dict, tag_strings: list[str]) -> dict:
+def _maybe_inject_tag_notes(result: dict, tag_strings: list[str], mark: bool = True) -> dict:
     """結果dictにtag_notesを注入する（notes があれば）
 
     Note: always_inject_namespacesは渡さない（意図的）。
     intent:タグがこの経路で_injected_tagsに登録されるが、
     check_in経路はalways_inject_namespacesで常時注入が保証されるため問題ない。
+
+    Args:
+        mark: False の場合、_injected_tags を参照も更新もしない（読み取り経路用）。
     """
     conn = get_connection()
     try:
-        notes = collect_tag_notes_for_injection(conn, tag_strings)
+        notes = collect_tag_notes_for_injection(conn, tag_strings, mark=mark)
     finally:
         conn.close()
     if notes:
@@ -258,7 +261,7 @@ def get_topics(
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("topics", []))
         if all_tags:
-            _maybe_inject_tag_notes(result, all_tags)
+            _maybe_inject_tag_notes(result, all_tags, mark=False)
     return result
 
 
@@ -273,7 +276,7 @@ def get_logs(
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("logs", []))
         if all_tags:
-            _maybe_inject_tag_notes(result, all_tags)
+            _maybe_inject_tag_notes(result, all_tags, mark=False)
     return result
 
 
@@ -288,7 +291,7 @@ def get_decisions(
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("decisions", []))
         if all_tags:
-            _maybe_inject_tag_notes(result, all_tags)
+            _maybe_inject_tag_notes(result, all_tags, mark=False)
     return result
 
 
@@ -523,7 +526,7 @@ def get_activities(
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("activities", []))
         if all_tags:
-            _maybe_inject_tag_notes(result, all_tags)
+            _maybe_inject_tag_notes(result, all_tags, mark=False)
     return result
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -167,6 +167,14 @@ def _maybe_inject_tag_notes(result: dict, tag_strings: list[str]) -> dict:
     return result
 
 
+def _collect_result_tags(items: list[dict]) -> list[str]:
+    """結果アイテムからユニークなタグを収集する"""
+    tags: set[str] = set()
+    for item in items:
+        tags.update(item.get("tags", []))
+    return sorted(tags)
+
+
 # MCPサーバーを作成
 mcp = FastMCP("cc-memory", instructions=build_instructions())
 
@@ -247,8 +255,10 @@ def get_topics(
     until: ISO日付文字列。この日付以前に作成されたトピックのみ返す
     """
     result = topic_service.get_topics(tags, limit, offset, since, until)
-    if "error" not in result and tags:
-        _maybe_inject_tag_notes(result, tags)
+    if "error" not in result:
+        all_tags = _collect_result_tags(result.get("topics", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
     return result
 
 
@@ -259,7 +269,12 @@ def get_logs(
     limit: int = 30,
 ) -> dict:
     """指定トピックの議論ログを取得する。"""
-    return discussion_log_service.get_logs(topic_id, start_id, limit)
+    result = discussion_log_service.get_logs(topic_id, start_id, limit)
+    if "error" not in result:
+        all_tags = _collect_result_tags(result.get("logs", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+    return result
 
 
 @mcp.tool()
@@ -269,7 +284,12 @@ def get_decisions(
     limit: int = 30,
 ) -> dict:
     """指定トピックに関連する決定事項を取得する。"""
-    return decision_service.get_decisions(topic_id, start_id, limit)
+    result = decision_service.get_decisions(topic_id, start_id, limit)
+    if "error" not in result:
+        all_tags = _collect_result_tags(result.get("decisions", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+    return result
 
 
 @mcp.tool()
@@ -500,8 +520,10 @@ def get_activities(
         アクティビティ一覧（total_countで該当ステータスの全件数を確認可能）
     """
     result = activity_service.get_activities(tags, status, limit, since, until)
-    if "error" not in result and tags:
-        _maybe_inject_tag_notes(result, tags)
+    if "error" not in result:
+        all_tags = _collect_result_tags(result.get("activities", []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
     return result
 
 

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -986,6 +986,7 @@ def collect_tag_notes_for_injection(
     conn: sqlite3.Connection,
     tag_strings: list[str],
     always_inject_namespaces: list[str] | None = None,
+    mark: bool = True,
 ) -> list[dict] | None:
     """未注入タグの notes を収集し、注入済みとしてマークする。
 
@@ -995,6 +996,8 @@ def collect_tag_notes_for_injection(
         always_inject_namespaces: 常時注入するnamespaceのリスト（例: ["intent"]）。
             このnamespaceに属するタグは _injected_tags チェックをスキップし、
             毎回 notes を返す。_injected_tags には登録しない。
+        mark: True（デフォルト）の場合、_injected_tags のチェックと更新を行う。
+            False の場合、_injected_tags を参照も更新もしない（読み取り経路用）。
 
     Returns:
         notes があるタグの一覧。なければ None
@@ -1014,14 +1017,17 @@ def collect_tag_notes_for_injection(
             normal_tags.append(t)
             normal_parsed.append((ns, name))
 
-    # 通常タグ: 未注入のもののみ
-    new_normal = [
-        (t, p) for t, p in zip(normal_tags, normal_parsed)
-        if t not in _injected_tags
-    ]
-
-    # 通常タグをすべてマーク（notes の有無に関わらず）
-    _injected_tags.update(t for t, _ in new_normal)
+    if mark:
+        # 通常タグ: 未注入のもののみ
+        new_normal = [
+            (t, p) for t, p in zip(normal_tags, normal_parsed)
+            if t not in _injected_tags
+        ]
+        # 通常タグをすべてマーク（notes の有無に関わらず）
+        _injected_tags.update(t for t, _ in new_normal)
+    else:
+        # mark=False: 全タグをクエリ対象にし、_injected_tags は更新しない
+        new_normal = list(zip(normal_tags, normal_parsed))
 
     # クエリ対象: new_normal + always（always_tagsは毎回クエリ）
     parsed = [p for _, p in new_normal] + always_parsed

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -3,6 +3,7 @@
 - update_tag の正常系・エラー系
 - 遭遇時注入の正常系・重複防止
 - get_by_ids での遭遇時注入
+- 4ツール（get_topics/get_activities/get_logs/get_decisions）の結果ベース注入
 """
 import os
 import tempfile
@@ -16,6 +17,8 @@ from src.services.tag_service import (
 )
 from src.services.topic_service import add_topic
 from src.services.decision_service import add_decision
+from src.services.discussion_log_service import add_log
+from src.services.activity_service import add_activity
 from src.services.search_service import get_by_ids
 import src.services.embedding_service as emb
 
@@ -389,3 +392,197 @@ class TestGetByIdsInjection:
             _maybe_inject_tag_notes(result, all_tags)
 
         assert "tag_notes" not in result
+
+
+# ========================================
+# 結果ベース tag_notes 注入テスト（4ツール）
+# ========================================
+
+
+def _apply_result_based_injection(result: dict, items_key: str) -> dict:
+    """テスト用ヘルパー: main.pyのハンドラと同じ結果ベース注入ロジックを適用する"""
+    from src.main import _collect_result_tags, _maybe_inject_tag_notes
+
+    if "error" not in result:
+        all_tags = _collect_result_tags(result.get(items_key, []))
+        if all_tags:
+            _maybe_inject_tag_notes(result, all_tags)
+    return result
+
+
+class TestGetTopicsResultBasedInjection:
+    """get_topics の結果ベース tag_notes 注入テスト"""
+
+    def test_injects_tag_notes_from_result_tags(self, temp_db):
+        """タグフィルタなしでも結果内のタグからtag_notesが注入される"""
+        from src.services.topic_service import get_topics
+
+        add_topic(title="Test Topic", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        result = get_topics()
+        assert "error" not in result
+        assert len(result["topics"]) >= 1
+
+        _apply_result_based_injection(result, "topics")
+
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:test" for n in result["tag_notes"])
+
+    def test_no_notes_no_key(self, temp_db):
+        """notesがないタグのみの場合はtag_notesキーが含まれない"""
+        from src.services.topic_service import get_topics
+
+        add_topic(title="Test Topic", description="Desc", tags=["domain:empty"])
+
+        result = get_topics()
+        assert "error" not in result
+
+        _apply_result_based_injection(result, "topics")
+
+        assert "tag_notes" not in result
+
+
+class TestGetActivitiesResultBasedInjection:
+    """get_activities の結果ベース tag_notes 注入テスト"""
+
+    def test_injects_tag_notes_from_result_tags(self, temp_db):
+        """タグフィルタなしでも結果内のタグからtag_notesが注入される"""
+        from src.services.activity_service import get_activities
+
+        add_activity(
+            title="Test Activity", description="Desc",
+            tags=["domain:test", "intent:implement"], check_in=False,
+        )
+        update_tag("domain:test", "テスト教訓")
+
+        result = get_activities()
+        assert "error" not in result
+        assert len(result["activities"]) >= 1
+
+        _apply_result_based_injection(result, "activities")
+
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:test" for n in result["tag_notes"])
+
+    def test_no_notes_no_key(self, temp_db):
+        """notesがないタグのみの場合はtag_notesキーが含まれない"""
+        from src.services.activity_service import get_activities
+
+        # intent:タグはマイグレーションでnotesが設定されるため、notesのないタグのみ使用
+        add_activity(
+            title="Test Activity", description="Desc",
+            tags=["domain:empty"], check_in=False,
+        )
+
+        result = get_activities()
+        assert "error" not in result
+
+        _apply_result_based_injection(result, "activities")
+
+        assert "tag_notes" not in result
+
+
+class TestGetLogsResultBasedInjection:
+    """get_logs の結果ベース tag_notes 注入テスト"""
+
+    def test_injects_tag_notes_from_result_tags(self, temp_db):
+        """結果内のタグからtag_notesが注入される"""
+        from src.services.discussion_log_service import get_logs
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:test"])
+        topic_id = topic["topic_id"]
+        add_log(topic_id, title="Test Log", content="content", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        result = get_logs(topic_id)
+        assert "error" not in result
+        assert len(result["logs"]) >= 1
+
+        _apply_result_based_injection(result, "logs")
+
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:test" for n in result["tag_notes"])
+
+    def test_no_notes_no_key(self, temp_db):
+        """notesがないタグのみの場合はtag_notesキーが含まれない"""
+        from src.services.discussion_log_service import get_logs
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:empty"])
+        topic_id = topic["topic_id"]
+        add_log(topic_id, title="Test Log", content="content")
+
+        result = get_logs(topic_id)
+        assert "error" not in result
+
+        _apply_result_based_injection(result, "logs")
+
+        assert "tag_notes" not in result
+
+
+class TestGetDecisionsResultBasedInjection:
+    """get_decisions の結果ベース tag_notes 注入テスト"""
+
+    def test_injects_tag_notes_from_result_tags(self, temp_db):
+        """結果内のタグからtag_notesが注入される"""
+        from src.services.decision_service import get_decisions
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:test"])
+        topic_id = topic["topic_id"]
+        add_decision("Test Decision", "reason", topic_id, tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        result = get_decisions(topic_id)
+        assert "error" not in result
+        assert len(result["decisions"]) >= 1
+
+        _apply_result_based_injection(result, "decisions")
+
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:test" for n in result["tag_notes"])
+
+    def test_no_notes_no_key(self, temp_db):
+        """notesがないタグのみの場合はtag_notesキーが含まれない"""
+        from src.services.decision_service import get_decisions
+
+        topic = add_topic(title="Test Topic", description="Desc", tags=["domain:empty"])
+        topic_id = topic["topic_id"]
+        add_decision("Test Decision", "reason", topic_id)
+
+        result = get_decisions(topic_id)
+        assert "error" not in result
+
+        _apply_result_based_injection(result, "decisions")
+
+        assert "tag_notes" not in result
+
+
+class TestCollectResultTags:
+    """_collect_result_tags ヘルパーのテスト"""
+
+    def test_collects_unique_tags(self):
+        """複数アイテムからユニークなタグを収集する"""
+        from src.main import _collect_result_tags
+
+        items = [
+            {"tags": ["domain:test", "intent:design"]},
+            {"tags": ["domain:test", "hooks"]},
+            {"tags": ["intent:design"]},
+        ]
+        result = _collect_result_tags(items)
+        assert set(result) == {"domain:test", "intent:design", "hooks"}
+
+    def test_empty_items(self):
+        """空リストの場合は空リストを返す"""
+        from src.main import _collect_result_tags
+
+        result = _collect_result_tags([])
+        assert result == []
+
+    def test_items_without_tags(self):
+        """tagsキーがないアイテムでもエラーにならない"""
+        from src.main import _collect_result_tags
+
+        items = [{"id": 1}, {"id": 2, "tags": ["domain:test"]}]
+        result = _collect_result_tags(items)
+        assert result == ["domain:test"]

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -406,7 +406,7 @@ def _apply_result_based_injection(result: dict, items_key: str) -> dict:
     if "error" not in result:
         all_tags = _collect_result_tags(result.get(items_key, []))
         if all_tags:
-            _maybe_inject_tag_notes(result, all_tags)
+            _maybe_inject_tag_notes(result, all_tags, mark=False)
     return result
 
 
@@ -586,3 +586,201 @@ class TestCollectResultTags:
         items = [{"id": 1}, {"id": 2, "tags": ["domain:test"]}]
         result = _collect_result_tags(items)
         assert result == ["domain:test"]
+
+
+# ========================================
+# mark=False による _injected_tags 非汚染テスト
+# ========================================
+
+
+class TestResultBasedInjectionDoesNotMark:
+    """結果ベース注入（mark=False）は _injected_tags を汚染しない"""
+
+    def test_result_based_injection_does_not_mark_injected_tags(self, temp_db):
+        """結果ベース注入は_injected_tagsを汚染しない"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        conn = get_connection()
+        try:
+            # mark=False で注入（読み取り経路）
+            result = collect_tag_notes_for_injection(conn, ["domain:test"], mark=False)
+            assert result is not None
+            assert len(result) == 1
+            assert result[0]["tag"] == "domain:test"
+
+            # _injected_tags に登録されていないことを確認
+            assert "domain:test" not in _injected_tags
+
+            # mark=True（書き込み経路）でも notes が注入されることを確認
+            result2 = collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert result2 is not None
+            assert len(result2) == 1
+            assert result2[0]["tag"] == "domain:test"
+        finally:
+            conn.close()
+
+    def test_mark_false_queries_all_tags_including_already_marked(self, temp_db):
+        """mark=False は既にマーク済みのタグも含めて全タグをクエリする"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "domain:other"])
+        update_tag("domain:test", "テスト教訓")
+        update_tag("domain:other", "その他の教訓")
+
+        conn = get_connection()
+        try:
+            # まず mark=True で domain:test をマーク
+            collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert "domain:test" in _injected_tags
+
+            # mark=False では domain:test もクエリ対象になる
+            result = collect_tag_notes_for_injection(
+                conn, ["domain:test", "domain:other"], mark=False
+            )
+            assert result is not None
+            assert len(result) == 2
+            tag_strs = {r["tag"] for r in result}
+            assert "domain:test" in tag_strs
+            assert "domain:other" in tag_strs
+        finally:
+            conn.close()
+
+    def test_write_after_read_still_injects(self, temp_db):
+        """読み取り経路後に書き込み経路でも notes が注入される（シナリオテスト）"""
+        from src.main import _maybe_inject_tag_notes
+
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        # Step 1: 読み取り経路（mark=False）
+        read_result = {"topics": [{"tags": ["domain:test"]}]}
+        _maybe_inject_tag_notes(read_result, ["domain:test"], mark=False)
+        assert "tag_notes" in read_result
+
+        # Step 2: 書き込み経路（mark=True、デフォルト）
+        write_result = {"topic_id": 1}
+        _maybe_inject_tag_notes(write_result, ["domain:test"])
+        assert "tag_notes" in write_result
+        assert write_result["tag_notes"][0]["tag"] == "domain:test"
+
+
+# ========================================
+# MCP ハンドラ経由テスト（FunctionTool.fn）
+# ========================================
+
+
+class TestHandlerGetTopicsInjection:
+    """get_topics ハンドラ経由で tag_notes が注入されるテスト"""
+
+    def test_handler_injects_tag_notes(self, temp_db):
+        """MCP ハンドラ経由で tag_notes が注入される"""
+        from src.main import get_topics
+
+        add_topic(title="Handler Test", description="Desc", tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        result = get_topics.fn()
+        assert "error" not in result
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:handler" for n in result["tag_notes"])
+
+    def test_handler_does_not_pollute_injected_tags(self, temp_db):
+        """get_topics ハンドラは _injected_tags を汚染しない"""
+        from src.main import get_topics
+
+        add_topic(title="Handler Test", description="Desc", tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        get_topics.fn()
+        assert "domain:handler" not in _injected_tags
+
+
+class TestHandlerGetActivitiesInjection:
+    """get_activities ハンドラ経由で tag_notes が注入されるテスト"""
+
+    def test_handler_injects_tag_notes(self, temp_db):
+        """MCP ハンドラ経由で tag_notes が注入される"""
+        from src.main import get_activities
+
+        add_activity(
+            title="Handler Activity", description="Desc",
+            tags=["domain:handler"], check_in=False,
+        )
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        result = get_activities.fn()
+        assert "error" not in result
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:handler" for n in result["tag_notes"])
+
+    def test_handler_does_not_pollute_injected_tags(self, temp_db):
+        """get_activities ハンドラは _injected_tags を汚染しない"""
+        from src.main import get_activities
+
+        add_activity(
+            title="Handler Activity", description="Desc",
+            tags=["domain:handler"], check_in=False,
+        )
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        get_activities.fn()
+        assert "domain:handler" not in _injected_tags
+
+
+class TestHandlerGetLogsInjection:
+    """get_logs ハンドラ経由で tag_notes が注入されるテスト"""
+
+    def test_handler_injects_tag_notes(self, temp_db):
+        """MCP ハンドラ経由で tag_notes が注入される"""
+        from src.main import get_logs
+
+        topic = add_topic(title="Handler Topic", description="Desc", tags=["domain:handler"])
+        topic_id = topic["topic_id"]
+        add_log(topic_id, title="Handler Log", content="content", tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        result = get_logs.fn(topic_id)
+        assert "error" not in result
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:handler" for n in result["tag_notes"])
+
+    def test_handler_does_not_pollute_injected_tags(self, temp_db):
+        """get_logs ハンドラは _injected_tags を汚染しない"""
+        from src.main import get_logs
+
+        topic = add_topic(title="Handler Topic", description="Desc", tags=["domain:handler"])
+        topic_id = topic["topic_id"]
+        add_log(topic_id, title="Handler Log", content="content", tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        get_logs.fn(topic_id)
+        assert "domain:handler" not in _injected_tags
+
+
+class TestHandlerGetDecisionsInjection:
+    """get_decisions ハンドラ経由で tag_notes が注入されるテスト"""
+
+    def test_handler_injects_tag_notes(self, temp_db):
+        """MCP ハンドラ経由で tag_notes が注入される"""
+        from src.main import get_decisions
+
+        topic = add_topic(title="Handler Topic", description="Desc", tags=["domain:handler"])
+        topic_id = topic["topic_id"]
+        add_decision("Handler Decision", "reason", topic_id, tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        result = get_decisions.fn(topic_id)
+        assert "error" not in result
+        assert "tag_notes" in result
+        assert any(n["tag"] == "domain:handler" for n in result["tag_notes"])
+
+    def test_handler_does_not_pollute_injected_tags(self, temp_db):
+        """get_decisions ハンドラは _injected_tags を汚染しない"""
+        from src.main import get_decisions
+
+        topic = add_topic(title="Handler Topic", description="Desc", tags=["domain:handler"])
+        topic_id = topic["topic_id"]
+        add_decision("Handler Decision", "reason", topic_id, tags=["domain:handler"])
+        update_tag("domain:handler", "ハンドラ経由テスト")
+
+        get_decisions.fn(topic_id)
+        assert "domain:handler" not in _injected_tags


### PR DESCRIPTION
## Summary
- get_topics / get_activities / get_logs / get_decisions の4ツールで、返却結果のアイテムに含まれるタグからtag_notesを収集して注入する方式に変更
- get_topics / get_activities: 既存のフィルタベース注入（tags引数指定時のみ）を結果ベースに置換
- get_logs / get_decisions: 結果ベース注入を新規追加
- `_collect_result_tags` ヘルパー追加（返り値はsortedで決定的）

## Related
- Activity #536
- Decisions: D#1355, D#1369, D#1409

## Test plan
- [x] 4ツール × 2パターン（notes有/無）= 8テスト追加
- [x] `_collect_result_tags` ヘルパー単体テスト3件追加
- [x] 既存テスト831件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)