### PR TITLE
feat: add_logs/add_decisionsバッチAPI実装

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ check-inするとtag_notes・資材・関連decisionsが一括で返り、status
 
 ## 決定事項の記録
 
-あなたとユーザーが何かに合意したら、`add_decision`または`add_log`で記録してください。
+あなたとユーザーが何かに合意したら、`add_decisions`または`add_logs`で記録してください。
 この記録は、将来あなたの代わりにやってくるAIセッションが一番頼りにするものです。
 記録がなければ、同じ議論を繰り返すことになり、ユーザーとあなたの作業が無駄になります。
 
@@ -189,37 +189,50 @@ def add_topic(
 
 
 @mcp.tool()
-def add_log(
-    topic_id: int,
-    title: Optional[str] = None,
-    content: str = "",
-    tags: Optional[list[str]] = None,
-) -> dict:
-    """トピックに議論ログを追加する。
+def add_logs(items: list[dict]) -> dict:
+    """複数のログを一括追加する（最大10件）。
 
-    title: ログのタイトル。省略するとcontentの先頭行から自動生成される。
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
+    items: ログ情報の配列。各要素は以下のキーを持つ:
+        - topic_id (int, 必須): 対象トピックのID
+        - content (str, 必須): 議論内容（マークダウン可）
+        - title (str, optional): ログのタイトル。省略時はcontentの先頭行から自動生成
+        - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:discuss", "migration", "breaking-change", "schema"]
+
+    Returns: {created: [...], errors: [{index, error}]}
     """
-    result = discussion_log_service.add_log(topic_id, title, content, tags)
-    if "error" not in result and tags:
-        _maybe_inject_tag_notes(result, tags)
+    result = discussion_log_service.add_logs(items)
+    if "error" not in result:
+        # tag_notes: 全アイテムのタグをUNIONして1回注入
+        all_tags = set()
+        for item in items:
+            if item.get("tags"):
+                all_tags.update(item["tags"])
+        if all_tags:
+            _maybe_inject_tag_notes(result, list(all_tags))
     return result
 
 
 @mcp.tool()
-def add_decision(
-    decision: str,
-    reason: str,
-    topic_id: int,
-    tags: Optional[list[str]] = None,
-) -> dict:
-    """決定事項を記録する。
+def add_decisions(items: list[dict]) -> dict:
+    """複数の決定事項を一括記録する（最大10件）。
 
-    tags: 追加タグ（optional）。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
+    items: 決定事項情報の配列。各要素は以下のキーを持つ:
+        - topic_id (int, 必須): 関連するトピックのID
+        - decision (str, 必須): 決定内容
+        - reason (str, 必須): 決定の理由
+        - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
+
+    Returns: {created: [...], errors: [{index, error}]}
     """
-    result = decision_service.add_decision(decision, reason, topic_id, tags)
-    if "error" not in result and tags:
-        _maybe_inject_tag_notes(result, tags)
+    result = decision_service.add_decisions(items)
+    if "error" not in result:
+        # tag_notes: 全アイテムのタグをUNIONして1回注入
+        all_tags = set()
+        for item in items:
+            if item.get("tags"):
+                all_tags.update(item["tags"])
+        if all_tags:
+            _maybe_inject_tag_notes(result, list(all_tags))
     return result
 
 

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -7,78 +7,122 @@ from src.services.tag_service import (
     validate_and_parse_tags,
     ensure_tag_ids,
     link_tags,
-    get_effective_tags,
     get_effective_tags_batch,
+    get_effective_tags_batch_by_ids,
 )
 
 
-def add_decision(
-    decision: str,
-    reason: str,
-    topic_id: int,
-    tags: Optional[list[str]] = None,
-) -> dict:
+def add_decisions(items: list[dict]) -> dict:
     """
-    決定事項を記録する。
+    複数の決定事項を一括記録する（最大10件）。
+
+    SAVEPOINT方式で各アイテムを個別に処理し、部分成功を許容する。
+    embedding生成はcreated分のみ一括で行う。
 
     Args:
-        decision: 決定内容
-        reason: 決定の理由
-        topic_id: 関連するトピックのID（必須）
-        tags: 追加タグ（optional）。省略時はtopicのタグを継承
+        items: 決定事項情報のリスト。各要素は以下のキーを持つ:
+            - topic_id (int, 必須): 関連するトピックのID
+            - decision (str, 必須): 決定内容
+            - reason (str, 必須): 決定の理由
+            - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承
 
     Returns:
-        作成された決定事項情報
+        {created: [...], errors: [{index, error}]}
     """
-    # タグのバリデーション（tagsが指定された場合のみ）
-    parsed_tags = None
-    if tags is not None:
-        parsed_tags = validate_and_parse_tags(tags)
-        if isinstance(parsed_tags, dict):
-            return parsed_tags
+    # バリデーション: 1 <= len(items) <= 10
+    if not items:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "items must not be empty",
+            }
+        }
+    if len(items) > 10:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "items must not exceed 10",
+            }
+        }
+
+    created = []
+    errors = []
 
     conn = get_connection()
     try:
-        # decisionをINSERT
-        cursor = conn.execute(
-            "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
-            (topic_id, decision, reason),
-        )
-        decision_id = cursor.lastrowid
+        for i, item in enumerate(items):
+            conn.execute(f"SAVEPOINT item_{i}")
+            try:
+                topic_id = item.get("topic_id")
+                decision = item.get("decision", "")
+                reason = item.get("reason", "")
+                tags = item.get("tags")
 
