### PR TITLE
feat: check-inにpinnedエンティティ自動注入を実装

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -816,7 +816,6 @@ def update_pin(entity_type: str, entity_id: int, pinned: bool) -> dict:
 
     pin基準: 「これを知らずに着手したら間違った方向に進む」レベルの情報。
     unpin基準: 「もう知らなくてもいい状態になったか」。
-    ※check-in時のpinnedエンティティ自動返却は将来実装予定。
 
     pinすべき例:
     - 方向転換を記録したログ（以前の方針と異なる判断をした経緯）

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -86,7 +86,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
 
 
 def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> int:
-    """複数トピックのdecisionsの総件数を取得する。"""
+    """複数トピックのdecisionsの総件数を取得する（pinned含む、coverage分母用）。"""
     if not topic_ids:
         return 0
     placeholders = ",".join("?" * len(topic_ids))

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -61,9 +61,9 @@ def _get_activities_overview(conn: sqlite3.Connection, activity_ids: list[int]) 
 
 
 def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
-    """複数トピックのdecisionsを横断取得し、新しい順にフラット化する。
+    """複数トピックの非pinnedのdecisionsを横断取得し、新しい順にフラット化する。
 
-    上位DECISIONS_FULL_LIMIT件はid+title、超過分はid+titleのみ。
+    上位DECISIONS_FULL_LIMIT件はid+title。pinnedは除外される（別途取得）。
     """
     if not topic_ids:
         return []
@@ -72,7 +72,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
         f"""
         SELECT id, decision
         FROM decisions
-        WHERE topic_id IN ({placeholders})
+        WHERE topic_id IN ({placeholders}) AND pinned = 0
         ORDER BY id DESC
         LIMIT {DECISIONS_FULL_LIMIT}
         """,
@@ -98,7 +98,7 @@ def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int])
 
 
 def _get_logs_catalog_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
-    """複数トピックのlogsカタログ（id + titleのみ）を横断取得し、新しい順にフラット化する。"""
+    """複数トピックの非pinnedのlogsカタログ（id + titleのみ）を横断取得し、新しい順にフラット化する。"""
     if not topic_ids:
         return []
     placeholders = ",".join("?" * len(topic_ids))
@@ -106,13 +106,62 @@ def _get_logs_catalog_from_topics(conn: sqlite3.Connection, topic_ids: list[int]
         f"""
         SELECT id, title
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders})
+        WHERE topic_id IN ({placeholders}) AND pinned = 0
         ORDER BY id DESC
         """,
         tuple(topic_ids),
     ).fetchall()
 
     return [{"id": row["id"], "title": row["title"]} for row in rows]
+
+
+def _get_pinned_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
+    """関連トピックのpinned decisionsをcontent付きで取得する。"""
+    if not topic_ids:
+        return []
+    placeholders = ",".join("?" * len(topic_ids))
+    rows = conn.execute(
+        f"""
+        SELECT id, decision, reason
+        FROM decisions
+        WHERE topic_id IN ({placeholders}) AND pinned = 1
+        ORDER BY id DESC
+        """,
+        tuple(topic_ids),
+    ).fetchall()
+    return [{"id": row["id"], "title": row["decision"], "reason": row["reason"]} for row in rows]
+
+
+def _get_pinned_logs_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
+    """関連トピックのpinned logsをcontent付きで取得する。"""
+    if not topic_ids:
+        return []
+    placeholders = ",".join("?" * len(topic_ids))
+    rows = conn.execute(
+        f"""
+        SELECT id, title, content
+        FROM discussion_logs
+        WHERE topic_id IN ({placeholders}) AND pinned = 1
+        ORDER BY id DESC
+        """,
+        tuple(topic_ids),
+    ).fetchall()
+    return [{"id": row["id"], "title": row["title"], "content": row["content"]} for row in rows]
+
+
+def _get_pinned_materials_for_activity(conn: sqlite3.Connection, activity_id: int) -> list[dict]:
+    """アクティビティに紐づくpinned materialsをcontent付きで取得する。"""
+    rows = conn.execute(
+        """
+        SELECT m.id, m.title, m.content
+        FROM materials m
+        JOIN activity_material_relations amr ON amr.material_id = m.id
+        WHERE amr.activity_id = ? AND m.pinned = 1
+        ORDER BY m.created_at ASC
+        """,
+        (activity_id,),
+    ).fetchall()
+    return [{"id": row["id"], "title": row["title"], "content": row["content"]} for row in rows]
 
 
 def _extract_intent_tag(tags: list[str]) -> str:
@@ -165,8 +214,8 @@ def check_in(activity_id: int) -> dict:
         activity_id: アクティビティID
 
     Returns:
-        check-in結果（coverage, activity, related_topics, related_activities, tag_notes,
-        materials, recent_decisions, logs, catalog, summary）
+        check-in結果（coverage, activity, related_topics, related_activities, pinned,
+        tag_notes, materials, recent_decisions, logs, catalog, summary）
     """
     conn = get_connection()
     try:
