### PR TITLE
feat: depends_on関係のCRUD・DFSサイクル検出を実装

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -750,20 +750,26 @@ def remove_relation(
     source_type: str,
     source_id: int,
     targets: list[dict],
+    relation_type: str = "related",
 ) -> dict:
     """
     エンティティ間のリレーションを削除する。
+
+    典型的な使い方:
+    - 関連リレーション削除: remove_relation("topic", 1, [{"type": "topic", "ids": [2]}])
+    - 依存関係削除: remove_relation("activity", 1, [{"type": "activity", "ids": [2]}], relation_type="depends_on")
 
     Args:
         source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
         source_id: 起点エンティティのID
         targets: ターゲットリスト [{"type": "topic"|"activity"|"material", "ids": [int, ...]}, ...]
+        relation_type: リレーションタイプ（"related" or "depends_on"）。depends_onはactivity同士のみ有効。
 
     Returns:
         成功時: {"removed": int}（実際に削除された件数）
         失敗時: {"error": {"code": ..., "message": ...}}
     """
-    return relation_service.remove_relation(source_type, source_id, targets)
+    return relation_service.remove_relation(source_type, source_id, targets, relation_type)
 
 
 @mcp.tool()

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -230,6 +230,9 @@ def _remove_depends_on_with_conn(conn: sqlite3.Connection, source_id: int, targe
     """
     removed = 0
     for target_id in target_ids:
+        # 自己参照はCHECK制約で存在し得ないが、明示的にスキップ
+        if source_id == target_id:
+            continue
         conn.execute(
             "DELETE FROM activity_dependencies WHERE dependent_id = ? AND dependency_id = ?",
             (source_id, target_id),
@@ -254,6 +257,26 @@ def _remove_relation_with_conn(conn: sqlite3.Connection, source_type: str, sourc
             )
             removed += conn.execute("SELECT changes()").fetchone()[0]
     return removed
+
+
+def _validate_depends_on_constraints(source_type: str, targets: list[dict]) -> dict | None:
+    """depends_onリレーションの制約をバリデーションする。activity→activityのみ有効。"""
+    if source_type != "activity":
+        return {
+            "error": {
+                "code": "INVALID_RELATION_TYPE",
+                "message": "depends_on relation is only valid for activity→activity",
+            }
+        }
+    for target in targets:
+        if target["type"] != "activity":
+            return {
+                "error": {
+                    "code": "INVALID_RELATION_TYPE",
+                    "message": "depends_on relation is only valid for activity→activity",
+                }
+            }
+    return None
 
 
 def add_relation(source_type: str, source_id: int, targets: list[dict], relation_type: str = "related") -> dict:
@@ -285,23 +308,10 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
     if err:
         return err
 
-    # depends_onはactivity→activityのみ
     if relation_type == "depends_on":
-        if source_type != "activity":
-            return {
-                "error": {
-                    "code": "INVALID_RELATION_TYPE",
-                    "message": "depends_on relation is only valid for activity→activity",
-                }
-            }
-        for target in targets:
-            if target["type"] != "activity":
-                return {
-                    "error": {
-                        "code": "INVALID_RELATION_TYPE",
-                        "message": "depends_on relation is only valid for activity→activity",
-                    }
-                }
+        err = _validate_depends_on_constraints(source_type, targets)
+        if err:
+            return err
 
     conn = get_connection()
     try:
@@ -358,23 +368,10 @@ def remove_relation(source_type: str, source_id: int, targets: list[dict], relat
     if err:
         return err
 
-    # depends_onはactivity→activityのみ
     if relation_type == "depends_on":
-        if source_type != "activity":
-            return {
-                "error": {
-                    "code": "INVALID_RELATION_TYPE",
-                    "message": "depends_on relation is only valid for activity→activity",
-                }
-            }
-        for target in targets:
-            if target["type"] != "activity":
-                return {
-                    "error": {
-                        "code": "INVALID_RELATION_TYPE",
-                        "message": "depends_on relation is only valid for activity→activity",
-                    }
-                }
+        err = _validate_depends_on_constraints(source_type, targets)
+        if err:
+            return err
 
     conn = get_connection()
     try:

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -217,6 +217,27 @@ def _add_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_i
     return added
 
 
+def _remove_depends_on_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> int:
+    """depends_onリレーションをactivity_dependenciesテーブルから削除する。
+
+    Args:
+        conn: DB接続
+        source_id: 依存元（dependent）のアクティビティID
+        target_ids: 依存先（dependency）のアクティビティIDリスト
+
+    Returns:
+        削除件数
+    """
+    removed = 0
+    for target_id in target_ids:
+        conn.execute(
+            "DELETE FROM activity_dependencies WHERE dependent_id = ? AND dependency_id = ?",
+            (source_id, target_id),
+        )
+        removed += conn.execute("SELECT changes()").fetchone()[0]
+    return removed
+
+
 def _remove_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]) -> int:
     """conn共有版: リレーションを削除する。削除件数を返す。"""
     removed = 0
@@ -308,18 +329,28 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
         conn.close()
 
 
-def remove_relation(source_type: str, source_id: int, targets: list[dict]) -> dict:
+def remove_relation(source_type: str, source_id: int, targets: list[dict], relation_type: str = "related") -> dict:
     """リレーションを削除する。
 
     Args:
-        source_type: 起点エンティティのタイプ（"topic" or "activity"）
+        source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
         source_id: 起点エンティティのID
         targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
+        relation_type: リレーションタイプ（"related" or "depends_on"）。
+            "depends_on" はactivity同士のみ有効。
 
     Returns:
         成功時: {"removed": int}
         失敗時: {"error": {"code": ..., "message": ...}}
     """
+    if relation_type not in VALID_RELATION_TYPES:
+        return {
+            "error": {
+                "code": "INVALID_RELATION_TYPE",
+                "message": f"Invalid relation_type: '{relation_type}'. Must be one of {sorted(VALID_RELATION_TYPES)}",
+            }
+        }
+
     err = _validate_entity_type(source_type)
     if err:
         return err
@@ -327,9 +358,32 @@ def remove_relation(source_type: str, source_id: int, targets: list[dict]) -> di
     if err:
         return err
 
+    # depends_onはactivity→activityのみ
+    if relation_type == "depends_on":
+        if source_type != "activity":
+            return {
+                "error": {
+                    "code": "INVALID_RELATION_TYPE",
+                    "message": "depends_on relation is only valid for activity→activity",
+                }
+            }
+        for target in targets:
+            if target["type"] != "activity":
+                return {
+                    "error": {
+                        "code": "INVALID_RELATION_TYPE",
+                        "message": "depends_on relation is only valid for activity→activity",
+                    }
+                }
+
     conn = get_connection()
     try:
-        removed = _remove_relation_with_conn(conn, source_type, source_id, targets)
+        if relation_type == "depends_on":
+            removed = 0
+            for target in targets:
+                removed += _remove_depends_on_with_conn(conn, source_id, target["ids"])
+        else:
+            removed = _remove_relation_with_conn(conn, source_type, source_id, targets)
         conn.commit()
         return {"removed": removed}
     except Exception as e:

--- a/tests/integration/test_activity_dependencies.py
+++ b/tests/integration/test_activity_dependencies.py
@@ -517,3 +517,229 @@ class TestCyclicDependencyDetection:
             assert count == 0
         finally:
             conn.close()
+
+    def test_depends_on_idempotent(self, temp_db):
+        """同一のdepends_on関係を再追加してもエラーにならずadded=0が返る"""
+        from src.services.relation_service import add_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result1 = add_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+        assert result1["added"] == 1
+
+        result2 = add_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+        assert "error" not in result2
+        assert result2["added"] == 0
+
+    def test_depends_on_target_not_activity_rejected(self, temp_db):
+        """depends_onのtarget_typeがactivity以外の場合エラーになる"""
+        from src.services.relation_service import add_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            cursor = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("Topic A", "Desc A"),
+            )
+            t1 = cursor.lastrowid
+            tag_ids = ensure_tag_ids(conn, [("domain", "test")])
+            link_tags(conn, "topic_tags", "topic_id", t1, tag_ids)
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = add_relation("activity", a1, [{"type": "topic", "ids": [t1]}], relation_type="depends_on")
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+
+class TestRemoveDependsOn:
+    """remove_relation(relation_type="depends_on")のテスト"""
+
+    def test_remove_depends_on_success(self, temp_db):
+        """depends_on関係を削除できる"""
+        from src.services.relation_service import add_relation, remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        add_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+
+        result = remove_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+        assert "error" not in result
+        assert result["removed"] == 1
+
+        # DBから消えていることを確認
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) as cnt FROM activity_dependencies WHERE dependent_id = ? AND dependency_id = ?",
+                (a1, a2),
+            ).fetchone()["cnt"]
+            assert count == 0
+        finally:
+            conn.close()
+
+    def test_remove_nonexistent_depends_on(self, temp_db):
+        """存在しないdepends_on関係の削除はエラーにならずremoved=0が返る"""
+        from src.services.relation_service import remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = remove_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+        assert "error" not in result
+        assert result["removed"] == 0
+
+    def test_remove_depends_on_non_activity_source_rejected(self, temp_db):
+        """depends_on削除でsource_typeがactivity以外の場合エラーになる"""
+        from src.services.relation_service import remove_relation
+
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("Topic A", "Desc A"),
+            )
+            t1 = cursor.lastrowid
+            tag_ids = ensure_tag_ids(conn, [("domain", "test")])
+            link_tags(conn, "topic_tags", "topic_id", t1, tag_ids)
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = remove_relation("topic", t1, [{"type": "topic", "ids": [t1]}], relation_type="depends_on")
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+    def test_remove_depends_on_non_activity_target_rejected(self, temp_db):
+        """depends_on削除でtarget_typeがactivity以外の場合エラーになる"""
+        from src.services.relation_service import remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            cursor = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("Topic A", "Desc A"),
+            )
+            t1 = cursor.lastrowid
+            tag_ids = ensure_tag_ids(conn, [("domain", "test")])
+            link_tags(conn, "topic_tags", "topic_id", t1, tag_ids)
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = remove_relation("activity", a1, [{"type": "topic", "ids": [t1]}], relation_type="depends_on")
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+    def test_remove_depends_on_allows_previously_cyclic_addition(self, temp_db):
+        """depends_on削除後、以前は循環になった依存関係を追加できるようになる"""
+        from src.services.relation_service import add_relation, remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # A→B追加
+        add_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+
+        # B→Aは循環で拒否
+        result = add_relation("activity", a2, [{"type": "activity", "ids": [a1]}], relation_type="depends_on")
+        assert "error" in result
+
+        # A→Bを削除
+        remove_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+
+        # B→Aが追加できるようになる
+        result = add_relation("activity", a2, [{"type": "activity", "ids": [a1]}], relation_type="depends_on")
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_remove_depends_on_multiple_targets(self, temp_db):
+        """depends_on関係の複数ターゲット一括削除ができる"""
+        from src.services.relation_service import add_relation, remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            a3 = _create_activity(conn, "Activity C")
+            conn.commit()
+        finally:
+            conn.close()
+
+        add_relation("activity", a1, [{"type": "activity", "ids": [a2, a3]}], relation_type="depends_on")
+
+        result = remove_relation("activity", a1, [{"type": "activity", "ids": [a2, a3]}], relation_type="depends_on")
+        assert "error" not in result
+        assert result["removed"] == 2
+
+    def test_remove_relation_default_type_is_related(self, temp_db):
+        """relation_typeを省略するとrelated（デフォルト）として動作し、depends_on行は削除されない"""
+        from src.services.relation_service import add_relation, remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # depends_on関係を追加
+        add_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="depends_on")
+
+        # relation_type省略（デフォルトrelated）で削除→activity_relationsテーブルには行がないのでremoved=0
+        result = remove_relation("activity", a1, [{"type": "activity", "ids": [a2]}])
+        assert "error" not in result
+        assert result["removed"] == 0
+
+        # depends_on関係はそのまま残っている
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) as cnt FROM activity_dependencies WHERE dependent_id = ? AND dependency_id = ?",
+                (a1, a2),
+            ).fetchone()["cnt"]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_remove_relation_invalid_relation_type(self, temp_db):
+        """不正なrelation_typeを指定するとエラーになる"""
+        from src.services.relation_service import remove_relation
+
+        conn = get_connection()
+        try:
+            a1 = _create_activity(conn, "Activity A")
+            a2 = _create_activity(conn, "Activity B")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = remove_relation("activity", a1, [{"type": "activity", "ids": [a2]}], relation_type="invalid_type")
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"


### PR DESCRIPTION
## Summary
- `add_relation` / `remove_relation` に `relation_type` 引数を追加（デフォルト `"related"` で後方互換）
- `relation_type="depends_on"` でactivity間の依存関係を追加・削除可能に
- DFSによる推移的循環依存検出（A→B→C→A等）をadd_relation時に実行
- テスト10件追加（冪等性、非activityターゲット拒否、削除系8件）、全1044件パス

## Context
アクティビティ優先順位スコアリング実装の3PR分割のうちPR-b（ロジック層）。
- PR-a（スキーマ）: #289 ✅
- **PR-b（ロジック）: 本PR**
- PR-c（統合）: 未着手

設計: activity #603, material #64

## Test plan
- [x] depends_on追加・削除の基本動作
- [x] 自己依存（CHECK制約）
- [x] DFS循環依存検出（直接A↔B、推移的A→B→C→A）
- [x] 非activity型でのdepends_on指定→エラー
- [x] CASCADE（依存先削除→関係も削除）
- [x] get_mapでdepends_on関係が走査される
- [x] 重複INSERT（冪等性: added=0）
- [x] relation_type省略時の後方互換
- [x] 全1044テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)