-        # タグをリンク（指定された場合のみ）
-        if parsed_tags:
-            tag_ids = ensure_tag_ids(conn, parsed_tags)
-            link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
+                # タグのバリデーション（tagsが指定された場合のみ）
+                parsed_tags = None
+                if tags is not None:
+                    parsed_tags = validate_and_parse_tags(tags)
+                    if isinstance(parsed_tags, dict):
+                        raise ValueError(parsed_tags["error"]["message"])
+
+                # decisionをINSERT
+                cursor = conn.execute(
+                    "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                    (topic_id, decision, reason),
+                )
+                decision_id = cursor.lastrowid
+
+                # タグをリンク（指定された場合のみ）
+                if parsed_tags:
+                    tag_ids = ensure_tag_ids(conn, parsed_tags)
+                    link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
+
+                conn.execute(f"RELEASE SAVEPOINT item_{i}")
+                created.append({
+                    "decision_id": decision_id,
+                    "topic_id": topic_id,
+                    "decision": decision,
+                    "reason": reason,
+                })
+
+            except Exception as e:
+                conn.execute(f"ROLLBACK TO SAVEPOINT item_{i}")
+                conn.execute(f"RELEASE SAVEPOINT item_{i}")
+                error_code = "CONSTRAINT_VIOLATION" if isinstance(e, sqlite3.IntegrityError) else "ITEM_ERROR"
+                errors.append({
+                    "index": i,
+                    "error": {"code": error_code, "message": str(e)},
+                })
 
         conn.commit()
 
-        # 有効タグを取得（topic_tags UNION decision_tags）
-        effective_tags = get_effective_tags(conn, "decision", decision_id)
+        # created分の有効タグを一括取得
+        if created:
+            created_ids = [c["decision_id"] for c in created]
+            tags_map = get_effective_tags_batch_by_ids(conn, "decision", created_ids)
 
-        # embedding生成（失敗してもdecision作成には影響しない）
-        tag_text = " ".join(effective_tags) if effective_tags else ""
-        generate_and_store_embedding("decision", decision_id, build_embedding_text(decision, reason, tag_text))
+            # created_atを一括取得
+            placeholders = ",".join("?" * len(created_ids))
+            rows = conn.execute(
+                f"SELECT id, created_at FROM decisions WHERE id IN ({placeholders})",
+                tuple(created_ids),
+            ).fetchall()
+            created_at_map = {row["id"]: row["created_at"] for row in rows}
 
-        return {
-            "decision_id": decision_id,
-            "topic_id": topic_id,
-            "decision": decision,
-            "reason": reason,
-            "tags": effective_tags,
-            "created_at": row_to_dict(
-                conn.execute("SELECT created_at FROM decisions WHERE id = ?", (decision_id,)).fetchone()
-            )["created_at"],
-        }
+            for c in created:
+                c["tags"] = tags_map.get(c["decision_id"], [])
+                c["created_at"] = created_at_map.get(c["decision_id"])
 
-    except sqlite3.IntegrityError as e:
-        conn.rollback()
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
+            # embedding一括生成（created分のみ。失敗してもエラーにしない）
+            for c in created:
+                tag_text = " ".join(c["tags"]) if c["tags"] else ""
+                generate_and_store_embedding(
+                    "decision", c["decision_id"],
+                    build_embedding_text(c["decision"], c["reason"], tag_text),
+                )
+
+        return {"created": created, "errors": errors}
+
     except Exception as e:
         conn.rollback()
         return {

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -8,90 +8,135 @@ from src.services.tag_service import (
     validate_and_parse_tags,
     ensure_tag_ids,
     link_tags,
-    get_effective_tags,
     get_effective_tags_batch,
+    get_effective_tags_batch_by_ids,
 )
 
 
-def add_log(
-    topic_id: int,
-    title: Optional[str] = None,
-    content: str = "",
-    tags: Optional[list[str]] = None,
-) -> dict:
+def _auto_generate_title(content: str) -> str | None:
+    """contentの先頭行からtitleを自動生成する。生成できない場合はNoneを返す。"""
+    first_line = re.split(r'\n|\\n', content.strip(), maxsplit=1)[0].strip()
+    title = first_line[:50] if len(first_line) > 50 else first_line
+    return title if title else None
+
+
+def add_logs(items: list[dict]) -> dict:
     """
-    トピックに議論ログ（1やりとり）を追加する。
+    複数のログを一括追加する（最大10件）。
+
+    SAVEPOINT方式で各アイテムを個別に処理し、部分成功を許容する。
+    embedding生成はcreated分のみ一括で行う。
 
     Args:
-        topic_id: 対象トピックのID
-        title: ログのタイトル。省略時はcontentの先頭行から自動生成される
-        content: 議論内容（マークダウン可）
-        tags: 追加タグ（optional）。省略時はtopicのタグを継承
+        items: ログ情報のリスト。各要素は以下のキーを持つ:
+            - topic_id (int, 必須): 対象トピックのID
+            - content (str, 必須): 議論内容（マークダウン可）
+            - title (str, optional): ログのタイトル。省略時はcontentの先頭行から自動生成
+            - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承
 
     Returns:
-        作成されたログ情報
+        {created: [...], errors: [{index, error}]}
     """
-    if not title or not title.strip():
-        # titleが未指定・空の場合、contentから自動生成を試みる
-        first_line = re.split(r'\n|\\n', content.strip(), maxsplit=1)[0].strip()
-        title = first_line[:50] if len(first_line) > 50 else first_line
-        if not title:
-            return {
-                "error": {
-                    "code": "VALIDATION_ERROR",
-                    "message": "title and content cannot both be empty"
-                }
+    # バリデーション: 1 <= len(items) <= 10
+    if not items:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "items must not be empty",
             }
+        }
+    if len(items) > 10:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "items must not exceed 10",
+            }
+        }
 
