### PR TITLE
refactor: get_topicsのdescriptionを200文字にtruncate

### DIFF
--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -14,6 +14,8 @@ from src.services.tag_service import (
     get_entity_tags_batch,
 )
 
+TOPIC_DESC_MAX_LEN = 200
+
 
 def get_recent_topics_with_conn(conn, limit: int = 10) -> list[dict]:
     """最近作成されたトピックのID・タイトルを取得する（conn共有版）。
@@ -234,7 +236,7 @@ def get_topics(
                 topics.append({
                     "id": topic["id"],
                     "title": topic["title"],
-                    "description": topic["description"],
+                    "description": (topic["description"] or "")[:TOPIC_DESC_MAX_LEN],
                     "tags": tags_map.get(topic["id"], []),
                     "created_at": topic["created_at"],
                 })

--- a/tests/unit/test_topic_read.py
+++ b/tests/unit/test_topic_read.py
@@ -10,6 +10,7 @@ from src.db import init_database, get_connection
 from src.services.topic_service import (
     add_topic,
     get_topics,
+    TOPIC_DESC_MAX_LEN,
 )
 from tests.helpers import add_log, add_decision
 from src.services.discussion_log_service import get_logs
@@ -352,6 +353,20 @@ def test_get_topics_has_tags_field(temp_db):
     assert "subject_id" not in topic
     assert "parent_topic_id" not in topic
     assert "ancestors" not in topic
+
+
+def test_get_topics_description_truncated(temp_db):
+    """descriptionが長い場合、TOPIC_DESC_MAX_LENで切り詰められる"""
+    long_desc = "A" * 500
+    add_topic(title="Long Desc Topic", description=long_desc, tags=DEFAULT_TAGS)
+
+    result = get_topics(tags=DEFAULT_TAGS)
+
+    assert "error" not in result
+    topic = result["topics"][0]
+    assert len(topic["description"]) == TOPIC_DESC_MAX_LEN
+    assert topic["description"] == "A" * TOPIC_DESC_MAX_LEN
+
 
 
 # ========================================


### PR DESCRIPTION
## Summary
- `get_topics`のレスポンスで`description`が全文返却されていた問題を修正
- `get_activities`と同じ200文字上限（`TOPIC_DESC_MAX_LEN`）を適用
- 全文が必要な場合は`get_by_ids`で取得可能

## Background
ツール仕様レビュー（D#1464）で指摘された「一覧取得でdescription全文が返る」問題の対応。
`get_activities`は既に`ACTIVITY_DESC_MAX_LEN=200`でtruncate済みだったが、`get_topics`だけ全文返却のまま残っていた。

## Test plan
- [x] `test_get_topics_description_truncated` — 500文字のdescriptionが200文字に切り詰められることを確認
- [x] 既存テスト33件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)