### PR TITLE
refactor: スキルディレクトリをカノニカル名にリネーム

### DIFF
--- a/skills/activity-finish/SKILL.md
+++ b/skills/activity-finish/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: activity-finish
+name: activity-finish (af)
 description: 【必須】アクティビティを完了にする。「/af」「/activity-finish」「アクティビティ終わり」「この作業完了」「クローズして」など、現在のアクティビティを終了・完了させる意図で発動する。このスキルを経由せずにupdate_activity(status="completed")を直接呼んではいけない。
 ---
 

--- a/skills/activity-start/SKILL.md
+++ b/skills/activity-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: activity-start
+name: activity-start (as)
 description: 【必須】新しいアクティビティを開始する。「/as」「/activity-start」「新しい作業始める」「アクティビティ作って」「これやる」など、新規アクティビティの作成・開始の意図で発動する。このスキルを経由せずにadd_activityを直接呼んではいけない。
 ---
 


### PR DESCRIPTION
## Summary
- `skills/af` → `skills/activity-finish`、`skills/as` → `skills/activity-start` にディレクトリリネーム
- `name` フィールドにparenthetical短縮名を追加（`activity-finish (af)`, `activity-start (as)`）
- `/af`・`/as` でオートコンプリートにマッチし、カノニカル名でも呼べるように

## Test plan
- [ ] プラグインキャッシュ再生成後、`/af` でオートコンプリートに `activity-finish (af)` が出ることを確認
- [ ] `/as` でオートコンプリートに `activity-start (as)` が出ることを確認
- [ ] 選択して発動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)