### PR TITLE
feat: decision/logの取り消し（retract）機能を追加

### DIFF
--- a/migrations/0031_add_retracted_at.sql
+++ b/migrations/0031_add_retracted_at.sql
@@ -1,0 +1,13 @@
+-- Migration 031: decisions, discussion_logsにretracted_atカラムを追加
+--
+-- depends: 0030_add_search_index_created_at
+--
+-- 背景:
+--   誤った決定事項やログを論理削除（取り消し）するための準備。
+--   NULLが有効（未取り消し）、値ありが取り消し済み。
+--
+-- 変更内容:
+--   decisions, discussion_logsの2テーブルにretracted_at TIMESTAMP NULLを追加
+
+ALTER TABLE decisions ADD COLUMN retracted_at TIMESTAMP NULL;
+ALTER TABLE discussion_logs ADD COLUMN retracted_at TIMESTAMP NULL;

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from src.services import (
     habit_service,
     relation_service,
     pin_service,
+    retract_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -270,6 +271,7 @@ def get_logs(
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
+    include_retracted: bool = False,
 ) -> dict:
     """
     指定エンティティの議論ログを取得する。
@@ -279,12 +281,13 @@ def get_logs(
         entity_id: 対象エンティティのID
         start_id: 取得開始位置のログID（ページネーション用）
         limit: 取得件数上限（最大30件）
+        include_retracted: Trueのとき取り消し済みログも含める（デフォルトFalse）
 
     Returns:
         議論ログ一覧（各logにtags付き）
         entity_type == "activity" の場合はrelated topics経由でlogs集約
     """
-    result = discussion_log_service.get_logs(entity_type, entity_id, start_id, limit)
+    result = discussion_log_service.get_logs(entity_type, entity_id, start_id, limit, include_retracted=include_retracted)
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("logs", []))
         if all_tags:
@@ -298,6 +301,7 @@ def get_decisions(
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
+    include_retracted: bool = False,
 ) -> dict:
     """
     指定エンティティに関連する決定事項を取得する。
@@ -307,12 +311,13 @@ def get_decisions(
         entity_id: 対象エンティティのID
         start_id: 取得開始位置の決定事項ID（ページネーション用）
         limit: 取得件数上限（最大30件）
+        include_retracted: Trueのとき取り消し済み決定事項も含める（デフォルトFalse）
 
     Returns:
         決定事項一覧（各decisionにtags付き）
         entity_type == "activity" の場合はrelated topics経由でdecisions集約
     """
-    result = decision_service.get_decisions(entity_type, entity_id, start_id, limit)
+    result = decision_service.get_decisions(entity_type, entity_id, start_id, limit, include_retracted=include_retracted)
     if "error" not in result:
         all_tags = _collect_result_tags(result.get("decisions", []))
         if all_tags:
@@ -332,6 +337,7 @@ def search(
     domain: Optional[str] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    include_retracted: bool = False,
 ) -> dict:
     """
     キーワードで横断検索する。
@@ -357,6 +363,7 @@ def search(
         domain: ドメインフィルタ。内部でtags=["domain:{domain}"]にマージされる
         date_after: 日付フィルタ（以降）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
         date_before: 日付フィルタ（以前）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
+        include_retracted: Trueのとき取り消し済みのdecision/logも含める（デフォルトFalse）
 
     Returns:
         検索結果一覧（type, id, title, score, snippet, tags）
@@ -364,7 +371,7 @@ def search(
         tagsはエンティティに紐づくタグ文字列のリスト。
         include_details=Trueの場合、上位10件にdetailsが追加される。
     """
-    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before)
+    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before, include_retracted=include_retracted)
     if "error" not in result and tags:
         _maybe_inject_tag_notes(result, tags)
     return result
@@ -833,6 +840,18 @@ def update_pin(entity_type: str, entity_id: int, pinned: bool) -> dict:
         pinned: True=pin, False=unpin
     """
     return pin_service.update_pin(entity_type, entity_id, pinned)
+
+
+@mcp.tool()
+def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
+    """決定事項やログを取り消す（論理削除）。取り消し済みエンティティは検索・取得でデフォルト除外される。
+
+    Args:
+        entity_type: "decision" | "log"
+        ids: 対象エンティティのIDリスト
+        undo: True=取り消しを元に戻す（un-retract）、False=取り消す（retract）
+    """
+    return retract_service.retract(entity_type, ids, undo)
 
 
 @mcp.tool()

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -72,7 +72,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
         f"""
         SELECT id, decision
         FROM decisions