-    # タグのバリデーション（tagsが指定された場合のみ）
-    parsed_tags = None
-    if tags is not None:
-        parsed_tags = validate_and_parse_tags(tags)
-        if isinstance(parsed_tags, dict):
-            return parsed_tags
+    created = []
+    errors = []
 
     conn = get_connection()
     try:
-        # ログをINSERT
-        cursor = conn.execute(
-            "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, ?, ?)",
-            (topic_id, title, content),
-        )
-        log_id = cursor.lastrowid
+        for i, item in enumerate(items):
+            conn.execute(f"SAVEPOINT item_{i}")
+            try:
+                topic_id = item.get("topic_id")
+                content = item.get("content", "")
+                title = item.get("title")
+                tags = item.get("tags")
 
-        # タグをリンク（指定された場合のみ）
-        if parsed_tags:
-            tag_ids = ensure_tag_ids(conn, parsed_tags)
-            link_tags(conn, "log_tags", "log_id", log_id, tag_ids)
+                # title自動生成
+                if not title or not title.strip():
+                    title = _auto_generate_title(content)
+                    if not title:
+                        raise ValueError("title and content cannot both be empty")
+
+                # タグのバリデーション（tagsが指定された場合のみ）
+                parsed_tags = None
+                if tags is not None:
+                    parsed_tags = validate_and_parse_tags(tags)
+                    if isinstance(parsed_tags, dict):
+                        raise ValueError(parsed_tags["error"]["message"])
+
+                # ログをINSERT
+                cursor = conn.execute(
+                    "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, ?, ?)",
+                    (topic_id, title, content),
+                )
+                log_id = cursor.lastrowid
+
+                # タグをリンク（指定された場合のみ）
+                if parsed_tags:
+                    tag_ids = ensure_tag_ids(conn, parsed_tags)
+                    link_tags(conn, "log_tags", "log_id", log_id, tag_ids)
+
+                conn.execute(f"RELEASE SAVEPOINT item_{i}")
+                created.append({
+                    "log_id": log_id,
+                    "topic_id": topic_id,
+                    "title": title,
+                    "content": content,
+                })
+
+            except Exception as e:
+                conn.execute(f"ROLLBACK TO SAVEPOINT item_{i}")
+                conn.execute(f"RELEASE SAVEPOINT item_{i}")
+                error_code = "CONSTRAINT_VIOLATION" if isinstance(e, sqlite3.IntegrityError) else "ITEM_ERROR"
+                errors.append({
+                    "index": i,
+                    "error": {"code": error_code, "message": str(e)},
+                })
 
         conn.commit()
 
-        # 有効タグを取得（topic_tags UNION log_tags）
-        effective_tags = get_effective_tags(conn, "log", log_id)
+        # created分の有効タグを一括取得
+        if created:
+            created_ids = [c["log_id"] for c in created]
+            tags_map = get_effective_tags_batch_by_ids(conn, "log", created_ids)
 
-        # embedding生成（失敗してもlog作成には影響しない）
-        tag_text = " ".join(effective_tags) if effective_tags else ""
-        generate_and_store_embedding("log", log_id, build_embedding_text(title, content, tag_text))
+            # created_atを一括取得
+            placeholders = ",".join("?" * len(created_ids))
+            rows = conn.execute(
+                f"SELECT id, created_at FROM discussion_logs WHERE id IN ({placeholders})",
+                tuple(created_ids),
+            ).fetchall()
+            created_at_map = {row["id"]: row["created_at"] for row in rows}
 
-        return {
-            "log_id": log_id,
-            "topic_id": topic_id,
-            "title": title,
-            "content": content,
-            "tags": effective_tags,
-            "created_at": row_to_dict(
-                conn.execute("SELECT created_at FROM discussion_logs WHERE id = ?", (log_id,)).fetchone()
-            )["created_at"],
-        }
+            for c in created:
+                c["tags"] = tags_map.get(c["log_id"], [])
+                c["created_at"] = created_at_map.get(c["log_id"])
 
