### PR TITLE
fix: dev依存をdependency-groupsに移行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen
 
       - name: Run tests with pytest
         run: uv run pytest -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "yoyo-migrations>=9,<10",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.24.0",

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ dependencies = [
     { name = "yoyo-migrations" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -249,14 +249,17 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.0,<4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sentence-transformers", specifier = ">=5,<6" },
     { name = "sqlite-vec", specifier = ">=0.1.6,<0.2" },
     { name = "yoyo-migrations", specifier = ">=9,<10" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=7.4.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+]
 
 [[package]]
 name = "click"


### PR DESCRIPTION
## Summary
- `[project.optional-dependencies] dev` を `[dependency-groups] dev` に移行
- CIの `uv sync --frozen --extra dev` から `--extra dev` を削除
- ローカルで `uv sync` するだけでpytest-asyncioがインストールされ、test_remote.pyのasyncテストが通るようになる

## Test plan
- [x] ローカルで `uv sync` → `uv run pytest tests/unit/test_remote.py -v` で14テスト全パス確認
- [ ] CIのテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)