-        WHERE topic_id IN ({placeholders}) AND pinned = 0
+        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL
         ORDER BY id DESC
         LIMIT {DECISIONS_FULL_LIMIT}
         """,
@@ -86,12 +86,12 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
 
 
 def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> int:
-    """複数トピックのdecisionsの総件数を取得する（pinned含む、coverage分母用）。"""
+    """複数トピックのdecisionsの総件数を取得する（pinned含む、retracted除外、coverage分母用）。"""
     if not topic_ids:
         return 0
     placeholders = ",".join("?" * len(topic_ids))
     row = conn.execute(
-        f"SELECT COUNT(*) FROM decisions WHERE topic_id IN ({placeholders})",
+        f"SELECT COUNT(*) FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL",
         tuple(topic_ids),
     ).fetchone()
     return row[0] if row else 0
@@ -118,7 +118,7 @@ def _get_logs_catalog_from_topics(
         f"""
         SELECT id, title, content
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 0
+        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL
         ORDER BY id DESC
         LIMIT 1
         """,
@@ -135,7 +135,7 @@ def _get_logs_catalog_from_topics(
         f"""
         SELECT id, title
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND id != ?
+        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL AND id != ?
         ORDER BY id DESC
         """,
         params + (latest_row["id"],),
@@ -154,7 +154,7 @@ def _get_pinned_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[
         f"""
         SELECT id, decision, reason
         FROM decisions
-        WHERE topic_id IN ({placeholders}) AND pinned = 1
+        WHERE topic_id IN ({placeholders}) AND pinned = 1 AND retracted_at IS NULL
         ORDER BY id DESC
         """,
         tuple(topic_ids),
@@ -171,7 +171,7 @@ def _get_pinned_logs_from_topics(conn: sqlite3.Connection, topic_ids: list[int])
         f"""
         SELECT id, title, content
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 1
+        WHERE topic_id IN ({placeholders}) AND pinned = 1 AND retracted_at IS NULL
         ORDER BY id DESC
         """,
         tuple(topic_ids),

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -180,6 +180,7 @@ def get_decisions(
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
+    include_retracted: bool = False,
 ) -> dict:
     """
     指定エンティティに関連する決定事項を取得する。
