### PR TITLE
refactor: add_logs/add_decisions/update_activity/update_materialのレスポンスを削減

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -29,19 +29,6 @@ ACTIVE_STATUSES = ("in_progress", "pending")
 VALID_STATUSES = REAL_STATUSES | {"active"}
 
 
-def _activity_to_response(activity: dict, tags: list[str]) -> dict:
-    """アクティビティデータをAPIレスポンス形式に変換"""
-    return {
-        "activity_id": activity["id"],
-        "title": activity["title"],
-        "description": activity["description"],
-        "status": activity["status"],
-        "tags": tags,
-        "created_at": activity["created_at"],
-        "updated_at": activity["updated_at"],
-    }
-
-
 def add_activity(
     title: str,
     description: str,
@@ -486,7 +473,7 @@ def update_activity(
                 build_embedding_text(updated["title"], updated["description"], tag_text),
             )
 
-        return _activity_to_response(row_to_dict(row), tag_strings)
+        return {"activity_id": activity_id, "status": row["status"]}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -464,16 +464,17 @@ def update_activity(
         # タグを取得
         tag_strings = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
 
+        updated = row_to_dict(row)
+
         # title/description/tagsが変更された場合、embeddingを再生成
         if title is not None or description is not None or parsed_tags is not None:
-            updated = row_to_dict(row)
             tag_text = " ".join(tag_strings) if tag_strings else ""
             generate_and_store_embedding(
                 "activity", activity_id,
                 build_embedding_text(updated["title"], updated["description"], tag_text),
             )
 
-        return {"activity_id": activity_id, "status": row["status"]}
+        return {"activity_id": activity_id, "status": updated["status"]}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -121,6 +121,14 @@ def add_decisions(items: list[dict]) -> dict:
                     build_embedding_text(c["decision"], c["reason"], tag_text),
                 )
 
+            # レスポンス軽量化: embedding生成後にdecision_id以外を除去
+            for c in created:
+                c.pop("decision", None)
+                c.pop("reason", None)
+                c.pop("topic_id", None)
+                c.pop("tags", None)
+                c.pop("created_at", None)
+
         return {"created": created, "errors": errors}
 
     except Exception as e:

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -135,6 +135,10 @@ def add_logs(items: list[dict]) -> dict:
                     build_embedding_text(c["title"], c["content"], tag_text),
                 )
 
+            # レスポンス軽量化: embedding生成後にcontentを除去
+            for c in created:
+                c.pop("content", None)
+
         return {"created": created, "errors": errors}
 
     except Exception as e:

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -237,10 +237,7 @@ def update_material(
             build_embedding_text(updated["title"], updated["content"], tag_text),
         )
 