@@ -208,34 +257,41 @@ def check_in(activity_id: int) -> dict:
         # 3. tag_notes収集
         tag_notes = collect_tag_notes_for_injection(conn, tags, always_inject_namespaces=["intent"]) or []
 
-        # 4. materials取得（リレーション経由、カタログ形式、共有コネクション使用）
-        materials = get_materials_by_relation_with_conn(conn, activity_id)
+        # 4. pinnedエンティティ取得（content付き）
+        pinned_decisions = _get_pinned_decisions_from_topics(conn, direct["topic"])
+        pinned_logs = _get_pinned_logs_from_topics(conn, direct["topic"])
+        pinned_materials = _get_pinned_materials_for_activity(conn, activity_id)
+        pinned_material_ids = {m["id"] for m in pinned_materials}
 
-        # 5. recent_decisions取得（関連topic横断、フラット15件）
+        # 5. materials取得（リレーション経由、カタログ形式、pinnedを除外）
+        all_materials = get_materials_by_relation_with_conn(conn, activity_id)
+        materials = [m for m in all_materials if m["id"] not in pinned_material_ids]
+
+        # 6. recent_decisions取得（関連topic横断、フラット15件、pinnedを除外）
         recent_decisions = _get_decisions_from_topics(conn, direct["topic"])
 
-        # 6. logsカタログ取得（id + titleのみ、関連topic横断）
+        # 7. logsカタログ取得（id + titleのみ、関連topic横断、pinnedを除外）
         logs_catalog = _get_logs_catalog_from_topics(conn, direct["topic"])
 
-        # 7. coverage算出
+        # 8. coverage算出（pinned件数を分子に加算）
         total_decisions = _count_decisions_from_topics(conn, direct["topic"])
         total_materials_row = conn.execute(
             "SELECT COUNT(*) FROM activity_material_relations WHERE activity_id = ?",
             (activity_id,),
         ).fetchone()
         total_materials = total_materials_row[0] if total_materials_row else 0
-        total_logs = len(logs_catalog)
+        total_logs = len(logs_catalog) + len(pinned_logs)
 
         coverage = {
-            "decisions": f"{len(recent_decisions)}/{total_decisions}",
-            "materials": f"{len(materials)}/{total_materials}",
-            "logs": f"0/{total_logs}",  # logsはタイトルのみ返却のため常に0
+            "decisions": f"{len(pinned_decisions) + len(recent_decisions)}/{total_decisions}",
+            "materials": f"{len(pinned_materials) + len(materials)}/{total_materials}",
+            "logs": f"{len(pinned_logs)}/{total_logs}",
         }
 
-        # 8. 2次カタログ取得（depth 1-2）
+        # 9. 2次カタログ取得（depth 1-2）
         catalog = _get_map_with_conn(conn, "activity", activity_id, min_depth=1, max_depth=2)
 
-        # 9. status自動更新（in_progress以外ならin_progressに変更）
+        # 10. status自動更新（in_progress以外ならin_progressに変更）
         # NOTE: update_activityは内部で別コネクションを使用する（既存APIの制約）。
         # check_inのトランザクションとは独立してコミットされる。
         if activity["status"] != "in_progress":
@@ -249,7 +305,7 @@ def check_in(activity_id: int) -> dict:
             else:
                 activity["status"] = "in_progress"
 
