### PR TITLE
feat: searchレスポンスにnearby_tags追加

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -72,6 +72,9 @@ QE_DISTANCE_THRESHOLD = 0.3   # コサイン距離。これ未満のタグを拡
 QE_MAX_EXPANSIONS = 5          # 全キーワード合計での最大拡張タグ数
 QE_EXCLUDE_NAMESPACES = True   # namespace付きタグを除外するか
 
+# nearby_tags パラメータ
+NEARBY_TAGS_LIMIT = 5          # 返却するnearby_tagsの最大件数
+
 
 def _escape_fts5_query(keyword: str) -> str:
     """FTS5クエリ用のエスケープ処理。ダブルクォートで囲む。"""
@@ -349,6 +352,105 @@ def _attach_tags(results: list[dict]) -> None:
             else:
                 for item in items:
                     item["tags"] = []
+    finally:
+        conn.close()
+
+
+# 共起テーブル定義: (テーブル名, エンティティIDカラム名)
+_CO_OCCURRENCE_TABLES = [
+    ("topic_tags", "topic_id"),
+    ("decision_tags", "decision_id"),
+    ("log_tags", "log_id"),
+    ("activity_tags", "activity_id"),
+    ("material_tags", "material_id"),
+]
+
+
+def _compute_nearby_tags(
+    results: list[dict],
+    query_tag_ids: list[int] | None,
+    offset: int,
+) -> list[dict]:
+    """検索結果のタグ共起から関連タグを計算する。
+
+    5タグテーブルのself-joinで共起関係を集計し、結果に含まれないタグを
+    co_count降順で返す。namespace付きタグ(domain:/intent:)は除外。
+
+    Args:
+        results: _attach_tags済みの検索結果
+        query_tag_ids: 検索フィルタに使用されたtag_id（除外用）
+        offset: ページネーションオフセット
+
+    Returns:
+        [{"tag": "tag_name", "co_count": N}, ...]
+    """
+    if offset > 0 or not results:
+        return []
+
+    # resultsからタグ文字列を収集
+    all_tag_strings: set[str] = set()
+    for item in results:
+        all_tag_strings.update(item.get("tags", []))
+
+    if not all_tag_strings:
+        return []
+
+    conn = get_connection()
+    try:
+        # タグ文字列→tag_id解決
+        result_tag_ids: set[int] = set()
+        for tag_str in all_tag_strings:
+            ns, name = parse_tag(tag_str)
+            row = conn.execute(
+                "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                (ns, name),
+            ).fetchone()
+            if row:
+                result_tag_ids.add(row["id"])
+
+        if not result_tag_ids:
+            return []
+
+        # 除外セット: 結果タグ + クエリフィルタタグ
+        exclude_ids = set(result_tag_ids)
+        if query_tag_ids:
+            exclude_ids.update(query_tag_ids)
+
+        result_ids_list = list(result_tag_ids)
+        exclude_ids_list = list(exclude_ids)
+
+        ph_in = ",".join("?" * len(result_ids_list))
+        ph_not = ",".join("?" * len(exclude_ids_list))
+
+        # 各テーブルでself-join → テーブル単位でGROUP BY → UNION ALL
+        unions = []
+        params: list = []
+        for table, id_col in _CO_OCCURRENCE_TABLES:
+            unions.append(f"""
+                SELECT t2.tag_id, COUNT(DISTINCT t1.{id_col}) AS co_count
+                FROM {table} t1
+                JOIN {table} t2 ON t1.{id_col} = t2.{id_col}
+                WHERE t1.tag_id IN ({ph_in})
+                  AND t2.tag_id NOT IN ({ph_not})
+                GROUP BY t2.tag_id
+            """)
+            params.extend(result_ids_list)
+            params.extend(exclude_ids_list)
+
+        union_sql = " UNION ALL ".join(unions)
+        query = f"""
+            SELECT t.name, SUM(sub.co_count) AS total_co_count
+            FROM ({union_sql}) sub
+            JOIN tags t ON t.id = sub.tag_id
+            WHERE t.namespace = ''
+            GROUP BY sub.tag_id, t.name
+            ORDER BY total_co_count DESC
+            LIMIT ?
+        """
+        params.append(NEARBY_TAGS_LIMIT)
+
+        rows = conn.execute(query, tuple(params)).fetchall()
+        return [{"tag": row["name"], "co_count": row["total_co_count"]} for row in rows]
     finally:
         conn.close()
 
