### PR TITLE
feat: get_timeline APIを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from src.services import (
     relation_service,
     pin_service,
     retract_service,
+    timeline_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -854,6 +855,32 @@ def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
         undo: True=取り消しを元に戻す（un-retract）、False=取り消す（retract）
     """
     return retract_service.retract(entity_type, ids, undo)
+
+
+@mcp.tool()
+def get_timeline(
+    topic_id: int | None = None,
+    activity_id: int | None = None,
+    entity_types: list[str] | None = None,
+    before: str | None = None,
+    limit: int = 50,
+    order: str = "desc",
+) -> dict:
+    """トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
+
+    Args:
+        topic_id: トピックID（activity_idと排他）
+        activity_id: アクティビティID（topic_idと排他）
+        entity_types: 取得するエンティティ型のリスト（"decision","log","material"のサブセット、未指定で全型）
+        before: ページネーション用カーソル（ISO 8601形式のcreated_at）
+        limit: 取得件数上限（デフォルト50、最大100）
+        order: ソート方向（"desc"または"asc"、デフォルト"desc"）
+    """
+    return timeline_service.get_timeline(
+        topic_id=topic_id, activity_id=activity_id,
+        entity_types=entity_types, before=before,
+        limit=limit, order=order,
+    )
 
 
 @mcp.tool()

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -7,6 +7,7 @@ from . import (
     activity_service,
     tag_service,
     pin_service,
+    timeline_service,
 )
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "activity_service",
     "tag_service",
     "pin_service",
+    "timeline_service",
 ]

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -3,6 +3,7 @@
 トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
 """
 import logging
+from datetime import datetime
 
 from src.db import get_connection
 
@@ -30,12 +31,17 @@ def get_timeline(
         topic_id: トピックID（activity_idと排他）
         activity_id: アクティビティID（topic_idと排他）
         entity_types: 取得するエンティティ型のリスト（"decision","log","material"のサブセット、未指定で全型）
-        before: ページネーション用カーソル（ISO 8601形式のcreated_at）
+        before: ページネーション用カーソル（ISO 8601形式のcreated_at、descでの前方ページネーション用）
         limit: 取得件数上限（デフォルト50、最大100）
         order: ソート方向（"desc"または"asc"、デフォルト"desc"）
 
+    Note:
+        beforeはdesc順での前方ページネーション用。asc順で次ページを取得するには
+        未対応（afterパラメータが必要だが現時点では未実装）。
+
     Returns:
         {items: [{id, type, title, created_at, replaces, replaced_by}], total}
+        totalはbefore条件に関係なく、entity_types・topic_id条件に合致する全件数を返す。
     """
     # --- バリデーション ---
 
@@ -70,6 +76,18 @@ def get_timeline(
                 "error": {
                     "code": "VALIDATION_ERROR",
                     "message": f"Invalid entity_types: {sorted(invalid)}. Valid types: {sorted(VALID_ENTITY_TYPES)}",
+                }
+            }
+
+    # before バリデーション
+    if before is not None:
+        try:
+            datetime.fromisoformat(before)
+        except (ValueError, TypeError):
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"Invalid before value: '{before}'. Must be ISO 8601 format (e.g. '2025-01-01 00:00:00')",
                 }
             }
 
@@ -143,24 +161,19 @@ def get_timeline(
             )
             count_params.extend(topic_ids)
 
-        if not union_parts:
-            return {"items": [], "total": 0}
-
         # before カーソル条件を外側のWHEREで適用
         base_query = " UNION ALL ".join(union_parts)
+
+        # totalは常にbefore条件なしの全件数を返す
+        count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c"
 
         if before:
             query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t WHERE t.created_at < ? ORDER BY t.created_at {order} LIMIT ?"
             params.append(before)
             params.append(limit)
-
-            count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c WHERE c.created_at < ?"
-            count_params.append(before)
         else:
             query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t ORDER BY t.created_at {order} LIMIT ?"
             params.append(limit)
-
-            count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c"
 
         # --- クエリ実行 ---
         rows = conn.execute(query, params).fetchall()

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -1,0 +1,192 @@
+"""タイムラインサービス
+
+トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
+"""
+import logging
+
+from src.db import get_connection
+
+logger = logging.getLogger(__name__)
+
+VALID_ENTITY_TYPES = {"decision", "log", "material"}
+MAX_LIMIT = 100
+
+
+def get_timeline(
+    topic_id: int | None = None,
+    activity_id: int | None = None,
+    entity_types: list[str] | None = None,
+    before: str | None = None,
+    limit: int = 50,
+    order: str = "desc",
+) -> dict:
+    """トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
+
+    topic_idまたはactivity_idのいずれか一方を必須で指定する（排他）。
+    activity_id指定時はtopic_activity_relationsから関連topic_idsを取得し、
+    それらのtopic_idsに紐づくエンティティを集約する。
+
+    Args:
+        topic_id: トピックID（activity_idと排他）
+        activity_id: アクティビティID（topic_idと排他）
+        entity_types: 取得するエンティティ型のリスト（"decision","log","material"のサブセット、未指定で全型）
+        before: ページネーション用カーソル（ISO 8601形式のcreated_at）
+        limit: 取得件数上限（デフォルト50、最大100）
+        order: ソート方向（"desc"または"asc"、デフォルト"desc"）
+
+    Returns:
+        {items: [{id, type, title, created_at, replaces, replaced_by}], total}
+    """
+    # --- バリデーション ---
+
+    # topic_id / activity_id 排他チェック
+    if topic_id is not None and activity_id is not None:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "topic_id and activity_id are mutually exclusive",
+            }
+        }
+    if topic_id is None and activity_id is None:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Either topic_id or activity_id is required",
+            }
+        }
+
+    # entity_types バリデーション
+    if entity_types is not None:
+        if not entity_types:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": "entity_types must not be empty when specified",
+                }
+            }
+        invalid = set(entity_types) - VALID_ENTITY_TYPES
+        if invalid:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"Invalid entity_types: {sorted(invalid)}. Valid types: {sorted(VALID_ENTITY_TYPES)}",
+                }
+            }
+
+    # order バリデーション
+    if order not in ("asc", "desc"):
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid order: '{order}'. Must be 'asc' or 'desc'",
+            }
+        }
+
+    # limit クランプ
+    if limit < 1:
+        limit = 1
+    if limit > MAX_LIMIT:
+        limit = MAX_LIMIT
+
+    # 取得対象の型を決定
+    types = set(entity_types) if entity_types else VALID_ENTITY_TYPES
+
+    conn = get_connection()
+    try:
+        # --- topic_ids の解決 ---
+        if activity_id is not None:
+            rows = conn.execute(
+                "SELECT topic_id FROM topic_activity_relations WHERE activity_id = ?",
+                (activity_id,),
+            ).fetchall()
+            topic_ids = [row["topic_id"] for row in rows]
+            if not topic_ids:
+                return {"items": [], "total": 0}
+        else:
+            topic_ids = [topic_id]
+
+        placeholders = ",".join("?" * len(topic_ids))
+
+        # --- UNION ALL クエリ構築 ---
+        union_parts = []
+        params: list = []
+        count_parts = []
+        count_params: list = []
+
+        if "log" in types:
+            union_parts.append(
+                f"SELECT id, 'log' AS type, title, created_at FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+            )
+            params.extend(topic_ids)
+            count_parts.append(
+                f"SELECT id, created_at FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+            )
+            count_params.extend(topic_ids)
+
+        if "decision" in types:
+            union_parts.append(
+                f"SELECT id, 'decision' AS type, decision AS title, created_at FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+            )
+            params.extend(topic_ids)
+            count_parts.append(
+                f"SELECT id, created_at FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+            )
+            count_params.extend(topic_ids)
+
+        if "material" in types:
+            union_parts.append(
+                f"SELECT DISTINCT m.id, 'material' AS type, m.title, m.created_at FROM materials m JOIN topic_material_relations tmr ON m.id = tmr.material_id WHERE tmr.topic_id IN ({placeholders})"
+            )
+            params.extend(topic_ids)
+            count_parts.append(
+                f"SELECT DISTINCT m.id, m.created_at FROM materials m JOIN topic_material_relations tmr ON m.id = tmr.material_id WHERE tmr.topic_id IN ({placeholders})"
+            )
+            count_params.extend(topic_ids)
+
+        if not union_parts:
+            return {"items": [], "total": 0}
+
+        # before カーソル条件を外側のWHEREで適用
+        base_query = " UNION ALL ".join(union_parts)
+
+        if before:
+            query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t WHERE t.created_at < ? ORDER BY t.created_at {order} LIMIT ?"
+            params.append(before)
+            params.append(limit)
+
+            count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c WHERE c.created_at < ?"
+            count_params.append(before)
+        else:
+            query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t ORDER BY t.created_at {order} LIMIT ?"
+            params.append(limit)
+
+            count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c"
+
+        # --- クエリ実行 ---
+        rows = conn.execute(query, params).fetchall()
+        total_row = conn.execute(count_query, count_params).fetchone()
+        total = total_row[0] if total_row else 0
+
+        items = [
+            {
+                "id": row["id"],
+                "type": row["type"],
+                "title": row["title"],
+                "created_at": row["created_at"],
+                "replaces": None,
+                "replaced_by": None,
+            }
+            for row in rows
+        ]
+
+        return {"items": items, "total": total}
+
+    except Exception as e:
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5,6 +5,9 @@ import pytest
 from src.db import init_database
 from src.services.topic_service import add_topic
 from src.services.activity_service import add_activity
+from src.services.discussion_log_service import add_logs
+from src.services.decision_service import add_decisions
+from src.services.timeline_service import get_timeline
 
 
 @pytest.fixture
@@ -67,3 +70,27 @@ def test_add_activity_tags_required(temp_db):
 
     assert "error" in result
     assert result["error"]["code"] == "TAGS_REQUIRED"
+
+
+def test_get_timeline_with_topic(temp_db):
+    """get_timelineがtopic_id指定でlogs・decisionsを時系列混合で返す"""
+    topic = add_topic(title="timeline-test", description="テスト", tags=["domain:test"])
+    tid = topic["topic_id"]
+
+    add_logs([{"topic_id": tid, "content": "ログ内容", "title": "テストログ"}])
+    add_decisions([{"topic_id": tid, "decision": "テスト決定", "reason": "理由"}])
+
+    result = get_timeline(topic_id=tid)
+
+    assert "error" not in result
+    assert result["total"] == 2
+    assert len(result["items"]) == 2
+    types = {item["type"] for item in result["items"]}
+    assert types == {"log", "decision"}
+
+
+def test_get_timeline_validation_error(temp_db):
+    """get_timelineがtopic_id・activity_id両方なしでバリデーションエラーを返す"""
+    result = get_timeline()
+    assert "error" in result
+    assert result["error"]["code"] == "VALIDATION_ERROR"

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -1,0 +1,578 @@
+"""timeline_service のテスト
+
+トピックまたはアクティビティに紐づくdecision・log・materialを
+時系列で混合取得するget_timeline関数をカバーする。
+"""
+import os
+import tempfile
+
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.discussion_log_service import add_logs
+from src.services.decision_service import add_decisions
+from src.services.material_service import add_material
+from src.services.activity_service import add_activity
+from src.services.relation_service import add_relation
+from src.services.retract_service import retract
+from src.services.timeline_service import get_timeline
+from src.services.tag_service import _injected_tags
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def topic_with_data(topic):
+    """decision, log, materialが紐づいたトピックを作成する"""
+    tid = topic["topic_id"]
+
+    # decision追加
+    dec_result = add_decisions([
+        {"topic_id": tid, "decision": "テスト決定1", "reason": "理由1"},
+    ])
+
+    # log追加
+    log_result = add_logs([
+        {"topic_id": tid, "content": "ログ内容1", "title": "テストログ1"},
+    ])
+
+    # material追加（topic関連付き）
+    mat_result = add_material(
+        title="テスト資材1",
+        content="資材の内容",
+        tags=DEFAULT_TAGS,
+        related=[{"type": "topic", "ids": [tid]}],
+    )
+
+    return {
+        "topic_id": tid,
+        "decision_id": dec_result["created"][0]["decision_id"],
+        "log_id": log_result["created"][0]["log_id"],
+        "material_id": mat_result["material_id"],
+    }
+
+
+class TestGetTimelineValidation:
+    """バリデーションエラー"""
+
+    def test_both_topic_and_activity_id_raises_error(self, temp_db):
+        """topic_idとactivity_idの両方を指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, activity_id=1)
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "mutually exclusive" in result["error"]["message"]
+
+    def test_neither_topic_nor_activity_id_raises_error(self, temp_db):
+        """topic_idとactivity_idのどちらも指定しないとバリデーションエラーになる"""
+        result = get_timeline()
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "required" in result["error"]["message"]
+
+    def test_invalid_entity_type(self, temp_db):
+        """無効なentity_typesを指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, entity_types=["invalid"])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "Invalid entity_types" in result["error"]["message"]
+
+    def test_empty_entity_types(self, temp_db):
+        """空のentity_typesを指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, entity_types=[])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_invalid_order(self, temp_db):
+        """無効なorderを指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, order="random")
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "Invalid order" in result["error"]["message"]
+
+    def test_partial_invalid_entity_types(self, temp_db):
+        """一部が無効なentity_typesを指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, entity_types=["decision", "invalid"])
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestGetTimelineByTopicId:
+    """topic_id指定でのタイムライン取得"""
+
+    def test_returns_all_entity_types(self, topic_with_data):
+        """topic_id指定でlogs/decisions/materialsが混合で返る"""
+        result = get_timeline(topic_id=topic_with_data["topic_id"])
+        assert "error" not in result
+        assert len(result["items"]) == 3
+        assert result["total"] == 3
+
+        types = {item["type"] for item in result["items"]}
+        assert types == {"decision", "log", "material"}
+
+    def test_each_item_has_required_fields(self, topic_with_data):
+        """各アイテムがid, type, title, created_at, replaces, replaced_byを持つ"""
+        result = get_timeline(topic_id=topic_with_data["topic_id"])
+        for item in result["items"]:
+            assert "id" in item
+            assert "type" in item
+            assert "title" in item
+            assert "created_at" in item
+            assert "replaces" in item
+            assert "replaced_by" in item
+
+    def test_replaces_and_replaced_by_are_null(self, topic_with_data):
+        """Phase 1ではreplaces/replaced_byは常にnull"""
+        result = get_timeline(topic_id=topic_with_data["topic_id"])
+        for item in result["items"]:
+            assert item["replaces"] is None
+            assert item["replaced_by"] is None
+
+    def test_nonexistent_topic_returns_empty(self, temp_db):
+        """存在しないtopic_idを指定すると空のリストが返る"""
+        result = get_timeline(topic_id=99999)
+        assert "error" not in result
+        assert result["items"] == []
+        assert result["total"] == 0
+
+    def test_decision_title_uses_decision_column(self, topic):
+        """decisionのtitleはdecisionカラムの値を使う"""
+        tid = topic["topic_id"]
+        add_decisions([
+            {"topic_id": tid, "decision": "決定の内容テキスト", "reason": "理由テキスト"},
+        ])
+
+        result = get_timeline(topic_id=tid)
+        decision_items = [i for i in result["items"] if i["type"] == "decision"]
+        assert len(decision_items) == 1
+        assert decision_items[0]["title"] == "決定の内容テキスト"
+
+
+class TestGetTimelineByActivityId:
+    """activity_id指定でのタイムライン取得"""
+
+    def test_aggregates_from_related_topics(self, temp_db):
+        """activity_id指定でrelated topicsのエンティティが集約される"""
+        # トピック作成
+        topic1 = add_topic(title="トピック1", description="テスト", tags=DEFAULT_TAGS)
+        topic2 = add_topic(title="トピック2", description="テスト", tags=DEFAULT_TAGS)
+        tid1 = topic1["topic_id"]
+        tid2 = topic2["topic_id"]
+
+        # アクティビティ作成・リレーション追加
+        act = add_activity(
+            title="テストアクティビティ",
+            description="テスト用",
+            tags=DEFAULT_TAGS,
+            related=[{"type": "topic", "ids": [tid1, tid2]}],
+            check_in=False,
+        )
+        aid = act["activity_id"]
+
+        # 各トピックにdecisionを追加
+        add_decisions([
+            {"topic_id": tid1, "decision": "トピック1の決定", "reason": "理由"},
+        ])
+        add_decisions([
+            {"topic_id": tid2, "decision": "トピック2の決定", "reason": "理由"},
+        ])
+
+        result = get_timeline(activity_id=aid)
+        assert "error" not in result
+        assert result["total"] == 2
+        titles = {item["title"] for item in result["items"]}
+        assert "トピック1の決定" in titles
+        assert "トピック2の決定" in titles
+
+    def test_nonexistent_activity_returns_empty(self, temp_db):
+        """関連トピックが存在しないactivity_idを指定すると空のリストが返る"""
+        result = get_timeline(activity_id=99999)
+        assert "error" not in result
+        assert result["items"] == []
+        assert result["total"] == 0
+
+
+class TestEntityTypesFilter:
+    """entity_typesフィルタ"""
+
+    def test_filter_decision_only(self, topic_with_data):
+        """entity_types=["decision"]でdecisionのみ返る"""
+        result = get_timeline(
+            topic_id=topic_with_data["topic_id"],
+            entity_types=["decision"],
+        )
+        assert "error" not in result
+        assert all(item["type"] == "decision" for item in result["items"])
+        assert result["total"] == 1
+
+    def test_filter_log_only(self, topic_with_data):
+        """entity_types=["log"]でlogのみ返る"""
+        result = get_timeline(
+            topic_id=topic_with_data["topic_id"],
+            entity_types=["log"],
+        )
+        assert "error" not in result
+        assert all(item["type"] == "log" for item in result["items"])
+        assert result["total"] == 1
+
+    def test_filter_material_only(self, topic_with_data):
+        """entity_types=["material"]でmaterialのみ返る"""
+        result = get_timeline(
+            topic_id=topic_with_data["topic_id"],
+            entity_types=["material"],
+        )
+        assert "error" not in result
+        assert all(item["type"] == "material" for item in result["items"])
+        assert result["total"] == 1
+
+    def test_filter_multiple_types(self, topic_with_data):
+        """entity_types=["decision","log"]で2種のみ返る"""
+        result = get_timeline(
+            topic_id=topic_with_data["topic_id"],
+            entity_types=["decision", "log"],
+        )
+        assert "error" not in result
+        types = {item["type"] for item in result["items"]}
+        assert types == {"decision", "log"}
+        assert result["total"] == 2
+
+    def test_no_filter_returns_all(self, topic_with_data):
+        """entity_types未指定で全型が返る"""
+        result = get_timeline(topic_id=topic_with_data["topic_id"])
+        assert "error" not in result
+        types = {item["type"] for item in result["items"]}
+        assert types == {"decision", "log", "material"}
+
+
+class TestPagination:
+    """beforeカーソルでのページネーション"""
+
+    def test_before_cursor_filters_older_items(self, topic):
+        """beforeで指定した日時より前のアイテムのみ返る"""
+        tid = topic["topic_id"]
+
+        # 異なるcreated_atを持つデータを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "古いログ", "古いログ", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "新しいログ", "新しいログ", "2025-06-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # beforeで新しいログの日時を指定 → 古いログのみ返る
+        result = get_timeline(topic_id=tid, before="2025-06-01 00:00:00")
+        assert "error" not in result
+        assert len(result["items"]) == 1
+        assert result["items"][0]["title"] == "古いログ"
+
+    def test_before_cursor_total_reflects_filtered_count(self, topic):
+        """beforeカーソル使用時のtotalはフィルタ後の件数を返す"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ1", "ログ1", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ2", "ログ2", "2025-03-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ3", "ログ3", "2025-06-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, before="2025-06-01 00:00:00")
+        assert result["total"] == 2
+
+    def test_limit_restricts_results(self, topic):
+        """limitで取得件数を制限できる"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            for i in range(5):
+                conn.execute(
+                    "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                    (tid, f"ログ{i}", f"ログ{i}", f"2025-01-0{i+1} 00:00:00"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, limit=2)
+        assert len(result["items"]) == 2
+        assert result["total"] == 5
+
+
+class TestSortOrder:
+    """ソート方向"""
+
+    def test_desc_order(self, topic):
+        """order=descで新しい順に返る"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "古い", "古いログ", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "新しい", "新しいログ", "2025-06-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, order="desc")
+        assert result["items"][0]["title"] == "新しいログ"
+        assert result["items"][1]["title"] == "古いログ"
+
+    def test_asc_order(self, topic):
+        """order=ascで古い順に返る"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "古い", "古いログ", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "新しい", "新しいログ", "2025-06-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, order="asc")
+        assert result["items"][0]["title"] == "古いログ"
+        assert result["items"][1]["title"] == "新しいログ"
+
+
+class TestLimitClamping:
+    """limit上限クランプ"""
+
+    def test_limit_over_100_is_clamped(self, topic):
+        """limit=200を指定しても100にクランプされる（エラーにならない）"""
+        tid = topic["topic_id"]
+        result = get_timeline(topic_id=tid, limit=200)
+        assert "error" not in result
+
+    def test_limit_zero_is_clamped_to_1(self, topic):
+        """limit=0を指定すると1にクランプされる"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title) VALUES (?, ?, ?)",
+                (tid, "ログ内容", "テストログ"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, limit=0)
+        assert "error" not in result
+        assert len(result["items"]) == 1
+
+
+class TestTotalCount:
+    """totalフィールドの正確性"""
+
+    def test_total_equals_all_matching_items(self, topic):
+        """totalはlimitに関係なく条件合致の全件数を返す"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            for i in range(10):
+                conn.execute(
+                    "INSERT INTO discussion_logs (topic_id, content, title) VALUES (?, ?, ?)",
+                    (tid, f"ログ{i}", f"ログ{i}"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, limit=3)
+        assert len(result["items"]) == 3
+        assert result["total"] == 10
+
+    def test_total_with_entity_type_filter(self, topic_with_data):
+        """entity_typesフィルタ適用時もtotalはフィルタ後の件数を返す"""
+        result = get_timeline(
+            topic_id=topic_with_data["topic_id"],
+            entity_types=["decision"],
+        )
+        assert result["total"] == 1
+
+    def test_total_with_before_cursor(self, topic):
+        """beforeカーソルとtotalが整合する"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ1", "ログ1", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ2", "ログ2", "2025-06-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "決定1", "理由1", "2025-03-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # before指定でフィルタ
+        result = get_timeline(topic_id=tid, before="2025-04-01 00:00:00")
+        assert result["total"] == 2  # ログ1 + 決定1
+
+
+class TestRetractedExclusion:
+    """retractされたエンティティはタイムラインから除外される"""
+
+    def test_retracted_decision_excluded(self, topic):
+        """retractされたdecisionはタイムラインに表示されない"""
+        tid = topic["topic_id"]
+        dec_result = add_decisions([
+            {"topic_id": tid, "decision": "通常の決定", "reason": "理由"},
+            {"topic_id": tid, "decision": "取り消す決定", "reason": "理由"},
+        ])
+        retract_id = dec_result["created"][1]["decision_id"]
+
+        retract(entity_type="decision", ids=[retract_id])
+
+        result = get_timeline(topic_id=tid)
+        assert result["total"] == 1
+        assert all(item["id"] != retract_id for item in result["items"])
+
+    def test_retracted_log_excluded(self, topic):
+        """retractされたlogはタイムラインに表示されない"""
+        tid = topic["topic_id"]
+        log_result = add_logs([
+            {"topic_id": tid, "content": "通常のログ", "title": "通常"},
+            {"topic_id": tid, "content": "取り消すログ", "title": "取り消し"},
+        ])
+        retract_id = log_result["created"][1]["log_id"]
+
+        retract(entity_type="log", ids=[retract_id])
+
+        result = get_timeline(topic_id=tid)
+        assert result["total"] == 1
+        assert all(item["id"] != retract_id for item in result["items"])
+
+
+class TestMaterialDedup:
+    """activity_id指定時のmaterial重複排除"""
+
+    def test_shared_material_not_duplicated(self, temp_db):
+        """複数トピックが共有するmaterialが重複して返らない"""
+        topic1 = add_topic(title="トピック1", description="テスト", tags=DEFAULT_TAGS)
+        topic2 = add_topic(title="トピック2", description="テスト", tags=DEFAULT_TAGS)
+        tid1 = topic1["topic_id"]
+        tid2 = topic2["topic_id"]
+
+        act = add_activity(
+            title="テストアクティビティ",
+            description="テスト用",
+            tags=DEFAULT_TAGS,
+            related=[{"type": "topic", "ids": [tid1, tid2]}],
+            check_in=False,
+        )
+        aid = act["activity_id"]
+
+        # 1つのmaterialを両方のトピックに紐づける
+        mat = add_material(
+            title="共有資材",
+            content="共有の内容",
+            tags=DEFAULT_TAGS,
+            related=[{"type": "topic", "ids": [tid1, tid2]}],
+        )
+
+        result = get_timeline(activity_id=aid, entity_types=["material"])
+        material_ids = [item["id"] for item in result["items"]]
+        assert len(material_ids) == 1
+        assert result["total"] == 1
+
+
+class TestMixedTimeline:
+    """異なるエンティティ型の混合ソート"""
+
+    def test_mixed_types_sorted_by_created_at(self, topic):
+        """異なるエンティティ型がcreated_atでソートされる"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "ログ", "ログA", "2025-01-01 00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason, created_at) VALUES (?, ?, ?, ?)",
+                (tid, "決定B", "理由", "2025-02-01 00:00:00"),
+            )
+            # material: topic_material_relationsを直接作成
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, created_at) VALUES (?, ?, ?)",
+                ("資材C", "内容", "2025-03-01 00:00:00"),
+            )
+            mat_id = cursor.lastrowid
+            conn.execute(
+                "INSERT INTO topic_material_relations (topic_id, material_id) VALUES (?, ?)",
+                (tid, mat_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, order="asc")
+        assert len(result["items"]) == 3
+        assert result["items"][0]["title"] == "ログA"
+        assert result["items"][0]["type"] == "log"
+        assert result["items"][1]["title"] == "決定B"
+        assert result["items"][1]["type"] == "decision"
+        assert result["items"][2]["title"] == "資材C"
+        assert result["items"][2]["type"] == "material"

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -116,6 +116,23 @@ class TestGetTimelineValidation:
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
 
+    def test_invalid_before_format(self, temp_db):
+        """不正なbefore文字列を指定するとバリデーションエラーになる"""
+        result = get_timeline(topic_id=1, before="not-a-date")
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "Invalid before" in result["error"]["message"]
+
+    def test_valid_before_format_accepted(self, topic):
+        """正しいISO 8601形式のbeforeは受け付けられる"""
+        result = get_timeline(topic_id=topic["topic_id"], before="2025-01-01 00:00:00")
+        assert "error" not in result
+
+    def test_valid_before_date_only_accepted(self, topic):
+        """日付のみのISO 8601形式も受け付けられる"""
+        result = get_timeline(topic_id=topic["topic_id"], before="2025-01-01")
+        assert "error" not in result
+
 
 class TestGetTimelineByTopicId:
     """topic_id指定でのタイムライン取得"""
@@ -292,8 +309,8 @@ class TestPagination:
         assert len(result["items"]) == 1
         assert result["items"][0]["title"] == "古いログ"
 
-    def test_before_cursor_total_reflects_filtered_count(self, topic):
-        """beforeカーソル使用時のtotalはフィルタ後の件数を返す"""
+    def test_before_cursor_total_reflects_all_count(self, topic):
+        """beforeカーソル使用時もtotalはbefore条件なしの全件数を返す"""
         tid = topic["topic_id"]
 
         conn = get_connection()
@@ -315,7 +332,8 @@ class TestPagination:
             conn.close()
 
         result = get_timeline(topic_id=tid, before="2025-06-01 00:00:00")
-        assert result["total"] == 2
+        assert len(result["items"]) == 2  # ログ1 + ログ2
+        assert result["total"] == 3  # 全3件
 
     def test_limit_restricts_results(self, topic):
         """limitで取得件数を制限できる"""
@@ -444,7 +462,7 @@ class TestTotalCount:
         assert result["total"] == 1
 
     def test_total_with_before_cursor(self, topic):
-        """beforeカーソルとtotalが整合する"""
+        """before指定時もtotalは全件数を返す"""
         tid = topic["topic_id"]
 
         conn = get_connection()
@@ -465,9 +483,10 @@ class TestTotalCount:
         finally:
             conn.close()
 
-        # before指定でフィルタ
+        # before指定でフィルタ → itemsは2件だがtotalは全3件
         result = get_timeline(topic_id=tid, before="2025-04-01 00:00:00")
-        assert result["total"] == 2  # ログ1 + 決定1
+        assert len(result["items"]) == 2  # ログ1 + 決定1
+        assert result["total"] == 3  # 全3件
 
 
 class TestRetractedExclusion:


### PR DESCRIPTION
## Summary
- topic_idまたはactivity_idを入力に、logs・decisions・materialsをUNION ALLで時系列混合して返す`get_timeline` MCPツールを追加
- created_atカーソルによるページネーション、entity_typesフィルタ、retract済みエンティティの除外、material重複排除に対応
- replaces/replaced_byはPhase 1としてnull固定（A#686完了後にPhase 2で対応予定）

## Test plan
- [x] topic_id指定でlogs/decisions/materialsが時系列混合で返る
- [x] activity_id指定でrelated topicsの全エンティティが集約される
- [x] entity_typesフィルタ、beforeカーソル、order、limitクランプ
- [x] retract済みdecision/logがタイムラインから除外される
- [x] 複数トピックが共有するmaterialが重複しない
- [x] バリデーションエラー系（排他チェック、無効entity_types等）
- [x] 32テスト追加、既存848テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)