### PR TITLE
chore: .gitignoreにCLAUDE.local.mdを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ htmlcov/
 
 # Work files
 work/
+
+# Local instructions
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- CLAUDE.local.mdをgit管理外にするため.gitignoreに追加

## Test plan
- [ ] CLAUDE.local.mdがgit statusに表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)