### PR TITLE
fix: スキル名からparenthetical aliasを削除

### DIFF
--- a/skills/activity-finish/SKILL.md
+++ b/skills/activity-finish/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: activity-finish (af)
+name: activity-finish
 description: 【必須】アクティビティを完了にする。「/af」「/activity-finish」「アクティビティ終わり」「この作業完了」「クローズして」など、現在のアクティビティを終了・完了させる意図で発動する。このスキルを経由せずにupdate_activity(status="completed")を直接呼んではいけない。
 ---
 

--- a/skills/activity-start/SKILL.md
+++ b/skills/activity-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: activity-start (as)
+name: activity-start
 description: 【必須】新しいアクティビティを開始する。「/as」「/activity-start」「新しい作業始める」「アクティビティ作って」「これやる」など、新規アクティビティの作成・開始の意図で発動する。このスキルを経由せずにadd_activityを直接呼んではいけない。
 ---
 


### PR DESCRIPTION
## Summary
- `activity-finish (af)` → `activity-finish`、`activity-start (as)` → `activity-start` に変更
- `(alias)` 形式のparenthetical nameがClaude Codeのnamespace解決を壊し、オートコンプリートから選択しても `Unknown skill` エラーになる問題の回避策

## Test plan
- [ ] キャッシュ再生成後、別プロジェクトで `/activity-finish` をオートコンプリートから選択して動作確認
- [ ] `/activity-start` も同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)