### PR TITLE
feat: tags.descriptionカラム追加 + intent:debug新設 + available_intentsレスポンス

### DIFF
--- a/migrations/0024_tag_description.sql
+++ b/migrations/0024_tag_description.sql
@@ -1,0 +1,57 @@
+-- Migration 0024: tags.descriptionカラム追加 + intent:debug新設
+--
+-- depends: 0023_material_independent_entity
+
+-- Step 1: descriptionカラム追加
+ALTER TABLE tags ADD COLUMN description TEXT DEFAULT NULL
+  CHECK(description IS NULL OR LENGTH(description) <= 100);
+
+-- Step 2: intent:debugタグ新設
+INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'debug');
+
+-- Step 3: intent:debugのnotes設定
+UPDATE tags SET notes = '境界: 修正しない。原因特定まで。
+
+目的: バグ・インシデントの根本原因を特定する。
+完了条件: 原因が事実ベースで特定され、修正方針が提示されていること。
+
+振る舞い:
+- ログなどの情報を徹底確認する — まず手元にある証拠を全部集める
+- サンドボックス環境で再現を試みる — 本番を触らず、隔離環境で検証
+- 一ステップずつ進む — 飛躍せず段階的に
+- 仮説は事実ベースで立てる — なぜそう思ったか・どう検証するかを、裏付けが取れた事実から始める
+- 調査結果はmaterialとして保存する
+- 推測で修正に走らない'
+WHERE namespace = 'intent' AND name = 'debug';
+
+-- Step 4: 6件のintentにdescription初期値設定
+UPDATE tags SET description = '会話を通じて要件の曖昧さを取り除き、What/Why/Scopeを決定事項として記録する'
+WHERE namespace = 'intent' AND name = 'discuss';
+
+UPDATE tags SET description = 'How/Interface/Edge casesを決定し、実装に必要な仕様を揃える'
+WHERE namespace = 'intent' AND name = 'design';
+
+UPDATE tags SET description = '仕様とdecisionに基づいて実装する'
+WHERE namespace = 'intent' AND name = 'implement';
+
+UPDATE tags SET description = '調査・情報収集に専念し、結果をmaterialとして保存する'
+WHERE namespace = 'intent' AND name = 'investigate';
+
+UPDATE tags SET description = 'コードの差分を実コードと照合して指摘する。変更はしない'
+WHERE namespace = 'intent' AND name = 'review';
+
+UPDATE tags SET description = 'バグ・インシデントの原因を特定する。証拠収集→再現→段階的検証→事実ベース仮説で進める'
+WHERE namespace = 'intent' AND name = 'debug';
+
+-- Step 5: intent:investigateのnotes更新
+UPDATE tags SET notes = '境界: 実装・修正しない。調査と情報整理まで。
+
+目的: 技術リサーチ・仕様調査・比較検討など、情報収集と整理に専念する。
+完了条件: 調査対象について事実ベースの情報が整理され、materialとして保存されていること。
+
+振る舞い:
+- 事実と推測を明確に分ける
+- 調査結果はmaterialとして保存する
+- 1次情報（公式ドキュメント、コードベース）を優先する
+- バグ・インシデントの原因調査はintent:debugを使う'
+WHERE namespace = 'intent' AND name = 'investigate';

--- a/src/main.py
+++ b/src/main.py
@@ -399,11 +399,13 @@ def update_tag(
     notes: Optional[str] = None,
     canonical: Optional[str] = None,
     rename: Optional[str] = None,
+    description: Optional[str] = None,
 ) -> dict:
     """
-    既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、またはname（リネーム）を更新する。
+    既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、name（リネーム）、
+    またはdescription（短い説明文）を更新する。
 
-    notes / canonical / rename は相互排他（1つだけ指定可能）。少なくとも1つを指定する。
+    notes / canonical / rename / description は相互排他（1つだけ指定可能）。少なくとも1つを指定する。
 
     notes: タグに紐づく教訓や運用ルールを記録する。CLAUDE.mdのタグ版として機能し、
     そのタグの文脈で作業するときに自動的にAIに注入される。上書き方式（全文置換）。
@@ -419,16 +421,19 @@ def update_tag(
     IDベースの参照なので紐付けはそのまま維持される。
     新名が既存タグと衝突する場合はエラー。
 
+    description: タグの短い説明文（最大100文字）。空文字はNULLに正規化される。
+
     Args:
         tag: 対象タグ（例: "domain:cc-memory", "hooks"）
         notes: 教訓・運用ルールのテキスト（全文置換）
         canonical: エイリアス先タグ（""で解除）
         rename: 新しいタグ名（例: "domain:hooks"）
+        description: タグの短い説明文（最大100文字）
 
     Returns:
         更新結果
     """
