### PR TITLE
docs: PRマージ後の反映手順を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,4 +29,5 @@ cc-memoryはローカルディレクトリをmarketplaceとして登録してお
 3. ローカルブランチを削除: `git branch -D <branch>`
 4. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
 5. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
-6. Claude Codeを再起動
+6. 既存のhttpサーバーを停止・再起動: `lsof -ti :52837 | xargs kill; uv run python -m src.launcher &`
+7. Claude Codeセッションを再起動（個別でOK、全セッション同時に落とす必要なし）


### PR DESCRIPTION
## Summary
- PRマージ後の反映手順にhttpサーバーの停止・再起動ステップを追加
- 「Claude Codeを再起動」を「個別再起動でOK」に明確化

## 背景
実験により、全Claude Codeセッションを同時に落とす必要がないことが判明。キャッシュ削除後にmainソースからlauncher.pyを再起動し、各セッションを個別に再起動すれば最新コードが反映される。

## Test plan
- [x] 実機で手順を検証済み（habitsリネームPR #284の反映で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)