### PR TITLE
feat: recency decayを指数減衰に変更し強度を強化

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,8 @@ PENDING_LIMIT: int = int(os.environ.get("CCM_PENDING_LIMIT", "2"))
 # --- Search ---
 # Recency boost の減衰率（指数減衰 e^(-kt)）。30日で約0.70倍、半減期約58日
 RECENCY_DECAY_RATE: float = float(os.environ.get("CCM_RECENCY_DECAY_RATE", "0.0119"))
+# Recency boost の下限。約160日以降はこの値で一定になる
+RECENCY_DECAY_FLOOR: float = float(os.environ.get("CCM_RECENCY_DECAY_FLOOR", "0.15"))
 
 # --- Snapshot ---
 SNAPSHOT_INTERVAL_HOURS: int = int(os.environ.get("CCM_SNAPSHOT_INTERVAL", "12"))

--- a/src/config.py
+++ b/src/config.py
@@ -14,8 +14,8 @@ IN_PROGRESS_LIMIT: int = int(os.environ.get("CCM_IN_PROGRESS_LIMIT", "3"))
 PENDING_LIMIT: int = int(os.environ.get("CCM_PENDING_LIMIT", "2"))
 
 # --- Search ---
-# Recency boost の減衰率。半年(182日)で約0.80倍、1年(365日)で約0.66倍
-RECENCY_DECAY_RATE: float = float(os.environ.get("CCM_RECENCY_DECAY_RATE", "0.0014"))
+# Recency boost の減衰率（指数減衰 e^(-kt)）。30日で約0.70倍、半減期約58日
+RECENCY_DECAY_RATE: float = float(os.environ.get("CCM_RECENCY_DECAY_RATE", "0.0119"))
 
 # --- Snapshot ---
 SNAPSHOT_INTERVAL_HOURS: int = int(os.environ.get("CCM_SNAPSHOT_INTERVAL", "12"))

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,5 +1,6 @@
 """FTS5 + ベクトル ハイブリッド検索サービス"""
 import logging
+import math
 import re
 from datetime import datetime, timezone
 from typing import Optional