@@ -195,6 +196,8 @@ def get_decisions(
         entity_type == "topic": 従来通りtopic_idで直接取得
         entity_type == "activity": related topics（上限10件）経由でdecisions集約
     """
+    retract_filter = "" if include_retracted else " AND retracted_at IS NULL"
+
     conn = get_connection()
     try:
         # limitを30件に制限
@@ -219,9 +222,9 @@ def get_decisions(
 
             if start_id is None:
                 rows = conn.execute(
-                    """
+                    f"""
                     SELECT * FROM decisions
-                    WHERE topic_id = ?
+                    WHERE topic_id = ?{retract_filter}
                     ORDER BY created_at ASC, id ASC
                     LIMIT ?
                     """,
@@ -229,9 +232,9 @@ def get_decisions(
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    """
+                    f"""
                     SELECT * FROM decisions
-                    WHERE topic_id = ? AND id >= ?
+                    WHERE topic_id = ? AND id >= ?{retract_filter}
                     ORDER BY created_at ASC, id ASC
                     LIMIT ?
                     """,
@@ -244,13 +247,16 @@ def get_decisions(
             decisions = []
             for row in rows:
                 dec = row_to_dict(row)
-                decisions.append({
+                item = {
                     "id": dec["id"],
                     "decision": dec["decision"],
                     "reason": dec["reason"],
                     "tags": tags_map.get(dec["id"], []),
                     "created_at": dec["created_at"],
-                })
+                }
+                if dec.get("retracted_at"):
+                    item["retracted_at"] = dec["retracted_at"]
+                decisions.append(item)
 
             return {
                 "topic_id": topic_id,
@@ -274,7 +280,7 @@ def get_decisions(
                 rows = conn.execute(
                     f"""
                     SELECT * FROM decisions
-                    WHERE topic_id IN ({placeholders})
+                    WHERE topic_id IN ({placeholders}){retract_filter}
                     ORDER BY id DESC
                     LIMIT ?
                     """,
@@ -284,7 +290,7 @@ def get_decisions(
                 rows = conn.execute(
                     f"""
                     SELECT * FROM decisions
-                    WHERE topic_id IN ({placeholders}) AND id <= ?
+                    WHERE topic_id IN ({placeholders}) AND id <= ?{retract_filter}
                     ORDER BY id DESC
                     LIMIT ?
                     """,
@@ -298,13 +304,16 @@ def get_decisions(
             decisions = []
             for row in rows:
                 dec = row_to_dict(row)
-                decisions.append({
+                item = {
                     "id": dec["id"],
                     "decision": dec["decision"],
                     "reason": dec["reason"],
                     "tags": tags_map.get(dec["id"], []),
                     "created_at": dec["created_at"],
-                })
+                }
+                if dec.get("retracted_at"):
+                    item["retracted_at"] = dec["retracted_at"]
+                decisions.append(item)
 
             return {"decisions": decisions}
 

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -158,6 +158,7 @@ def get_logs(
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
+    include_retracted: bool = False,
 ) -> dict:
     """
     指定エンティティの議論ログを取得する。
@@ -167,12 +168,15 @@ def get_logs(
         entity_id: 対象エンティティのID
         start_id: 取得開始位置のログID（ページネーション用）
         limit: 取得件数上限（最大30件）
+        include_retracted: Trueのとき取り消し済みログも含める（デフォルトFalse）
 
     Returns:
         議論ログ一覧（各logにtags付き）
         entity_type == "topic": 従来通りtopic_idで直接取得
         entity_type == "activity": related topics（上限10件）経由でlogs集約
     """
+    retract_filter = "" if include_retracted else " AND retracted_at IS NULL"
+
     conn = get_connection()
     try:
         # limitを30件に制限
@@ -182,9 +186,9 @@ def get_logs(
             topic_id = entity_id
             if start_id is None:
                 rows = conn.execute(
-                    """
+                    f"""
                     SELECT * FROM discussion_logs
-                    WHERE topic_id = ?
+                    WHERE topic_id = ?{retract_filter}
                     ORDER BY created_at ASC, id ASC
                     LIMIT ?
                     """,
@@ -192,9 +196,9 @@ def get_logs(
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    """
+                    f"""
                     SELECT * FROM discussion_logs
-                    WHERE topic_id = ? AND id >= ?
+                    WHERE topic_id = ? AND id >= ?{retract_filter}
                     ORDER BY created_at ASC, id ASC
                     LIMIT ?
                     """,
@@ -207,14 +211,17 @@ def get_logs(
             logs = []
             for row in rows:
                 log = row_to_dict(row)
-                logs.append({
+                item = {
                     "id": log["id"],
                     "topic_id": log["topic_id"],
                     "title": log["title"],
                     "content": log["content"],
                     "tags": tags_map.get(log["id"], []),
                     "created_at": log["created_at"],
-                })
+                }
+                if log.get("retracted_at"):
+                    item["retracted_at"] = log["retracted_at"]
+                logs.append(item)
 
             return {"logs": logs}
 
@@ -234,7 +241,7 @@ def get_logs(
                 rows = conn.execute(
                     f"""
                     SELECT * FROM discussion_logs
-                    WHERE topic_id IN ({placeholders})
+                    WHERE topic_id IN ({placeholders}){retract_filter}
                     ORDER BY id DESC
                     LIMIT ?
                     """,
@@ -244,7 +251,7 @@ def get_logs(
                 rows = conn.execute(
                     f"""
                     SELECT * FROM discussion_logs
-                    WHERE topic_id IN ({placeholders}) AND id <= ?
+                    WHERE topic_id IN ({placeholders}) AND id <= ?{retract_filter}
                     ORDER BY id DESC
                     LIMIT ?
                     """,
@@ -258,14 +265,17 @@ def get_logs(
             logs = []
             for row in rows:
                 log = row_to_dict(row)
-                logs.append({
+                item = {
                     "id": log["id"],
                     "topic_id": log["topic_id"],
                     "title": log["title"],
                     "content": log["content"],
                     "tags": tags_map.get(log["id"], []),
                     "created_at": log["created_at"],
-                })
+                }
+                if log.get("retracted_at"):
+                    item["retracted_at"] = log["retracted_at"]
+                logs.append(item)
 
             return {"logs": logs}
 

--- a/src/services/retract_service.py
+++ b/src/services/retract_service.py
@@ -1,0 +1,107 @@
+"""エンティティの取り消し（retract）管理サービス"""
+import logging
+import sqlite3
+from datetime import datetime, timezone
+
+from src.db import get_connection
+
+logger = logging.getLogger(__name__)
+
+ENTITY_TABLE_MAP = {
+    "decision": "decisions",
+    "log": "discussion_logs",
+}
+
+
+def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
+    """エンティティを取り消し（retract）またはun-retractする。
+
+    SAVEPOINT方式で各IDを個別処理し、部分成功を許容する。
+    冪等: 既にretracted状態でretractしても成功扱い、
+    既に非retracted状態でun-retractしても成功扱い。
+
+    Args:
+        entity_type: エンティティ種別 ("decision" | "log")
+        ids: 対象エンティティのIDリスト
+        undo: True=un-retract（retracted_atをNULLに戻す）、False=retract
+
+    Returns:
+        {success: [int, ...], errors: [{id, error}]}
+        またはエラー {"error": {"code": str, "message": str}}
+    """
+    # entity_type検証
+    if entity_type not in ENTITY_TABLE_MAP:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid entity_type: {entity_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
+            }
+        }
+
+    # ids検証
+    if not ids:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "ids must not be empty",
+            }
+        }
+
+    table = ENTITY_TABLE_MAP[entity_type]
+    success = []
+    errors = []
+
+    conn = get_connection()
+    try:
+        for i, entity_id in enumerate(ids):
+            conn.execute(f"SAVEPOINT retract_{i}")
+            try:
+                # 存在確認
+                row = conn.execute(
+                    f"SELECT id, retracted_at FROM {table} WHERE id = ?",
+                    (entity_id,),
+                ).fetchone()
+
+                if not row:
+                    raise ValueError(f"{entity_type} with id {entity_id} not found")
+
+                if undo:
+                    # un-retract: retracted_at IS NOT NULLの場合のみ更新
+                    if row["retracted_at"] is not None:
+                        conn.execute(
+                            f"UPDATE {table} SET retracted_at = NULL WHERE id = ?",
+                            (entity_id,),
+                        )
+                else:
+                    # retract: retracted_at IS NULLの場合のみ更新
+                    if row["retracted_at"] is None:
+                        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                        conn.execute(
+                            f"UPDATE {table} SET retracted_at = ? WHERE id = ?",
+                            (now, entity_id),
+                        )
+
+                conn.execute(f"RELEASE SAVEPOINT retract_{i}")
+                success.append(entity_id)
+
+            except Exception as e:
+                conn.execute(f"ROLLBACK TO SAVEPOINT retract_{i}")
+                conn.execute(f"RELEASE SAVEPOINT retract_{i}")
+                errors.append({
+                    "id": entity_id,
+                    "error": {"code": "ITEM_ERROR", "message": str(e)},
+                })
+
+        conn.commit()
+        return {"success": success, "errors": errors}
+
+    except Exception as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -48,6 +48,19 @@ TAG_LIKE_MAX_TAG_IDS = 100
 
 # details付与パラメータ
 DETAILS_MAX_RESULTS = 10
+
+# retracted除外フィルタ: search_indexのsource_type='decision'/'log'のみ対象
+# decision/logはretracted_atカラムを持つが、topic/activity/materialは持たない
+RETRACT_FILTER_SQL = """
+  AND NOT EXISTS (
+    SELECT 1 FROM decisions d
+    WHERE d.id = si.source_id AND si.source_type = 'decision' AND d.retracted_at IS NOT NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM discussion_logs dl
+    WHERE dl.id = si.source_id AND si.source_type = 'log' AND dl.retracted_at IS NOT NULL
+  )
+"""
 DETAILS_DESCRIPTION_MAX = 500
 # RRFパラメータ
 RRF_K = 60
@@ -559,6 +572,7 @@ def _fts_search(
     original_keyword_count: Optional[int] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    include_retracted: bool = False,
 ) -> list[dict]:
     """FTS5検索。結果はBM25ランク順のリスト。
 
@@ -573,6 +587,7 @@ def _fts_search(
             残りをOR追加する（Query Expansion用）。未指定時は従来通り。
         date_after: 日付フィルタ（以降）
         date_before: 日付フィルタ（以前）
+        include_retracted: Trueのとき取り消し済みdecision/logも含める
     """
     # OR時: 3文字以上のキーワードだけでFTS5クエリを組む（2文字はフィルタ除外）
     if keyword_mode == "or":
@@ -604,6 +619,7 @@ def _fts_search(
         date_clauses.append("AND si.created_at <= ?")
         date_params.append(date_before)
     date_sql = "\n          ".join(date_clauses)
+    retract_sql = "" if include_retracted else RETRACT_FILTER_SQL
 
     if tag_ids:
         cte_sql, cte_params = _build_tag_filter_cte(tag_ids)
@@ -619,6 +635,7 @@ def _fts_search(
         WHERE search_index_fts MATCH ?
           AND (? IS NULL OR si.source_type = ?)
           {date_sql}
+          {retract_sql}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -634,6 +651,7 @@ def _fts_search(
         WHERE search_index_fts MATCH ?
           AND (? IS NULL OR si.source_type = ?)
           {date_sql}
+          {retract_sql}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -659,9 +677,25 @@ def _vector_search(
     keyword_mode: str = "and",
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    include_retracted: bool = False,
 ) -> Optional[list[dict]]:
     """ベクトル検索。ベクトル検索無効時はNoneを返す。"""
     try:
+        # retractフィルタ（search_indexのsiエイリアスを使う版）
+        # _vector_searchではsearch_indexにsiエイリアスがないクエリがあるため、
+        # search_index直接参照版を使う
+        retract_sql_si = "" if include_retracted else RETRACT_FILTER_SQL
+        retract_sql_direct = "" if include_retracted else """
+  AND NOT EXISTS (
+    SELECT 1 FROM decisions d
+    WHERE d.id = search_index.source_id AND search_index.source_type = 'decision' AND d.retracted_at IS NOT NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM discussion_logs dl
+    WHERE dl.id = search_index.source_id AND search_index.source_type = 'log' AND dl.retracted_at IS NOT NULL
+  )
+"""
+
         # 日付フィルタの動的WHERE句構築
         date_clauses = []
         date_params_list: list = []
@@ -711,6 +745,7 @@ def _vector_search(
                           AND tf.source_id = search_index.source_id
                       )
                       {date_sql}
+                      {retract_sql_direct}
                     """
                     params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
                 else:
@@ -720,6 +755,7 @@ def _vector_search(
                     WHERE id IN ({rowid_placeholders})
                       AND (? IS NULL OR source_type = ?)
                       {date_sql}
+                      {retract_sql_direct}
                     """
                     params = (*rowids, entity_type, entity_type, *date_params_list)
 
@@ -782,6 +818,7 @@ def _vector_search(
                       AND tf.source_id = search_index.source_id
                   )
                   {date_sql}
+                  {retract_sql_direct}
                 """
                 params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
             else:
@@ -791,6 +828,7 @@ def _vector_search(
                 WHERE id IN ({rowid_placeholders})
                   AND (? IS NULL OR source_type = ?)
                   {date_sql}
+                  {retract_sql_direct}
                 """
                 params = (*rowids, entity_type, entity_type, *date_params_list)
 
@@ -893,6 +931,7 @@ def _tag_like_search(
     keyword_mode: str = "and",
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    include_retracted: bool = False,
 ) -> list[dict]:
     """タグ名のLIKE検索。キーワードにマッチするタグを持つエンティティを返す。
 
@@ -958,6 +997,7 @@ def _tag_like_search(
         date_clauses.append("AND si.created_at <= ?")
         date_params_tl.append(date_before)
     date_sql = "\n      ".join(date_clauses)
+    retract_sql = "" if include_retracted else RETRACT_FILTER_SQL
 
     # 各中間テーブルからエンティティを収集（UNION ALL）
     query = f"""
@@ -966,6 +1006,7 @@ def _tag_like_search(
     WHERE
       (? IS NULL OR si.source_type = ?)
       {date_sql}
+      {retract_sql}
       AND (
         EXISTS (
             SELECT 1 FROM topic_tags tt
@@ -1154,6 +1195,7 @@ def search(
     domain: Optional[str] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    include_retracted: bool = False,
 ) -> dict:
     """
     キーワードで横断検索する。
@@ -1313,22 +1355,22 @@ def search(
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before, include_retracted)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
             # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
             if min_len >= 3:
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before, include_retracted)
                 methods_used.append("fts5")
 
         # ベクトル検索（元のキーワードのまま、拡張なし）
-        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
+        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted)
         if vec_results is not None:
             methods_used.append("vector")
 
         # タグLIKE検索（キーワード長の制限なし）
-        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
+        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted)
         if tag_like_results:
             methods_used.append("tag_like")
 
@@ -1393,7 +1435,7 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
             "created_at": data["created_at"],
         }
     elif type_name == 'decision':
-        return {
+        result = {
             "id": data["id"],
             "topic_id": data["topic_id"],
             "decision": data["decision"],
@@ -1401,6 +1443,9 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
             "tags": tags,
             "created_at": data["created_at"],
         }
+        if data.get("retracted_at"):
+            result["retracted_at"] = data["retracted_at"]
+        return result
     elif type_name == 'activity':
         return {
             "id": data["id"],
@@ -1415,7 +1460,7 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
         title = data["title"]
         if not title:
             title = data["content"][:50]
-        return {
+        result = {
             "id": data["id"],
             "topic_id": data["topic_id"],
             "title": title,
@@ -1423,6 +1468,9 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
             "tags": tags,
             "created_at": data["created_at"],
         }
+        if data.get("retracted_at"):
+            result["retracted_at"] = data["retracted_at"]
+        return result
     elif type_name == 'material':
         return {
             "material_id": data["id"],

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -684,7 +684,6 @@ def _vector_search(
         # retractフィルタ（search_indexのsiエイリアスを使う版）
         # _vector_searchではsearch_indexにsiエイリアスがないクエリがあるため、
         # search_index直接参照版を使う
-        retract_sql_si = "" if include_retracted else RETRACT_FILTER_SQL
         retract_sql_direct = "" if include_retracted else """
   AND NOT EXISTS (
     SELECT 1 FROM decisions d
@@ -1355,22 +1354,22 @@ def search(
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before, include_retracted)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before, include_retracted=include_retracted)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
             # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
             if min_len >= 3:
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before, include_retracted)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before, include_retracted=include_retracted)
                 methods_used.append("fts5")
 
         # ベクトル検索（元のキーワードのまま、拡張なし）
-        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted)
+        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted=include_retracted)
         if vec_results is not None:
             methods_used.append("vector")
 
         # タグLIKE検索（キーワード長の制限なし）
-        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted)
+        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted=include_retracted)
         if tag_like_results:
             methods_used.append("tag_like")
 

--- a/tests/unit/test_retract_filter.py
+++ b/tests/unit/test_retract_filter.py
@@ -1,0 +1,280 @@
+"""retractフィルタのテスト
+
+get_decisions, get_logs, check_in, searchで
+retractされたエンティティがデフォルト除外されることを確認する。
+"""
+import os
+import tempfile
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.discussion_log_service import add_logs, get_logs
+from src.services.decision_service import add_decisions, get_decisions
+from src.services.pin_service import update_pin
+from src.services.retract_service import retract
+from src.services.checkin_service import check_in
+from src.services.activity_service import add_activity
+from src.services.relation_service import add_relation
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def activity_with_topic(topic):
+    """テスト用アクティビティとトピックを作成しリレーションを張る"""
+    tid = topic["topic_id"]
+    act = add_activity(title="テストアクティビティ", description="テスト用", tags=DEFAULT_TAGS)
+    aid = act["activity_id"]
+    add_relation("activity", aid, [{"type": "topic", "ids": [tid]}])
+    return {"topic_id": tid, "activity_id": aid}
+
+
+class TestGetDecisionsFilter:
+    """get_decisionsのretractフィルタ"""
+
+    def test_retracted_excluded_by_default(self, topic):
+        """retractされたdecisionはデフォルトで除外される"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "有効な決定", "reason": "理由1"},
+            {"topic_id": tid, "decision": "取り消す決定", "reason": "理由2"},
+        ])
+        retracted_id = result["created"][1]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        decisions = get_decisions("topic", tid)
+        ids = [d["id"] for d in decisions["decisions"]]
+        assert retracted_id not in ids
+        assert len(decisions["decisions"]) == 1
+
+    def test_include_retracted_true(self, topic):
+        """include_retracted=Trueでretracted含む"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "有効な決定", "reason": "理由1"},
+            {"topic_id": tid, "decision": "取り消す決定", "reason": "理由2"},
+        ])
+        retracted_id = result["created"][1]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        decisions = get_decisions("topic", tid, include_retracted=True)
+        ids = [d["id"] for d in decisions["decisions"]]
+        assert retracted_id in ids
+        assert len(decisions["decisions"]) == 2
+
+
+class TestGetLogsFilter:
+    """get_logsのretractフィルタ"""
+
+    def test_retracted_excluded_by_default(self, topic):
+        """retractされたlogはデフォルトで除外される"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "有効なログ", "title": "ログ1"},
+            {"topic_id": tid, "content": "取り消すログ", "title": "ログ2"},
+        ])
+        retracted_id = result["created"][1]["log_id"]
+
+        retract("log", [retracted_id])
+
+        logs = get_logs("topic", tid)
+        ids = [l["id"] for l in logs["logs"]]
+        assert retracted_id not in ids
+        assert len(logs["logs"]) == 1
+
+    def test_include_retracted_true(self, topic):
+        """include_retracted=Trueでretracted含む"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "有効なログ", "title": "ログ1"},
+            {"topic_id": tid, "content": "取り消すログ", "title": "ログ2"},
+        ])
+        retracted_id = result["created"][1]["log_id"]
+
+        retract("log", [retracted_id])
+
+        logs = get_logs("topic", tid, include_retracted=True)
+        ids = [l["id"] for l in logs["logs"]]
+        assert retracted_id in ids
+        assert len(logs["logs"]) == 2
+
+
+class TestCheckInFilter:
+    """check_inのretractフィルタ"""
+
+    def test_retracted_decision_excluded_from_checkin(self, activity_with_topic):
+        """retractされたdecisionはcheck-inのrecent_decisionsに含まれない"""
+        tid = activity_with_topic["topic_id"]
+        aid = activity_with_topic["activity_id"]
+
+        result = add_decisions([
+            {"topic_id": tid, "decision": "有効な決定", "reason": "理由"},
+            {"topic_id": tid, "decision": "取り消す決定", "reason": "理由"},
+        ])
+        retracted_id = result["created"][1]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        checkin = check_in(aid)
+        assert "error" not in checkin
+        decision_ids = [d["id"] for d in checkin.get("recent_decisions", [])]
+        assert retracted_id not in decision_ids
+
+    def test_retracted_log_excluded_from_checkin(self, activity_with_topic):
+        """retractされたlogはcheck-inのlatest_log/logsに含まれない"""
+        tid = activity_with_topic["topic_id"]
+        aid = activity_with_topic["activity_id"]
+
+        result = add_logs([
+            {"topic_id": tid, "content": "有効なログ", "title": "ログ1"},
+            {"topic_id": tid, "content": "取り消すログ（最新）", "title": "ログ2"},
+        ])
+        retracted_id = result["created"][1]["log_id"]
+        valid_id = result["created"][0]["log_id"]
+
+        # 最新のログをretract
+        retract("log", [retracted_id])
+
+        checkin = check_in(aid)
+        assert "error" not in checkin
+
+        # latest_logがretractされたものではないことを確認
+        if checkin.get("latest_log"):
+            assert checkin["latest_log"]["id"] != retracted_id
+
+    def test_pinned_retracted_decision_excluded_from_checkin(self, activity_with_topic):
+        """pinned + retractedのdecisionはcheck-inのpinnedに含まれない"""
+        tid = activity_with_topic["topic_id"]
+        aid = activity_with_topic["activity_id"]
+
+        result = add_decisions([
+            {"topic_id": tid, "decision": "pinしてretractする決定", "reason": "理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        # pin → retract
+        update_pin("decision", decision_id, True)
+        retract("decision", [decision_id])
+
+        checkin = check_in(aid)
+        assert "error" not in checkin
+
+        # pinnedセクションに含まれないこと
+        pinned = checkin.get("pinned", {})
+        pinned_decision_ids = [d["id"] for d in pinned.get("decisions", [])]
+        assert decision_id not in pinned_decision_ids
+
+    def test_pinned_retracted_log_excluded_from_checkin(self, activity_with_topic):
+        """pinned + retractedのlogはcheck-inのpinnedに含まれない"""
+        tid = activity_with_topic["topic_id"]
+        aid = activity_with_topic["activity_id"]
+
+        result = add_logs([
+            {"topic_id": tid, "content": "pinしてretractするログ", "title": "ログ"},
+        ])
+        log_id = result["created"][0]["log_id"]
+
+        # pin → retract
+        update_pin("log", log_id, True)
+        retract("log", [log_id])
+
+        checkin = check_in(aid)
+        assert "error" not in checkin
+
+        pinned = checkin.get("pinned", {})
+        pinned_log_ids = [l["id"] for l in pinned.get("logs", [])]
+        assert log_id not in pinned_log_ids
+
+    def test_retracted_excluded_from_count(self, activity_with_topic):
+        """retractされたdecisionはcoverage分母のカウントに含まれない"""
+        tid = activity_with_topic["topic_id"]
+        aid = activity_with_topic["activity_id"]
+
+        result = add_decisions([
+            {"topic_id": tid, "decision": "有効な決定", "reason": "理由"},
+            {"topic_id": tid, "decision": "取り消す決定", "reason": "理由"},
+        ])
+        retracted_id = result["created"][1]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        checkin = check_in(aid)
+        assert "error" not in checkin
+        # coverage分母が1（retracted分を含まない）
+        assert checkin["coverage"]["decisions"] == "1/1"
+
+
+class TestSearchFilter:
+    """searchのretractフィルタ"""
+
+    def test_retracted_decision_excluded_from_search(self, topic):
+        """retractされたdecisionはsearchでデフォルト除外される"""
+        from src.services.search_service import search
+
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "検索対象のユニーク決定ABC", "reason": "理由"},
+        ])
+        retracted_id = result["created"][0]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        search_result = search("ユニーク決定ABC")
+        ids = [(r["type"], r["id"]) for r in search_result.get("results", [])]
+        assert ("decision", retracted_id) not in ids
+
+    def test_retracted_log_excluded_from_search(self, topic):
+        """retractされたlogはsearchでデフォルト除外される"""
+        from src.services.search_service import search
+
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "検索対象のユニークログXYZ", "title": "ユニークログXYZ"},
+        ])
+        retracted_id = result["created"][0]["log_id"]
+
+        retract("log", [retracted_id])
+
+        search_result = search("ユニークログXYZ")
+        ids = [(r["type"], r["id"]) for r in search_result.get("results", [])]
+        assert ("log", retracted_id) not in ids
+
+    def test_retracted_included_with_flag(self, topic):
+        """include_retracted=Trueでretractされたエンティティが検索結果に含まれる"""
+        from src.services.search_service import search
+
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "撤回テスト用ユニーク決定DEF", "reason": "理由"},
+        ])
+        retracted_id = result["created"][0]["decision_id"]
+
+        retract("decision", [retracted_id])
+
+        search_result = search("撤回テスト用ユニーク決定DEF", include_retracted=True)
+        ids = [(r["type"], r["id"]) for r in search_result.get("results", [])]
+        assert ("decision", retracted_id) in ids

--- a/tests/unit/test_retract_service.py
+++ b/tests/unit/test_retract_service.py
@@ -1,0 +1,258 @@
+"""retract_service のテスト
+
+エンティティ（decision, log）のretract/un-retract操作、
+冪等性、部分成功、バリデーションエラーをカバーする。
+"""
+import os
+import tempfile
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.discussion_log_service import add_logs
+from src.services.decision_service import add_decisions
+from src.services.pin_service import update_pin
+from src.services.retract_service import retract
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+class TestRetractDecision:
+    """decisionのretract"""
+
+    def test_retract_decision(self, topic):
+        """decisionをretractできる"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        retract_result = retract("decision", [decision_id])
+        assert "error" not in retract_result
+        assert decision_id in retract_result["success"]
+        assert retract_result["errors"] == []
+
+        # DB上でもretracted_atが設定されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT retracted_at FROM decisions WHERE id = ?", (decision_id,)
+            ).fetchone()
+            assert row["retracted_at"] is not None
+        finally:
+            conn.close()
+
+    def test_retract_multiple_decisions(self, topic):
+        """複数のdecisionを一括retractできる"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "決定1", "reason": "理由1"},
+            {"topic_id": tid, "decision": "決定2", "reason": "理由2"},
+        ])
+        ids = [c["decision_id"] for c in result["created"]]
+
+        retract_result = retract("decision", ids)
+        assert len(retract_result["success"]) == 2
+        assert retract_result["errors"] == []
+
+
+class TestUnretractDecision:
+    """decisionのun-retract"""
+
+    def test_unretract_decision(self, topic):
+        """retract済みdecisionをun-retractできる"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        # retract → un-retract
+        retract("decision", [decision_id])
+        unretract_result = retract("decision", [decision_id], undo=True)
+
+        assert "error" not in unretract_result
+        assert decision_id in unretract_result["success"]
+
+        # DB上でretracted_atがNULLに戻っていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT retracted_at FROM decisions WHERE id = ?", (decision_id,)
+            ).fetchone()
+            assert row["retracted_at"] is None
+        finally:
+            conn.close()
+
+
+class TestRetractLog:
+    """logのretract"""
+
+    def test_retract_log(self, topic):
+        """logをretractできる"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "テストログ内容", "title": "テストログ"},
+        ])
+        log_id = result["created"][0]["log_id"]
+
+        retract_result = retract("log", [log_id])
+        assert "error" not in retract_result
+        assert log_id in retract_result["success"]
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT retracted_at FROM discussion_logs WHERE id = ?", (log_id,)
+            ).fetchone()
+            assert row["retracted_at"] is not None
+        finally:
+            conn.close()
+
+    def test_unretract_log(self, topic):
+        """retract済みlogをun-retractできる"""
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "テストログ内容", "title": "テストログ"},
+        ])
+        log_id = result["created"][0]["log_id"]
+
+        retract("log", [log_id])
+        unretract_result = retract("log", [log_id], undo=True)
+
+        assert "error" not in unretract_result
+        assert log_id in unretract_result["success"]
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT retracted_at FROM discussion_logs WHERE id = ?", (log_id,)
+            ).fetchone()
+            assert row["retracted_at"] is None
+        finally:
+            conn.close()
+
+
+class TestRetractIdempotent:
+    """retract操作の冪等性"""
+
+    def test_retract_twice_no_error(self, topic):
+        """既にretracted状態でretractしても成功する"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        result1 = retract("decision", [decision_id])
+        result2 = retract("decision", [decision_id])
+
+        assert "error" not in result1
+        assert "error" not in result2
+        assert decision_id in result2["success"]
+
+    def test_unretract_nonretracted_no_error(self, topic):
+        """retractされていない状態でun-retractしても成功する"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        unretract_result = retract("decision", [decision_id], undo=True)
+        assert "error" not in unretract_result
+        assert decision_id in unretract_result["success"]
+
+
+class TestRetractPartialSuccess:
+    """部分成功"""
+
+    def test_partial_success_with_nonexistent_id(self, topic):
+        """存在するID + 存在しないIDで部分成功する"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        retract_result = retract("decision", [decision_id, 99999])
+        assert decision_id in retract_result["success"]
+        assert len(retract_result["errors"]) == 1
+        assert retract_result["errors"][0]["id"] == 99999
+        assert "not found" in retract_result["errors"][0]["error"]["message"]
+
+
+class TestRetractValidationErrors:
+    """バリデーションエラー"""
+
+    def test_invalid_entity_type_material(self, temp_db):
+        """materialはretract対象外でバリデーションエラーになる"""
+        result = retract("material", [1])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "Invalid entity_type" in result["error"]["message"]
+
+    def test_invalid_entity_type_topic(self, temp_db):
+        """topicはretract対象外でバリデーションエラーになる"""
+        result = retract("topic", [1])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_empty_ids(self, temp_db):
+        """空のidsでバリデーションエラーになる"""
+        result = retract("decision", [])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "ids must not be empty" in result["error"]["message"]
+
+
+class TestRetractWithPin:
+    """pinned + retractの組み合わせ"""
+
+    def test_retract_pinned_decision(self, topic):
+        """pinされたdecisionもretractできる"""
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "pinされた決定", "reason": "理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        # pin → retract
+        update_pin("decision", decision_id, True)
+        retract_result = retract("decision", [decision_id])
+
+        assert "error" not in retract_result
+        assert decision_id in retract_result["success"]
+
+        # pinned=1かつretracted_atが設定されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT pinned, retracted_at FROM decisions WHERE id = ?", (decision_id,)
+            ).fetchone()
+            assert row["pinned"] == 1
+            assert row["retracted_at"] is not None
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
- decisions/discussion_logsに`retracted_at`カラムを追加し、論理削除による取り消し機能を実装
- `retract`ツール（retract/un-retract、SAVEPOINT部分成功、冪等性保証）を新設
- search/get_decisions/get_logs/check_inでretractedをデフォルト除外、`include_retracted=True`で含める
- pinned + retracted → retracted優先で除外（D#1829）
- embeddingは削除しない（D#1830）、materialはretract対象外（D#1831）

## Related
- cc-memory activity: #679
- Design decisions: D#1818, D#1820, D#1821, D#1828, D#1829, D#1830, D#1831, D#1832, D#1839

## Test plan
- [ ] retract/un-retract動作確認（decision, log）
- [ ] 冪等性・部分成功の確認
- [ ] get_decisions/get_logsでデフォルト除外、include_retracted=Trueで含む
- [ ] check_inでretracted完全無視（pinned+retracted含む）
- [ ] searchでretracted除外（FTS/ベクトル）
- [ ] 既存テスト全パス（1086 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)