-    return _update_tag(tag, notes=notes, canonical=canonical, rename=rename)
+    return _update_tag(tag, notes=notes, canonical=canonical, rename=rename, description=description)
 
 
 @mcp.tool()

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -14,6 +14,7 @@ from src.services.tag_service import (
     link_tags,
     get_entity_tags,
     get_entity_tags_batch,
+    get_available_intents,
 )
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,10 @@ def add_activity(
         generate_and_store_embedding("activity", activity_id, build_embedding_text(title, description, tag_text))
 
         result = {"activity_id": activity_id}
+        try:
+            result["available_intents"] = get_available_intents()
+        except Exception:
+            result["available_intents"] = []
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -556,7 +556,7 @@ def search_tags(
             if namespace is not None:
                 like_rows = conn.execute(
                     """
-                    SELECT t.id, t.namespace, t.name, t.notes, t.canonical_id,
+                    SELECT t.id, t.namespace, t.name, t.notes, t.description, t.canonical_id,
                       ct.namespace AS canonical_namespace, ct.name AS canonical_name,
                       (SELECT COUNT(*) FROM topic_tags WHERE tag_id = t.id) +
                       (SELECT COUNT(*) FROM activity_tags WHERE tag_id = t.id) +
@@ -574,7 +574,7 @@ def search_tags(
             else:
                 like_rows = conn.execute(
                     """
-                    SELECT t.id, t.namespace, t.name, t.notes, t.canonical_id,
+                    SELECT t.id, t.namespace, t.name, t.notes, t.description, t.canonical_id,
                       ct.namespace AS canonical_namespace, ct.name AS canonical_name,
                       (SELECT COUNT(*) FROM topic_tags WHERE tag_id = t.id) +
                       (SELECT COUNT(*) FROM activity_tags WHERE tag_id = t.id) +
@@ -646,7 +646,7 @@ def search_tags(
                 placeholders = ",".join("?" * len(missing_ids))
                 missing_rows = conn.execute(
                     f"""
-                    SELECT t.id, t.namespace, t.name, t.notes, t.canonical_id,
+                    SELECT t.id, t.namespace, t.name, t.notes, t.description, t.canonical_id,
                       ct.namespace AS canonical_namespace, ct.name AS canonical_name,
                       (SELECT COUNT(*) FROM topic_tags WHERE tag_id = t.id) +
                       (SELECT COUNT(*) FROM activity_tags WHERE tag_id = t.id) +
@@ -687,6 +687,7 @@ def search_tags(
                     "usage_count": r["usage_count"],
                     "score": round(score, 4),
                     "canonical": canonical,
+                    "description": r["description"],
                 }
                 if include_notes:
                     entry["notes"] = r["notes"]
@@ -720,8 +721,10 @@ def update_tag(
     notes: str | None = None,
     canonical: str | None = None,
     rename: str | None = None,
+    description: str | None = None,
 ) -> dict:
-    """既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、またはname（リネーム）を更新する。
+    """既存タグの notes（教訓・運用ルール）、canonical（エイリアス先）、name（リネーム）、
+    またはdescription（短い説明文）を更新する。
 
     Args:
         tag: タグ文字列（例: "domain:cc-memory", "hooks"）
@@ -731,20 +734,22 @@ def update_tag(
                    付け替え済みの紐付けは戻らない。
         rename: 新しいタグ名。namespace変更も可能（例: "hooks" → "domain:hooks"）。
                 新名が既存タグと衝突する場合はエラー。
+        description: タグの短い説明文（最大100文字）。空文字はNULLに正規化される。
 
     Returns:
         成功時: {"tag": str, "notes": str, "updated": True} (notes更新時)
                 {"tag": str, "canonical": str | None, "updated": True} (canonical更新時)
                 {"tag": str, "renamed_to": str, "updated": True} (rename時)
+                {"tag": str, "description": str | None, "updated": True} (description更新時)
         失敗時: {"error": {"code": ..., "message": ...}}
     """
-    # バリデーション: 相互排他（notes, canonical, rename は1つだけ指定可能）
-    specified = [p for p in (notes, canonical, rename) if p is not None]
+    # バリデーション: 相互排他（notes, canonical, rename, description は1つだけ指定可能）
+    specified = [p for p in (notes, canonical, rename, description) if p is not None]
     if len(specified) > 1:
         return {
             "error": {
                 "code": "CONFLICTING_PARAMS",
-                "message": "Only one of 'notes', 'canonical', or 'rename' can be specified. Use separate calls.",
+                "message": "Only one of 'notes', 'canonical', 'rename', or 'description' can be specified. Use separate calls.",
             }
         }
 
@@ -753,7 +758,7 @@ def update_tag(
         return {
             "error": {
                 "code": "MISSING_PARAMS",
-                "message": "At least one of 'notes', 'canonical', or 'rename' must be specified.",
+                "message": "At least one of 'notes', 'canonical', 'rename', or 'description' must be specified.",
             }
         }
 
@@ -825,6 +830,18 @@ def update_tag(
             conn.commit()
             new_tag_str = f"{new_namespace}:{new_name}" if new_namespace else new_name
             return {"tag": tag_str, "renamed_to": new_tag_str, "updated": True}
+
+        # --- description 更新 ---
+        if description is not None:
+            # 空文字→NULL正規化
+            if description == "":
+                description = None
+            conn.execute(
+                "UPDATE tags SET description = ? WHERE id = ?",
+                (description, tag_id),
+            )
+            conn.commit()
+            return {"tag": tag_str, "description": description, "updated": True}
 
         # --- notes 更新 ---
         if notes is not None:
@@ -970,6 +987,25 @@ def update_tag(
                 "message": str(e),
             }
         }
+    finally:
+        conn.close()
+
+
+def get_available_intents() -> list[dict]:
+    """intent:タグ一覧をdescription付きで返す（canonical除外、アルファベット順）"""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT name, description FROM tags
+            WHERE namespace = 'intent' AND canonical_id IS NULL
+            ORDER BY name ASC
+            """,
+        ).fetchall()
+        return [
+            {"tag": f"intent:{r['name']}", "description": r["description"]}
+            for r in rows
+        ]
     finally:
         conn.close()
 

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -52,6 +52,7 @@ class TestAddActivity:
         assert "error" not in result
         assert result["activity_id"] > 0
         assert "check_in_result" not in result
+        assert "available_intents" in result
 
     def test_add_activity_tags_required(self, temp_db):
         """tags=[]でTAGS_REQUIREDエラーになる"""
@@ -209,6 +210,70 @@ class TestAddActivity:
         assert "related_topics" in check_in_result
         assert any(t["id"] == topic_id for t in check_in_result["related_topics"])
         assert "recent_decisions" in check_in_result
+
+    def test_add_activity_available_intents_format(self, temp_db):
+        """available_intentsの各要素に"tag"と"description"がある"""
+        result = add_activity(
+            title="Activity",
+            description="Desc",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+
+        assert "error" not in result
+        assert "available_intents" in result
+        for intent in result["available_intents"]:
+            assert "tag" in intent
+            assert "description" in intent
+            assert intent["tag"].startswith("intent:")
+
+    def test_add_activity_available_intents_alphabetical(self, temp_db):
+        """available_intentsがアルファベット順"""
+        result = add_activity(
+            title="Activity",
+            description="Desc",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+
+        assert "error" not in result
+        intent_names = [i["tag"] for i in result["available_intents"]]
+        assert intent_names == sorted(intent_names)
+
+    def test_add_activity_available_intents_excludes_canonical(self, temp_db):
+        """canonical_id持ちのintentはavailable_intentsから除外される"""
+        from src.services.tag_service import update_tag
+
+        # intent:debugとintent:investigateを作成するためにactivityを作成
+        add_activity(
+            title="Setup",
+            description="Desc",
+            tags=["domain:test", "intent:investigate"],
+            check_in=False,
+        )
+
+        # intent:testaliasを作ってintent:investigateのエイリアスにする
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO tags (namespace, name) VALUES ('intent', 'testalias')",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        update_tag("intent:testalias", canonical="intent:investigate")
+
+        result = add_activity(
+            title="Activity",
+            description="Desc",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+
+        assert "error" not in result
+        intent_tags = [i["tag"] for i in result["available_intents"]]
+        assert "intent:testalias" not in intent_tags
 
 
 class TestGetActivities:

--- a/tests/unit/test_search_tags.py
+++ b/tests/unit/test_search_tags.py
@@ -157,9 +157,22 @@ def test_search_tags_response_format(temp_db):
     assert "usage_count" in tag
     assert "score" in tag
     assert "canonical" in tag
+    assert "description" in tag
     assert isinstance(tag["id"], int)
     assert isinstance(tag["usage_count"], int)
     assert isinstance(tag["score"], float)
+
+
+def test_search_tags_description_value(temp_db):
+    """descriptionが設定されたタグで値が正しく返る"""
+    from src.services.tag_service import update_tag
+    add_topic(title="Topic 1", description="Desc", tags=["domain:test"])
+    update_tag("domain:test", description="テスト用タグ")
+
+    result = search_tags("test")
+    assert "error" not in result
+    test_tag = next(t for t in result["tags"] if t["name"] == "test")
+    assert test_tag["description"] == "テスト用タグ"
 
 
 def test_search_tags_canonical(temp_db):

--- a/tests/unit/test_tag_description.py
+++ b/tests/unit/test_tag_description.py
@@ -1,0 +1,129 @@
+"""update_tag description機能のユニットテスト"""
+import os
+import tempfile
+import pytest
+from src.db import init_database, get_connection
+from src.services.tag_service import update_tag
+from src.services.topic_service import add_topic
+import src.services.embedding_service as emb
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def test_update_tag_description_set(temp_db):
+    """descriptionを設定できる"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+
+    result = update_tag("domain:test", description="テスト用タグ")
+    assert "error" not in result
+    assert result["updated"] is True
+    assert result["tag"] == "domain:test"
+    assert result["description"] == "テスト用タグ"
+
+    # DB確認
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT description FROM tags WHERE namespace = 'domain' AND name = 'test'"
+        ).fetchone()
+        assert row["description"] == "テスト用タグ"
+    finally:
+        conn.close()
+
+
+def test_update_tag_description_update(temp_db):
+    """descriptionを更新できる"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+    update_tag("domain:test", description="初期値")
+
+    result = update_tag("domain:test", description="更新値")
+    assert "error" not in result
+    assert result["description"] == "更新値"
+
+
+def test_update_tag_description_null(temp_db):
+    """description=""でNULLに正規化される"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+    update_tag("domain:test", description="初期値")
+
+    result = update_tag("domain:test", description="")
+    assert "error" not in result
+    assert result["description"] is None
+
+    # DB確認
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT description FROM tags WHERE namespace = 'domain' AND name = 'test'"
+        ).fetchone()
+        assert row["description"] is None
+    finally:
+        conn.close()
+
+
+def test_update_tag_description_empty_string_normalized(temp_db):
+    """空文字descriptionがNULLに正規化される"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+
+    result = update_tag("domain:test", description="")
+    assert "error" not in result
+    assert result["updated"] is True
+    assert result["description"] is None
+
+
+def test_update_tag_description_too_long(temp_db):
+    """101文字でCHECK制約エラー"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+
+    long_desc = "a" * 101
+    result = update_tag("domain:test", description=long_desc)
+    assert "error" in result
+    assert result["error"]["code"] == "DATABASE_ERROR"
+
+
+def test_update_tag_description_mutual_exclusion(temp_db):
+    """notes/canonical/renameとdescriptionの同時指定でエラー"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+
+    # description + notes
+    result = update_tag("domain:test", description="desc", notes="notes")
+    assert "error" in result
+    assert result["error"]["code"] == "CONFLICTING_PARAMS"
+
+    # description + canonical
+    result = update_tag("domain:test", description="desc", canonical="domain:other")
+    assert "error" in result
+    assert result["error"]["code"] == "CONFLICTING_PARAMS"
+
+    # description + rename
+    result = update_tag("domain:test", description="desc", rename="domain:renamed")
+    assert "error" in result
+    assert result["error"]["code"] == "CONFLICTING_PARAMS"
+
+
+def test_update_tag_description_100_chars_ok(temp_db):
+    """100文字ちょうどはOK"""
+    add_topic(title="T", description="D", tags=["domain:test"])
+
+    desc_100 = "a" * 100
+    result = update_tag("domain:test", description=desc_100)
+    assert "error" not in result
+    assert result["description"] == desc_100


### PR DESCRIPTION
## Summary
- tagsテーブルに`description`カラム（TEXT, CHECK <= 100字）を追加し、intentタグの発見性を改善
- `intent:debug`タグを新設（バグ・インシデント調査用、4ステップの行動ルール付き）
- `add_activity`レスポンスに`available_intents`（intent一覧 + description）をトップレベルで返却
- `search_tags`の返り値に`description`フィールドを追加
- `update_tag`に`description`パラメータを追加（空文字→NULL正規化対応）
- `intent:investigate`のnotesを更新（`intent:debug`との境界明示）

## Test plan
- [x] 全906テストパス
- [x] migration: descriptionカラム追加・CHECK制約・6件初期値が正しく設定される
- [x] add_activity: available_intentsが返る（アルファベット順、canonical除外）
- [x] search_tags: descriptionフィールドが返る
- [x] update_tag: description設定・更新・NULL化（空文字正規化）・CHECK制約・相互排他
- [x] 新規テスト7件 + 既存テスト修正4件

## Related
- cc-memory activity: #567
- design activity: #555 (completed)
- decisions: D#1447-1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)