@@ -1028,9 +1029,9 @@ def _tag_like_search(
 
 
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:
-    """RRFスコアにrecency boost（時間減衰）を適用する（in-place）。
+    """RRFスコアにrecency boost（指数減衰）を適用する（in-place）。
 
-    recency_factor = 1 / (1 + age_days * RECENCY_DECAY_RATE)
+    recency_factor = exp(-age_days * RECENCY_DECAY_RATE)
     をスコアに乗算し、スコア降順で再ソートする。
     """
     if not results:
@@ -1060,7 +1061,7 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
             if created_str:
                 created = datetime.fromisoformat(created_str).replace(tzinfo=timezone.utc)
                 age_days = max(0, (now - created).days)
-                recency_factor = 1.0 / (1.0 + age_days * RECENCY_DECAY_RATE)
+                recency_factor = math.exp(-age_days * RECENCY_DECAY_RATE)
                 item["score"] *= recency_factor
 
     # スコア降順で再ソート

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -67,7 +67,7 @@ assert all(
     for i in range(len(ADAPTIVE_RRF_THRESHOLDS) - 1)
 ), "ADAPTIVE_RRF_THRESHOLDS must be sorted in ascending order of threshold"
 
-from src.config import RECENCY_DECAY_RATE
+from src.config import RECENCY_DECAY_FLOOR, RECENCY_DECAY_RATE
 
 # Query Expansion パラメータ
 QE_DISTANCE_THRESHOLD = 0.3   # コサイン距離。これ未満のタグを拡張候補とする
@@ -1031,7 +1031,7 @@ def _tag_like_search(
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:
     """RRFスコアにrecency boost（指数減衰）を適用する（in-place）。
 
-    recency_factor = exp(-age_days * RECENCY_DECAY_RATE)
+    recency_factor = max(exp(-age_days * RECENCY_DECAY_RATE), RECENCY_DECAY_FLOOR)
     をスコアに乗算し、スコア降順で再ソートする。
     """
     if not results:
@@ -1061,7 +1061,7 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
             if created_str:
                 created = datetime.fromisoformat(created_str).replace(tzinfo=timezone.utc)
                 age_days = max(0, (now - created).days)
-                recency_factor = math.exp(-age_days * RECENCY_DECAY_RATE)
+                recency_factor = max(math.exp(-age_days * RECENCY_DECAY_RATE), RECENCY_DECAY_FLOOR)
                 item["score"] *= recency_factor
 
     # スコア降順で再ソート

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -14,7 +14,7 @@ from src.db import init_database, get_connection
 from src.services.search_service import (
     _rrf_merge, _apply_recency_boost, _attach_details, _compute_adaptive_weights,
     find_similar_topics, _expand_query_with_tags,
-    RRF_K, RRF_W_FTS, RRF_W_VEC, RRF_W_TAG, RECENCY_DECAY_RATE,
+    RRF_K, RRF_W_FTS, RRF_W_VEC, RRF_W_TAG, RECENCY_DECAY_RATE, RECENCY_DECAY_FLOOR,
     QE_DISTANCE_THRESHOLD, QE_MAX_EXPANSIONS, QE_EXCLUDE_NAMESPACES,
     ADAPTIVE_RRF_ENABLED, ADAPTIVE_RRF_THRESHOLDS,
     DETAILS_MAX_RESULTS, DETAILS_DESCRIPTION_MAX,
@@ -486,7 +486,7 @@ def test_recency_boost_decay_formula(temp_db):
 
     # created_atを固定日時に設定し、nowも固定して厳密に検証
     created_at = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    now = datetime(2025, 7, 2, 0, 0, 0, tzinfo=timezone.utc)  # 182日後
+    now = datetime(2025, 4, 1, 0, 0, 0, tzinfo=timezone.utc)  # 90日後
     conn = get_connection()
     conn.execute(
         "UPDATE discussion_topics SET created_at = ? WHERE id = ?",
@@ -502,9 +502,39 @@ def test_recency_boost_decay_formula(temp_db):
 
     _apply_recency_boost(results, now=now)
 
-    # 指数減衰: factor = exp(-182 * 0.0119) ≈ 0.115
-    expected_factor = math.exp(-182 * RECENCY_DECAY_RATE)
+    # 指数減衰: factor = exp(-90 * 0.0119) ≈ 0.343（floorより上）
+    expected_factor = math.exp(-90 * RECENCY_DECAY_RATE)
     assert results[0]["score"] == pytest.approx(base_score * expected_factor)
+
+
+def test_recency_boost_floor(temp_db):
+    """recency boost: 非常に古いアイテムでもFLOOR値を下回らない"""
+    t = add_topic(
+        title="floor検証用",
+        description="テスト用",
+        tags=DEFAULT_TAGS,
+    )
+
+    # 730日前（約2年前）に設定
+    created_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    now = datetime(2025, 12, 31, 0, 0, 0, tzinfo=timezone.utc)  # 730日後
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = ? WHERE id = ?",
+        (created_at.strftime("%Y-%m-%d %H:%M:%S"), t["topic_id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    base_score = 1.0
+    results = [
+        {"type": "topic", "id": t["topic_id"], "title": "floor検証用", "score": base_score},
+    ]
+
+    _apply_recency_boost(results, now=now)
+
+    # exp(-730 * 0.0119) ≈ 0.000165 だが、floorで0.15になる
+    assert results[0]["score"] == pytest.approx(base_score * RECENCY_DECAY_FLOOR)
 
 
 def test_recency_boost_empty_list():

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -3,6 +3,7 @@
 _rrf_merge単体テスト + _apply_recency_boost単体テスト + タグ対応の統合テスト。
 """
 import hashlib
+import math
 import os
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -501,8 +502,8 @@ def test_recency_boost_decay_formula(temp_db):
 
     _apply_recency_boost(results, now=now)
 
-    # 182日 × 0.0014 = 0.2548, factor = 1/(1+0.2548) ≈ 0.797
-    expected_factor = 1.0 / (1.0 + 182 * RECENCY_DECAY_RATE)
+    # 指数減衰: factor = exp(-182 * 0.0119) ≈ 0.115
+    expected_factor = math.exp(-182 * RECENCY_DECAY_RATE)
     assert results[0]["score"] == pytest.approx(base_score * expected_factor)
 
 
@@ -533,8 +534,8 @@ def test_recency_boost_reorders_by_score(temp_db):
 
     _apply_recency_boost(results)
 
-    # 730日前: factor = 1/(1+730*0.0014) = 1/2.022 ≈ 0.495
-    # t1: 0.012 * 0.495 ≈ 0.00594
+    # 730日前: factor = exp(-730*0.0119) ≈ 0.000165
+    # t1: 0.012 * 0.000165 ≈ 0.000002
     # t2 (今日): 0.010 * ~1.0 = 0.010
     # t2が上位に来るはず
     assert results[0]["id"] == t2["topic_id"]


### PR DESCRIPTION
## Summary
- recency boostの数式を双曲線 `1/(1+kt)` から指数 `e^(-kt)` に変更
- デフォルト減衰レートを `0.0014` → `0.0119` に変更（30日で約30%減、半減期約58日）
- 全entity typeに一律適用、保護メカニズムは導入しない（YAGNI）

## Background
データ分析の結果、現行decay（30日で4%減）では全searchableエンティティの65%が1ヶ月以上前のもので、スコアがほぼ横並びになっていた。案A（30日30%減）+指数減衰への変更により、新旧の差が明確に出るようになる。

関連: A#609（検索Phase 2）、D#1783、D#1784

## Test plan
- [x] recency boost関連6テスト全pass
- [x] 全テスト1070 passed（5 failedは既存のtest_remote.py、変更と無関係）
- [ ] デプロイ後、searchで新しいエンティティが適切に上位に来ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)