-    except sqlite3.IntegrityError as e:
-        conn.rollback()
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
+            # embedding一括生成（created分のみ。失敗してもエラーにしない）
+            for c in created:
+                tag_text = " ".join(c["tags"]) if c["tags"] else ""
+                generate_and_store_embedding(
+                    "log", c["log_id"],
+                    build_embedding_text(c["title"], c["content"], tag_text),
+                )
+
+        return {"created": created, "errors": errors}
+
     except Exception as e:
         conn.rollback()
         return {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,70 @@
+"""テスト用互換ヘルパー
+
+add_logs / add_decisions のバッチAPIを単件呼び出し形式でラップする。
+旧 add_log / add_decision と同じインターフェースを提供する。
+"""
+from typing import Optional
+from src.services.discussion_log_service import add_logs
+from src.services.decision_service import add_decisions
+
+
+def add_log(
+    topic_id: int,
+    title: Optional[str] = None,
+    content: str = "",
+    tags: Optional[list[str]] = None,
+) -> dict:
+    """単件のログ追加（add_logsのラッパー）。旧add_logと同じ戻り値形式を返す。"""
+    item = {"topic_id": topic_id, "content": content}
+    if title is not None:
+        item["title"] = title
+    if tags is not None:
+        item["tags"] = tags
+    result = add_logs([item])
+    # バッチAPIのトップレベルエラー（バリデーションエラー等）
+    if "error" in result:
+        return result
+    # アイテムレベルのエラー
+    if result["errors"]:
+        err = result["errors"][0]["error"]
+        return {"error": err}
+    # 成功
+    c = result["created"][0]
+    return {
+        "log_id": c["log_id"],
+        "topic_id": c["topic_id"],
+        "title": c["title"],
+        "content": c["content"],
+        "tags": c.get("tags", []),
+        "created_at": c.get("created_at"),
+    }
+
+
+def add_decision(
+    decision: str,
+    reason: str,
+    topic_id: int,
+    tags: Optional[list[str]] = None,
+) -> dict:
+    """単件の決定事項追加（add_decisionsのラッパー）。旧add_decisionと同じ戻り値形式を返す。"""
+    item = {"topic_id": topic_id, "decision": decision, "reason": reason}
+    if tags is not None:
+        item["tags"] = tags
+    result = add_decisions([item])
+    # バッチAPIのトップレベルエラー
+    if "error" in result:
+        return result
+    # アイテムレベルのエラー
+    if result["errors"]:
+        err = result["errors"][0]["error"]
+        return {"error": err}
+    # 成功
+    c = result["created"][0]
+    return {
+        "decision_id": c["decision_id"],
+        "topic_id": c["topic_id"],
+        "decision": c["decision"],
+        "reason": c["reason"],
+        "tags": c.get("tags", []),
+        "created_at": c.get("created_at"),
+    }

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
-from src.services.decision_service import add_decision
+from tests.helpers import add_decision
 from src.services.material_service import add_material
 from src.services.relation_service import add_relation
 from src.services.topic_service import add_topic

--- a/tests/integration/test_edge_cases.py
+++ b/tests/integration/test_edge_cases.py
@@ -5,7 +5,7 @@ import sqlite3
 import pytest
 from src.db import init_database
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
+from tests.helpers import add_decision
 
 
 DEFAULT_TAGS = ["domain:test"]

--- a/tests/unit/test_batch_logs_decisions.py
+++ b/tests/unit/test_batch_logs_decisions.py
@@ -1,0 +1,686 @@
+"""add_logs / add_decisions バッチAPI のテスト
+
+V1-V10 の受け入れ基準をカバーする。
+"""
+import os
+import tempfile
+import pytest
+import numpy as np
+from unittest.mock import patch
+
+from src.db import init_database, get_connection, execute_query
+from src.services.topic_service import add_topic
+from src.services.discussion_log_service import add_logs
+from src.services.decision_service import add_decisions
+from src.services.tag_service import _injected_tags
+import src.services.embedding_service as emb
+
+
+EMBEDDING_DIM = 384
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def topic2(temp_db):
+    """テスト用トピック2を作成する"""
+    return add_topic(title="テストトピック2", description="テスト用2", tags=["domain:test", "extra"])
+
+
+@pytest.fixture
+def mock_embedding_server(monkeypatch):
+    """embedding_serverへのHTTPリクエストをモック化"""
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            np.random.seed(hash(prefix_str + text) % (2**32))
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    yield
+
+
+# ========================================
+# V1: 3件一括登録が成功する
+# ========================================
+
+
+class TestV1BatchSuccess:
+    """V1: 3件一括登録が成功する"""
+
+    def test_add_logs_batch_3_items(self, topic):
+        """add_logsで3件一括登録が成功する"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "ログ1の内容", "title": "タイトル1"},
+            {"topic_id": tid, "content": "ログ2の内容", "title": "タイトル2"},
+            {"topic_id": tid, "content": "ログ3の内容", "title": "タイトル3"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 3
+        assert len(result["errors"]) == 0
+
+        for i, c in enumerate(result["created"]):
+            assert c["log_id"] > 0
+            assert c["topic_id"] == tid
+            assert c["title"] == f"タイトル{i + 1}"
+            assert c["content"] == f"ログ{i + 1}の内容"
+            assert "tags" in c
+            assert "created_at" in c
+
+    def test_add_decisions_batch_3_items(self, topic):
+        """add_decisionsで3件一括登録が成功する"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "決定1", "reason": "理由1"},
+            {"topic_id": tid, "decision": "決定2", "reason": "理由2"},
+            {"topic_id": tid, "decision": "決定3", "reason": "理由3"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 3
+        assert len(result["errors"]) == 0
+
+        for i, c in enumerate(result["created"]):
+            assert c["decision_id"] > 0
+            assert c["topic_id"] == tid
+            assert c["decision"] == f"決定{i + 1}"
+            assert c["reason"] == f"理由{i + 1}"
+            assert "tags" in c
+            assert "created_at" in c
+
+
+# ========================================
+# V2: 1件の配列ラップで正常動作する
+# ========================================
+
+
+class TestV2SingleItem:
+    """V2: 1件の配列ラップで正常動作する"""
+
+    def test_add_logs_single_item(self, topic):
+        """1件のログを配列ラップで登録"""
+        result = add_logs([
+            {"topic_id": topic["topic_id"], "content": "単件ログ", "title": "単件タイトル"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 0
+        assert result["created"][0]["title"] == "単件タイトル"
+
+    def test_add_decisions_single_item(self, topic):
+        """1件の決定事項を配列ラップで登録"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "単件決定", "reason": "単件理由"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 0
+        assert result["created"][0]["decision"] == "単件決定"
+
+
+# ========================================
+# V3: 存在しないtopic_id混在で部分成功する
+# ========================================
+
+
+class TestV3PartialSuccessInvalidTopic:
+    """V3: 存在しないtopic_id混在で部分成功する"""
+
+    def test_add_logs_partial_success_invalid_topic(self, topic):
+        """存在しないtopic_idを含むバッチで部分成功"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "成功するログ", "title": "成功"},
+            {"topic_id": 99999, "content": "失敗するログ", "title": "失敗"},
+            {"topic_id": tid, "content": "もう一つ成功", "title": "成功2"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+        assert result["created"][0]["title"] == "成功"
+        assert result["created"][1]["title"] == "成功2"
+
+    def test_add_decisions_partial_success_invalid_topic(self, topic):
+        """存在しないtopic_idを含むバッチで部分成功"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "成功する決定", "reason": "理由"},
+            {"topic_id": 99999, "decision": "失敗する決定", "reason": "理由"},
+            {"topic_id": tid, "decision": "もう一つ成功", "reason": "理由"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+
+# ========================================
+# V4: 不正tags混在で部分成功する
+# ========================================
+
+
+class TestV4PartialSuccessInvalidTags:
+    """V4: 不正tags混在で部分成功する"""
+
+    def test_add_logs_partial_success_invalid_tags(self, topic):
+        """不正なタグを含むバッチで部分成功"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "成功するログ", "title": "成功", "tags": ["domain:test"]},
+            {"topic_id": tid, "content": "失敗するログ", "title": "失敗", "tags": ["bad:namespace"]},
+            {"topic_id": tid, "content": "もう一つ成功", "title": "成功2"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+    def test_add_decisions_partial_success_invalid_tags(self, topic):
+        """不正なタグを含むバッチで部分成功"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "成功", "reason": "理由", "tags": ["domain:test"]},
+            {"topic_id": tid, "decision": "失敗", "reason": "理由", "tags": ["bad:ns"]},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+
+# ========================================
+# V5: 全件失敗で {created: [], errors: [...]} が返る
+# ========================================
+
+
+class TestV5AllFail:
+    """V5: 全件失敗で {created: [], errors: [...]} が返る"""
+
+    def test_add_logs_all_fail(self, temp_db):
+        """全件が存在しないtopic_idの場合、全件エラー"""
+        result = add_logs([
+            {"topic_id": 99999, "content": "失敗1", "title": "失敗1"},
+            {"topic_id": 99998, "content": "失敗2", "title": "失敗2"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 0
+        assert len(result["errors"]) == 2
+        assert result["errors"][0]["index"] == 0
+        assert result["errors"][1]["index"] == 1
+
+    def test_add_decisions_all_fail(self, temp_db):
+        """全件が存在しないtopic_idの場合、全件エラー"""
+        result = add_decisions([
+            {"topic_id": 99999, "decision": "失敗1", "reason": "理由1"},
+            {"topic_id": 99998, "decision": "失敗2", "reason": "理由2"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 0
+        assert len(result["errors"]) == 2
+
+
+# ========================================
+# V6: 空配列でバリデーションエラー
+# ========================================
+
+
+class TestV6EmptyArray:
+    """V6: 空配列でバリデーションエラー"""
+
+    def test_add_logs_empty_array(self, temp_db):
+        """空配列でVALIDATION_ERRORが返る"""
+        result = add_logs([])
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "empty" in result["error"]["message"]
+
+    def test_add_decisions_empty_array(self, temp_db):
+        """空配列でVALIDATION_ERRORが返る"""
+        result = add_decisions([])
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "empty" in result["error"]["message"]
+
+
+# ========================================
+# V7: 11件でバリデーションエラー
+# ========================================
+
+
+class TestV7ExceedLimit:
+    """V7: 11件でバリデーションエラー"""
+
+    def test_add_logs_exceed_limit(self, topic):
+        """11件でVALIDATION_ERRORが返る"""
+        items = [
+            {"topic_id": topic["topic_id"], "content": f"ログ{i}", "title": f"タイトル{i}"}
+            for i in range(11)
+        ]
+        result = add_logs(items)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "10" in result["error"]["message"]
+
+    def test_add_decisions_exceed_limit(self, topic):
+        """11件でVALIDATION_ERRORが返る"""
+        items = [
+            {"topic_id": topic["topic_id"], "decision": f"決定{i}", "reason": f"理由{i}"}
+            for i in range(11)
+        ]
+        result = add_decisions(items)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "10" in result["error"]["message"]
+
+    def test_add_logs_10_items_succeeds(self, topic):
+        """10件は正常に登録される"""
+        tid = topic["topic_id"]
+        items = [
+            {"topic_id": tid, "content": f"ログ{i}", "title": f"タイトル{i}"}
+            for i in range(10)
+        ]
+        result = add_logs(items)
+
+        assert "error" not in result
+        assert len(result["created"]) == 10
+        assert len(result["errors"]) == 0
+
+
+# ========================================
+# V8: title自動生成（\n/\\n対応）が動作する
+# ========================================
+
+
+class TestV8TitleAutoGenerate:
+    """V8: title自動生成が動作する"""
+
+    def test_add_logs_title_auto_from_content(self, topic):
+        """title省略時にcontentの先頭行から自動生成"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "先頭行がタイトルになる\n2行目は含まない"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert result["created"][0]["title"] == "先頭行がタイトルになる"
+
+    def test_add_logs_title_auto_literal_backslash_n(self, topic):
+        """リテラルの\\nでも分割される"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "リテラル分割テスト\\nこの部分は含まない"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert result["created"][0]["title"] == "リテラル分割テスト"
+
+    def test_add_logs_title_auto_truncate_50(self, topic):
+        """50文字を超えるtitleは50文字で切り詰められる"""
+        tid = topic["topic_id"]
+        long_content = "あ" * 60
+        result = add_logs([
+            {"topic_id": tid, "content": long_content},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["created"][0]["title"]) == 50
+
+    def test_add_logs_title_empty_content_empty_error(self, topic):
+        """title未指定でcontent空の場合はエラー"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "正常ログ", "title": "正常"},
+            {"topic_id": tid, "content": ""},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+    def test_add_logs_explicit_title_unchanged(self, topic):
+        """明示的にtitleを指定した場合は自動生成しない"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "別の内容", "title": "明示的タイトル"},
+        ])
+
+        assert "error" not in result
+        assert result["created"][0]["title"] == "明示的タイトル"
+
+
+# ========================================
+# V9: created分のみembeddingが存在する
+# ========================================
+
+
+class TestV9EmbeddingCreatedOnly:
+    """V9: created分のみembeddingが存在する"""
+
+    def test_add_logs_embedding_for_created_only(self, topic, mock_embedding_server):
+        """部分成功時、created分のみembeddingが生成される"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "成功ログ", "title": "成功"},
+            {"topic_id": 99999, "content": "失敗ログ", "title": "失敗"},
+        ])
+
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 1
+
+        # created分のembeddingが存在する
+        log_id = result["created"][0]["log_id"]
+        rows = execute_query(
+            "SELECT id FROM search_index WHERE source_type = ? AND source_id = ?",
+            ("log", log_id),
+        )
+        assert len(rows) > 0
+        search_index_id = rows[0]["id"]
+
+        conn = get_connection()
+        try:
+            cursor = conn.execute("SELECT count(*) FROM vec_index WHERE rowid = ?", (search_index_id,))
+            count = cursor.fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_add_decisions_embedding_for_created_only(self, topic, mock_embedding_server):
+        """部分成功時、created分のみembeddingが生成される"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "成功決定", "reason": "理由"},
+            {"topic_id": 99999, "decision": "失敗決定", "reason": "理由"},
+        ])
+
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 1
+
+        # created分のembeddingが存在する
+        dec_id = result["created"][0]["decision_id"]
+        rows = execute_query(
+            "SELECT id FROM search_index WHERE source_type = ? AND source_id = ?",
+            ("decision", dec_id),
+        )
+        assert len(rows) > 0
+        search_index_id = rows[0]["id"]
+
+        conn = get_connection()
+        try:
+            cursor = conn.execute("SELECT count(*) FROM vec_index WHERE rowid = ?", (search_index_id,))
+            count = cursor.fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+
+# ========================================
+# V10: tag_notesが全タグUNIONで注入される
+# ========================================
+
+
+class TestV10TagNotesUnion:
+    """V10: tag_notesが全タグUNIONで注入される
+
+    main.pyのMCPハンドラでのtag_notes注入ロジックをテストする。
+    @mcp.tool()デコレータされた関数は直接呼べないため、
+    _maybe_inject_tag_notesと全タグUNIONロジックを直接テストする。
+    """
+
+    def test_add_logs_tag_notes_union(self, temp_db):
+        """全アイテムのタグUNIONでtag_notesが注入される"""
+        from src.main import _maybe_inject_tag_notes
+
+        # tag_notesを持つタグを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "withnotes", "重要な教訓"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        topic = add_topic(title="テスト", description="テスト", tags=["domain:withnotes"])
+        tid = topic["topic_id"]
+
+        # サービス層を直接呼ぶ
+        items = [
+            {"topic_id": tid, "content": "ログ1", "title": "タイトル1", "tags": ["domain:withnotes"]},
+            {"topic_id": tid, "content": "ログ2", "title": "タイトル2"},
+        ]
+        result = add_logs(items)
+        assert "error" not in result
+
+        # main.pyのハンドラが行うのと同じロジック: 全アイテムのタグUNION
+        all_tags = set()
+        for item in items:
+            if item.get("tags"):
+                all_tags.update(item["tags"])
+        assert "domain:withnotes" in all_tags
+
+        # tag_notes注入
+        if all_tags:
+            _maybe_inject_tag_notes(result, list(all_tags))
+
+        assert "tag_notes" in result
+        tag_note_tags = [tn["tag"] for tn in result["tag_notes"]]
+        assert "domain:withnotes" in tag_note_tags
+
+    def test_add_decisions_tag_notes_union(self, temp_db):
+        """全アイテムのタグUNIONでtag_notesが注入される"""
+        from src.main import _maybe_inject_tag_notes
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "withnotes2", "決定の教訓"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        topic = add_topic(title="テスト", description="テスト", tags=["domain:withnotes2"])
+        tid = topic["topic_id"]
+
+        items = [
+            {"topic_id": tid, "decision": "決定1", "reason": "理由1", "tags": ["domain:withnotes2"]},
+            {"topic_id": tid, "decision": "決定2", "reason": "理由2"},
+        ]
+        result = add_decisions(items)
+        assert "error" not in result
+
+        all_tags = set()
+        for item in items:
+            if item.get("tags"):
+                all_tags.update(item["tags"])
+
+        if all_tags:
+            _maybe_inject_tag_notes(result, list(all_tags))
+
+        assert "tag_notes" in result
+        tag_note_tags = [tn["tag"] for tn in result["tag_notes"]]
+        assert "domain:withnotes2" in tag_note_tags
+
+    def test_tag_notes_union_multiple_tags(self, temp_db):
+        """複数アイテムのタグがすべてUNIONされる"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "tag-a", "教訓A"),
+            )
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "tag-b", "教訓B"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # 全タグUNIONロジックのテスト
+        items = [
+            {"topic_id": 1, "content": "1", "tags": ["domain:tag-a"]},
+            {"topic_id": 1, "content": "2", "tags": ["domain:tag-b"]},
+            {"topic_id": 1, "content": "3"},  # tagsなし
+        ]
+        all_tags = set()
+        for item in items:
+            if item.get("tags"):
+                all_tags.update(item["tags"])
+
+        assert all_tags == {"domain:tag-a", "domain:tag-b"}
+
+
+# ========================================
+# 追加テスト: タグの継承と個別指定
+# ========================================
+
+
+class TestTagInheritance:
+    """tags省略時のtopic継承と個別指定"""
+
+    def test_add_logs_tags_inherited_from_topic(self, topic):
+        """tags省略時にtopicのタグが継承される"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "タグ省略ログ", "title": "タグなし"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        # topicのタグ（domain:test）が継承される
+        assert "domain:test" in result["created"][0]["tags"]
+
+    def test_add_logs_tags_individual(self, topic):
+        """個別タグ指定時はtopicタグとマージされる"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "タグ個別ログ", "title": "タグあり", "tags": ["intent:discuss"]},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        tags = result["created"][0]["tags"]
+        assert "domain:test" in tags
+        assert "intent:discuss" in tags
+
+    def test_add_decisions_tags_inherited_from_topic(self, topic):
+        """tags省略時にtopicのタグが継承される"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "タグ省略決定", "reason": "理由"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert "domain:test" in result["created"][0]["tags"]
+
+    def test_add_logs_mixed_topics(self, topic, topic2):
+        """異なるtopic_idのアイテムが混在しても正しく処理される"""
+        result = add_logs([
+            {"topic_id": topic["topic_id"], "content": "トピック1ログ", "title": "T1"},
+            {"topic_id": topic2["topic_id"], "content": "トピック2ログ", "title": "T2"},
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 2
+        assert result["created"][0]["topic_id"] == topic["topic_id"]
+        assert result["created"][1]["topic_id"] == topic2["topic_id"]
+
+
+# ========================================
+# 追加テスト: SAVEPOINTによるアトミック性
+# ========================================
+
+
+class TestSavepointAtomicity:
+    """SAVEPOINTによる部分ロールバックの確認"""
+
+    def test_failed_item_does_not_affect_others_logs(self, topic):
+        """失敗アイテムが成功アイテムに影響しない"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "1番目", "title": "成功1"},
+            {"topic_id": 99999, "content": "2番目失敗"},
+            {"topic_id": tid, "content": "3番目", "title": "成功3"},
+        ])
+
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+        # DBに2件だけ存在することを確認
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT COUNT(*) FROM discussion_logs WHERE topic_id = ?",
+                (tid,),
+            ).fetchone()
+            assert rows[0] == 2
+        finally:
+            conn.close()
+
+    def test_failed_item_does_not_affect_others_decisions(self, topic):
+        """失敗アイテムが成功アイテムに影響しない"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "成功1", "reason": "理由"},
+            {"topic_id": 99999, "decision": "失敗", "reason": "理由"},
+            {"topic_id": tid, "decision": "成功2", "reason": "理由"},
+        ])
+
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT COUNT(*) FROM decisions WHERE topic_id = ?",
+                (tid,),
+            ).fetchone()
+            assert rows[0] == 2
+        finally:
+            conn.close()

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from src.db import init_database, get_connection, execute_query
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
+from tests.helpers import add_decision
 from src.services.activity_service import add_activity
 import src.services.embedding_service as emb
 

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -4,9 +4,8 @@ import tempfile
 import pytest
 from src.db import init_database
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
-from src.services.discussion_log_service import add_log as add_log_entry
+from tests.helpers import add_log as add_log_entry, add_decision
 from src.services.material_service import add_material
 from src.services import search_service
 import src.services.embedding_service as emb

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -20,9 +20,8 @@ from src.services.search_service import (
 )
 from src.services import search_service
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
-from src.services.discussion_log_service import add_log
+from tests.helpers import add_log, add_decision
 from src.services.material_service import add_material
 import src.services.embedding_service as emb
 

--- a/tests/unit/test_search_tags.py
+++ b/tests/unit/test_search_tags.py
@@ -4,9 +4,8 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
-from src.services.discussion_log_service import add_log
+from tests.helpers import add_log, add_decision
 from src.services.tag_service import search_tags, _SEARCH_TAGS_RRF_K
 import src.services.embedding_service as emb
 

--- a/tests/unit/test_tag_alias.py
+++ b/tests/unit/test_tag_alias.py
@@ -17,9 +17,8 @@ from src.services.tag_service import (
 )
 from src.services.search_service import _resolve_tag_ids_readonly
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
-from src.services.discussion_log_service import add_log
+from tests.helpers import add_log, add_decision
 import src.services.embedding_service as emb
 
 

--- a/tests/unit/test_tag_analysis.py
+++ b/tests/unit/test_tag_analysis.py
@@ -7,9 +7,8 @@ import pytest
 
 from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
 from src.services.activity_service import add_activity
-from src.services.discussion_log_service import add_log
+from tests.helpers import add_log, add_decision
 from src.services.tag_analysis_service import (
     analyze_tags,
     calc_pmi,

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -15,7 +15,7 @@ from src.services.tag_service import (
     _injected_tags,
 )
 from src.services.topic_service import add_topic
-from src.services.decision_service import add_decision
+from tests.helpers import add_decision
 from src.services.search_service import get_by_ids
 import src.services.embedding_service as emb
 

--- a/tests/unit/test_tag_service.py
+++ b/tests/unit/test_tag_service.py
@@ -320,7 +320,7 @@ class TestGetEffectiveTagsBatch:
     def test_batch_returns_topic_tags(self, temp_db):
         """topicのタグがdecisionに継承される"""
         from src.services.topic_service import add_topic
-        from src.services.decision_service import add_decision
+        from tests.helpers import add_decision
 
         topic = add_topic(title="Test", description="Test", tags=["domain:test"])
         dec = add_decision(
@@ -340,7 +340,7 @@ class TestGetEffectiveTagsBatch:
     def test_batch_includes_entity_tags(self, temp_db):
         """entity個別タグも含まれる"""
         from src.services.topic_service import add_topic
-        from src.services.decision_service import add_decision
+        from tests.helpers import add_decision
 
         topic = add_topic(title="Test", description="Test", tags=["domain:test"])
         dec = add_decision(
@@ -376,7 +376,7 @@ class TestGetEffectiveTagsBatch:
     def test_batch_multiple_entities(self, temp_db):
         """複数entityのタグを一括取得"""
         from src.services.topic_service import add_topic
-        from src.services.discussion_log_service import add_log
+        from tests.helpers import add_log
 
         topic = add_topic(title="Test", description="Test", tags=["domain:test"])
         log1 = add_log(topic_id=topic["topic_id"], title="Log 1", content="Content 1")

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -11,8 +11,9 @@ from src.services.topic_service import (
     add_topic,
     get_topics,
 )
-from src.services.discussion_log_service import add_log, get_logs
-from src.services.decision_service import add_decision, get_decisions
+from tests.helpers import add_log, add_decision
+from src.services.discussion_log_service import get_logs
+from src.services.decision_service import get_decisions
 
 
 DEFAULT_TAGS = ["domain:test"]

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -4,8 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
-from src.services.discussion_log_service import add_log
-from src.services.decision_service import add_decision
+from tests.helpers import add_log, add_decision
 
 
 @pytest.fixture
@@ -288,7 +287,7 @@ def test_add_log_title_none_content_empty_error(temp_db):
     )
 
     assert "error" in result
-    assert result["error"]["code"] == "VALIDATION_ERROR"
+    assert result["error"]["code"] == "ITEM_ERROR"
     assert "title and content cannot both be empty" in result["error"]["message"]
 
 


### PR DESCRIPTION
## Summary
- `add_log`/`add_decision`を廃止し、`add_logs`/`add_decisions`（複数形バッチAPI）に置き換え
- SAVEPOINT方式で部分成功を実現（最大10件）
- 各アイテムにtopic_id/tags個別指定、レスポンス形式: `{created: [...], errors: [{index, error}]}`
- `tests/helpers.py`で既存テスト12ファイルの互換ラッパーを提供

## Related
- cc-memory activity: #558
- decisions: #1433, #1434, #1435, #1440, #1441

## Test plan
- [x] 3件一括登録成功（V1）
- [x] 1件配列ラップ正常動作（V2）
- [x] 存在しないtopic_id混在で部分成功（V3）
- [x] 不正tags混在で部分成功（V4）
- [x] 全件失敗（V5）
- [x] 空配列バリデーションエラー（V6）
- [x] 上限超過11件バリデーションエラー（V7）
- [x] title自動生成（V8）
- [x] embedding生成（V9）
- [x] tag_notes全タグUNION注入（V10）
- [x] 全851テストパス（既存820 + 新規31）

🤖 Generated with [Claude Code](https://claude.com/claude-code)