### PR TITLE
feat: ツール仕様の小修正3件（related引数追加・statusリネーム・bool化）

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -187,13 +187,15 @@ def add_topic(
     title: str,
     description: str,
     tags: list[str],
+    related: list[dict] | None = None,
 ) -> dict:
     """新しい議論トピックを追加する。
 
     tags: タグ配列(必須、1個以上)。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
+    related: 関連エンティティ（optional）。[{"type": "topic"|"activity", "ids": [int, ...]}] 形式。作成と同時にリレーションを張る
 
     レスポンスに類似トピック(similar_topics)が含まれる場合がある。重複トピックの防止やリレーション追加の参考にすること。"""
-    result = topic_service.add_topic(title, description, tags)
+    result = topic_service.add_topic(title, description, tags, related=related)
     if "error" not in result:
         _maybe_inject_tag_notes(result, tags)
     return result
@@ -542,7 +544,7 @@ def get_activities(
 @mcp.tool()
 def update_activity(
     activity_id: int,
-    new_status: Optional[str] = None,
+    status: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[list[str]] = None,
@@ -551,8 +553,8 @@ def update_activity(
     アクティビティのステータス・タイトル・説明・タグを更新する。
 
     典型的な使い方:
-    - アクティビティ開始: update_activity(activity_id, new_status="in_progress")
-    - アクティビティ完了: update_activity(activity_id, new_status="completed")
+    - アクティビティ開始: update_activity(activity_id, status="in_progress")
+    - アクティビティ完了: update_activity(activity_id, status="completed")
     - タイトル変更: update_activity(activity_id, title="新しいタイトル")
     - 説明更新: update_activity(activity_id, description="新しい説明")
     - タグ変更: update_activity(activity_id, tags=["domain:cc-memory", "intent:implement"])
@@ -561,7 +563,7 @@ def update_activity(
 
     Args:
         activity_id: アクティビティID
-        new_status: 新しいステータス（pending/in_progress/completed）
+        status: 新しいステータス（pending/in_progress/completed）
         title: 新しいタイトル
         description: 新しい説明
         tags: 新しいタグ配列（指定時は全置換。1個以上必須）
@@ -569,7 +571,7 @@ def update_activity(
     Returns:
         更新されたアクティビティ情報
     """
-    return activity_service.update_activity(activity_id, new_status, title, description, tags)
+    return activity_service.update_activity(activity_id, status, title, description, tags)
 
 
 @mcp.tool()
@@ -758,8 +760,8 @@ def list_reminders() -> dict:
 
 
 @mcp.tool()
-def update_reminder(reminder_id: int, content: Optional[str] = None, active: Optional[int] = None) -> dict:
-    """リマインダーを更新する。active=0で無効化、active=1で再有効化。"""
+def update_reminder(reminder_id: int, content: Optional[str] = None, active: Optional[bool] = None) -> dict:
+    """リマインダーを更新する。active=Falseで無効化、active=Trueで再有効化。"""
     return reminder_service.update_reminder(reminder_id, content=content, active=active)
 
 

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
-from src.services.relation_service import _add_relation_with_conn
+from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.tag_service import (
     validate_and_parse_tags,
     ensure_tag_ids,
@@ -54,6 +54,12 @@ def add_activity(
     parsed_tags = validate_and_parse_tags(tags, required=True)
     if isinstance(parsed_tags, dict):
         return parsed_tags
+
+    # relatedのバリデーション
+    if related:
+        err = _validate_targets("activity", related)
+        if err:
+            return err
 
     conn = get_connection()
     try:

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -353,7 +353,7 @@ def get_active_activities_by_tag(tag_id: int) -> list[dict]:
 
 def update_activity(
     activity_id: int,
-    new_status: Optional[str] = None,
+    status: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[list[str]] = None,
@@ -363,7 +363,7 @@ def update_activity(
 
     Args:
         activity_id: アクティビティID
-        new_status: 新しいステータス（optional）
+        status: 新しいステータス（optional）
         title: 新しいタイトル（optional）
         description: 新しい説明（optional）
         tags: 新しいタグ配列（optional、指定時は全置換。1個以上必須）
@@ -372,11 +372,11 @@ def update_activity(
         更新されたアクティビティ情報
     """
     # 最低1つのオプショナルパラメータが必要
-    if new_status is None and title is None and description is None and tags is None:
+    if status is None and title is None and description is None and tags is None:
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "At least one of new_status, title, description, or tags must be provided",
+                "message": "At least one of status, title, description, or tags must be provided",
             }
         }
 
@@ -388,11 +388,11 @@ def update_activity(
             return parsed_tags
 
     # ステータスバリデーション
-    if new_status is not None and new_status not in REAL_STATUSES:
+    if status is not None and status not in REAL_STATUSES:
         return {
             "error": {
                 "code": "INVALID_STATUS",
-                "message": f"Invalid status: {new_status}. Must be one of {sorted(REAL_STATUSES)}",
+                "message": f"Invalid status: {status}. Must be one of {sorted(REAL_STATUSES)}",
             }
         }
 
@@ -430,9 +430,9 @@ def update_activity(
         set_parts = []
         values = []
 
-        if new_status is not None:
+        if status is not None:
             set_parts.append("status = ?")
-            values.append(new_status)
+            values.append(status)
 
         if title is not None:
             set_parts.append("title = ?")

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -181,7 +181,7 @@ def check_in(activity_id: int) -> dict:
         # NOTE: update_activityは内部で別コネクションを使用する（既存APIの制約）。
         # check_inのトランザクションとは独立してコミットされる。
         if activity["status"] != "in_progress":
-            update_result = activity_service.update_activity(activity_id, new_status="in_progress")
+            update_result = activity_service.update_activity(activity_id, status="in_progress")
             if "error" in update_result:
                 logger.warning(
                     "Failed to update activity %d status: %s",

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -4,7 +4,7 @@ import sqlite3
 
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
-from src.services.relation_service import _add_relation_with_conn
+from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.tag_service import (
     validate_and_parse_tags,
     ensure_tag_ids,
@@ -63,6 +63,12 @@ def add_material(title: str, content: str, tags: list[str], related: list[dict] 
     parsed_tags = validate_and_parse_tags(tags, required=True)
     if isinstance(parsed_tags, dict):
         return parsed_tags
+
+    # relatedのバリデーション
+    if related:
+        err = _validate_targets("material", related)
+        if err:
+            return err
 
     conn = get_connection()
     try:

--- a/src/services/reminder_service.py
+++ b/src/services/reminder_service.py
@@ -96,13 +96,13 @@ def list_reminders() -> dict:
         conn.close()
 
 
-def update_reminder(reminder_id: int, content: str | None = None, active: int | None = None) -> dict:
+def update_reminder(reminder_id: int, content: str | None = None, active: bool | None = None) -> dict:
     """リマインダーを更新する。
 
     Args:
         reminder_id: リマインダーID
         content: 新しい内容（optional）
-        active: 有効/無効フラグ（0 or 1、optional）
+        active: 有効/無効フラグ（True/False、optional）
 
     Returns:
         更新されたリマインダー情報
@@ -123,11 +123,11 @@ def update_reminder(reminder_id: int, content: str | None = None, active: int | 
             }
         }
 
-    if active is not None and active not in (0, 1):
+    if active is not None and not isinstance(active, bool):
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "active must be 0 or 1",
+                "message": "active must be True or False",
             }
         }
 

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -4,6 +4,7 @@ import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
+from src.services.relation_service import _add_relation_with_conn
 from src.services.search_service import find_similar_topics
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -32,6 +33,7 @@ def add_topic(
     title: str,
     description: str,
     tags: list[str],
+    related: list[dict] | None = None,
 ) -> dict:
     """
     新しい議論トピックを追加する。
@@ -40,6 +42,7 @@ def add_topic(
         title: トピックのタイトル
         description: トピックの説明（必須）
         tags: タグ配列（必須、1個以上）
+        related: 関連エンティティ [{"type": "topic", "ids": [1, 2]}, ...] (optional)
 
     Returns:
         作成されたトピック情報
@@ -61,6 +64,10 @@ def add_topic(
         # タグをリンク
         tag_ids = ensure_tag_ids(conn, parsed_tags)
         link_tags(conn, "topic_tags", "topic_id", topic_id, tag_ids)
+
+        # リレーションを追加
+        if related:
+            _add_relation_with_conn(conn, "topic", topic_id, related)
 
         conn.commit()
 

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
-from src.services.relation_service import _add_relation_with_conn
+from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.search_service import find_similar_topics
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -51,6 +51,12 @@ def add_topic(
     parsed_tags = validate_and_parse_tags(tags, required=True)
     if isinstance(parsed_tags, dict):
         return parsed_tags
+
+    # relatedのバリデーション
+    if related:
+        err = _validate_targets("topic", related)
+        if err:
+            return err
 
     conn = get_connection()
     try:

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -316,7 +316,7 @@ class TestGetActivities:
         """tags未指定 + status指定で全ドメインからフィルタ"""
         activity_a = add_activity(title="Activity A", description="Desc", tags=["domain:test"], check_in=False)
         add_activity(title="Activity B", description="Desc", tags=["domain:other"], check_in=False)
-        update_activity(activity_a["activity_id"], new_status="completed")
+        update_activity(activity_a["activity_id"], status="completed")
 
         result = get_activities(status="completed")
 
@@ -328,8 +328,8 @@ class TestGetActivities:
         """completedのソート順がupdated_at DESCになっている"""
         a1 = add_activity(title="Old completed", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         a2 = add_activity(title="New completed", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        update_activity(a1["activity_id"], new_status="completed")
-        update_activity(a2["activity_id"], new_status="completed")
+        update_activity(a1["activity_id"], status="completed")
+        update_activity(a2["activity_id"], status="completed")
 
         # a1のupdated_atを古い値に書き換えてソート順を明確にする
         conn = get_connection()
@@ -433,7 +433,7 @@ class TestGetActivities:
         """since + status組み合わせ"""
         a1 = add_activity(title="Old Completed", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         a2 = add_activity(title="New Pending", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        update_activity(a1["activity_id"], new_status="completed")
+        update_activity(a1["activity_id"], status="completed")
 
         # update_activityが内部でupdated_at=CURRENT_TIMESTAMPを設定するため、
         # テスト用に手動で上書きしてsince条件の検証を可能にする
@@ -504,7 +504,7 @@ class TestUpdateActivity:
     def test_update_status_to_in_progress(self, activity_with_db):
         """ステータスをin_progressに更新できる"""
         activity = activity_with_db["activity"]
-        result = update_activity(activity["activity_id"], new_status="in_progress")
+        result = update_activity(activity["activity_id"], status="in_progress")
 
         assert "error" not in result
         assert result["status"] == "in_progress"
@@ -512,7 +512,7 @@ class TestUpdateActivity:
     def test_update_status_to_completed(self, activity_with_db):
         """ステータスをcompletedに更新できる"""
         activity = activity_with_db["activity"]
-        result = update_activity(activity["activity_id"], new_status="completed")
+        result = update_activity(activity["activity_id"], status="completed")
 
         assert "error" not in result
         assert result["status"] == "completed"
@@ -520,14 +520,14 @@ class TestUpdateActivity:
     def test_update_status_invalid(self, activity_with_db):
         """無効なステータスでエラーになる"""
         activity = activity_with_db["activity"]
-        result = update_activity(activity["activity_id"], new_status="invalid_status")
+        result = update_activity(activity["activity_id"], status="invalid_status")
 
         assert "error" in result
         assert result["error"]["code"] == "INVALID_STATUS"
 
     def test_update_activity_not_found(self, temp_db):
         """存在しないアクティビティIDでエラーになる"""
-        result = update_activity(9999, new_status="in_progress")
+        result = update_activity(9999, status="in_progress")
 
         assert "error" in result
         assert result["error"]["code"] == "NOT_FOUND"

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -82,7 +82,7 @@ class TestCheckIn:
     def test_check_in_already_in_progress(self, activity_id):
         """すでにin_progressの場合、status変更なしでcheck-in成功"""
         # 先にin_progressに変更
-        update_activity(activity_id, new_status="in_progress")
+        update_activity(activity_id, status="in_progress")
 
         result = check_in(activity_id)
 
@@ -91,7 +91,7 @@ class TestCheckIn:
 
     def test_check_in_completed_activity(self, activity_id):
         """completedのアクティビティもin_progressに戻る"""
-        update_activity(activity_id, new_status="completed")
+        update_activity(activity_id, status="completed")
 
         result = check_in(activity_id)
 

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -188,7 +188,7 @@ class TestBuildActiveContextHeartbeat:
             title="[作業] HB機能実装", description="Desc", tags=["domain:hb-ctx"], check_in=False,
         )
         aid = activity["activity_id"]
-        update_activity(aid, new_status="in_progress")
+        update_activity(aid, status="in_progress")
 
         # heartbeatを活性化
         conn = get_connection()
@@ -225,7 +225,7 @@ class TestBuildActiveContextHeartbeat:
             title="[作業] HB活性", description="Desc", tags=["domain:hb-mix"], check_in=False,
         )
         hb_aid = hb_activity["activity_id"]
-        update_activity(hb_aid, new_status="in_progress")
+        update_activity(hb_aid, status="in_progress")
 
         normal_activity = add_activity(
             title="[作業] 通常", description="Desc", tags=["domain:hb-mix"], check_in=False,

--- a/tests/unit/test_active_context.py
+++ b/tests/unit/test_active_context.py
@@ -139,7 +139,7 @@ def test_get_active_domains_excludes_completed(temp_db):
         title="Done", description="Desc",
         tags=["domain:completed-proj"], check_in=False,
     )
-    update_activity(result["activity_id"], new_status="completed")
+    update_activity(result["activity_id"], status="completed")
 
     domains = get_active_domains()
     names = [d["name"] for d in domains]
@@ -220,7 +220,7 @@ def test_get_active_activities_by_tag_has_updated_at(temp_db):
 def test_get_active_activities_by_tag_excludes_completed(temp_db):
     """completedアクティビティは含まれない"""
     result = add_activity(title="Done Activity", description="Desc", tags=["domain:test-proj"], check_in=False)
-    update_activity(result["activity_id"], new_status="completed")
+    update_activity(result["activity_id"], status="completed")
 
     tag_id = _get_tag_id("domain", "test-proj")
     activities = get_active_activities_by_tag(tag_id)
@@ -232,7 +232,7 @@ def test_get_active_activities_by_tag_sort_order(temp_db):
     """in_progressが先、その後pending"""
     r1 = add_activity(title="Pending Activity", description="Desc", tags=["domain:test-proj"], check_in=False)
     r2 = add_activity(title="In Progress Activity", description="Desc", tags=["domain:test-proj"], check_in=False)
-    update_activity(r2["activity_id"], new_status="in_progress")
+    update_activity(r2["activity_id"], status="in_progress")
 
     tag_id = _get_tag_id("domain", "test-proj")
     activities = get_active_activities_by_tag(tag_id)
@@ -294,7 +294,7 @@ def test_build_activities_section_status_marker_pending(temp_db):
 def test_build_activities_section_status_marker_in_progress(temp_db):
     """in_progressアクティビティに●マーカーが付く"""
     r = add_activity(title="[作業] 実装する", description="Desc", tags=["domain:myapp"], check_in=False)
-    update_activity(r["activity_id"], new_status="in_progress")
+    update_activity(r["activity_id"], status="in_progress")
 
     result = _build_active_context_wrapper()
 
@@ -339,7 +339,7 @@ def test_build_activities_section_in_progress_limit(temp_db):
             title=f"[作業] IP Activity {i}", description="Desc",
             tags=["domain:myapp"], check_in=False,
         )
-        update_activity(r["activity_id"], new_status="in_progress")
+        update_activity(r["activity_id"], status="in_progress")
 
     result = _build_active_context_wrapper()
 
@@ -369,7 +369,7 @@ def test_build_activities_section_overflow_count(temp_db):
             title=f"[作業] IP {i}", description="Desc",
             tags=["domain:myapp"], check_in=False,
         )
-        update_activity(r["activity_id"], new_status="in_progress")
+        update_activity(r["activity_id"], status="in_progress")
     for i in range(3):
         add_activity(
             title=f"[作業] Pending {i}", description="Desc",
@@ -388,7 +388,7 @@ def test_build_activities_section_no_overflow_when_within_limits(temp_db):
         title="[作業] IP 1", description="Desc",
         tags=["domain:myapp"], check_in=False,
     )
-    update_activity(r["activity_id"], new_status="in_progress")
+    update_activity(r["activity_id"], status="in_progress")
     add_activity(
         title="[作業] Pending 1", description="Desc",
         tags=["domain:myapp"], check_in=False,
@@ -454,7 +454,7 @@ def test_build_activities_section_raises_on_invalid_db(temp_db):
 def test_build_activities_section_completed_activities_excluded(temp_db):
     """completedアクティビティは表示されない"""
     result = add_activity(title="Done Activity", description="Desc", tags=["domain:myapp"], check_in=False)
-    update_activity(result["activity_id"], new_status="completed")
+    update_activity(result["activity_id"], status="completed")
 
     ctx = _build_active_context_wrapper()
 
@@ -467,7 +467,7 @@ def test_build_activities_section_format(temp_db):
         title="[議論] stop_hookのスキップ機能", description="Desc",
         tags=["domain:cc-memory"], check_in=False,
     )
-    update_activity(r["activity_id"], new_status="in_progress")
+    update_activity(r["activity_id"], status="in_progress")
     add_activity(
         title="[作業] アクティブコンテキスト改善", description="Desc",
         tags=["domain:cc-memory"], check_in=False,

--- a/tests/unit/test_reminder_service.py
+++ b/tests/unit/test_reminder_service.py
@@ -103,24 +103,24 @@ class TestUpdateReminder:
         assert result["content"] == "更新後のリマインダー"
         assert result["active"] == 1
 
-    def test_update_active_to_zero(self, temp_db):
-        """active=0で無効化できる"""
+    def test_update_active_to_false(self, temp_db):
+        """active=Falseで無効化できる"""
         created = add_reminder("無効化するリマインダー")
         reminder_id = created["reminder_id"]
 
-        result = update_reminder(reminder_id, active=0)
+        result = update_reminder(reminder_id, active=False)
 
         assert "error" not in result
         assert result["reminder_id"] == reminder_id
         assert result["active"] == 0
 
-    def test_update_active_to_one(self, temp_db):
-        """active=1で再有効化できる"""
+    def test_update_active_to_true(self, temp_db):
+        """active=Trueで再有効化できる"""
         created = add_reminder("再有効化するリマインダー")
         reminder_id = created["reminder_id"]
-        update_reminder(reminder_id, active=0)
+        update_reminder(reminder_id, active=False)
 
-        result = update_reminder(reminder_id, active=1)
+        result = update_reminder(reminder_id, active=True)
 
         assert "error" not in result
         assert result["active"] == 1
@@ -130,7 +130,7 @@ class TestUpdateReminder:
         created = add_reminder("元のリマインダー")
         reminder_id = created["reminder_id"]
 
-        result = update_reminder(reminder_id, content="新しいリマインダー", active=0)
+        result = update_reminder(reminder_id, content="新しいリマインダー", active=False)
 
         assert "error" not in result
         assert result["content"] == "新しいリマインダー"
@@ -163,12 +163,12 @@ class TestUpdateReminder:
         assert result["error"]["code"] == "VALIDATION_ERROR"
 
     def test_update_invalid_active(self, temp_db):
-        """active=2のような無効値でバリデーションエラーになる"""
+        """非bool値でバリデーションエラーになる"""
         created = add_reminder("元のリマインダー")
         reminder_id = created["reminder_id"]
 
-        result = update_reminder(reminder_id, active=2)
+        result = update_reminder(reminder_id, active="invalid")
 
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
-        assert "active must be 0 or 1" in result["error"]["message"]
+        assert "active must be True or False" in result["error"]["message"]

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -585,6 +585,66 @@ def test_add_topic_with_related_activity(temp_db):
         conn.close()
 
 
+def test_add_topic_related_missing_ids_key(temp_db):
+    """related内にidsキーが欠落している場合にVALIDATION_ERRORが返る"""
+    result = add_topic(
+        title="idsキー欠落",
+        description="テスト",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "topic"}],
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_add_topic_related_missing_type_key(temp_db):
+    """related内にtypeキーが欠落している場合にVALIDATION_ERRORが返る"""
+    result = add_topic(
+        title="typeキー欠落",
+        description="テスト",
+        tags=DEFAULT_TAGS,
+        related=[{"ids": [1]}],
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_add_topic_related_invalid_type(temp_db):
+    """related内のtypeが不正な場合にINVALID_ENTITY_TYPEが返る"""
+    result = add_topic(
+        title="不正type",
+        description="テスト",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "invalid", "ids": [1]}],
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "INVALID_ENTITY_TYPE"
+
+
+def test_add_topic_related_empty_ids(temp_db):
+    """related内のidsが空リストの場合にVALIDATION_ERRORが返る"""
+    result = add_topic(
+        title="空ids",
+        description="テスト",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "topic", "ids": []}],
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_add_topic_related_empty_list(temp_db):
+    """related=[]の場合はリレーションなしでトピックが正常に作成される"""
+    result = add_topic(
+        title="空リスト",
+        description="related空リスト",
+        tags=DEFAULT_TAGS,
+        related=[],
+    )
+    assert "error" not in result
+    assert result["topic_id"] > 0
+
+
 def test_add_topic_without_related(temp_db):
     """related未指定でリレーションなしのトピックが作成される"""
     t = add_topic(

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
+from src.services.activity_service import add_activity
 from tests.helpers import add_log, add_decision
 
 
@@ -512,5 +513,102 @@ def test_on_delete_cascade_discussion_logs(temp_db):
 
     # discussion_logsがカスケード削除されて0件になることを確認
     assert _count_logs(topic_id) == 0
+
+
+# ========================================
+# add_topic の related 引数テスト
+# ========================================
+
+
+def test_add_topic_with_related_topic(temp_db):
+    """related指定でトピック作成時にトピック間リレーションが張られる"""
+    # 先にリレーション先のトピックを作成
+    t1 = add_topic(title="関連トピック", description="関連先", tags=DEFAULT_TAGS)
+    assert "error" not in t1
+
+    # related付きでトピックを作成
+    t2 = add_topic(
+        title="新しいトピック",
+        description="related付き",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "topic", "ids": [t1["topic_id"]]}],
+    )
+
+    assert "error" not in t2
+    assert t2["topic_id"] > 0
+
+    # topic_relationsにリレーションが保存されていることを確認
+    conn = get_connection()
+    try:
+        id_1 = min(t1["topic_id"], t2["topic_id"])
+        id_2 = max(t1["topic_id"], t2["topic_id"])
+        row = conn.execute(
+            "SELECT * FROM topic_relations WHERE topic_id_1 = ? AND topic_id_2 = ?",
+            (id_1, id_2),
+        ).fetchone()
+        assert row is not None
+    finally:
+        conn.close()
+
+
+def test_add_topic_with_related_activity(temp_db):
+    """related指定でトピック作成時にトピック-アクティビティ間リレーションが張られる"""
+    # アクティビティを先に作成
+    activity = add_activity(
+        title="テストアクティビティ",
+        description="テスト用",
+        tags=DEFAULT_TAGS,
+        check_in=False,
+    )
+    assert "error" not in activity
+
+    # related付きでトピックを作成
+    t = add_topic(
+        title="アクティビティ関連トピック",
+        description="related付き",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "activity", "ids": [activity["activity_id"]]}],
+    )
+
+    assert "error" not in t
+    assert t["topic_id"] > 0
+
+    # topic_activity_relationsにリレーションが保存されていることを確認
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM topic_activity_relations WHERE topic_id = ? AND activity_id = ?",
+            (t["topic_id"], activity["activity_id"]),
+        ).fetchone()
+        assert row is not None
+    finally:
+        conn.close()
+
+
+def test_add_topic_without_related(temp_db):
+    """related未指定でリレーションなしのトピックが作成される"""
+    t = add_topic(
+        title="リレーションなし",
+        description="related未指定",
+        tags=DEFAULT_TAGS,
+    )
+
+    assert "error" not in t
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) as cnt FROM topic_relations WHERE topic_id_1 = ? OR topic_id_2 = ?",
+            (t["topic_id"], t["topic_id"]),
+        ).fetchone()
+        assert row["cnt"] == 0
+
+        row = conn.execute(
+            "SELECT COUNT(*) as cnt FROM topic_activity_relations WHERE topic_id = ?",
+            (t["topic_id"],),
+        ).fetchone()
+        assert row["cnt"] == 0
+    finally:
+        conn.close()
 
 

--- a/tests/unit/test_update_activity.py
+++ b/tests/unit/test_update_activity.py
@@ -43,7 +43,7 @@ class TestUpdateActivitySuccess:
 
     def test_update_status(self, test_activity):
         """ステータスのみ変更できる"""
-        result = update_activity(test_activity["activity_id"], new_status="in_progress")
+        result = update_activity(test_activity["activity_id"], status="in_progress")
 
         assert "error" not in result
         assert result["activity_id"] == test_activity["activity_id"]
@@ -69,7 +69,7 @@ class TestUpdateActivitySuccess:
         """複数フィールドを同時に変更できる"""
         result = update_activity(
             test_activity["activity_id"],
-            new_status="in_progress",
+            status="in_progress",
             title="Updated Title",
             description="Updated Description",
         )
@@ -81,7 +81,7 @@ class TestUpdateActivitySuccess:
     def test_update_persists_via_get_activities(self, test_activity):
         """更新がDBに永続化されていることをget_activitiesで確認する"""
         activity_id = test_activity["activity_id"]
-        update_activity(activity_id, title="Persisted Title", description="Persisted Desc", new_status="in_progress")
+        update_activity(activity_id, title="Persisted Title", description="Persisted Desc", status="in_progress")
 
         result = get_activities(status="in_progress")
         activities = result["activities"]
@@ -93,7 +93,7 @@ class TestUpdateActivitySuccess:
 
     def test_update_preserves_tags(self, test_activity):
         """update_activityでタグが保持される（レスポンスはactivity_id+statusのみ）"""
-        result = update_activity(test_activity["activity_id"], new_status="in_progress")
+        result = update_activity(test_activity["activity_id"], status="in_progress")
 
         assert "error" not in result
         assert result["activity_id"] == test_activity["activity_id"]
@@ -117,21 +117,21 @@ class TestUpdateActivityError:
 
     def test_not_found(self, temp_db):
         """存在しないアクティビティIDでNOT_FOUNDになる"""
-        result = update_activity(9999, new_status="in_progress")
+        result = update_activity(9999, status="in_progress")
 
         assert "error" in result
         assert result["error"]["code"] == "NOT_FOUND"
 
     def test_invalid_status(self, test_activity):
         """無効なステータスでINVALID_STATUSになる"""
-        result = update_activity(test_activity["activity_id"], new_status="invalid")
+        result = update_activity(test_activity["activity_id"], status="invalid")
 
         assert "error" in result
         assert result["error"]["code"] == "INVALID_STATUS"
 
     def test_active_status_rejected(self, test_activity):
         """activeはget_activities用エイリアスであり、update_activityでは無効"""
-        result = update_activity(test_activity["activity_id"], new_status="active")
+        result = update_activity(test_activity["activity_id"], status="active")
 
         assert "error" in result
         assert result["error"]["code"] == "INVALID_STATUS"
@@ -170,7 +170,7 @@ class TestUpdateActivityError:
 
     def test_blocked_status_rejected(self, test_activity):
         """blockedステータスがINVALID_STATUSになる"""
-        result = update_activity(test_activity["activity_id"], new_status="blocked")
+        result = update_activity(test_activity["activity_id"], status="blocked")
 
         assert "error" in result
         assert result["error"]["code"] == "INVALID_STATUS"
@@ -202,7 +202,7 @@ class TestUpdateActivityTags:
     def test_update_tags_none(self, test_activity):
         """tags=None（未指定）ではタグ変更なし（レスポンスはactivity_id+statusのみ）"""
         # まずステータスだけ変更
-        result = update_activity(test_activity["activity_id"], new_status="in_progress")
+        result = update_activity(test_activity["activity_id"], status="in_progress")
 
         assert "error" not in result
         assert result["activity_id"] == test_activity["activity_id"]


### PR DESCRIPTION
## Summary
- `add_topic`に`related`引数を追加（add_activity/add_materialとのAPI統一）
- `update_activity`の`new_status`パラメータを`status`にリネーム（同ツール内パラメータ名の一貫性）
- `update_reminder`の`active`パラメータを`int(0/1)`から`bool`に変更（他boolフラグとの型一貫性）

## Related
- cc-memory activity: #568
- Decisions: D#1459, D#1461, D#1462
- Topic: #368（cc-memoryツール仕様の違和感レビュー）

## Test plan
- [x] add_topicでrelated指定時にリレーションが保存される（テスト3件追加）
- [x] update_activityで`status=`パラメータが動作する
- [x] update_reminderで`active=True/False`が動作する
- [x] 全916テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)