### PR TITLE
feat: HTTP_PORTをCCM_HTTP_PORT環境変数で設定可能にする

### DIFF
--- a/src/http_config.py
+++ b/src/http_config.py
@@ -3,5 +3,7 @@
 launcher.py と main.py の両方から参照される定数を集約する。
 """
 
+import os
+
 HTTP_HOST = "localhost"
-HTTP_PORT = 52837
+HTTP_PORT = int(os.environ.get("CCM_HTTP_PORT", "52837"))


### PR DESCRIPTION
## Summary
- `http_config.py`の`HTTP_PORT`を`CCM_HTTP_PORT`環境変数で上書き可能にした
- デフォルト値は52837のまま（既存動作に影響なし）
- dev-serverで別ポートのインスタンスを起動するための前提変更

## Test plan
- [x] デフォルト値（52837）の動作確認
- [x] `CCM_HTTP_PORT=52838`での動作確認
- [x] 既存テスト全976件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)