-        result = _material_to_response(updated, tag_strings)
-        if content is not None:
-            result["hint"] = "contentの先頭1-2文は内容の説明・要約を書いてください。check-inやsearchのsnippetに使われます。"
-        return result
+        return {"material_id": material_id}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,15 +29,7 @@ def add_log(
         err = result["errors"][0]["error"]
         return {"error": err}
     # 成功
-    c = result["created"][0]
-    return {
-        "log_id": c["log_id"],
-        "topic_id": c["topic_id"],
-        "title": c["title"],
-        "content": c["content"],
-        "tags": c.get("tags", []),
-        "created_at": c.get("created_at"),
-    }
+    return result["created"][0]
 
 
 def add_decision(
@@ -59,12 +51,4 @@ def add_decision(
         err = result["errors"][0]["error"]
         return {"error": err}
     # 成功
-    c = result["created"][0]
-    return {
-        "decision_id": c["decision_id"],
-        "topic_id": c["topic_id"],
-        "decision": c["decision"],
-        "reason": c["reason"],
-        "tags": c.get("tags", []),
-        "created_at": c.get("created_at"),
-    }
+    return result["created"][0]

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -274,10 +274,10 @@ class TestUpdateMaterial:
 
         assert "error" not in result
         assert result["material_id"] == material_id
-        assert result["content"] == "Updated content"
-        assert result["title"] == "Original Title"  # unchanged
-        assert "hint" in result
-        assert sorted(result["tags"]) == sorted(["design", "domain:test"])
+        # レスポンス軽量化: material_idのみ
+        assert "content" not in result
+        assert "title" not in result
+        assert "tags" not in result
 
     def test_update_title(self, temp_db):
         """Updating title only succeeds"""
@@ -288,10 +288,10 @@ class TestUpdateMaterial:
 
         assert "error" not in result
         assert result["material_id"] == material_id
-        assert result["title"] == "Updated Title"
-        assert result["content"] == "Original content"  # unchanged
-        assert "hint" in result
-        assert sorted(result["tags"]) == sorted(["design", "domain:test"])
+        # レスポンス軽量化: material_idのみ
+        assert "title" not in result
+        assert "content" not in result
+        assert "tags" not in result
 
     def test_update_both(self, temp_db):
         """Updating both content and title succeeds"""
@@ -302,9 +302,9 @@ class TestUpdateMaterial:
 
         assert "error" not in result
         assert result["material_id"] == material_id
-        assert result["title"] == "New Title"
-        assert result["content"] == "New content"
-        assert "hint" in result
+        # レスポンス軽量化: material_idのみ
+        assert "content" not in result
+        assert "title" not in result
 
     def test_update_neither_returns_validation_error(self, temp_db):
         """Providing neither content nor title returns VALIDATION_ERROR"""

--- a/tests/unit/test_batch_logs_decisions.py
+++ b/tests/unit/test_batch_logs_decisions.py
@@ -87,7 +87,7 @@ class TestV1BatchSuccess:
             assert c["log_id"] > 0
             assert c["topic_id"] == tid
             assert c["title"] == f"タイトル{i + 1}"
-            assert c["content"] == f"ログ{i + 1}の内容"
+            assert "content" not in c  # レスポンス軽量化
             assert "tags" in c
             assert "created_at" in c
 
@@ -106,11 +106,12 @@ class TestV1BatchSuccess:
 
         for i, c in enumerate(result["created"]):
             assert c["decision_id"] > 0
-            assert c["topic_id"] == tid
-            assert c["decision"] == f"決定{i + 1}"
-            assert c["reason"] == f"理由{i + 1}"
-            assert "tags" in c
-            assert "created_at" in c
+            # レスポンス軽量化: decision_idのみ含まれる
+            assert "topic_id" not in c
+            assert "decision" not in c
+            assert "reason" not in c
+            assert "tags" not in c
+            assert "created_at" not in c
 
 
 # ========================================
@@ -141,7 +142,7 @@ class TestV2SingleItem:
         assert "error" not in result
         assert len(result["created"]) == 1
         assert len(result["errors"]) == 0
-        assert result["created"][0]["decision"] == "単件決定"
+        assert result["created"][0]["decision_id"] > 0
 
 
 # ========================================
@@ -608,7 +609,7 @@ class TestTagInheritance:
         assert "intent:discuss" in tags
 
     def test_add_decisions_tags_inherited_from_topic(self, topic):
-        """tags省略時にtopicのタグが継承される"""
+        """tags省略時にtopicのタグが継承される（レスポンスにはdecision_idのみ）"""
         tid = topic["topic_id"]
         result = add_decisions([
             {"topic_id": tid, "decision": "タグ省略決定", "reason": "理由"},
@@ -616,7 +617,9 @@ class TestTagInheritance:
 
         assert "error" not in result
         assert len(result["created"]) == 1
-        assert "domain:test" in result["created"][0]["tags"]
+        assert result["created"][0]["decision_id"] > 0
+        # レスポンス軽量化: tagsは含まれない
+        assert "tags" not in result["created"][0]
 
     def test_add_logs_mixed_topics(self, topic, topic2):
         """異なるtopic_idのアイテムが混在しても正しく処理される"""

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -175,7 +175,7 @@ def test_add_log_success(temp_db):
     assert result["log_id"] > 0
     assert result["topic_id"] == topic["topic_id"]
     assert result["title"] == "プランモードの議論"
-    assert "AI: プランモードは設計議論フェーズでは不要だと考えます" in result["content"]
+    assert "content" not in result
     assert "tags" in result
     # tagsはtopicから継承
     assert "domain:test" in result["tags"]
@@ -351,13 +351,10 @@ def test_add_decision_success(temp_db):
 
     assert "error" not in result
     assert result["decision_id"] > 0
-    assert result["topic_id"] == topic["topic_id"]
-    assert result["decision"] == "設計議論フェーズではプランモード不要。"
-    assert result["reason"] == "設計議論では自由に発散→収束させたい。"
-    assert "tags" in result
-    # tagsはtopicから継承
-    assert "domain:test" in result["tags"]
-    assert "created_at" in result
+    assert "decision" not in result
+    assert "reason" not in result
+    assert "topic_id" not in result
+    assert "tags" not in result
 
 
 def test_add_decision_with_tags(temp_db):
@@ -372,9 +369,8 @@ def test_add_decision_with_tags(temp_db):
     )
 
     assert "error" not in result
-    # topic_tags UNION decision_tags
-    assert "domain:test" in result["tags"]
-    assert "extra" in result["tags"]
+    assert result["decision_id"] > 0
+    assert "tags" not in result
 
 
 def test_add_decision_without_tags(temp_db):
@@ -388,9 +384,8 @@ def test_add_decision_without_tags(temp_db):
     )
 
     assert "error" not in result
-    # topicの継承タグが効いている
-    assert "domain:test" in result["tags"]
-    assert "intent:design" in result["tags"]
+    assert result["decision_id"] > 0
+    assert "tags" not in result
 
 
 def test_add_decision_without_topic(temp_db):

--- a/tests/unit/test_update_activity.py
+++ b/tests/unit/test_update_activity.py
@@ -46,26 +46,23 @@ class TestUpdateActivitySuccess:
         result = update_activity(test_activity["activity_id"], new_status="in_progress")
 
         assert "error" not in result
+        assert result["activity_id"] == test_activity["activity_id"]
         assert result["status"] == "in_progress"
-        assert result["title"] == "Original Title"
-        assert result["description"] == "Original Description"
 
     def test_update_title(self, test_activity):
         """タイトルのみ変更できる"""
         result = update_activity(test_activity["activity_id"], title="New Title")
 
         assert "error" not in result
-        assert result["title"] == "New Title"
+        assert result["activity_id"] == test_activity["activity_id"]
         assert result["status"] == "pending"
-        assert result["description"] == "Original Description"
 
     def test_update_description(self, test_activity):
         """説明のみ変更できる"""
         result = update_activity(test_activity["activity_id"], description="New Description")
 
         assert "error" not in result
-        assert result["description"] == "New Description"
-        assert result["title"] == "Original Title"
+        assert result["activity_id"] == test_activity["activity_id"]
         assert result["status"] == "pending"
 
     def test_update_multiple_fields(self, test_activity):
@@ -78,17 +75,16 @@ class TestUpdateActivitySuccess:
         )
 
         assert "error" not in result
+        assert result["activity_id"] == test_activity["activity_id"]
         assert result["status"] == "in_progress"
-        assert result["title"] == "Updated Title"
-        assert result["description"] == "Updated Description"
 
     def test_update_preserves_tags(self, test_activity):
-        """update_activityでタグが保持される"""
+        """update_activityでタグが保持される（レスポンスはactivity_id+statusのみ）"""
         result = update_activity(test_activity["activity_id"], new_status="in_progress")
 
         assert "error" not in result
-        assert "tags" in result
-        assert "domain:test" in result["tags"]
+        assert result["activity_id"] == test_activity["activity_id"]
+        assert result["status"] == "in_progress"
 
 
 # ========================================
@@ -176,15 +172,12 @@ class TestUpdateActivityTags:
     """update_activityのタグ更新テスト"""
 
     def test_update_tags(self, test_activity):
-        """タグ全置換"""
+        """タグ全置換（レスポンスはactivity_id+statusのみ）"""
         result = update_activity(test_activity["activity_id"], tags=["intent:design", "domain:cc-memory"])
 
         assert "error" not in result
-        assert "tags" in result
-        assert "intent:design" in result["tags"]
-        assert "domain:cc-memory" in result["tags"]
-        # 旧タグは除去されている
-        assert "domain:test" not in result["tags"]
+        assert result["activity_id"] == test_activity["activity_id"]
+        assert result["status"] == "pending"
 
     def test_update_tags_empty_list(self, test_activity):
         """tags=[]でTAGS_REQUIREDエラー"""
@@ -194,9 +187,10 @@ class TestUpdateActivityTags:
         assert result["error"]["code"] == "TAGS_REQUIRED"
 
     def test_update_tags_none(self, test_activity):
-        """tags=None（未指定）ではタグ変更なし"""
+        """tags=None（未指定）ではタグ変更なし（レスポンスはactivity_id+statusのみ）"""
         # まずステータスだけ変更
         result = update_activity(test_activity["activity_id"], new_status="in_progress")
 
         assert "error" not in result
-        assert result["tags"] == ["domain:test"]  # 元のタグが保持される
+        assert result["activity_id"] == test_activity["activity_id"]
+        assert result["status"] == "in_progress"

--- a/tests/unit/test_update_activity.py
+++ b/tests/unit/test_update_activity.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import pytest
 from src.db import init_database
-from src.services.activity_service import add_activity, update_activity
+from src.services.activity_service import add_activity, update_activity, get_activities
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -77,6 +77,19 @@ class TestUpdateActivitySuccess:
         assert "error" not in result
         assert result["activity_id"] == test_activity["activity_id"]
         assert result["status"] == "in_progress"
+
+    def test_update_persists_via_get_activities(self, test_activity):
+        """更新がDBに永続化されていることをget_activitiesで確認する"""
+        activity_id = test_activity["activity_id"]
+        update_activity(activity_id, title="Persisted Title", description="Persisted Desc", new_status="in_progress")
+
+        result = get_activities(status="in_progress")
+        activities = result["activities"]
+        match = [a for a in activities if a["id"] == activity_id]
+        assert len(match) == 1
+        assert match[0]["title"] == "Persisted Title"
+        assert match[0]["description"] == "Persisted Desc"
+        assert match[0]["status"] == "in_progress"
 
     def test_update_preserves_tags(self, test_activity):
         """update_activityでタグが保持される（レスポンスはactivity_id+statusのみ）"""


### PR DESCRIPTION
## Summary
- add_logs/add_decisionsのcreated配列からcontent/decision/reason全文のエコーバックを除去（D#1437の漏れ修正）
- update_activity/update_materialのレスポンスをID+最低限のフィードバックのみに削減（新規対応）
- デッドコード化した`_activity_to_response`を削除

## 変更対象

| ツール | Before | After |
|---|---|---|
| add_logs | log_id, topic_id, title, **content**, tags, created_at | log_id, topic_id, title, tags, created_at |
| add_decisions | decision_id, topic_id, **decision**, **reason**, tags, created_at | **decision_id のみ** |
| update_activity | activity_id, title, **description**, status, tags, created_at, updated_at | **activity_id + status のみ** |
| update_material | material_id, title, **content**, tags, created_at, hint | **material_id のみ** |

## 関連
- D#1437: add系ツールのレスポンス削減方針（バッチ化スコープに委譲済み）
- D#1445, D#1446: 今回の具体仕様
- PR #270: add系ツールのレスポンス削減（add_topic, add_activity, add_material対応済み）

## Test plan
- [x] 全895テスト PASSED
- [x] レスポンスフィールドの不在テスト追加（`assert "content" not in result` 等）
- [x] デッドコード削除後もテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)