@@ -1167,10 +1269,13 @@ def search(
             details_targets = results[:DETAILS_MAX_RESULTS]
             _attach_details(details_targets)
 
+        nearby_tags = _compute_nearby_tags(results, tag_ids, offset)
+
         return {
             "results": results,
             "total_count": total_count,
             "search_methods_used": methods_used,
+            "nearby_tags": nearby_tags,
         }
 
     except Exception as e:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -397,16 +397,8 @@ def _compute_nearby_tags(
 
     conn = get_connection()
     try:
-        # タグ文字列→tag_id解決
-        result_tag_ids: set[int] = set()
-        for tag_str in all_tag_strings:
-            ns, name = parse_tag(tag_str)
-            row = conn.execute(
-                "SELECT id FROM tags WHERE namespace = ? AND name = ?",
-                (ns, name),
-            ).fetchone()
-            if row:
-                result_tag_ids.add(row["id"])
+        # タグ文字列→tag_id解決（エイリアスも考慮）
+        result_tag_ids = set(_resolve_tag_ids_readonly(conn, list(all_tag_strings)))
 
         if not result_tag_ids:
             return []

--- a/tests/unit/test_nearby_tags.py
+++ b/tests/unit/test_nearby_tags.py
@@ -1,0 +1,275 @@
+"""nearby_tags（タグ共起サジェスト）のテスト
+
+_compute_nearby_tags単体テスト + search統合テスト。
+"""
+import hashlib
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.search_service import (
+    _compute_nearby_tags,
+    NEARBY_TAGS_LIMIT,
+)
+from src.services import search_service
+from src.services.topic_service import add_topic
+from src.services.activity_service import add_activity
+from tests.helpers import add_log, add_decision
+from src.services.material_service import add_material
+import src.services.embedding_service as emb
+
+
+EMBEDDING_DIM = 384
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def mock_embedding_model(monkeypatch):
+    """embedding_serverへのHTTPリクエストをモック化"""
+
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            seed = int(hashlib.sha256((prefix_str + text).encode()).hexdigest(), 16) % (2**32)
+            np.random.seed(seed)
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+
+@pytest.fixture
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+
+# ========================================
+# _compute_nearby_tags 単体テスト
+# ========================================
+
+
+def test_compute_nearby_tags_basic(temp_db):
+    """共起タグが正しく返される基本ケース"""
+    # topic1: tags=[alpha, beta, gamma]
+    # topic2: tags=[alpha, delta]
+    # 検索結果にalphaが含まれる → beta, gamma, deltaが共起候補
+    add_topic(title="T1", description="test", tags=["alpha", "beta", "gamma"])
+    add_topic(title="T2", description="test", tags=["alpha", "delta"])
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    tag_names = [n["tag"] for n in nearby]
+    assert "beta" in tag_names
+    assert "gamma" in tag_names
+    assert "delta" in tag_names
+    assert "alpha" not in tag_names  # 入力タグは除外
+
+
+def test_compute_nearby_tags_excludes_namespace(temp_db):
+    """domain:/intent:タグはnearby_tagsから除外される"""
+    add_topic(title="T1", description="test", tags=["alpha", "domain:cc-memory", "intent:design"])
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    tag_names = [n["tag"] for n in nearby]
+    assert "domain:cc-memory" not in tag_names
+    assert "intent:design" not in tag_names
+
+
+def test_compute_nearby_tags_excludes_query_tags(temp_db):
+    """検索フィルタに使用されたタグはnearby_tagsから除外される"""
+    add_topic(title="T1", description="test", tags=["alpha", "beta", "gamma"])
+
+    # betaのtag_idを取得
+    conn = get_connection()
+    row = conn.execute("SELECT id FROM tags WHERE namespace = '' AND name = 'beta'").fetchone()
+    beta_tag_id = row["id"]
+    conn.close()
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, [beta_tag_id], 0)
+
+    tag_names = [n["tag"] for n in nearby]
+    assert "beta" not in tag_names  # クエリタグは除外
+    assert "gamma" in tag_names
+
+
+def test_compute_nearby_tags_empty_results(temp_db):
+    """結果0件のときは空配列"""
+    nearby = _compute_nearby_tags([], None, 0)
+    assert nearby == []
+
+
+def test_compute_nearby_tags_offset_skip(temp_db):
+    """offset>0のときは空配列"""
+    add_topic(title="T1", description="test", tags=["alpha", "beta"])
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 1)
+    assert nearby == []
+
+
+def test_compute_nearby_tags_all_namespace_tags(temp_db):
+    """結果のタグが全てnamespace付きの場合、共起候補もnamespace付きなら空配列"""
+    add_topic(title="T1", description="test", tags=["domain:cc-memory", "intent:design"])
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["domain:cc-memory"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    # intent:designは除外されるので空
+    tag_names = [n["tag"] for n in nearby]
+    assert "intent:design" not in tag_names
+
+
+def test_compute_nearby_tags_co_count_order(temp_db):
+    """co_count降順でソートされる"""
+    # beta: topic1, topic2, topic3 に共起 → co_count=3
+    # gamma: topic1 にのみ共起 → co_count=1
+    add_topic(title="T1", description="test", tags=["alpha", "beta", "gamma"])
+    add_topic(title="T2", description="test", tags=["alpha", "beta"])
+    add_topic(title="T3", description="test", tags=["alpha", "beta"])
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+        {"type": "topic", "id": 2, "tags": ["alpha"]},
+        {"type": "topic", "id": 3, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    assert len(nearby) >= 2
+    # betaがgammaより上位
+    beta_idx = next(i for i, n in enumerate(nearby) if n["tag"] == "beta")
+    gamma_idx = next(i for i, n in enumerate(nearby) if n["tag"] == "gamma")
+    assert beta_idx < gamma_idx
+    assert nearby[beta_idx]["co_count"] > nearby[gamma_idx]["co_count"]
+
+
+def test_compute_nearby_tags_cross_table(temp_db):
+    """複数テーブルにまたがる共起がSUMされる"""
+    # alphaとbetaの共起: topic_tags + activity_tags
+    topic = add_topic(title="T1", description="test", tags=["alpha", "beta"])
+    add_activity(title="A1", description="test", tags=["alpha", "beta"], check_in=False)
+
+    results = [
+        {"type": "topic", "id": topic["topic_id"], "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    beta_entry = next((n for n in nearby if n["tag"] == "beta"), None)
+    assert beta_entry is not None
+    assert beta_entry["co_count"] >= 2  # topic_tags + activity_tags
+
+
+def test_compute_nearby_tags_limit(temp_db):
+    """NEARBY_TAGS_LIMITを超えない"""
+    # 大量のタグを作成
+    tags = ["alpha"] + [f"tag{i}" for i in range(NEARBY_TAGS_LIMIT + 5)]
+    add_topic(title="T1", description="test", tags=tags)
+
+    results = [
+        {"type": "topic", "id": 1, "tags": ["alpha"]},
+    ]
+    nearby = _compute_nearby_tags(results, None, 0)
+
+    assert len(nearby) <= NEARBY_TAGS_LIMIT
+
+
+# ========================================
+# search統合テスト
+# ========================================
+
+
+def test_search_returns_nearby_tags(temp_db, mock_embedding_model):
+    """searchレスポンスにnearby_tagsフィールドが含まれる"""
+    add_topic(title="nearby検索テスト対象", description="テスト用", tags=["search-test", "extra-tag"])
+    add_topic(title="nearby検索テスト関連", description="テスト用", tags=["search-test", "related-tag"])
+
+    result = search_service.search(keyword="nearby検索テスト")
+
+    assert "error" not in result
+    assert "nearby_tags" in result
+    assert isinstance(result["nearby_tags"], list)
+
+
+def test_search_nearby_tags_structure(temp_db, mock_embedding_model):
+    """nearby_tagsの各要素がtag/co_countを持つ"""
+    # 検索結果のタグと共起するが結果には含まれないタグを作る
+    add_topic(title="構造テスト対象", description="構造テスト用", tags=["struct-tag"])
+    # struct-tagと共起するタグを別トピックに作成（検索にはヒットしない）
+    add_topic(title="ZZZZZZ", description="ZZZZZZ", tags=["struct-tag", "nearby-candidate"])
+
+    result = search_service.search(keyword="構造テスト対象")
+
+    assert "error" not in result
+    for entry in result["nearby_tags"]:
+        assert "tag" in entry
+        assert "co_count" in entry
+        assert isinstance(entry["tag"], str)
+        assert isinstance(entry["co_count"], int)
+        assert entry["co_count"] > 0
+
+
+def test_search_nearby_tags_with_offset(temp_db, mock_embedding_model):
+    """offset>0のときnearby_tagsは空配列"""
+    add_topic(title="offsetテスト用トピック", description="テスト", tags=["offset-test", "some-tag"])
+
+    result = search_service.search(keyword="offsetテスト用", offset=1)
+
+    assert "error" not in result
+    assert result["nearby_tags"] == []
+
+
+def test_search_nearby_tags_with_tag_filter(temp_db, mock_embedding_model):
+    """tagsフィルタで絞った場合もnearby_tagsが返る（フィルタタグは除外）"""
+    add_topic(
+        title="フィルタnearbyテスト",
+        description="テスト",
+        tags=["domain:test", "filter-nearby", "extra-nearby"],
+    )
+
+    result = search_service.search(keyword="フィルタnearbyテスト", tags=["domain:test"])
+
+    assert "error" not in result
+    assert "nearby_tags" in result
+    nearby_tag_names = [n["tag"] for n in result["nearby_tags"]]
+    assert "domain:test" not in nearby_tag_names  # フィルタタグは除外
+
+
+def test_search_nearby_tags_empty_results(temp_db, mock_embedding_model):
+    """検索結果0件のときnearby_tagsは空配列"""
+    result = search_service.search(keyword="存在しないキーワードXYZ")
+
+    assert "error" not in result
+    assert result["nearby_tags"] == []


### PR DESCRIPTION
## Summary
- searchレスポンスに`nearby_tags`フィールドを追加。検索結果のタグと共起するタグをco_count降順で返す
- 5タグテーブル（topic/decision/log/activity/material）のself-join → UNION ALL → SUM で共起集計
- namespace付きタグ(domain:/intent:)は除外、offset>0時はスキップ（空配列）

## 関連
- 設計: activity #617, material #78
- 決定事項: D#1653(C案採用), D#1655(フィールド名), D#1666(常時返却), D#1671(素タグ限定)

## Test plan
- [x] `_compute_nearby_tags` ユニットテスト9件（基本共起、namespace除外、queryタグ除外、空結果、offset、ソート順、クロステーブル、limit）
- [x] `search` 統合テスト5件（フィールド存在、構造、offset、タグフィルタ、空結果）
- [x] 既存テスト91件パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)