### PR TITLE
feat: CC_MEMORY_URL環境変数でlauncher接続先を切り替え可能にする

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -35,6 +35,10 @@ class ServerDisconnected(Exception):
 _REMOTE_URL = os.environ.get("CC_MEMORY_URL")
 
 if _REMOTE_URL:
+    if not _REMOTE_URL.startswith(("http://", "https://")):
+        raise ValueError(
+            f"CC_MEMORY_URL must start with http:// or https://, got: {_REMOTE_URL!r}"
+        )
     _base = _REMOTE_URL.rstrip("/")
     MCP_ENDPOINT = f"{_base}/mcp"
     _IS_LOCAL = False
@@ -298,12 +302,12 @@ def main() -> None:
         logger.info("Remote mode: connecting to %s", MCP_ENDPOINT)
 
     for attempt in range(MAX_RETRIES + 1):
-        # 1. HTTPサーバーの起動確認（ローカルのみ）
+        # 1. HTTPサーバーの起動確認（ローカルのみ。リモートはOAuth等の制約があるためスキップ）
         if _IS_LOCAL and not _ensure_server_running():
             logger.error("Failed to ensure HTTP server is running")
             sys.exit(1)
 
-        # 2. セッション登録（ローカルのみ）
+        # 2. セッション登録（ローカルのみ。リモートサーバーにはセッションAPIがない）
         if _IS_LOCAL and not _register_session():
             logger.error("Failed to register session")
             sys.exit(1)

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -29,12 +29,23 @@ class ServerDisconnected(Exception):
     pass
 
 
-# サーバー接続設定（HTTP_HOST, HTTP_PORTはmain.pyと共有）
-from src.http_config import HTTP_HOST, HTTP_PORT
+# サーバー接続設定
+# CC_MEMORY_URL が設定されていればそのURLを使い、未設定ならローカルHTTPサーバーに接続する。
+# リモートURL指定時はサーバー自動起動・セッション管理をスキップする。
+_REMOTE_URL = os.environ.get("CC_MEMORY_URL")
 
-MCP_ENDPOINT = f"http://{HTTP_HOST}:{HTTP_PORT}/mcp"
-SESSION_REGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/register"
-SESSION_UNREGISTER_URL = f"http://{HTTP_HOST}:{HTTP_PORT}/session/unregister"
+if _REMOTE_URL:
+    _base = _REMOTE_URL.rstrip("/")
+    MCP_ENDPOINT = f"{_base}/mcp"
+    _IS_LOCAL = False
+else:
+    from src.http_config import HTTP_HOST, HTTP_PORT
+    _base = f"http://{HTTP_HOST}:{HTTP_PORT}"
+    MCP_ENDPOINT = f"{_base}/mcp"
+    _IS_LOCAL = True
+
+SESSION_REGISTER_URL = f"{_base}/session/register"
+SESSION_UNREGISTER_URL = f"{_base}/session/unregister"
 
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 
@@ -279,18 +290,21 @@ def main() -> None:
         stream=sys.stderr,
     )
 
-    # クリーンアップ登録（ループの外で1回だけ）
-    atexit.register(_cleanup)
-    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))  # atexitが発火する
+    if _IS_LOCAL:
+        # ローカル接続: セッション管理あり
+        atexit.register(_cleanup)
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))  # atexitが発火する
+    else:
+        logger.info("Remote mode: connecting to %s", MCP_ENDPOINT)
 
     for attempt in range(MAX_RETRIES + 1):
-        # 1. HTTPサーバーの起動確認
-        if not _ensure_server_running():
+        # 1. HTTPサーバーの起動確認（ローカルのみ）
+        if _IS_LOCAL and not _ensure_server_running():
             logger.error("Failed to ensure HTTP server is running")
             sys.exit(1)
 
-        # 2. セッション登録
-        if not _register_session():
+        # 2. セッション登録（ローカルのみ）
+        if _IS_LOCAL and not _register_session():
             logger.error("Failed to register session")
             sys.exit(1)
 
@@ -313,7 +327,8 @@ def main() -> None:
             )
             time.sleep(backoff)
 
-    _cleanup()
+    if _IS_LOCAL:
+        _cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -336,6 +336,7 @@ class TestMainRetryLoop:
 
         bridge_side_effectsにはasyncio.run(_bridge())の戻り値/例外のリストを渡す。
         """
+        monkeypatch.setattr(launcher, "_IS_LOCAL", True)
         monkeypatch.setattr(launcher, "_cleanup_done", False)
         monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)
         monkeypatch.setattr(launcher, "_register_session", lambda: True)
@@ -434,6 +435,7 @@ class TestMainRetryLoop:
         def counting_cleanup():
             cleanup_count["calls"] += 1
 
+        monkeypatch.setattr(launcher, "_IS_LOCAL", True)
         monkeypatch.setattr(launcher, "_cleanup_done", False)
         monkeypatch.setattr(launcher, "_cleanup", counting_cleanup)
         monkeypatch.setattr(launcher, "_ensure_server_running", lambda: True)


### PR DESCRIPTION
## Summary
- `CC_MEMORY_URL` 環境変数でlauncher.pyの接続先をローカルHTTP/リモートに切り替え可能にする
- 未設定時は従来通りlocalhost:52837に接続（デフォルト動作に変更なし）
- リモートURL指定時はサーバー自動起動・セッション管理をスキップ

## Test plan
- [x] 既存テスト全件パス（1075 passed）
- [ ] `CC_MEMORY_URL` 未設定で従来通りローカル接続できること
- [ ] `CC_MEMORY_URL=https://mcp.isizono.com` でリモート接続できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)