### PR TITLE
feat: update_materialにtags引数を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -608,27 +608,31 @@ def update_material(
     material_id: int,
     content: str | None = None,
     title: str | None = None,
+    tags: list[str] | None = None,
 ) -> dict:
     """
-    既存の資材を更新する。contentとtitleを個別または同時に更新できる。
+    既存の資材を更新する。content、title、tagsを個別または同時に更新できる。
 
     contentは全体置換（部分更新やappendではない）。
+    tagsは全置換（指定時は既存タグを全削除して新しいタグに置き換える）。
     少なくとも1つのパラメータを指定する必要がある。
 
     典型的な使い方:
     - 内容を改訂: update_material(material_id=5, content="# 改訂版\n...")
     - タイトル変更: update_material(material_id=5, title="新しいタイトル")
-    - 両方更新: update_material(material_id=5, content="...", title="...")
+    - タグ変更: update_material(material_id=5, tags=["domain:cc-memory", "design"])
+    - 複数同時: update_material(material_id=5, content="...", title="...", tags=["..."])
 
     Args:
         material_id: 資材のID
         content: 新しい本文（全体置換。optional）。先頭1-2文は内容の説明・要約を書くこと（check-inやsearchのsnippetに使われるため）
         title: 新しいタイトル（optional）
+        tags: 新しいタグ配列（指定時は全置換。1個以上必須。optional）
 
     Returns:
-        更新された資材情報（material_id, title, content, tags, created_at）
+        更新された資材情報
     """
-    return material_service.update_material(material_id, content=content, title=title)
+    return material_service.update_material(material_id, content=content, title=title, tags=tags)
 
 
 @mcp.tool()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -148,25 +148,34 @@ def update_material(
     material_id: int,
     content: str | None = None,
     title: str | None = None,
+    tags: list[str] | None = None,
 ) -> dict:
     """
-    Update an existing material's content and/or title.
+    Update an existing material's content, title, and/or tags.
 
     Args:
         material_id: ID of the material to update
         content: New content (full replace, optional)
         title: New title (optional)
+        tags: New tags (full replace, optional. At least 1 required when specified)
 
     Returns:
         Updated material info
     """
-    if content is None and title is None:
+    if content is None and title is None and tags is None:
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "At least one of content or title must be provided",
+                "message": "At least one of content, title, or tags must be provided",
             }
         }
+
+    # タグのバリデーション（tags指定時のみ）
+    parsed_tags = None
+    if tags is not None:
+        parsed_tags = validate_and_parse_tags(tags, required=True)
+        if isinstance(parsed_tags, dict):
+            return parsed_tags
 
     if title is not None and not title.strip():
         return {
@@ -198,7 +207,7 @@ def update_material(
                 }
             }
 
-        # Build dynamic SQL
+        # Build dynamic SQL for title/content
         set_parts = []
         values = []
 
@@ -210,13 +219,20 @@ def update_material(
             set_parts.append("content = ?")
             values.append(content)
 
-        set_clause = ", ".join(set_parts)
-        values.append(material_id)
+        if set_parts:
+            set_clause = ", ".join(set_parts)
+            values.append(material_id)
+            conn.execute(
+                f"UPDATE materials SET {set_clause} WHERE id = ?",
+                tuple(values),
+            )
 
-        conn.execute(
-            f"UPDATE materials SET {set_clause} WHERE id = ?",
-            tuple(values),
-        )
+        # タグの全置換（tags指定時のみ）
+        if parsed_tags is not None:
+            conn.execute("DELETE FROM material_tags WHERE material_id = ?", (material_id,))
+            tag_ids = ensure_tag_ids(conn, parsed_tags)
+            link_tags(conn, "material_tags", "material_id", material_id, tag_ids)
+
         conn.commit()
 
         # Retrieve updated material

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -357,3 +357,49 @@ class TestUpdateMaterial:
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
         assert "content" in result["error"]["message"]
+
+    def test_update_tags(self, temp_db):
+        """Updating tags only succeeds and replaces all tags"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, tags=["domain:new", "refactor"])
+
+        assert "error" not in result
+        assert result["material_id"] == material_id
+
+        fetched = get_material(material_id)
+        assert sorted(fetched["tags"]) == sorted(["domain:new", "refactor"])
+
+    def test_update_tags_empty_list(self, temp_db):
+        """Empty tags list returns TAGS_REQUIRED error"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, tags=[])
+
+        assert "error" in result
+        assert result["error"]["code"] == "TAGS_REQUIRED"
+
+    def test_update_tags_with_content(self, temp_db):
+        """Updating tags and content simultaneously succeeds"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="New content", tags=["domain:updated"])
+
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "New content"
+        assert fetched["tags"] == ["domain:updated"]
+
+    def test_update_tags_none_preserves_existing(self, temp_db):
+        """tags=None does not change existing tags"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        update_material(material_id, title="New Title")
+
+        fetched = get_material(material_id)
+        assert sorted(fetched["tags"]) == sorted(["design", "domain:test"])

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -399,7 +399,8 @@ class TestUpdateMaterial:
         created = self._create_material()
         material_id = created["material_id"]
 
-        update_material(material_id, title="New Title")
+        result = update_material(material_id, title="New Title")
+        assert "error" not in result
 
         fetched = get_material(material_id)
         assert sorted(fetched["tags"]) == sorted(["design", "domain:test"])


### PR DESCRIPTION
## Summary
- `update_material`に`tags`引数を追加し、`update_activity`と同様にタグの全置換更新を可能にした
- tags-only更新時はmaterialsテーブルのUPDATE SQLをスキップし、タグ処理のみ実行する
- テスト4件追加（タグ更新、空リストエラー、content同時更新、None時の既存タグ保持）

## Related
- D#1460（決定事項）
- Activity #576

## Test plan
- [x] 既存テスト8件パス（リグレッションなし）
- [x] 新規テスト4件パス
  - tags-only更新で全置換される
  - 空リストでTAGS_REQUIREDエラー
  - content+tags同時更新
  - tags=Noneで既存タグ保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)