### PR TITLE
refactor: add系ツールのレスポンスをID+新情報のみに削減

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -89,19 +89,11 @@ def add_activity(
         # タグを取得
         tag_strings = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
 
-        # 作成したアクティビティを取得
-        cursor = conn.execute("SELECT * FROM activities WHERE id = ?", (activity_id,))
-        row = cursor.fetchone()
-        if not row:
-            raise Exception("Failed to retrieve created activity")
-
-        activity = row_to_dict(row)
-
         # embedding生成（失敗してもactivity作成には影響しない）
         tag_text = " ".join(tag_strings) if tag_strings else ""
         generate_and_store_embedding("activity", activity_id, build_embedding_text(title, description, tag_text))
 
-        result = _activity_to_response(activity, tag_strings)
+        result = {"activity_id": activity_id}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -90,20 +90,13 @@ def add_material(title: str, content: str, tags: list[str], related: list[dict] 
         # タグを取得（commit前）
         tag_strings = get_entity_tags(conn, "material_tags", "material_id", material_id)
 
-        # 作成した資材を取得（commit前）
-        row = conn.execute(
-            "SELECT * FROM materials WHERE id = ?", (material_id,)
-        ).fetchone()
-        if not row:
-            raise Exception("Failed to retrieve created material")
-
         conn.commit()
 
         # embedding生成（失敗してもmaterial作成には影響しない）
         tag_text = " ".join(tag_strings) if tag_strings else ""
         generate_and_store_embedding("material", material_id, build_embedding_text(title, content, tag_text))
 
-        return _material_to_response(row_to_dict(row), tag_strings)
+        return {"material_id": material_id}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/reminder_service.py
+++ b/src/services/reminder_service.py
@@ -44,20 +44,7 @@ def add_reminder(content: str) -> dict:
         reminder_id = cursor.lastrowid
         conn.commit()
 
-        row = conn.execute(
-            "SELECT * FROM reminders WHERE id = ?",
-            (reminder_id,),
-        ).fetchone()
-        if not row:
-            raise Exception("Failed to retrieve created reminder")
-
-        reminder = row_to_dict(row)
-        return {
-            "reminder_id": reminder["id"],
-            "content": reminder["content"],
-            "active": reminder["active"],
-            "created_at": reminder["created_at"],
-        }
+        return {"reminder_id": reminder_id}
 
     except Exception as e:
         conn.rollback()

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -67,16 +67,6 @@ def add_topic(
         # タグを取得
         tag_strings = get_entity_tags(conn, "topic_tags", "topic_id", topic_id)
 
-        # 作成したトピックを取得
-        cursor = conn.execute(
-            "SELECT * FROM discussion_topics WHERE id = ?", (topic_id,)
-        )
-        row = cursor.fetchone()
-        if not row:
-            raise Exception("Failed to retrieve created topic")
-
-        topic = row_to_dict(row)
-
         # embedding生成（失敗してもtopic作成には影響しない）
         tag_text = " ".join(tag_strings) if tag_strings else ""
         embedding_text = build_embedding_text(title, description, tag_text)
@@ -85,13 +75,7 @@ def add_topic(
         # 類似トピックをサジェスト（生成済みembeddingを再利用しHTTPリクエストを削減）
         similar = find_similar_topics(embedding_text, exclude_id=topic_id, embedding=embedding_vec)
 
-        result = {
-            "topic_id": topic["id"],
-            "title": topic["title"],
-            "description": topic["description"],
-            "tags": tag_strings,
-            "created_at": topic["created_at"],
-        }
+        result = {"topic_id": topic_id}
         if similar:
             result["similar_topics"] = similar
         return result

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -51,11 +51,6 @@ class TestAddActivity:
 
         assert "error" not in result
         assert result["activity_id"] > 0
-        assert result["title"] == "New Activity"
-        assert result["description"] == "Activity description"
-        assert result["status"] == "pending"
-        assert "tags" in result
-        assert "domain:test" in result["tags"]
         assert "check_in_result" not in result
 
     def test_add_activity_tags_required(self, temp_db):
@@ -79,7 +74,25 @@ class TestAddActivity:
         )
 
         assert "error" not in result
-        assert sorted(result["tags"]) == ["domain:cc-memory", "hooks"]
+        assert result["activity_id"] > 0
+
+        # DBで直接確認
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT t.namespace, t.name
+                FROM tags t
+                JOIN activity_tags at ON t.id = at.tag_id
+                WHERE at.activity_id = ?
+                ORDER BY t.namespace, t.name
+                """,
+                (result["activity_id"],),
+            ).fetchall()
+            tag_names = sorted(f"{r['namespace']}:{r['name']}" if r['namespace'] else r['name'] for r in rows)
+            assert tag_names == ["domain:cc-memory", "hooks"]
+        finally:
+            conn.close()
 
     def test_add_activity_with_check_in_default(self, temp_db):
         """デフォルト（check_in=True）でcheck_in_resultが含まれる"""
@@ -108,7 +121,6 @@ class TestAddActivity:
         )
 
         assert "error" not in result
-        assert result["status"] == "pending"
         assert "check_in_result" not in result
 
     def test_add_activity_with_related(self, temp_db):

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -48,14 +48,6 @@ class TestAddMaterial:
 
         assert "error" not in result
         assert result["material_id"] > 0
-        assert result["title"] == "Test Material"
-        assert result["content"] == "# Test Content\n\nThis is a test material."
-        assert "tags" in result
-        assert "domain:test" in result["tags"]
-        assert "design" in result["tags"]
-        assert "created_at" in result
-        # activity_idが含まれないこと
-        assert "activity_id" not in result
 
     def test_add_material_with_related(self, activity_id):
         """relatedを指定してリレーション付きで資材を作成できる"""

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -30,10 +30,6 @@ def test_add_topic_with_tags(temp_db):
 
     assert "error" not in result
     assert result["topic_id"] > 0
-    assert result["title"] == "test-topic"
-    assert result["description"] == "テストトピック"
-    assert "domain:test" in result["tags"]
-    assert "created_at" in result
 
 
 def test_add_topic_tags_required(temp_db):
@@ -59,9 +55,6 @@ def test_add_activity_with_tags(temp_db):
 
     assert "error" not in result
     assert result["activity_id"] > 0
-    assert result["title"] == "test-activity"
-    assert result["status"] == "pending"
-    assert "domain:test" in result["tags"]
 
 
 def test_add_activity_tags_required(temp_db):

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -376,7 +376,6 @@ def test_add_topic_succeeds_when_embedding_fails(temp_db, monkeypatch):
 
     assert "error" not in topic
     assert topic["topic_id"] is not None
-    assert topic["title"] == "Embedding失敗テスト"
 
     # vec_indexにはembeddingがない
     rows = execute_query(

--- a/tests/unit/test_reminder_service.py
+++ b/tests/unit/test_reminder_service.py
@@ -27,9 +27,6 @@ class TestAddReminder:
 
         assert "error" not in result
         assert result["reminder_id"] is not None
-        assert result["content"] == "テストリマインダー"
-        assert result["active"] == 1
-        assert result["created_at"] is not None
 
     def test_add_reminder_empty_content(self, temp_db):
         """空文字のcontentでバリデーションエラーになる"""

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -34,11 +34,6 @@ def test_add_topic_success(temp_db):
 
     assert "error" not in result
     assert result["topic_id"] > 0
-    assert result["title"] == "開発フローの詳細"
-    assert result["description"] == "プランモードの使い方、タスク分解の粒度を決定する"
-    assert "tags" in result
-    assert "domain:test" in result["tags"]
-    assert "created_at" in result
 
 
 def test_add_topic_tags_stored(temp_db):
@@ -50,7 +45,6 @@ def test_add_topic_tags_stored(temp_db):
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == ["domain:cc-memory", "hooks", "intent:design"]
 
     # DBで直接確認
     conn = get_connection()
@@ -103,7 +97,25 @@ def test_add_topic_duplicate_tags(temp_db):
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == ["domain:test", "hooks"]
+    assert result["topic_id"] > 0
+
+    # DBで直接確認
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.namespace, t.name
+            FROM tags t
+            JOIN topic_tags tt ON t.id = tt.tag_id
+            WHERE tt.topic_id = ?
+            ORDER BY t.namespace, t.name
+            """,
+            (result["topic_id"],),
+        ).fetchall()
+        tag_names = sorted(f"{r['namespace']}:{r['name']}" if r['namespace'] else r['name'] for r in rows)
+        assert tag_names == ["domain:test", "hooks"]
+    finally:
+        conn.close()
 
 
 def test_add_topic_empty_string_tags(temp_db):
@@ -115,7 +127,25 @@ def test_add_topic_empty_string_tags(temp_db):
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == ["domain:test", "hooks"]
+    assert result["topic_id"] > 0
+
+    # DBで直接確認
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.namespace, t.name
+            FROM tags t
+            JOIN topic_tags tt ON t.id = tt.tag_id
+            WHERE tt.topic_id = ?
+            ORDER BY t.namespace, t.name
+            """,
+            (result["topic_id"],),
+        ).fetchall()
+        tag_names = sorted(f"{r['namespace']}:{r['name']}" if r['namespace'] else r['name'] for r in rows)
+        assert tag_names == ["domain:test", "hooks"]
+    finally:
+        conn.close()
 
 
 def test_add_topic_empty_string_tags_only(temp_db):
@@ -181,7 +211,9 @@ def test_add_log_without_tags(temp_db):
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == sorted(topic["tags"])
+    # topicの継承タグが効いている
+    assert "domain:test" in result["tags"]
+    assert "hooks" in result["tags"]
 
 
 def test_add_log_multiple(temp_db):
@@ -357,7 +389,9 @@ def test_add_decision_without_tags(temp_db):
     )
 
     assert "error" not in result
-    assert sorted(result["tags"]) == sorted(topic["tags"])
+    # topicの継承タグが効いている
+    assert "domain:test" in result["tags"]
+    assert "intent:design" in result["tags"]
 
 
 def test_add_decision_without_topic(temp_db):


### PR DESCRIPTION
## Summary
- add系ツール4つ（add_topic, add_activity, add_material, add_reminder）のレスポンスから、呼び出し側が渡した値のエコーバックを除去
- 各ツールはID + サーバー側で初めて生成される情報のみ返すように変更
  - `add_topic` → `{topic_id, similar_topics}`
  - `add_activity` → `{activity_id, check_in_result}`
  - `add_material` → `{material_id}`
  - `add_reminder` → `{reminder_id}`
- 特に`add_material`のcontent全文返却が最も大きな削減効果
- `add_relation`は既にミニマル（`{added: N}`）なので変更なし
- `add_decision` / `add_log`は複数形作り直し（D#1433）のスコープで扱うため対象外

## Test plan
- [x] 全820テストパス（147秒）
- [ ] 実際のMCPツール呼び出しでレスポンスが削減されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)