### PR TITLE
feat: supersedes・5エンティティ対応・get_mapフィルタを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -738,14 +738,17 @@ def add_relation(
     - トピック同士を関連付け: add_relation("topic", 1, [{"type": "topic", "ids": [2, 3]}])
     - アクティビティとトピックを関連付け: add_relation("activity", 10, [{"type": "topic", "ids": [1]}])
     - 資材とアクティビティを関連付け: add_relation("material", 5, [{"type": "activity", "ids": [10]}])
+    - 決定事項とトピックを関連付け: add_relation("decision", 1, [{"type": "topic", "ids": [1]}])
     - 複数タイプを一度に: add_relation("topic", 1, [{"type": "topic", "ids": [2]}, {"type": "activity", "ids": [10, 11]}])
     - 依存関係を追加: add_relation("activity", 1, [{"type": "activity", "ids": [2]}], relation_type="depends_on")
+    - 上書き関係を追加: add_relation("decision", 2, [{"type": "decision", "ids": [1]}], relation_type="supersedes")
 
     Args:
-        source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
+        source_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         source_id: 起点エンティティのID
-        targets: ターゲットリスト [{"type": "topic"|"activity"|"material", "ids": [int, ...]}, ...]
-        relation_type: リレーションタイプ（"related" or "depends_on"）。depends_onはactivity同士のみ有効。
+        targets: ターゲットリスト [{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...]
+        relation_type: リレーションタイプ（"related", "depends_on", or "supersedes"）。
+            depends_onはactivity同士のみ、supersedesはdecision同士のみ有効。
 
     Returns:
         成功時: {"added": int}（実際に追加された件数。重複はカウントしない）
@@ -767,12 +770,14 @@ def remove_relation(
     典型的な使い方:
     - 関連リレーション削除: remove_relation("topic", 1, [{"type": "topic", "ids": [2]}])
     - 依存関係削除: remove_relation("activity", 1, [{"type": "activity", "ids": [2]}], relation_type="depends_on")
+    - 上書き関係削除: remove_relation("decision", 2, [{"type": "decision", "ids": [1]}], relation_type="supersedes")
 
     Args:
-        source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
+        source_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         source_id: 起点エンティティのID
-        targets: ターゲットリスト [{"type": "topic"|"activity"|"material", "ids": [int, ...]}, ...]
-        relation_type: リレーションタイプ（"related" or "depends_on"）。depends_onはactivity同士のみ有効。
+        targets: ターゲットリスト [{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...]
+        relation_type: リレーションタイプ（"related", "depends_on", or "supersedes"）。
+            depends_onはactivity同士のみ、supersedesはdecision同士のみ有効。
 
     Returns:
         成功時: {"removed": int}（実際に削除された件数）
@@ -792,10 +797,11 @@ def get_map(
     リレーショングラフを走査し、到達可能エンティティのカタログを返す。
 
     再帰的にリレーションを辿り、指定深度範囲のエンティティをカタログ形式で返す。
+    decision/logノードはグラフ走査の経由ノードとして使用するが、返却カタログにはtopic/activity/materialのみ含める。
     check-in時の2次カタログと同じロジックを使用。
 
     Args:
-        entity_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
+        entity_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         entity_id: 起点エンティティのID
         min_depth: 最小深度（デフォルト: 0。0=起点自身を含む）
         max_depth: 最大深度（デフォルト: 2、上限: 10）

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -386,7 +386,8 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
     except ValueError as e:
         conn.rollback()
         logger.warning(f"add_relation rejected: {e}")
-        return {"error": {"code": "CIRCULAR_DEPENDENCY", "message": str(e)}}
+        code = "CIRCULAR_SUPERSEDES" if relation_type == "supersedes" else "CIRCULAR_DEPENDENCY"
+        return {"error": {"code": code, "message": str(e)}}
     except sqlite3.IntegrityError as e:
         conn.rollback()
         logger.error(f"add_relation failed: {e}")

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -10,7 +10,7 @@ from src.services.tag_service import (
 logger = logging.getLogger(__name__)
 
 VALID_ENTITY_TYPES = {"topic", "activity", "material", "decision", "log"}
-VALID_RELATION_TYPES = {"related", "depends_on"}
+VALID_RELATION_TYPES = {"related", "depends_on", "supersedes"}
 
 
 def _validate_entity_type(entity_type: str) -> dict | None:
@@ -50,14 +50,6 @@ def _validate_targets(source_type: str, targets: list[dict]) -> dict | None:
                 "error": {
                     "code": "VALIDATION_ERROR",
                     "message": f"'ids' for type '{target['type']}' must be a non-empty list",
-                }
-            }
-        # material同士のリレーションは非サポート
-        if source_type == "material" and target["type"] == "material":
-            return {
-                "error": {
-                    "code": "UNSUPPORTED_RELATION",
-                    "message": "material-to-material relations are not supported",
                 }
             }
     return None
@@ -230,15 +222,123 @@ def _validate_depends_on_constraints(source_type: str, targets: list[dict]) -> d
     return None
 
 
+def _validate_supersedes_constraints(source_type: str, targets: list[dict]) -> dict | None:
+    """supersedesリレーションの制約をバリデーションする。decision→decisionのみ有効。"""
+    if source_type != "decision":
+        return {
+            "error": {
+                "code": "INVALID_RELATION_TYPE",
+                "message": "supersedes relation is only valid for decision→decision",
+            }
+        }
+    for target in targets:
+        if target["type"] != "decision":
+            return {
+                "error": {
+                    "code": "INVALID_RELATION_TYPE",
+                    "message": "supersedes relation is only valid for decision→decision",
+                }
+            }
+    return None
+
+
+def _has_supersedes_path(conn: sqlite3.Connection, from_id: int, to_id: int) -> bool:
+    """DFSでfrom_idからto_idへのsupersedes経路が存在するか判定する。
+
+    decision_supersedesテーブルを辿り、from_id → ... → to_id の到達可能性をチェックする。
+    循環検出に使用: 新たに source→target を追加する前に、
+    target→source への既存経路があればサイクルになる。
+    """
+    visited: set[int] = set()
+    stack = [from_id]
+    while stack:
+        current = stack.pop()
+        if current == to_id:
+            return True
+        if current in visited:
+            continue
+        visited.add(current)
+        rows = conn.execute(
+            "SELECT target_id FROM decision_supersedes WHERE source_id = ?",
+            (current,),
+        ).fetchall()
+        for row in rows:
+            stack.append(row["target_id"])
+    return False
+
+
+def _add_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> int:
+    """supersedesリレーションをdecision_supersedesテーブルに追加する。
+
+    循環を検出した場合はValueErrorを送出する。
+
+    Args:
+        conn: DB接続
+        source_id: 上書き元のdecision ID
+        target_ids: 上書き先のdecision IDリスト
+
+    Returns:
+        追加件数
+
+    Raises:
+        ValueError: 循環が検出された場合
+    """
+    added = 0
+    for target_id in target_ids:
+        # 自己参照はCHECK制約で弾かれるが、明示的にスキップ
+        if source_id == target_id:
+            continue
+
+        # 循環チェック: target_id → source_id への経路が既に存在すればサイクル
+        if _has_supersedes_path(conn, target_id, source_id):
+            raise ValueError(
+                f"Circular supersedes detected: adding {source_id}→{target_id} "
+                f"would create a cycle"
+            )
+
+        conn.execute(
+            "INSERT OR IGNORE INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
+            (source_id, target_id),
+        )
+        if conn.execute("SELECT changes()").fetchone()[0] > 0:
+            added += 1
+    return added
+
+
+def _remove_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> int:
+    """supersedesリレーションをdecision_supersedesテーブルから削除する。
+
+    Args:
+        conn: DB接続
+        source_id: 上書き元のdecision ID
+        target_ids: 上書き先のdecision IDリスト
+
+    Returns:
+        削除件数
+    """
+    removed = 0
+    for target_id in target_ids:
+        # 自己参照はCHECK制約で存在し得ないが、明示的にスキップ
+        if source_id == target_id:
+            continue
+        conn.execute(
+            "DELETE FROM decision_supersedes WHERE source_id = ? AND target_id = ?",
+            (source_id, target_id),
+        )
+        removed += conn.execute("SELECT changes()").fetchone()[0]
+    return removed
+
+
 def add_relation(source_type: str, source_id: int, targets: list[dict], relation_type: str = "related") -> dict:
     """リレーションを追加する。
 
     Args:
-        source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
+        source_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         source_id: 起点エンティティのID
         targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
-        relation_type: リレーションタイプ（"related" or "depends_on"）。
+        relation_type: リレーションタイプ（"related", "depends_on", or "supersedes"）。
             "depends_on" はactivity同士のみ有効で、循環依存を検出した場合はエラーを返す。
+            "supersedes" はdecision同士のみ有効で、循環を検出した場合はエラーを返す。
 
     Returns:
         成功時: {"added": int}
@@ -264,12 +364,21 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
         if err:
             return err
 
+    if relation_type == "supersedes":
+        err = _validate_supersedes_constraints(source_type, targets)
+        if err:
+            return err
+
     conn = get_connection()
     try:
         if relation_type == "depends_on":
             added = 0
             for target in targets:
                 added += _add_depends_on_with_conn(conn, source_id, target["ids"])
+        elif relation_type == "supersedes":
+            added = 0
+            for target in targets:
+                added += _add_supersedes_with_conn(conn, source_id, target["ids"])
         else:
             added = _add_relation_with_conn(conn, source_type, source_id, targets)
         conn.commit()
@@ -294,11 +403,12 @@ def remove_relation(source_type: str, source_id: int, targets: list[dict], relat
     """リレーションを削除する。
 
     Args:
-        source_type: 起点エンティティのタイプ（"topic", "activity", or "material"）
+        source_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         source_id: 起点エンティティのID
         targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
-        relation_type: リレーションタイプ（"related" or "depends_on"）。
+        relation_type: リレーションタイプ（"related", "depends_on", or "supersedes"）。
             "depends_on" はactivity同士のみ有効。
+            "supersedes" はdecision同士のみ有効。
 
     Returns:
         成功時: {"removed": int}
@@ -324,12 +434,21 @@ def remove_relation(source_type: str, source_id: int, targets: list[dict], relat
         if err:
             return err
 
+    if relation_type == "supersedes":
+        err = _validate_supersedes_constraints(source_type, targets)
+        if err:
+            return err
+
     conn = get_connection()
     try:
         if relation_type == "depends_on":
             removed = 0
             for target in targets:
                 removed += _remove_depends_on_with_conn(conn, source_id, target["ids"])
+        elif relation_type == "supersedes":
+            removed = 0
+            for target in targets:
+                removed += _remove_supersedes_with_conn(conn, source_id, target["ids"])
         else:
             removed = _remove_relation_with_conn(conn, source_type, source_id, targets)
         conn.commit()
@@ -363,7 +482,7 @@ def _get_map_with_conn(
         )
         SELECT DISTINCT entity_type, entity_id, MIN(depth) AS depth
         FROM reachable
-        WHERE depth >= ?
+        WHERE depth >= ? AND entity_type IN ('topic', 'activity', 'material')
         GROUP BY entity_type, entity_id
         """,
         (entity_type, entity_id, max_depth, min_depth),
@@ -452,8 +571,11 @@ def _get_map_with_conn(
 def get_map(entity_type: str, entity_id: int, min_depth: int = 0, max_depth: int = 2) -> dict:
     """リレーショングラフを走査し、到達可能エンティティのカタログを返す。
 
+    decision/logノードはグラフ走査の経由ノードとして使用するが、
+    返却するカタログにはtopic/activity/materialのみ含める。
+
     Args:
-        entity_type: 起点エンティティのタイプ（"topic" or "activity"）
+        entity_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         entity_id: 起点エンティティのID
         min_depth: 最小深度（デフォルト: 0）
         max_depth: 最大深度（デフォルト: 2）

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -658,18 +658,368 @@ class TestMaterialRelations:
         assert "tags" in mat_entry
         assert isinstance(mat_entry["tags"], list)
 
-    def test_material_self_reference_rejected(self, sample_entities):
-        """material-materialの自己参照はバリデーションで弾かれる"""
+    def test_material_self_reference_skipped(self, sample_entities):
+        """material-materialの自己参照はスキップされる（エラーにならない）"""
         e = sample_entities
         result = add_relation("material", e["m1"], [{"type": "material", "ids": [e["m1"]]}])
 
-        assert "error" in result
-        assert result["error"]["code"] == "UNSUPPORTED_RELATION"
+        assert "error" not in result
+        assert result["added"] == 0
 
-    def test_material_material_relation_rejected(self, sample_entities):
-        """material-material（異なるID）はバリデーションで弾かれる"""
+    def test_material_material_relation_success(self, sample_entities):
+        """material-material（異なるID）のrelatedリレーションが追加できる"""
         e = sample_entities
         result = add_relation("material", e["m1"], [{"type": "material", "ids": [e["m2"]]}])
 
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_remove_material_material_relation(self, sample_entities):
+        """material-materialリレーション削除が動作する"""
+        e = sample_entities
+        add_relation("material", e["m1"], [{"type": "material", "ids": [e["m2"]]}])
+
+        result = remove_relation("material", e["m1"], [{"type": "material", "ids": [e["m2"]]}])
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+
+def _create_decision(conn, topic_id, title="Test Decision"):
+    """テスト用decisionを作成する"""
+    cursor = conn.execute(
+        "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+        (topic_id, title, f"Reason for {title}"),
+    )
+    return cursor.lastrowid
+
+
+def _create_log(conn, topic_id, title="Test Log"):
+    """テスト用discussion_logを作成する"""
+    cursor = conn.execute(
+        "INSERT INTO discussion_logs (topic_id, content) VALUES (?, ?)",
+        (topic_id, f"Content for {title}"),
+    )
+    return cursor.lastrowid
+
+
+@pytest.fixture
+def entities_with_decision_log(temp_db):
+    """テスト用のtopic, activity, material, decision, logを作成する"""
+    conn = get_connection()
+    try:
+        t1 = _create_topic(conn, "Topic A")
+        t2 = _create_topic(conn, "Topic B")
+        a1 = _create_activity(conn, "Activity X")
+        a2 = _create_activity(conn, "Activity Y")
+        m1 = _create_material(conn, "Material P")
+        m2 = _create_material(conn, "Material Q")
+        d1 = _create_decision(conn, t1, "Decision 1")
+        d2 = _create_decision(conn, t1, "Decision 2")
+        d3 = _create_decision(conn, t2, "Decision 3")
+        l1 = _create_log(conn, t1, "Log 1")
+        l2 = _create_log(conn, t2, "Log 2")
+        conn.commit()
+    finally:
+        conn.close()
+    return {
+        "t1": t1, "t2": t2,
+        "a1": a1, "a2": a2,
+        "m1": m1, "m2": m2,
+        "d1": d1, "d2": d2, "d3": d3,
+        "l1": l1, "l2": l2,
+    }
+
+
+class TestNewEntityTypeRelations:
+    """decision/logエンティティタイプのrelatedリレーションテスト"""
+
+    def test_decision_decision_related(self, entities_with_decision_log):
+        """decision↔decisionのrelatedリレーションが追加・削除できる"""
+        e = entities_with_decision_log
+        result = add_relation("decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+        result = remove_relation("decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}])
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_log_log_related(self, entities_with_decision_log):
+        """log↔logのrelatedリレーションが追加・削除できる"""
+        e = entities_with_decision_log
+        result = add_relation("log", e["l1"], [{"type": "log", "ids": [e["l2"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+        result = remove_relation("log", e["l1"], [{"type": "log", "ids": [e["l2"]]}])
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_topic_decision_related(self, entities_with_decision_log):
+        """topic↔decisionのrelatedリレーションが追加できる"""
+        e = entities_with_decision_log
+        result = add_relation("topic", e["t1"], [{"type": "decision", "ids": [e["d1"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_activity_log_related(self, entities_with_decision_log):
+        """activity↔logのrelatedリレーションが追加できる"""
+        e = entities_with_decision_log
+        result = add_relation("activity", e["a1"], [{"type": "log", "ids": [e["l1"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_decision_material_related(self, entities_with_decision_log):
+        """decision↔materialのrelatedリレーションが追加できる"""
+        e = entities_with_decision_log
+        result = add_relation("decision", e["d1"], [{"type": "material", "ids": [e["m1"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+    def test_log_topic_related(self, entities_with_decision_log):
+        """log→topicのrelatedリレーション（逆方向指定）が追加できる"""
+        e = entities_with_decision_log
+        result = add_relation("log", e["l1"], [{"type": "topic", "ids": [e["t1"]]}])
+        assert "error" not in result
+        assert result["added"] == 1
+
+
+class TestSupersedes:
+    """supersedesリレーションのテスト"""
+
+    def test_supersedes_add_and_remove(self, entities_with_decision_log):
+        """decision→decisionのsupersedesリレーションが追加・削除できる"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["added"] == 1
+
+        result = remove_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_supersedes_direct_cycle_rejected(self, entities_with_decision_log):
+        """supersedes直接循環（A→B, B→A）がCIRCULAR_DEPENDENCYエラーで拒否される"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["added"] == 1
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
         assert "error" in result
-        assert result["error"]["code"] == "UNSUPPORTED_RELATION"
+        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+
+    def test_supersedes_transitive_cycle_rejected(self, entities_with_decision_log):
+        """supersedes推移的循環（A→B, B→C, C→A）がCIRCULAR_DEPENDENCYエラーで拒否される"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d3"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+
+        result = add_relation(
+            "decision", e["d3"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+
+    def test_supersedes_non_decision_source_rejected(self, entities_with_decision_log):
+        """supersedesのsource_typeがdecision以外の場合INVALID_RELATION_TYPEエラーになる"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "topic", e["t1"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+    def test_supersedes_non_decision_target_rejected(self, entities_with_decision_log):
+        """supersedesのtarget_typeがdecision以外の場合INVALID_RELATION_TYPEエラーになる"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d1"], [{"type": "topic", "ids": [e["t1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+    def test_supersedes_idempotent(self, entities_with_decision_log):
+        """同じsupersedesペアを再追加してもエラーにならずadded=0が返る"""
+        e = entities_with_decision_log
+        result1 = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert result1["added"] == 1
+
+        result2 = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result2
+        assert result2["added"] == 0
+
+    def test_supersedes_cycle_rollback(self, entities_with_decision_log):
+        """循環検出時にトランザクションがロールバックされ、同一バッチ内の先行追加も取り消される"""
+        e = entities_with_decision_log
+        # d1→d2 を先に追加
+        add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+
+        # d2→d3 と d2→d1 を同一バッチで追加（d2→d1で循環検出）
+        result = add_relation(
+            "decision", e["d2"],
+            [{"type": "decision", "ids": [e["d3"], e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+
+        # d2→d3も追加されていないことを確認（ロールバック）
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) as cnt FROM decision_supersedes WHERE source_id = ? AND target_id = ?",
+                (e["d2"], e["d3"]),
+            ).fetchone()["cnt"]
+            assert count == 0
+        finally:
+            conn.close()
+
+    def test_supersedes_self_reference_skipped(self, entities_with_decision_log):
+        """supersedes自己参照はスキップされる（エラーにならない）"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["added"] == 0
+
+    def test_remove_supersedes_non_decision_rejected(self, entities_with_decision_log):
+        """supersedes削除でsource_typeがdecision以外の場合エラーになる"""
+        e = entities_with_decision_log
+        result = remove_relation(
+            "topic", e["t1"], [{"type": "topic", "ids": [e["t2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "INVALID_RELATION_TYPE"
+
+    def test_remove_nonexistent_supersedes(self, entities_with_decision_log):
+        """存在しないsupersedesの削除はエラーにならずremoved=0が返る"""
+        e = entities_with_decision_log
+        result = remove_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["removed"] == 0
+
+
+class TestGetMapDecisionLogFilter:
+    """get_mapのdecision/logフィルタテスト"""
+
+    def test_get_map_excludes_decision_from_output(self, entities_with_decision_log):
+        """decision経由で走査するが、出力にdecisionが含まれない"""
+        e = entities_with_decision_log
+        # t1 - d1 - t2 のチェーン（t1→d1はrelated、d1→t2もrelated）
+        add_relation("topic", e["t1"], [{"type": "decision", "ids": [e["d1"]]}])
+        add_relation("decision", e["d1"], [{"type": "topic", "ids": [e["t2"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        types_in_result = {ent["type"] for ent in result["entities"]}
+        assert "decision" not in types_in_result
+        # t1(depth=0) と t2(depth=2, decision経由) が含まれる
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", e["t1"]) in ids_in_result
+        assert ("topic", e["t2"]) in ids_in_result
+
+    def test_get_map_excludes_log_from_output(self, entities_with_decision_log):
+        """log経由で走査するが、出力にlogが含まれない"""
+        e = entities_with_decision_log
+        # a1 - l1 - a2 のチェーン
+        add_relation("activity", e["a1"], [{"type": "log", "ids": [e["l1"]]}])
+        add_relation("activity", e["a2"], [{"type": "log", "ids": [e["l1"]]}])
+
+        result = get_map("activity", e["a1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        types_in_result = {ent["type"] for ent in result["entities"]}
+        assert "log" not in types_in_result
+        # a1(depth=0) と a2(depth=2, log経由) が含まれる
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("activity", e["a1"]) in ids_in_result
+        assert ("activity", e["a2"]) in ids_in_result
+
+    def test_get_map_decision_traversal_reaches_material(self, entities_with_decision_log):
+        """decision経由でmaterialに到達できる"""
+        e = entities_with_decision_log
+        # t1 - d1 - m1 のチェーン
+        add_relation("topic", e["t1"], [{"type": "decision", "ids": [e["d1"]]}])
+        add_relation("decision", e["d1"], [{"type": "material", "ids": [e["m1"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("material", e["m1"]) in ids_in_result
+        assert ("topic", e["t1"]) in ids_in_result
+
+    def test_get_map_decision_origin_returns_no_decision(self, entities_with_decision_log):
+        """decisionを起点にget_mapを実行すると、起点のdecision自体も出力から除外される"""
+        e = entities_with_decision_log
+        add_relation("decision", e["d1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        result = get_map("decision", e["d1"], min_depth=0, max_depth=1)
+
+        assert "error" not in result
+        types_in_result = {ent["type"] for ent in result["entities"]}
+        assert "decision" not in types_in_result
+        # depth=1のtopicだけ返る
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", e["t1"]) in ids_in_result
+
+
+class TestFKLossImpact:
+    """FK制約がないことによる影響テスト"""
+
+    def test_nonexistent_id_relation_excluded_from_get_map(self, entities_with_decision_log):
+        """存在しないIDへのリレーション追加後、get_mapで正しく除外される"""
+        e = entities_with_decision_log
+        # 存在するtopicと存在しないtopicの両方にリレーションを追加
+        add_relation("topic", e["t1"], [{"type": "topic", "ids": [99999, e["t2"]]}])
+
+        result = get_map("topic", e["t1"], min_depth=1, max_depth=1)
+
+        assert "error" not in result
+        # 存在しないID 99999はカタログに含まれない
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", 99999) not in ids_in_result
+        # 存在するt2は含まれる
+        assert ("topic", e["t2"]) in ids_in_result

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -806,7 +806,7 @@ class TestSupersedes:
         assert result["removed"] == 1
 
     def test_supersedes_direct_cycle_rejected(self, entities_with_decision_log):
-        """supersedes直接循環（A→B, B→A）がCIRCULAR_DEPENDENCYエラーで拒否される"""
+        """supersedes直接循環（A→B, B→A）がCIRCULAR_SUPERSEDESエラーで拒否される"""
         e = entities_with_decision_log
         result = add_relation(
             "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
@@ -820,10 +820,10 @@ class TestSupersedes:
             relation_type="supersedes",
         )
         assert "error" in result
-        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+        assert result["error"]["code"] == "CIRCULAR_SUPERSEDES"
 
     def test_supersedes_transitive_cycle_rejected(self, entities_with_decision_log):
-        """supersedes推移的循環（A→B, B→C, C→A）がCIRCULAR_DEPENDENCYエラーで拒否される"""
+        """supersedes推移的循環（A→B, B→C, C→A）がCIRCULAR_SUPERSEDESエラーで拒否される"""
         e = entities_with_decision_log
         result = add_relation(
             "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
@@ -842,7 +842,7 @@ class TestSupersedes:
             relation_type="supersedes",
         )
         assert "error" in result
-        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+        assert result["error"]["code"] == "CIRCULAR_SUPERSEDES"
 
     def test_supersedes_non_decision_source_rejected(self, entities_with_decision_log):
         """supersedesのsource_typeがdecision以外の場合INVALID_RELATION_TYPEエラーになる"""
@@ -896,7 +896,7 @@ class TestSupersedes:
             relation_type="supersedes",
         )
         assert "error" in result
-        assert result["error"]["code"] == "CIRCULAR_DEPENDENCY"
+        assert result["error"]["code"] == "CIRCULAR_SUPERSEDES"
 
         # d2→d3も追加されていないことを確認（ロールバック）
         conn = get_connection()
@@ -1004,6 +1004,26 @@ class TestGetMapDecisionLogFilter:
         # depth=1のtopicだけ返る
         ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
         assert ("topic", e["t1"]) in ids_in_result
+
+    def test_get_map_traverses_supersedes_edge(self, entities_with_decision_log):
+        """supersedes経由でdecisionに紐づくtopicに到達できる"""
+        e = entities_with_decision_log
+        # d2 supersedes d1、d1 related t1 のチェーン
+        add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        add_relation("decision", e["d1"], [{"type": "topic", "ids": [e["t1"]]}])
+
+        result = get_map("decision", e["d2"], min_depth=0, max_depth=2)
+
+        assert "error" not in result
+        # supersedes経由でd1に到達し、d1→t1のrelatedでt1に到達する
+        ids_in_result = {(ent["type"], ent["id"]) for ent in result["entities"]}
+        assert ("topic", e["t1"]) in ids_in_result
+        # decision自体は出力に含まれない
+        types_in_result = {ent["type"] for ent in result["entities"]}
+        assert "decision" not in types_in_result
 
 
 class TestFKLossImpact:


### PR DESCRIPTION
## Summary
- `VALID_ENTITY_TYPES`にdecision/log、`VALID_RELATION_TYPES`にsupersedesを追加
- supersedes用の循環検出・追加・削除関数群（depends_onパターン踏襲）
- material同士のリレーション制限を撤廃（D#1870）
- get_mapのCTE走査はdecision/logを経由しつつ出力からフィルタ（D#1856）
- MCPツールdocstringを5エンティティ+supersedes対応に更新
- テスト21件追加、2件修正

## Test plan
- [x] フルテスト通過（1089 passed、test_remote.pyの1件は既存問題）
- [x] 新エンティティタイプの全6組み合わせテスト
- [x] supersedes: 追加/削除/循環検出/冪等性/ロールバック
- [x] get_mapフィルタ: decision/log経由走査・出力除外
- [x] FK喪失テスト: 存在しないIDのget_map除外

## 関連
- cc-memory activity: #686
- 依存PR: #320（スキーマ変更）
- 統合ブランチ: feature/relation-expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)