### PR TITLE
feat: get_timelineのreplaces/replaced_byにsupersedes実データを返す

### DIFF
--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -142,10 +142,13 @@ def get_timeline(
             count_params.extend(topic_ids)
 
         if "decision" in types:
+            # supersedes関係はスカラー（1:1前提）で返す。
+            # decision_supersedesは多対多のスキーマだが、APIレスポンスのreplaces/replaced_byは
+            # D#1874で{type, id}のスカラーと定義されているため、最新の1件のみ返す。
             union_parts.append(
                 f"SELECT d.id, 'decision' AS type, d.decision AS title, d.created_at,"
-                f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id LIMIT 1) AS replaces_id,"
-                f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id LIMIT 1) AS replaced_by_id"
+                f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaces_id,"
+                f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaced_by_id"
                 f" FROM decisions d WHERE d.topic_id IN ({placeholders}) AND d.retracted_at IS NULL"
             )
             params.extend(topic_ids)

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -133,7 +133,7 @@ def get_timeline(
 
         if "log" in types:
             union_parts.append(
-                f"SELECT id, 'log' AS type, title, created_at FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+                f"SELECT id, 'log' AS type, title, created_at, NULL AS replaces_id, NULL AS replaced_by_id FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
             )
             params.extend(topic_ids)
             count_parts.append(
@@ -143,7 +143,10 @@ def get_timeline(
 
         if "decision" in types:
             union_parts.append(
-                f"SELECT id, 'decision' AS type, decision AS title, created_at FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+                f"SELECT d.id, 'decision' AS type, d.decision AS title, d.created_at,"
+                f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id LIMIT 1) AS replaces_id,"
+                f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id LIMIT 1) AS replaced_by_id"
+                f" FROM decisions d WHERE d.topic_id IN ({placeholders}) AND d.retracted_at IS NULL"
             )
             params.extend(topic_ids)
             count_parts.append(
@@ -153,7 +156,7 @@ def get_timeline(
 
         if "material" in types:
             union_parts.append(
-                f"SELECT DISTINCT m.id, 'material' AS type, m.title, m.created_at FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.target_id IN ({placeholders})"
+                f"SELECT DISTINCT m.id, 'material' AS type, m.title, m.created_at, NULL AS replaces_id, NULL AS replaced_by_id FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.target_id IN ({placeholders})"
             )
             params.extend(topic_ids)
             count_parts.append(
@@ -168,11 +171,11 @@ def get_timeline(
         count_query = f"SELECT COUNT(*) FROM ({' UNION ALL '.join(count_parts)}) AS c"
 
         if before:
-            query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t WHERE t.created_at < ? ORDER BY t.created_at {order} LIMIT ?"
+            query = f"SELECT id, type, title, created_at, replaces_id, replaced_by_id FROM ({base_query}) AS t WHERE t.created_at < ? ORDER BY t.created_at {order} LIMIT ?"
             params.append(before)
             params.append(limit)
         else:
-            query = f"SELECT id, type, title, created_at FROM ({base_query}) AS t ORDER BY t.created_at {order} LIMIT ?"
+            query = f"SELECT id, type, title, created_at, replaces_id, replaced_by_id FROM ({base_query}) AS t ORDER BY t.created_at {order} LIMIT ?"
             params.append(limit)
 
         # --- クエリ実行 ---
@@ -186,8 +189,8 @@ def get_timeline(
                 "type": row["type"],
                 "title": row["title"],
                 "created_at": row["created_at"],
-                "replaces": None,
-                "replaced_by": None,
+                "replaces": {"type": "decision", "id": row["replaces_id"]} if row["replaces_id"] else None,
+                "replaced_by": {"type": "decision", "id": row["replaced_by_id"]} if row["replaced_by_id"] else None,
             }
             for row in rows
         ]

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -660,9 +660,28 @@ class TestSupersedes:
         assert items_by_id[2001]["replaced_by"] == {"type": "decision", "id": 2002}
         assert items_by_id[2001]["replaces"] is None
 
-    def test_log_and_material_replaces_always_null(self, topic):
-        """log/materialのreplaces/replaced_byはsupersedes関係があってもnull"""
+    def test_log_and_material_replaces_null_even_with_supersedes(self, topic):
+        """supersedes関係を持つdecisionが存在してもlog/materialのreplaces/replaced_byはnull"""
         tid = topic["topic_id"]
+
+        # supersedes関係のあるdecisionを作成
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (3001, tid, "旧決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (3002, tid, "新決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
+                (3002, 3001),
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
         add_logs([{"topic_id": tid, "content": "テストログ", "title": "ログ"}])
         add_material(

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -159,8 +159,8 @@ class TestGetTimelineByTopicId:
             assert "replaces" in item
             assert "replaced_by" in item
 
-    def test_replaces_and_replaced_by_are_null(self, topic_with_data):
-        """Phase 1ではreplaces/replaced_byは常にnull"""
+    def test_replaces_and_replaced_by_null_without_supersedes(self, topic_with_data):
+        """supersedes関係がないエンティティのreplaces/replaced_byはnull"""
         result = get_timeline(topic_id=topic_with_data["topic_id"])
         for item in result["items"]:
             assert item["replaces"] is None
@@ -597,3 +597,85 @@ class TestMixedTimeline:
         assert result["items"][1]["type"] == "decision"
         assert result["items"][2]["title"] == "資材C"
         assert result["items"][2]["type"] == "material"
+
+
+class TestSupersedes:
+    """decision_supersedesによるreplaces/replaced_byの表示"""
+
+    def test_decision_replaces_shows_target(self, topic):
+        """supersedesのsource側decisionのreplacesにtarget情報が入る"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (1001, tid, "旧決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (1002, tid, "新決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
+                (1002, 1001),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, entity_types=["decision"])
+        items_by_id = {item["id"]: item for item in result["items"]}
+
+        # 新決定(source)は旧決定(target)をreplaces
+        assert items_by_id[1002]["replaces"] == {"type": "decision", "id": 1001}
+        assert items_by_id[1002]["replaced_by"] is None
+
+    def test_decision_replaced_by_shows_source(self, topic):
+        """supersedesのtarget側decisionのreplaced_byにsource情報が入る"""
+        tid = topic["topic_id"]
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (2001, tid, "旧決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
+                (2002, tid, "新決定", "理由"),
+            )
+            conn.execute(
+                "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
+                (2002, 2001),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = get_timeline(topic_id=tid, entity_types=["decision"])
+        items_by_id = {item["id"]: item for item in result["items"]}
+
+        # 旧決定(target)は新決定(source)にreplaced_by
+        assert items_by_id[2001]["replaced_by"] == {"type": "decision", "id": 2002}
+        assert items_by_id[2001]["replaces"] is None
+
+    def test_log_and_material_replaces_always_null(self, topic):
+        """log/materialのreplaces/replaced_byはsupersedes関係があってもnull"""
+        tid = topic["topic_id"]
+
+        add_logs([{"topic_id": tid, "content": "テストログ", "title": "ログ"}])
+        add_material(
+            title="テスト資材",
+            content="内容",
+            tags=DEFAULT_TAGS,
+            source="テスト用データ",
+            related=[{"type": "topic", "ids": [tid]}],
+        )
+
+        result = get_timeline(topic_id=tid)
+        non_decision_items = [i for i in result["items"] if i["type"] != "decision"]
+        assert len(non_decision_items) == 2
+        for item in non_decision_items:
+            assert item["replaces"] is None
+            assert item["replaced_by"] is None


### PR DESCRIPTION
## Summary
- get_timelineのPhase 2: replaces/replaced_byフィールドにdecision_supersedesの実データを返すように変更
- decisionのUNION ALLパートでスカラーサブクエリを使ってsupersedes関係を取得
- log/materialのreplaces/replaced_byは引き続きnull
- テスト3件追加（supersedes source側、target側、log/material null確認）

## Related
- D#1881: replaces情報の2フェーズ対応（Phase 2）
- PR#324: relation拡張（統一テーブル + decision_supersedes）
- PR#323: get_timeline API追加（Phase 1）

## Test plan
- [x] 既存32テスト全パス
- [x] 新規3テスト（TestSupersedesクラス）パス
- [x] 全ユニットテスト854件パス、リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)