### PR TITLE
feat: add_decisionsにpropagate_toオプションを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -234,6 +234,10 @@ def add_decisions(items: list[dict]) -> dict:
         - decision (str, 必須): 決定内容
         - reason (str, 必須): 決定の理由
         - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
+        - propagate_to (dict, optional): 決定事項を注入先に伝搬する。
+            - type: "habit" | "tag_note"
+            - content: 伝搬先に書き込む文（decisionテキストとは別にエージェントが書き分ける）
+            - tag: タグ文字列（type="tag_note"の場合のみ必須）
 
     Returns: {created: [...], errors: [{index, error}]}
     """

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -87,8 +87,6 @@ def add_decisions(items: list[dict]) -> dict:
                     try:
                         p_type = propagate_to.get("type")
                         p_content = propagate_to.get("content", "")
-                        if not p_content or not p_content.strip():
-                            raise ValueError("propagate_to.content must not be empty")
                         if p_type == "habit":
                             p_id = _add_habit_with_conn(conn, p_content)
                             propagation_result = {"status": "ok", "type": "habit", "id": p_id}

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -9,7 +9,9 @@ from src.services.tag_service import (
     link_tags,
     get_effective_tags_batch,
     get_effective_tags_batch_by_ids,
+    _append_tag_notes_with_conn,
 )
+from src.services.habit_service import _add_habit_with_conn
 
 
 def add_decisions(items: list[dict]) -> dict:
@@ -77,13 +79,43 @@ def add_decisions(items: list[dict]) -> dict:
                     tag_ids = ensure_tag_ids(conn, parsed_tags)
                     link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
 
+                # propagate_to 処理
+                propagate_to = item.get("propagate_to")
+                propagation_result = None
+                if propagate_to:
+                    conn.execute(f"SAVEPOINT propagate_{i}")
+                    try:
+                        p_type = propagate_to.get("type")
+                        p_content = propagate_to.get("content", "")
+                        if not p_content or not p_content.strip():
+                            raise ValueError("propagate_to.content must not be empty")
+                        if p_type == "habit":
+                            p_id = _add_habit_with_conn(conn, p_content)
+                            propagation_result = {"status": "ok", "type": "habit", "id": p_id}
+                        elif p_type == "tag_note":
+                            p_tag = propagate_to.get("tag")
+                            if not p_tag:
+                                raise ValueError("propagate_to.tag is required when type is 'tag_note'")
+                            p_id = _append_tag_notes_with_conn(conn, p_tag, p_content)
+                            propagation_result = {"status": "ok", "type": "tag_note", "id": p_id}
+                        else:
+                            raise ValueError(f"Invalid propagate_to.type: {p_type}")
+                        conn.execute(f"RELEASE SAVEPOINT propagate_{i}")
+                    except Exception as e:
+                        conn.execute(f"ROLLBACK TO SAVEPOINT propagate_{i}")
+                        conn.execute(f"RELEASE SAVEPOINT propagate_{i}")
+                        propagation_result = {"status": "error", "type": propagate_to.get("type", "unknown"), "message": str(e)}
+
                 conn.execute(f"RELEASE SAVEPOINT item_{i}")
-                created.append({
+                created_item = {
                     "decision_id": decision_id,
                     "topic_id": topic_id,
                     "decision": decision,
                     "reason": reason,
-                })
+                }
+                if propagation_result:
+                    created_item["propagation"] = propagation_result
+                created.append(created_item)
 
             except Exception as e:
                 conn.execute(f"ROLLBACK TO SAVEPOINT item_{i}")

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -13,6 +13,8 @@ from src.services.tag_service import (
 )
 from src.services.habit_service import _add_habit_with_conn
 
+PROPAGATE_TYPES = {"habit", "tag_note"}
+
 
 def add_decisions(items: list[dict]) -> dict:
     """
@@ -87,6 +89,8 @@ def add_decisions(items: list[dict]) -> dict:
                     try:
                         p_type = propagate_to.get("type")
                         p_content = propagate_to.get("content", "")