-        # 10. summary生成
+        # 11. summary生成
         summary = _build_summary(activity, tags)
 
         # 戻り値組み立て（coverageをトップレベルの最初のキーに）
@@ -274,6 +330,13 @@ def check_in(activity_id: int) -> dict:
 
         if dependencies:
             result["dependencies"] = dependencies
+
+        if pinned_decisions or pinned_logs or pinned_materials:
+            result["pinned"] = {
+                "decisions": pinned_decisions,
+                "logs": pinned_logs,
+                "materials": pinned_materials,
+            }
 
         result["tag_notes"] = tag_notes
         result["materials"] = materials

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -6,6 +6,7 @@ from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
 from tests.helpers import add_decision, add_log
 from src.services.material_service import add_material
+from src.services.pin_service import update_pin
 from src.services.relation_service import add_relation
 from src.services.topic_service import add_topic
 from src.services.checkin_service import check_in, DECISIONS_FULL_LIMIT
@@ -607,3 +608,184 @@ class TestCheckInDependencies:
 
         assert "error" not in result
         assert result["dependencies"][0]["status"] == "in_progress"
+
+
+class TestCheckInPinned:
+    """pinnedエンティティのcheck-in注入テスト"""
+
+    def test_no_pinned_field_when_nothing_pinned(self, temp_db):
+        """pinnedエンティティが0件の場合、pinnedフィールドは省略される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        add_decision(decision="通常の決定", reason="理由", topic_id=topic["topic_id"])
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" not in result
+
+    def test_pinned_decision_in_pinned_field(self, temp_db):
+        """pinされたdecisionがpinned.decisionsにcontent付きで返る"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d = add_decision(decision="重要な決定", reason="根本的な理由", topic_id=topic["topic_id"])
+        update_pin("decision", d["decision_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert len(result["pinned"]["decisions"]) == 1
+        assert result["pinned"]["decisions"][0]["title"] == "重要な決定"
+        assert result["pinned"]["decisions"][0]["reason"] == "根本的な理由"
+
+    def test_pinned_decision_excluded_from_recent_decisions(self, temp_db):
+        """pinされたdecisionはrecent_decisionsから除外される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d1 = add_decision(decision="pinされた決定", reason="理由1", topic_id=topic["topic_id"])
+        add_decision(decision="通常の決定", reason="理由2", topic_id=topic["topic_id"])
+        update_pin("decision", d1["decision_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # recent_decisionsにはpinされていないものだけ
+        assert len(result["recent_decisions"]) == 1
+        assert result["recent_decisions"][0]["title"] == "通常の決定"
+        # pinnedにはpinされたものだけ
+        assert len(result["pinned"]["decisions"]) == 1
+        assert result["pinned"]["decisions"][0]["title"] == "pinされた決定"
+
+    def test_pinned_log_in_pinned_field(self, temp_db):
+        """pinされたlogがpinned.logsにcontent付きで返る"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        log = add_log(topic_id=topic["topic_id"], title="方向転換ログ", content="## 経緯\n重要な方向転換")
+        update_pin("log", log["log_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert len(result["pinned"]["logs"]) == 1
+        assert result["pinned"]["logs"][0]["title"] == "方向転換ログ"
+        assert result["pinned"]["logs"][0]["content"] == "## 経緯\n重要な方向転換"
+
+    def test_pinned_log_excluded_from_logs_catalog(self, temp_db):
+        """pinされたlogはlogsカタログから除外される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
+        add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
+        update_pin("log", log1["log_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # logsカタログにはpinされていないものだけ
+        assert len(result["logs"]) == 1
+        assert result["logs"][0]["title"] == "通常ログ"
+
+    def test_pinned_material_in_pinned_field(self, temp_db):
+        """pinされたmaterialがpinned.materialsにcontent付きで返る"""
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        m = add_material("設計書", "# 設計\n詳細な内容", DEFAULT_TAGS,
+                         related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        update_pin("material", m["material_id"], True)
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert len(result["pinned"]["materials"]) == 1
+        assert result["pinned"]["materials"][0]["title"] == "設計書"
+        assert result["pinned"]["materials"][0]["content"] == "# 設計\n詳細な内容"
+
+    def test_pinned_material_excluded_from_materials(self, temp_db):
+        """pinされたmaterialは通常のmaterialsフィールドから除外される"""
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        m1 = add_material("pin資材", "内容1", DEFAULT_TAGS,
+                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        add_material("通常資材", "内容2", DEFAULT_TAGS,
+                     related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        update_pin("material", m1["material_id"], True)
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # materialsにはpinされていないものだけ
+        assert len(result["materials"]) == 1
+        assert result["materials"][0]["title"] == "通常資材"
+
+    def test_coverage_includes_pinned_decisions(self, temp_db):
+        """coverageのdecisions分子にpinned件数が加算される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d1 = add_decision(decision="pin決定", reason="理由", topic_id=topic["topic_id"])
+        add_decision(decision="通常決定1", reason="理由", topic_id=topic["topic_id"])
+        add_decision(decision="通常決定2", reason="理由", topic_id=topic["topic_id"])
+        update_pin("decision", d1["decision_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # pinned 1件 + 通常 2件 = 3件, 全体 3件
+        assert result["coverage"]["decisions"] == "3/3"
+
+    def test_coverage_includes_pinned_logs(self, temp_db):
+        """coverageのlogs分子にpinned件数が加算される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
+        add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
+        update_pin("log", log1["log_id"], True)
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # pinned 1件 / 全体 2件（pinned=contentあり=分子に加算）
+        assert result["coverage"]["logs"] == "1/2"
+
+    def test_coverage_includes_pinned_materials(self, temp_db):
+        """coverageのmaterials分子にpinned件数が加算される"""
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        m1 = add_material("pin資材", "内容1", DEFAULT_TAGS,
+                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        add_material("通常資材", "内容2", DEFAULT_TAGS,
+                     related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        update_pin("material", m1["material_id"], True)
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # pinned 1件 + 通常 1件 = 2件, 全体 2件
+        assert result["coverage"]["materials"] == "2/2"
+
+    def test_all_types_pinned_together(self, temp_db):
+        """decision, log, materialすべてpinされた場合、pinnedフィールドに3種とも含まれる"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d = add_decision(decision="重要決定", reason="理由", topic_id=topic["topic_id"])
+        log = add_log(topic_id=topic["topic_id"], title="重要ログ", content="内容")
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        m = add_material("重要資材", "内容", DEFAULT_TAGS,
+                         related=[{"type": "activity", "ids": [a["activity_id"]]}])
+        update_pin("decision", d["decision_id"], True)
+        update_pin("log", log["log_id"], True)
+        update_pin("material", m["material_id"], True)
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert len(result["pinned"]["decisions"]) == 1
+        assert len(result["pinned"]["logs"]) == 1
+        assert len(result["pinned"]["materials"]) == 1


### PR DESCRIPTION
## Summary
- check-inレスポンスにpinnedエンティティ（decision/log/material）をcontent付きで自動注入
- 通常フィールド（recent_decisions, logs, materials）からpinnedエンティティを除外して重複を防止
- coverage計算にpinned件数を分子として加算
- `update_pin` tool descriptionから「将来実装予定」の注記を削除

## 関連decision
- D#1642: pinnedフィールドの構造（`pinned: {decisions, logs, materials}`）
- D#1643: 通常フィールドからの除外
- D#1644: coverage計算へのpinned加算
- D#1646: 取得スコープは関連トピック経由のみ

## Test plan
- [x] pinnedエンティティが0件の場合、pinnedフィールドが省略される
- [x] pinされたdecisionがpinned.decisionsにcontent付き（title+reason）で返る
- [x] pinされたdecisionがrecent_decisionsから除外される
- [x] pinされたlogがpinned.logsにcontent付きで返る
- [x] pinされたlogがlogsカタログから除外される
- [x] pinされたmaterialがpinned.materialsにcontent付きで返る
- [x] pinされたmaterialが通常materialsから除外される
- [x] coverage分子にpinned件数が加算される（decisions, logs, materials各種）
- [x] 3種すべてpinされた場合に正しく動作する
- [x] 既存テスト39件がすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)