### PR TITLE
feat: shelvedステータス追加

### DIFF
--- a/migrations/0027_add_shelved_status.sql
+++ b/migrations/0027_add_shelved_status.sql
@@ -1,0 +1,96 @@
+-- Migration 027: activitiesテーブルのCHECK制約にshelvedを追加
+--
+-- depends: 0026_add_snoozed_status
+--
+-- 背景:
+--   「後で考える」系の話題を棚上げする「shelved」ステータスを追加する。
+--   snoozedと異なり自動復活しない。期限未定で棚上げするユースケース向け。
+--   SQLiteではCHECK制約のALTERができないため、テーブル再作成が必要。
+--
+-- 変更内容:
+--   1. activitiesテーブルを再作成（CHECK制約にshelved追加）
+--   2. データ移行
+--   3. FTS5トリガー（activities関連3つ）をDROP→再CREATE
+
+-- ================================================
+-- Step 1: 新テーブル作成（shelved追加のCHECK制約）
+-- ================================================
+
+CREATE TABLE activities_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title VARCHAR(255) NOT NULL,
+  description TEXT NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'completed', 'snoozed', 'shelved')),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_heartbeat_at TEXT
+);
+
+-- ================================================
+-- Step 2: データ移行
+-- ================================================
+
+INSERT INTO activities_new SELECT
+  id, title, description, status, created_at, updated_at, last_heartbeat_at
+FROM activities;
+
+-- ================================================
+-- Step 3: FTS5トリガー一時削除（activitiesテーブルを参照しているもの）
+-- ================================================
+
+DROP TRIGGER IF EXISTS trg_search_activities_insert;
+DROP TRIGGER IF EXISTS trg_search_activities_update;
+DROP TRIGGER IF EXISTS trg_search_activities_delete;
+
+-- ================================================
+-- Step 4: 旧テーブル削除 + リネーム
+-- ================================================
+
+DROP TABLE activities;
+ALTER TABLE activities_new RENAME TO activities;
+
+-- ================================================
+-- Step 5: インデックス再作成
+-- ================================================
+
+CREATE INDEX IF NOT EXISTS idx_activities_status ON activities(status);
+
+-- ================================================
+-- Step 6: FTS5トリガー再作成
+-- 0011_rename_task_to_activity.sql で定義されたトリガーを再作成
+-- ================================================
+
+CREATE TRIGGER IF NOT EXISTS trg_search_activities_insert
+AFTER INSERT ON activities
+BEGIN
+  INSERT INTO search_index (source_type, source_id, title)
+  VALUES ('activity', NEW.id, NEW.title);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.title, NEW.description);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_search_activities_update
+AFTER UPDATE ON activities
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'activity' AND source_id = OLD.id),
+    OLD.title, OLD.description);
+  UPDATE search_index
+  SET title = NEW.title
+  WHERE source_type = 'activity' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'activity' AND source_id = NEW.id),
+    NEW.title, NEW.description);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_search_activities_delete
+AFTER DELETE ON activities
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'activity' AND source_id = OLD.id),
+    OLD.title, OLD.description);
+  DELETE FROM search_index WHERE source_type = 'activity' AND source_id = OLD.id;
+END;