+                        if p_type not in PROPAGATE_TYPES:
+                            raise ValueError(f"Invalid propagate_to.type: {p_type}")
                         if p_type == "habit":
                             p_id = _add_habit_with_conn(conn, p_content)
                             propagation_result = {"status": "ok", "type": "habit", "id": p_id}
@@ -96,8 +100,6 @@ def add_decisions(items: list[dict]) -> dict:
                                 raise ValueError("propagate_to.tag is required when type is 'tag_note'")
                             p_id = _append_tag_notes_with_conn(conn, p_tag, p_content)
                             propagation_result = {"status": "ok", "type": "tag_note", "id": p_id}
-                        else:
-                            raise ValueError(f"Invalid propagate_to.type: {p_type}")
                         conn.execute(f"RELEASE SAVEPOINT propagate_{i}")
                     except Exception as e:
                         conn.execute(f"ROLLBACK TO SAVEPOINT propagate_{i}")

--- a/src/services/habit_service.py
+++ b/src/services/habit_service.py
@@ -18,6 +18,17 @@ def get_active_habit_contents_with_conn(conn) -> list[str]:
     return [r["content"] for r in rows]
 
 
+def _add_habit_with_conn(conn, content: str) -> int:
+    """振る舞いをINSERTしてhabit_idを返す（conn共有版）。バリデーションエラー時はValueError。"""
+    if not content or not content.strip():
+        raise ValueError("content must not be empty")
+    cursor = conn.execute(
+        "INSERT INTO habits (content) VALUES (?)",
+        (content,),
+    )
+    return cursor.lastrowid
+
+
 def add_habit(content: str) -> dict:
     """振る舞いを追加する。
 

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1085,3 +1085,24 @@ def collect_tag_notes_for_injection(
         results.append({"tag": tag_str, "notes": row["notes"]})
 
     return results if results else None
+
+
+def _append_tag_notes_with_conn(conn, tag_str: str, content: str) -> int:
+    """タグのnotesにcontentを追記しtag_idを返す。タグ不在時はValueError。"""
+    if not content or not content.strip():
+        raise ValueError("content must not be empty")
+    parsed = validate_and_parse_tags([tag_str])
+    if isinstance(parsed, dict):
+        raise ValueError(parsed["error"]["message"])
+    namespace, name = parsed[0]
+    row = conn.execute(
+        "SELECT id, notes FROM tags WHERE namespace = ? AND name = ?",
+        (namespace, name),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"Tag '{tag_str}' not found")
+    tag_id = row["id"]
+    existing = row["notes"]
+    new_notes = f"{existing}\n\n{content}" if existing else content
+    conn.execute("UPDATE tags SET notes = ? WHERE id = ?", (new_notes, tag_id))
+    return tag_id

--- a/tests/unit/test_propagate_to.py
+++ b/tests/unit/test_propagate_to.py
@@ -1,0 +1,306 @@
+"""propagate_to オプションのテスト
+
+decision保存と同時にhabit/tag-noteへの伝搬を検証する。
+"""
+import os
+import tempfile
+import pytest
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.decision_service import add_decisions
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+class TestPropagateToHabit:
+    """decision + habit伝搬のテスト"""
+
+    def test_propagate_to_habit_success(self, topic):
+        """decision + habit伝搬 → propagation.status=="ok", habit_id取得可能"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "常に簡潔に応答する",
+                "reason": "冗長な応答を避けるため",
+                "propagate_to": {
+                    "type": "habit",
+                    "content": "応答は簡潔にすること",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 0
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert "propagation" in created
+        assert created["propagation"]["status"] == "ok"
+        assert created["propagation"]["type"] == "habit"
+        assert created["propagation"]["id"] > 0
+
+        # habitがDBに実際に存在することを確認
+        habit_id = created["propagation"]["id"]
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT content, active FROM habits WHERE id = ?",
+                (habit_id,),
+            ).fetchone()
+            assert row is not None
+            assert row["content"] == "応答は簡潔にすること"
+            assert row["active"] == 1
+        finally:
+            conn.close()
+
+
+class TestPropagateToTagNote:
+    """decision + tag-note伝搬のテスト"""
+
+    def test_propagate_to_tag_note_with_existing_notes(self, topic):
+        """既存notes有のタグにappend → notes末尾に追記されている"""
+        tid = topic["topic_id"]
+
+        # 既存notesを持つタグを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "myproject", "既存のメモ"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "命名規則をcamelCaseに統一する",
+                "reason": "チーム間の一貫性のため",
+                "propagate_to": {
+                    "type": "tag_note",
+                    "tag": "domain:myproject",
+                    "content": "命名規則: camelCaseを使用すること",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+
+        created = result["created"][0]
+        assert "propagation" in created
+        assert created["propagation"]["status"] == "ok"
+        assert created["propagation"]["type"] == "tag_note"
+
+        # notesが追記されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT notes FROM tags WHERE namespace = ? AND name = ?",
+                ("domain", "myproject"),
+            ).fetchone()
+            assert row is not None
+            assert row["notes"] == "既存のメモ\n\n命名規則: camelCaseを使用すること"
+        finally:
+            conn.close()
+
+    def test_propagate_to_tag_note_without_existing_notes(self, topic):
+        """既存notesなしのタグ → contentがそのままnotesにSET"""
+        tid = topic["topic_id"]
+
+        # notesなしのタグを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                ("domain", "newproject"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "テストカバレッジ80%以上を維持する",
+                "reason": "品質保証のため",
+                "propagate_to": {
+                    "type": "tag_note",
+                    "tag": "domain:newproject",
+                    "content": "テストカバレッジ80%以上を維持すること",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        created = result["created"][0]
+        assert created["propagation"]["status"] == "ok"
+
+        # notesがそのままSETされていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT notes FROM tags WHERE namespace = ? AND name = ?",
+                ("domain", "newproject"),
+            ).fetchone()
+            assert row is not None
+            assert row["notes"] == "テストカバレッジ80%以上を維持すること"
+        finally:
+            conn.close()
+
+
+class TestPropagateToErrors:
+    """propagate_to エラーケースのテスト"""
+
+    def test_nonexistent_tag_error_decision_remains(self, topic):
+        """存在しないタグ → propagation.status=="error", decisionは残る"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "存在しないタグへの伝搬テスト",
+                "reason": "エラー処理のテスト",
+                "propagate_to": {
+                    "type": "tag_note",
+                    "tag": "domain:nonexistent",
+                    "content": "伝搬失敗するはず",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 0
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert created["propagation"]["status"] == "error"
+        assert created["propagation"]["type"] == "tag_note"
+        assert "not found" in created["propagation"]["message"].lower()
+
+        # decisionがDBに残っていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM decisions WHERE id = ?",
+                (created["decision_id"],),
+            ).fetchone()
+            assert row is not None
+            assert row["decision"] == "存在しないタグへの伝搬テスト"
+        finally:
+            conn.close()
+
+    def test_empty_content_error_decision_remains(self, topic):
+        """空content → propagation.status=="error", decisionは残る"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "空contentでの伝搬テスト",
+                "reason": "バリデーションテスト",
+                "propagate_to": {
+                    "type": "habit",
+                    "content": "",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert created["propagation"]["status"] == "error"
+        assert created["propagation"]["type"] == "habit"
+
+        # decisionがDBに残っていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM decisions WHERE id = ?",
+                (created["decision_id"],),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_invalid_type_error_decision_remains(self, topic):
+        """不正type → propagation.status=="error", decisionは残る"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "不正typeでの伝搬テスト",
+                "reason": "バリデーションテスト",
+                "propagate_to": {
+                    "type": "invalid_type",
+                    "content": "何かしらのコンテンツ",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert created["propagation"]["status"] == "error"
+        assert created["propagation"]["type"] == "invalid_type"
+        assert "invalid" in created["propagation"]["message"].lower()
+
+        # decisionがDBに残っていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM decisions WHERE id = ?",
+                (created["decision_id"],),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+
+class TestPropagateToAbsent:
+    """propagate_to未指定時のテスト"""
+
+    def test_no_propagate_to_conventional_behavior(self, topic):
+        """propagate_toなし → 従来通りの挙動（propagationフィールドなし）"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "通常の決定事項",
+                "reason": "通常の理由",
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert "propagation" not in created

--- a/tests/unit/test_propagate_to.py
+++ b/tests/unit/test_propagate_to.py
@@ -9,9 +9,18 @@ from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
 from src.services.decision_service import add_decisions
 from src.services.tag_service import _injected_tags
+import src.services.embedding_service as emb
 
 
 DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
 
 
 @pytest.fixture
@@ -271,6 +280,39 @@ class TestPropagateToErrors:
         assert created["propagation"]["status"] == "error"
         assert created["propagation"]["type"] == "invalid_type"
         assert "invalid" in created["propagation"]["message"].lower()
+
+        # decisionがDBに残っていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM decisions WHERE id = ?",
+                (created["decision_id"],),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_missing_type_key_error_decision_remains(self, topic):
+        """typeキー省略 → type=Noneでpropagation.status=="error", decisionは残る"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {
+                "topic_id": tid,
+                "decision": "typeキー省略での伝搬テスト",
+                "reason": "バリデーションテスト",
+                "propagate_to": {
+                    "content": "何かしらのコンテンツ",
+                },
+            },
+        ])
+
+        assert "error" not in result
+        assert len(result["created"]) == 1
+
+        created = result["created"][0]
+        assert created["decision_id"] > 0
+        assert created["propagation"]["status"] == "error"
+        assert "Invalid propagate_to.type: None" in created["propagation"]["message"]
 
         # decisionがDBに残っていることを確認
         conn = get_connection()

--- a/tests/unit/test_propagate_to.py
+++ b/tests/unit/test_propagate_to.py
@@ -329,8 +329,8 @@ class TestPropagateToErrors:
 class TestPropagateToAbsent:
     """propagate_to未指定時のテスト"""
 
-    def test_no_propagate_to_conventional_behavior(self, topic):
-        """propagate_toなし → 従来通りの挙動（propagationフィールドなし）"""
+    def test_no_propagate_to_decision_only(self, topic):
+        """propagate_toなし → decisionのみ保存され、propagationフィールドは含まれない"""
         tid = topic["topic_id"]
         result = add_decisions([
             {


### PR DESCRIPTION
## Summary
- `add_decisions`の各itemに`propagate_to`オプショナルフィールドを追加
- decision保存と同時にhabits/tag-notesへ伝搬し、注入先への転記漏れを防止
- SAVEPOINTネストにより、伝搬失敗時もdecisionは保持される

## 変更内容
- `habit_service.py`: `_add_habit_with_conn(conn, content)` 追加
- `tag_service.py`: `_append_tag_notes_with_conn(conn, tag_str, content)` 追加
- `decision_service.py`: SAVEPOINTネストによるpropagate処理追加
- `main.py`: tool定義のdocstringにpropagate_to説明追加
- `test_propagate_to.py`: 7テストケース（正常系3 + 異常系3 + 従来動作1）

## 関連
- cc-memory activity: #627
- 設計decisions: D#1615, D#1616, D#1657-1661

## Test plan
- [x] habit伝搬成功
- [x] tag-note追記（既存notes有/無）
- [x] 存在しないタグ → error, decisionは残る
- [x] 空content → error, decisionは残る
- [x] 不正type → error, decisionは残る
- [x] propagate_to未指定 → 従来動作
- [x] 全742テスト回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)