### PR TITLE
feat: SQLite WAL + busy_timeout追加

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -93,6 +93,8 @@ def get_connection() -> sqlite3.Connection:
     db_path = get_db_path()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row  # 辞書ライクなアクセスを可能にする
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA foreign_keys = ON")  # 外部キー制約を有効化
     try:
         _load_sqlite_vec(conn)


### PR DESCRIPTION
## Summary
- `get_connection()`に`PRAGMA journal_mode=WAL`と`PRAGMA busy_timeout=5000`を追加
- リモートサーバー化（A#657）の前提条件（D#1751）
- internal版でも同時アクセス耐性が向上する

## Test plan
- [ ] 既存テストがパス
- [ ] `PRAGMA journal_mode`の戻り値が`wal`であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)