--- a/src/main.py
+++ b/src/main.py
@@ -550,8 +550,8 @@ def get_activities(
 
     Args:
         tags: タグ配列（optional）。指定時はAND条件でフィルタ。未指定時は全件返す。例: ["domain:cc-memory"]
-        status: フィルタするステータス（active/pending/in_progress/completed/snoozed、デフォルト: active）
-                "active"はpending+in_progressの両方を返すエイリアス（snoozedは含まない）
+        status: フィルタするステータス（active/pending/in_progress/completed/snoozed/shelved、デフォルト: active）
+                "active"はpending+in_progressの両方を返すエイリアス（snoozed/shelvedは含まない）
         limit: 取得件数上限（デフォルト: 5）
         since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
         until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す
@@ -582,6 +582,7 @@ def update_activity(
     - アクティビティ開始: update_activity(activity_id, status="in_progress")
     - アクティビティ完了: update_activity(activity_id, status="completed")
     - アクティビティを寝かせる: update_activity(activity_id, status="snoozed")
+    - アクティビティを棚上げする: update_activity(activity_id, status="shelved")
     - タイトル変更: update_activity(activity_id, title="新しいタイトル")
     - 説明更新: update_activity(activity_id, description="新しい説明")
     - タグ変更: update_activity(activity_id, tags=["domain:cc-memory", "intent:implement"])
@@ -590,7 +591,7 @@ def update_activity(
 
     Args:
         activity_id: アクティビティID
-        status: 新しいステータス（pending/in_progress/completed/snoozed）
+        status: 新しいステータス（pending/in_progress/completed/snoozed/shelved）
         title: 新しいタイトル
         description: 新しい説明
         tags: 新しいタグ配列（指定時は全置換。1個以上必須）

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 ACTIVITY_DESC_MAX_LEN = 200
 from src.config import HEARTBEAT_TIMEOUT_MINUTES, SNOOZE_DURATION_DAYS
 # DB格納可能なステータス値
-REAL_STATUSES = {"pending", "in_progress", "completed", "snoozed"}
+REAL_STATUSES = {"pending", "in_progress", "completed", "snoozed", "shelved"}
 # "active"エイリアスが展開されるステータス
 ACTIVE_STATUSES = ("in_progress", "pending")
 # get_activities用（エイリアス含む）
@@ -133,8 +133,8 @@ def get_activities(
 
     Args:
         tags: タグ配列（optional。指定時はAND条件でフィルタ、未指定時は全件）
-        status: フィルタするステータス（active/pending/in_progress/completed/snoozed、デフォルト: active）
-                "active"はpending+in_progressの両方を返すエイリアス（snoozedは含まない）
+        status: フィルタするステータス（active/pending/in_progress/completed/snoozed/shelved、デフォルト: active）
+                "active"はpending+in_progressの両方を返すエイリアス（snoozed/shelvedは含まない）
         limit: 取得件数上限（デフォルト: 5）
         since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
         until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す

--- a/tests/integration/test_activity_service.py
+++ b/tests/integration/test_activity_service.py
@@ -619,3 +619,46 @@ class TestSnoozedStatus:
 
         assert "error" not in result
         assert result["status"] == "completed"
+
+
+class TestShelvedStatus:
+    """shelvedステータスの統合テスト"""
+
+    def test_set_status_to_shelved(self, activity_with_db):
+        """アクティビティをshelvedに変更できる"""
+        activity = activity_with_db["activity"]
+        result = update_activity(activity["activity_id"], status="shelved")
+
+        assert "error" not in result
+        assert result["status"] == "shelved"
+
+    def test_shelved_excluded_from_active(self, temp_db):
+        """shelvedアクティビティはstatus='active'に含まれない"""
+        a = add_activity(title="Shelved", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        update_activity(a["activity_id"], status="shelved")
+
+        result = get_activities(status="active")
+
+        assert "error" not in result
+        assert result["total_count"] == 0
+
+    def test_shelved_returned_with_status_filter(self, temp_db):
+        """get_activities(status='shelved')でshelvedアクティビティが返る"""
+        a = add_activity(title="Shelved", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        update_activity(a["activity_id"], status="shelved")
+
+        result = get_activities(status="shelved")
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        assert result["activities"][0]["title"] == "Shelved"
+
+    def test_field_update_does_not_wake_shelved(self, temp_db):
+        """shelved中にtitle更新してもshelvedのまま（snoozedとの差分）"""
+        a = add_activity(title="On Shelf", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        update_activity(a["activity_id"], status="shelved")
+
+        result = update_activity(a["activity_id"], title="Still On Shelf")
+
+        assert "error" not in result
+        assert result["status"] == "shelved"


### PR DESCRIPTION
## Summary
- 期限未定で棚上げできる`shelved`ステータスを追加
- snoozedと違い自動復活なし、フィールド更新でも復活しない
- `get_activities(status="shelved")`で手動棚卸し

## Changes
- `migrations/0027_add_shelved_status.sql`: CHECK制約に`shelved`追加（テーブル再作成パターン）
- `src/services/activity_service.py`: `REAL_STATUSES`に追加 + docstring更新
- `src/main.py`: `get_activities`・`update_activity`のdocstringにshelved追加
- `tests/integration/test_activity_service.py`: `TestShelvedStatus`（4テストケース）

## Design decisions
- D#1632: 新ステータスとして独立追加（snoozed拡張ではない）
- D#1636: フィールド更新で復活しない（snoozedとの差分）
- D#1639: check-inでin_progressに自動遷移（既存ロジックで対応済み）

## Test plan
- [x] shelvedに変更できる
- [x] active一覧に含まれない
- [x] status filterで取得できる
- [x] フィールド更新で復活しない
- [x] 既存37テスト + 新規4テスト = 全41パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)