### PR TITLE
feat: launcher.pyにサーバー切断時の自動再接続ロジックを追加

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -3,7 +3,7 @@
 Claude Code が stdio プロトコルで接続してくるエントリーポイント。
 HTTPサーバーが未起動なら自動でデーモン起動し、
 stdinからのJSON-RPCメッセージをStreamable HTTP経由で転送する。
-終了時にセッション解除を行う。
+サーバー側切断時は自動再接続を試み、stdin EOF時にセッション解除を行う。
 """
 import asyncio
 import atexit
@@ -19,6 +19,15 @@ import uuid
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# リトライ設定
+MAX_RETRIES = 3
+
+
+class ServerDisconnected(Exception):
+    """サーバー側の切断を示す例外。stdin EOFとの区別に使用する。"""
+    pass
+
 
 # サーバー接続設定（HTTP_HOST, HTTP_PORTはmain.pyと共有）
 from src.http_config import HTTP_HOST, HTTP_PORT
@@ -169,6 +178,7 @@ async def _bridge() -> None:
     """stdinからJSON-RPCメッセージを読み、HTTP POST /mcpに転送し、レスポンスをstdoutに書く。
 
     MCP SDK の streamable_http_client を利用し、ストリーム間のブリッジを行う。
+    正常終了（stdin EOF）時はreturn、サーバー側切断時はServerDisconnectedをraiseする。
     """
     # 遅延import: デーモン起動ロジックはMCP SDKに依存しないため、
     # ブリッジ実行時まで重いimportを遅延させて起動速度を確保する
@@ -177,6 +187,11 @@ async def _bridge() -> None:
     from mcp.client.streamable_http import streamable_http_client
     from mcp.shared.message import SessionMessage
 
+    # stdin EOFとサーバー切断を区別するためのフラグ
+    # stdin EOF: stdin_to_serverが先に終了 → 正常終了
+    # サーバー切断: server_to_stdoutが先に終了 → stdin_eofがFalse → ServerDisconnected
+    stdin_eof = False
+
     async with streamable_http_client(
         url=MCP_ENDPOINT,
         terminate_on_close=False,
@@ -184,6 +199,7 @@ async def _bridge() -> None:
 
         async def stdin_to_server() -> None:
             """stdinから1行ずつ読み、write_streamに送る。"""
+            nonlocal stdin_eof
             loop = asyncio.get_running_loop()
             reader = asyncio.StreamReader()
             transport, _ = await loop.connect_read_pipe(
@@ -195,6 +211,7 @@ async def _bridge() -> None:
                 while True:
                     chunk = await reader.read(65536)
                     if not chunk:
+                        stdin_eof = True
                         break
                     buffer += chunk
                     while b"\n" in buffer:
@@ -219,7 +236,11 @@ async def _bridge() -> None:
                 await write_stream.aclose()
 
         async def server_to_stdout() -> None:
-            """read_streamからメッセージを受信し、stdoutに書く。"""
+            """read_streamからメッセージを受信し、stdoutに書く。
+
+            read_streamが終了したとき、stdin_eofがFalseならサーバー側切断と判断し
+            ServerDisconnectedをraiseしてtask group全体をキャンセルする。
+            """
             try:
                 async for session_msg_or_exc in read_stream:
                     if isinstance(session_msg_or_exc, Exception):
@@ -235,6 +256,9 @@ async def _bridge() -> None:
                 pass
             except Exception:
                 logger.debug("stdout writer ended", exc_info=True)
+            finally:
+                if not stdin_eof:
+                    raise ServerDisconnected("Server connection lost")
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(stdin_to_server)
@@ -242,7 +266,11 @@ async def _bridge() -> None:
 
 
 def main() -> None:
-    """ランチャーのメインエントリーポイント"""
+    """ランチャーのメインエントリーポイント
+
+    サーバー側切断時は自動でリトライする（最大MAX_RETRIES回）。
+    stdin EOF（Claude Code終了）時は即座に終了する。
+    """
     # ログ設定（stderrへ出力、stdoutはMCPプロトコル用）
     logging.basicConfig(
         level=logging.INFO,
@@ -250,27 +278,49 @@ def main() -> None:
         stream=sys.stderr,
     )
 
-    # 1. HTTPサーバーの起動確認
-    if not _ensure_server_running():
-        logger.error("Failed to ensure HTTP server is running")
-        sys.exit(1)
-
-    # 2. セッション登録
-    if not _register_session():
-        logger.error("Failed to register session")
-        sys.exit(1)
-
-    # 3. クリーンアップ登録
+    # クリーンアップ登録（ループの外で1回だけ）
     atexit.register(_cleanup)
     signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))  # atexitが発火する
 
-    # 4. stdio <-> HTTP ブリッジ起動
-    try:
-        asyncio.run(_bridge())
-    except KeyboardInterrupt:
-        pass
-    finally:
-        _cleanup()
+    for attempt in range(MAX_RETRIES + 1):
+        # 1. HTTPサーバーの起動確認
+        if not _ensure_server_running():
+            logger.error("Failed to ensure HTTP server is running")
+            sys.exit(1)
+
+        # 2. セッション登録
+        if not _register_session():
+            logger.error("Failed to register session")
+            sys.exit(1)
+
+        # 3. stdio <-> HTTP ブリッジ起動
+        try:
+            asyncio.run(_bridge())
+            break  # stdin EOF → 正常終了
+        except KeyboardInterrupt:
+            break
+        except ServerDisconnected as e:
+            if attempt >= MAX_RETRIES:
+                logger.error("Bridge disconnected, max retries (%d) exceeded: %s", MAX_RETRIES, e)
+                break
+            backoff = 2 ** (attempt + 1)  # 2秒, 4秒, 8秒
+            logger.warning(
+                "Bridge disconnected (%s), retrying in %ds (%d/%d)",
+                e, backoff, attempt + 1, MAX_RETRIES,
+            )
+            time.sleep(backoff)
+        except Exception as e:
+            if attempt >= MAX_RETRIES:
+                logger.error("Bridge failed unexpectedly, max retries (%d) exceeded: %s", MAX_RETRIES, e)
+                break
+            backoff = 2 ** (attempt + 1)
+            logger.warning(
+                "Bridge failed unexpectedly (%s), retrying in %ds (%d/%d)",
+                e, backoff, attempt + 1, MAX_RETRIES,
+            )
+            time.sleep(backoff)
+
+    _cleanup()
 
 
 if __name__ == "__main__":

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -226,6 +226,7 @@ async def _bridge() -> None:
                         except Exception:
                             logger.exception("Failed to parse stdin message")
             except Exception:
+                stdin_eof = True  # stdin エラーも「stdin 側起因」として扱う
                 logger.debug("stdin reader ended")
             finally:
                 if buffer.strip():
@@ -299,23 +300,15 @@ def main() -> None:
             break  # stdin EOF → 正常終了
         except KeyboardInterrupt:
             break
-        except ServerDisconnected as e:
+        except Exception as e:
+            # anyioのExceptionGroupによりServerDisconnectedが直接キャッチできない
+            # ケースがあるため、例外の種類を問わず統一的にリトライする
             if attempt >= MAX_RETRIES:
-                logger.error("Bridge disconnected, max retries (%d) exceeded: %s", MAX_RETRIES, e)
+                logger.error("Bridge failed, max retries (%d) exceeded: %s", MAX_RETRIES, e)
                 break
             backoff = 2 ** (attempt + 1)  # 2秒, 4秒, 8秒
             logger.warning(
-                "Bridge disconnected (%s), retrying in %ds (%d/%d)",
-                e, backoff, attempt + 1, MAX_RETRIES,
-            )
-            time.sleep(backoff)
-        except Exception as e:
-            if attempt >= MAX_RETRIES:
-                logger.error("Bridge failed unexpectedly, max retries (%d) exceeded: %s", MAX_RETRIES, e)
-                break
-            backoff = 2 ** (attempt + 1)
-            logger.warning(
-                "Bridge failed unexpectedly (%s), retrying in %ds (%d/%d)",
+                "Bridge failed (%s), retrying in %ds (%d/%d)",
                 e, backoff, attempt + 1, MAX_RETRIES,
             )
             time.sleep(backoff)

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -400,25 +400,12 @@ class TestMainRetryLoop:
             ensure_count["calls"] += 1
             return True
 
-        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        self._setup_main(monkeypatch, [
+            launcher.ServerDisconnected("lost"),
+            None,
+        ])
+        # _setup_mainの後にcounting_ensureで再上書き
         monkeypatch.setattr(launcher, "_ensure_server_running", counting_ensure)
-        monkeypatch.setattr(launcher, "_register_session", lambda: True)
-        monkeypatch.setattr(launcher, "_unregister_session", lambda: True)
-        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
-
-        bridge_effects = [launcher.ServerDisconnected("lost"), None]
-        call_count = {"bridge": 0}
-
-        def fake_asyncio_run(coro):
-            coro.close()
-            idx = call_count["bridge"]
-            call_count["bridge"] += 1
-            effect = bridge_effects[idx]
-            if isinstance(effect, Exception):
-                raise effect
-            return effect
-
-        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
         launcher.main()
         assert ensure_count["calls"] == 2
 
@@ -429,30 +416,14 @@ class TestMainRetryLoop:
         def tracking_sleep(seconds):
             sleep_values.append(seconds)
 
-        monkeypatch.setattr(launcher, "_cleanup_done", False)
-        monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)
-        monkeypatch.setattr(launcher, "_register_session", lambda: True)
-        monkeypatch.setattr(launcher, "_unregister_session", lambda: True)
+        self._setup_main(monkeypatch, [
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+        ])
+        # _setup_mainのsleep上書きの後にtracking_sleepで再上書き
         monkeypatch.setattr(launcher.time, "sleep", tracking_sleep)
-
-        bridge_effects = [
-            launcher.ServerDisconnected("lost"),
-            launcher.ServerDisconnected("lost"),
-            launcher.ServerDisconnected("lost"),
-            launcher.ServerDisconnected("lost"),
-        ]
-        call_count = {"bridge": 0}
-
-        def fake_asyncio_run(coro):
-            coro.close()
-            idx = call_count["bridge"]
-            call_count["bridge"] += 1
-            effect = bridge_effects[idx]
-            if isinstance(effect, Exception):
-                raise effect
-            return effect
-
-        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
         launcher.main()
         assert sleep_values == [2, 4, 8]
 

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -315,3 +315,164 @@ class TestProjectRoot:
         import os
         assert os.path.isdir(launcher._PROJECT_ROOT)
         assert os.path.isfile(os.path.join(launcher._PROJECT_ROOT, "pyproject.toml"))
+
+
+class TestServerDisconnected:
+    def test_is_exception(self):
+        """ServerDisconnectedがExceptionのサブクラスである"""
+        assert issubclass(launcher.ServerDisconnected, Exception)
+
+    def test_can_be_raised_and_caught(self):
+        """ServerDisconnectedをraise/catchできる"""
+        with pytest.raises(launcher.ServerDisconnected, match="test message"):
+            raise launcher.ServerDisconnected("test message")
+
+
+class TestMainRetryLoop:
+    """main()のリトライループの動作検証"""
+
+    def _setup_main(self, monkeypatch, bridge_side_effects):
+        """main()テスト用の共通セットアップ
+
+        bridge_side_effectsにはasyncio.run(_bridge())の戻り値/例外のリストを渡す。
+        """
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)
+        monkeypatch.setattr(launcher, "_register_session", lambda: True)
+        monkeypatch.setattr(launcher, "_unregister_session", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+        call_count = {"bridge": 0}
+
+        def fake_asyncio_run(coro):
+            # コルーチンを破棄（awaitしない）
+            coro.close()
+            idx = call_count["bridge"]
+            call_count["bridge"] += 1
+            effect = bridge_side_effects[idx]
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
+        return call_count
+
+    def test_normal_exit_no_retry(self, monkeypatch):
+        """stdin EOF（正常終了）ではリトライしない"""
+        call_count = self._setup_main(monkeypatch, [None])  # bridge returns None
+        launcher.main()
+        assert call_count["bridge"] == 1
+
+    def test_server_disconnected_retries(self, monkeypatch):
+        """ServerDisconnectedでリトライし、次の接続で成功する"""
+        call_count = self._setup_main(monkeypatch, [
+            launcher.ServerDisconnected("lost"),  # attempt 0: fail
+            None,  # attempt 1: success
+        ])
+        launcher.main()
+        assert call_count["bridge"] == 2
+
+    def test_max_retries_exceeded(self, monkeypatch):
+        """MAX_RETRIES回リトライしても失敗したら終了する"""
+        call_count = self._setup_main(monkeypatch, [
+            launcher.ServerDisconnected("lost"),  # attempt 0
+            launcher.ServerDisconnected("lost"),  # attempt 1
+            launcher.ServerDisconnected("lost"),  # attempt 2
+            launcher.ServerDisconnected("lost"),  # attempt 3 (max)
+        ])
+        launcher.main()
+        assert call_count["bridge"] == launcher.MAX_RETRIES + 1
+
+    def test_unexpected_exception_retries(self, monkeypatch):
+        """予期しない例外でもリトライする"""
+        call_count = self._setup_main(monkeypatch, [
+            ConnectionError("connection reset"),  # attempt 0: fail
+            None,  # attempt 1: success
+        ])
+        launcher.main()
+        assert call_count["bridge"] == 2
+
+    def test_ensure_server_called_each_attempt(self, monkeypatch):
+        """リトライのたびに_ensure_server_runningが呼ばれる"""
+        ensure_count = {"calls": 0}
+
+        def counting_ensure():
+            ensure_count["calls"] += 1
+            return True
+
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        monkeypatch.setattr(launcher, "_ensure_server_running", counting_ensure)
+        monkeypatch.setattr(launcher, "_register_session", lambda: True)
+        monkeypatch.setattr(launcher, "_unregister_session", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+        bridge_effects = [launcher.ServerDisconnected("lost"), None]
+        call_count = {"bridge": 0}
+
+        def fake_asyncio_run(coro):
+            coro.close()
+            idx = call_count["bridge"]
+            call_count["bridge"] += 1
+            effect = bridge_effects[idx]
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
+        launcher.main()
+        assert ensure_count["calls"] == 2
+
+    def test_backoff_values(self, monkeypatch):
+        """バックオフが2秒, 4秒, 8秒の順で適用される"""
+        sleep_values = []
+
+        def tracking_sleep(seconds):
+            sleep_values.append(seconds)
+
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)
+        monkeypatch.setattr(launcher, "_register_session", lambda: True)
+        monkeypatch.setattr(launcher, "_unregister_session", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", tracking_sleep)
+
+        bridge_effects = [
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+            launcher.ServerDisconnected("lost"),
+        ]
+        call_count = {"bridge": 0}
+
+        def fake_asyncio_run(coro):
+            coro.close()
+            idx = call_count["bridge"]
+            call_count["bridge"] += 1
+            effect = bridge_effects[idx]
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
+        launcher.main()
+        assert sleep_values == [2, 4, 8]
+
+    def test_cleanup_called_once(self, monkeypatch):
+        """main()終了時にcleanupが1回だけ呼ばれる"""
+        cleanup_count = {"calls": 0}
+
+        def counting_cleanup():
+            cleanup_count["calls"] += 1
+
+        monkeypatch.setattr(launcher, "_cleanup_done", False)
+        monkeypatch.setattr(launcher, "_cleanup", counting_cleanup)
+        monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)
+        monkeypatch.setattr(launcher, "_register_session", lambda: True)
+        monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+        def fake_asyncio_run(coro):
+            coro.close()
+            return None
+
+        monkeypatch.setattr(launcher.asyncio, "run", fake_asyncio_run)
+        launcher.main()
+        assert cleanup_count["calls"] == 1


### PR DESCRIPTION
## Summary
- launcher.pyの`_bridge()`にサーバー切断検出ロジックを追加（`stdin_eof`フラグ + `ServerDisconnected`例外）
- `main()`をリトライループ化し、サーバー側切断時に自動で再接続を試行（最大3回、exponential backoff 2/4/8秒）
- stdin EOF（Claude Code終了）時は即座に正常終了する既存動作を維持

## Background
httpサーバーkill実験（D#1481）で、サーバーが死ぬとlauncher.pyも終了し、Claude Codeがツールを除外することが判明。
この変更により、`pkill`一発でコード更新を反映可能になる（セッション再起動不要）。

## Design
- **切断原因の区別**: `stdin_eof`フラグで、`stdin_to_server`が先に終了（stdin EOF = 正常終了）か、`server_to_stdout`が先に終了（サーバー切断 = リトライ）かを判別
- **リトライ仕様**: 各リトライで`_ensure_server_running()`を再実行し、最新コードでサーバーを再起動
- **stdinバッファ**: リトライ中のメッセージはOSパイプバッファに蓄積され、再接続時に自然に読み取られる

## Test plan
- [x] 既存22テスト全パス（既存動作の非破壊確認）
- [x] `ServerDisconnected`例外の基本テスト（2件）
- [x] `main()`リトライループのテスト（7件）: 正常終了、リトライ成功、最大リトライ超過、予期しない例外、`_ensure_server_running`再呼び出し、バックオフ値、クリーンアップ
- [ ] 手動検証: httpサーバーをkillして再接続が行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)