### PR TITLE
feat: add_decisions hint注入 + record block廃止・nudge増殖

### DIFF
--- a/hooks/pretooluse_hook.py
+++ b/hooks/pretooluse_hook.py
@@ -32,15 +32,17 @@ def _make_hook_output(message: str) -> dict:
 
 _FOLLOW_UP_NUDGE_MESSAGE = (
     "<system-reminder>"
-    "決定事項を記録しました。関連するエンティティ（topic・logs・activity）の"
-    "作成や更新も忘れずに行ってください。該当しなければ無視してください。"
+    "決定事項を記録しました。以下を確認してください:\n"
+    "- 関連するエンティティ（topic・logs・activity）の作成や更新\n"
+    "- 資材（material）として残すべき成果物がないか\n"
+    "- tag_notesへ転記すべき運用ルールや設計指針がないか\n"
+    "該当しなければ無視してください。"
     "</system-reminder>"
 )
 
 _RECORD_NUDGE_MESSAGE = (
     "<system-reminder>"
     "記録が遅れています。議論の途中でもいいので add_logs / add_decisions / add_topic で記録してください。"
-    "2ターン以内に記録がなければblockが走ります。"
     "</system-reminder>"
 )
 
@@ -85,7 +87,9 @@ def main() -> None:
                 print(json.dumps(_make_hook_output(_FOLLOW_UP_NUDGE_MESSAGE), ensure_ascii=False))
                 return
             elif e.get("type") == "record":
-                print(json.dumps(_make_hook_output(_RECORD_NUDGE_MESSAGE), ensure_ascii=False))
+                repeat = e.get("repeat", 1)
+                message = _RECORD_NUDGE_MESSAGE * repeat
+                print(json.dumps(_make_hook_output(message), ensure_ascii=False))
                 return
 
         # 5. 何もなし

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -7,8 +7,7 @@
 4. events.jsonl全読み
 5. Skill Span判定 → Span中なら即approve（安全弁: MAX_SKILL_SPAN_TURNS）
 6. check-in判定（e:toolでcheck_in/add_activityが1件でもあるか、猶予あり）
-7. record escalation（4ターン連続記録なし → block）
-8. nudge判定 + 状態更新 → approve
+7. nudge判定 + 状態更新 → approve
 """
 import json
 import os
@@ -35,7 +34,6 @@ _BLOCK_LIMIT = 1
 _CHECKIN_DEFER_TURNS = 2
 _MAX_SKILL_SPAN_TURNS = 20
 _NUDGE_INTERVAL = 2
-_ESCALATION_BLOCK_TURNS = 4
 
 
 def _output(decision: str, reason: str = "") -> None:
@@ -116,20 +114,7 @@ def main() -> None:
             )
             return
 
-        # 7. record escalation (4ターン連続記録なし → block)
-        # nudgeと同じ_NUDGE_INTERVAL境界でのみ判定（偶数ターン専用）
-        if current_turn > 0 and current_turn % _NUDGE_INTERVAL == 0:
-            turns_since = _turns_since_last_recording(all_events, current_turn)
-            if turns_since >= _ESCALATION_BLOCK_TURNS:
-                state.increment_block_count()
-                _output(
-                    "block",
-                    "記録が漏れています。このターンのレスポンス内で、直近の議論を "
-                    "add_logs / add_decisions / add_topic で記録してください。",
-                )
-                return
-
-        # 8. nudge判定 + 状態更新 + approve
+        # 7. nudge判定 + 状態更新 + approve
         state.reset_block_count()
         _output("approve")
         _safe_post_approve(
@@ -236,7 +221,7 @@ def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> N
     """
     nudge_events: list[dict] = []
 
-    # record nudge: _NUDGE_INTERVAL turnごとに記録がなければ発火
+    # record nudge: _NUDGE_INTERVAL turnごとに記録がなければ発火（増殖式）
     if current_turn > 0 and current_turn % _NUDGE_INTERVAL == 0:
         recent_turn_threshold = current_turn - _NUDGE_INTERVAL
         has_recent_record = any(
@@ -246,10 +231,13 @@ def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> N
             for e in events
         )
         if not has_recent_record:
+            turns_since = _turns_since_last_recording(events, current_turn)
+            repeat = max(1, min(turns_since // _NUDGE_INTERVAL, 3))
             nudge_events.append({
                 "e": "nudge",
                 "type": "record",
                 "turn": current_turn,
+                "repeat": repeat,
             })
 
     # follow_up nudge: 直近turnにadd_decisionsあり & 他の記録系/check-in系ツールなし

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 """MCPサーバーのメインエントリーポイント"""
 import logging
 import random
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
 from typing import Optional
 from src.services import (
     topic_service,
@@ -167,8 +167,8 @@ mcp = FastMCP("cc-memory", instructions=build_instructions())
 # セッション管理（HTTPモードで使用）
 _session_manager = None
 
-# ハーネス: 条件#4（整合性確認hint）のセッション内表示済みフラグ
-_shown_consistency_hint = False
+# ハーネス: 条件#4（整合性確認hint）のセッション別表示済みフラグ
+_shown_consistency_hints: set[str] = set()
 
 
 def get_session_manager():
@@ -221,7 +221,7 @@ def add_logs(items: list[dict]) -> dict:
 
 
 @mcp.tool()
-def add_decisions(items: list[dict]) -> dict:
+def add_decisions(items: list[dict], ctx: Context) -> dict:
     """複数の決定事項を一括記録する（最大10件）。
 
     items: 決定事項情報の配列。各要素は以下のキーを持つ:
@@ -247,19 +247,20 @@ def add_decisions(items: list[dict]) -> dict:
             _maybe_inject_tag_notes(result, list(all_tags))
 
         # ハーネス: 推奨行動hintを注入
-        global _shown_consistency_hint
+        session_key = ctx.session_id or "__default__"
+        shown = session_key in _shown_consistency_hints
         all_hints: list[str] = []
         seen_topics: set[int] = set()
         for item in items:
             tid = item.get("topic_id")
             if tid and tid not in seen_topics:
                 seen_topics.add(tid)
-                hints = harness_service.get_recommendations(tid, _shown_consistency_hint)
+                hints = harness_service.get_recommendations(tid, shown)
                 all_hints.extend(hints)
         if all_hints:
             result["hints"] = list(dict.fromkeys(all_hints))
             if any(h == harness_service.HINT_CONSISTENCY_CHECK for h in all_hints):
-                _shown_consistency_hint = True
+                _shown_consistency_hints.add(session_key)
     return result
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from src.services import (
     pin_service,
     retract_service,
     timeline_service,
+    harness_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -166,6 +167,9 @@ mcp = FastMCP("cc-memory", instructions=build_instructions())
 # セッション管理（HTTPモードで使用）
 _session_manager = None
 
+# ハーネス: 条件#4（整合性確認hint）のセッション内表示済みフラグ
+_shown_consistency_hint = False
+
 
 def get_session_manager():
     """現在のSessionManagerインスタンスを返す。HTTPモード以外ではNone。"""
@@ -241,6 +245,21 @@ def add_decisions(items: list[dict]) -> dict:
                 all_tags.update(item["tags"])
         if all_tags:
             _maybe_inject_tag_notes(result, list(all_tags))
+
+        # ハーネス: 推奨行動hintを注入
+        global _shown_consistency_hint
+        all_hints: list[str] = []
+        seen_topics: set[int] = set()
+        for item in items:
+            tid = item.get("topic_id")
+            if tid and tid not in seen_topics:
+                seen_topics.add(tid)
+                hints = harness_service.get_recommendations(tid, _shown_consistency_hint)
+                all_hints.extend(hints)
+        if all_hints:
+            result["hints"] = list(dict.fromkeys(all_hints))
+            if any(h == harness_service.HINT_CONSISTENCY_CHECK for h in all_hints):
+                _shown_consistency_hint = True
     return result
 
 

--- a/src/services/harness_service.py
+++ b/src/services/harness_service.py
@@ -1,0 +1,73 @@
+"""ツールレスポンスへの推奨行動hint注入サービス"""
+
+from src.db import get_connection
+
+# --- hint文言定数 ---
+
+HINT_LOGS_SPARSE = (
+    "このトピックはdecisionsに対してlogsが少ないです。"
+    "議論の経緯をadd_logsで記録してください。"
+    "決定事項だけでは、なぜその結論に至ったかが将来のセッションで失われます。"
+)
+
+HINT_CONSISTENCY_CHECK = (
+    "このトピックにはdecisionsが多数蓄積されています。"
+    "新しい決定が既存の決定事項と矛盾していないか、get_decisionsで確認してください。"
+)
+
+# --- 閾値定数 ---
+
+# 条件#3: logs蓄積不足
+MIN_DECISIONS_FOR_LOG_HINT = 3  # logs==0のとき、この件数以上で発火
+DL_RATIO_THRESHOLD = 3.0  # d/l比がこの値を超えたら発火
+
+# 条件#4: 整合性確認
+MIN_DECISIONS_FOR_CONSISTENCY = 15
+
+
+def _count_decisions_and_logs(conn, topic_id: int) -> tuple[int, int]:
+    """topicのdecisions数とlogs数を取得する（retracted除外）"""
+    row = conn.execute(
+        "SELECT COUNT(*) as cnt FROM decisions WHERE topic_id = ? AND retracted_at IS NULL",
+        (topic_id,),
+    ).fetchone()
+    decision_count = row["cnt"] if row else 0
+
+    row = conn.execute(
+        "SELECT COUNT(*) as cnt FROM discussion_logs WHERE topic_id = ? AND retracted_at IS NULL",
+        (topic_id,),
+    ).fetchone()
+    log_count = row["cnt"] if row else 0
+
+    return decision_count, log_count
+
+
+def get_recommendations(topic_id: int, shown_consistency_hint: bool = False) -> list[str]:
+    """add_decisionsレスポンスに付与する推奨行動hintを返す。
+
+    Args:
+        topic_id: 対象トピックID
+        shown_consistency_hint: セッション内で条件#4のhintを既に表示済みか
+
+    Returns:
+        hintメッセージのリスト（0〜2件）
+    """
+    hints: list[str] = []
+
+    conn = get_connection()
+    try:
+        decision_count, log_count = _count_decisions_and_logs(conn, topic_id)
+    finally:
+        conn.close()
+
+    # 条件#3: logs蓄積不足
+    if decision_count >= MIN_DECISIONS_FOR_LOG_HINT and log_count == 0:
+        hints.append(HINT_LOGS_SPARSE)
+    elif log_count > 0 and decision_count / log_count > DL_RATIO_THRESHOLD:
+        hints.append(HINT_LOGS_SPARSE)
+
+    # 条件#4: 整合性確認（セッション内初回のみ）
+    if not shown_consistency_hint and decision_count >= MIN_DECISIONS_FOR_CONSISTENCY:
+        hints.append(HINT_CONSISTENCY_CHECK)
+
+    return hints

--- a/tests/e2e/test_pretooluse_hook.py
+++ b/tests/e2e/test_pretooluse_hook.py
@@ -98,6 +98,46 @@ class TestRecordNudge:
         assert json.loads(result.stdout) == {}
 
 
+class TestRecordNudgeMultiplication:
+    """record nudge増殖: repeatフィールドに応じてメッセージが繰り返される"""
+
+    def test_repeat_2_doubles_message(self, state_dir):
+        """repeat=2 → メッセージが2回注入される"""
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 4, "repeat": 2}],
+            state_dir,
+        )
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert ctx.count("記録が遅れています") == 2
+
+    def test_repeat_3_triples_message(self, state_dir):
+        """repeat=3 → メッセージが3回注入される"""
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 6, "repeat": 3}],
+            state_dir,
+        )
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert ctx.count("記録が遅れています") == 3
+
+    def test_no_repeat_field_defaults_to_1(self, state_dir):
+        """repeatフィールドなし → メッセージ1回（後方互換）"""
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 2}],
+            state_dir,
+        )
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert ctx.count("記録が遅れています") == 1
+
+
 class TestFollowUpNudge:
     """follow_up nudgeイベント → system-reminder注入"""
 
@@ -115,6 +155,8 @@ class TestFollowUpNudge:
         ctx = output["hookSpecificOutput"]["additionalContext"]
         assert "決定事項" in ctx
         assert "topic" in ctx
+        assert "material" in ctx
+        assert "tag_notes" in ctx
 
     def test_follow_up_nudge_takes_priority(self, state_dir):
         """follow_up nudgeが最新なら、record nudgeより優先"""

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -538,13 +538,12 @@ class TestStateUpdatedOnApprove:
         assert offset_val == transcript.stat().st_size
 
 
-class TestRecordEscalation:
-    """record nudge escalation: 4ターン記録なしでblock"""
+class TestRecordNudgeMultiplication:
+    """record nudge増殖: 記録なしターンが続くとrepeatが増える（blockはしない）"""
 
-    def test_block_at_4_turns_without_recording(self, env_setup):
-        """4ターン記録なし → block"""
+    def test_4_turns_without_recording_approve_with_nudge(self, env_setup):
+        """4ターン記録なし → blockせずapprove、nudgeにrepeat=2"""
         state_dir = env_setup["state_dir"]
-        # check-in済みの状態を作る
         _write_events(
             [
                 {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
@@ -554,7 +553,6 @@ class TestRecordEscalation:
         Path(state_dir, "current_turn_test-session").write_text("1")
         Path(state_dir, "checked_in_activity_test-session").write_text("1")
 
-        # turn 2, 3, 4を進める（記録なし）
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -571,12 +569,15 @@ class TestRecordEscalation:
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
         )
-        # turn 4で block（4ターン記録なし）
-        assert result["decision"] == "block"
-        assert "記録が漏れています" in result["reason"]
+        assert result["decision"] == "approve"
 
-    def test_no_block_at_2_turns_without_recording(self, env_setup):
-        """2ターン記録なし → blockではなくapprove（警告nudgeのみ）"""
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) >= 1
+        assert record_nudges[-1]["repeat"] == 2
+
+    def test_2_turns_without_recording_nudge_repeat_1(self, env_setup):
+        """2ターン記録なし → nudge repeat=1"""
         state_dir = env_setup["state_dir"]
         _write_events(
             [
@@ -601,15 +602,53 @@ class TestRecordEscalation:
         )
         assert result["decision"] == "approve"
 
-        # 警告nudgeイベントが生成されている
         events = _read_events(state_dir, "test-session")
         record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
         assert len(record_nudges) >= 1
+        assert record_nudges[-1]["repeat"] == 1
 
-    def test_recording_resets_escalation(self, env_setup):
-        """記録後はカウンターリセット → blockしない"""
+    def test_6_turns_without_recording_nudge_repeat_3_ceiling(self, env_setup):
+        """6ターン記録なし → nudge repeat=3（天井）"""
         state_dir = env_setup["state_dir"]
-        # turn 1でcheck-in、turn 3で記録
+        _write_events(
+            [
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "checked_in_activity_test-session").write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("turn2"),
+                _make_assistant_entry(text="response 2"),
+                _make_user_entry("turn3"),
+                _make_assistant_entry(text="response 3"),
+                _make_user_entry("turn4"),
+                _make_assistant_entry(text="response 4"),
+                _make_user_entry("turn5"),
+                _make_assistant_entry(text="response 5"),
+                _make_user_entry("turn6"),
+                _make_assistant_entry(text="response 6"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) >= 1
+        assert record_nudges[-1]["repeat"] == 3
+
+    def test_recording_resets_nudge_repeat(self, env_setup):
+        """記録後はrepeatがリセットされる"""
+        state_dir = env_setup["state_dir"]
         _write_events(
             [
                 {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
@@ -620,7 +659,6 @@ class TestRecordEscalation:
         Path(state_dir, "current_turn_test-session").write_text("3")
         Path(state_dir, "checked_in_activity_test-session").write_text("1")
 
-        # turn 4, 5を進める
         transcript = env_setup["tmp_path"] / "transcript.jsonl"
         _write_transcript(
             [
@@ -635,5 +673,4 @@ class TestRecordEscalation:
         result = _run_stop_hook(
             str(transcript), "test-session", env_setup["env_override"],
         )
-        # turn 5: 記録(turn3)から2ターン → blockではなくapprove
         assert result["decision"] == "approve"

--- a/tests/unit/test_harness_service.py
+++ b/tests/unit/test_harness_service.py
@@ -134,14 +134,14 @@ class TestCondition3LogsSparse:
         assert HINT_LOGS_SPARSE not in hints
 
     def test_retracted_logs_excluded(self, topic, mock_embedding_server):
-        """retractされたlogsはカウントに含めない"""
+        """retractされたlogsはカウントに含めない: retractで発火/非発火が切り替わる"""
         tid = topic["topic_id"]
-        _add_n_decisions(tid, 7)
+        _add_n_decisions(tid, 6)
         _add_n_logs(tid, 2)
-        # d/l = 7/2 = 3.5 → 発火
-        assert HINT_LOGS_SPARSE in get_recommendations(tid)
+        # d/l = 6/2 = 3.0（閾値ちょうど） → 発火しない
+        assert HINT_LOGS_SPARSE not in get_recommendations(tid)
 
-        # 1件retractしてlogs=1 → d/l = 7/1 = 7.0 → まだ発火
+        # 1件retractして有効logs=1 → d/l = 6/1 = 6.0 > 3.0 → 発火する
         conn = get_connection()
         try:
             conn.execute(

--- a/tests/unit/test_harness_service.py
+++ b/tests/unit/test_harness_service.py
@@ -1,0 +1,206 @@
+"""harness_service: add_decisionsレスポンスへの推奨行動hint注入のテスト"""
+
+import os
+import tempfile
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.decision_service import add_decisions
+from src.services.discussion_log_service import add_logs
+from src.services.tag_service import _injected_tags
+from src.services.harness_service import (
+    get_recommendations,
+    HINT_LOGS_SPARSE,
+    HINT_CONSISTENCY_CHECK,
+    MIN_DECISIONS_FOR_LOG_HINT,
+    DL_RATIO_THRESHOLD,
+    MIN_DECISIONS_FOR_CONSISTENCY,
+)
+import src.services.embedding_service as emb
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def mock_embedding_server(monkeypatch):
+    """embedding生成をスキップする"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    yield
+
+
+def _add_n_decisions(topic_id: int, n: int):
+    """指定数のdecisionsをまとめて追加する"""
+    batch_size = 10
+    for start in range(0, n, batch_size):
+        count = min(batch_size, n - start)
+        items = [
+            {"topic_id": topic_id, "decision": f"決定{start + i + 1}", "reason": "テスト"}
+            for i in range(count)
+        ]
+        add_decisions(items)
+
+
+def _add_n_logs(topic_id: int, n: int):
+    """指定数のlogsをまとめて追加する"""
+    batch_size = 10
+    for start in range(0, n, batch_size):
+        count = min(batch_size, n - start)
+        items = [
+            {"topic_id": topic_id, "content": f"ログ{start + i + 1}"}
+            for i in range(count)
+        ]
+        add_logs(items)
+
+
+class TestCondition3LogsSparse:
+    """条件#3: decisions対比でlogsが薄いときにhintが出る"""
+
+    def test_decisions_2_logs_0_no_hint(self, topic, mock_embedding_server):
+        """decisions 2件・logs 0件ではhintが出ない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 2)
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE not in hints
+
+    def test_decisions_3_logs_0_fires(self, topic, mock_embedding_server):
+        """decisions 3件・logs 0件で条件#3が発火する"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 3)
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE in hints
+
+    def test_dl_ratio_above_threshold_fires(self, topic, mock_embedding_server):
+        """d/l比が3.0を超えるとhintが出る（例: decisions 7件・logs 2件 = 3.5）"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 7)
+        _add_n_logs(tid, 2)
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE in hints
+
+    def test_dl_ratio_at_threshold_no_hint(self, topic, mock_embedding_server):
+        """d/l比がちょうど3.0ではhintが出ない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 6)
+        _add_n_logs(tid, 2)
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE not in hints
+
+    def test_dl_ratio_below_threshold_no_hint(self, topic, mock_embedding_server):
+        """d/l比が3.0未満ではhintが出ない（例: decisions 5件・logs 2件 = 2.5）"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 5)
+        _add_n_logs(tid, 2)
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE not in hints
+
+    def test_retracted_decisions_excluded(self, topic, mock_embedding_server):
+        """retractされたdecisionsはカウントに含めない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 3)
+
+        # 1件retractして有効2件にする → hintは出ない
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE decisions SET retracted_at = datetime('now') WHERE id = (SELECT id FROM decisions WHERE topic_id = ? AND retracted_at IS NULL LIMIT 1)",
+                (tid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        hints = get_recommendations(tid)
+        assert HINT_LOGS_SPARSE not in hints
+
+    def test_retracted_logs_excluded(self, topic, mock_embedding_server):
+        """retractされたlogsはカウントに含めない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 7)
+        _add_n_logs(tid, 2)
+        # d/l = 7/2 = 3.5 → 発火
+        assert HINT_LOGS_SPARSE in get_recommendations(tid)
+
+        # 1件retractしてlogs=1 → d/l = 7/1 = 7.0 → まだ発火
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE discussion_logs SET retracted_at = datetime('now') WHERE id = (SELECT id FROM discussion_logs WHERE topic_id = ? AND retracted_at IS NULL LIMIT 1)",
+                (tid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert HINT_LOGS_SPARSE in get_recommendations(tid)
+
+
+class TestCondition4Consistency:
+    """条件#4: decision数が15以上でセッション初回のhint"""
+
+    def test_decisions_14_no_hint(self, topic, mock_embedding_server):
+        """decisions 14件ではhintが出ない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 14)
+        hints = get_recommendations(tid, shown_consistency_hint=False)
+        assert HINT_CONSISTENCY_CHECK not in hints
+
+    def test_decisions_15_fires(self, topic, mock_embedding_server):
+        """decisions 15件で条件#4が発火する"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 15)
+        hints = get_recommendations(tid, shown_consistency_hint=False)
+        assert HINT_CONSISTENCY_CHECK in hints
+
+    def test_shown_flag_suppresses(self, topic, mock_embedding_server):
+        """shown_consistency_hint=Trueのときは条件#4が出ない"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 15)
+        hints = get_recommendations(tid, shown_consistency_hint=True)
+        assert HINT_CONSISTENCY_CHECK not in hints
+
+
+class TestBothConditions:
+    """条件#3と#4が同時該当するケース"""
+
+    def test_both_fire(self, topic, mock_embedding_server):
+        """decisions 15件・logs 0件で両方発火する"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 15)
+        hints = get_recommendations(tid, shown_consistency_hint=False)
+        assert HINT_LOGS_SPARSE in hints
+        assert HINT_CONSISTENCY_CHECK in hints
+        assert len(hints) == 2
+
+    def test_no_hints_when_healthy(self, topic, mock_embedding_server):
+        """健全な状態ではhintが出ない（decisions 10件・logs 5件 = d/l 2.0）"""
+        tid = topic["topic_id"]
+        _add_n_decisions(tid, 10)
+        _add_n_logs(tid, 5)
+        hints = get_recommendations(tid, shown_consistency_hint=False)
+        assert len(hints) == 0
+
+    def test_zero_decisions_no_hint(self, topic, mock_embedding_server):
+        """decisions 0件ではhintが出ない"""
+        tid = topic["topic_id"]
+        hints = get_recommendations(tid)
+        assert len(hints) == 0


### PR DESCRIPTION
## Summary
- harness_service新規作成: add_decisionsレスポンスに推奨行動hint注入（条件#3: logs蓄積不足、条件#4: 整合性確認促進）
- stop_hookのrecord escalation block(Step 7)を廃止し、nudge増殖式（repeat天井3）に移行
- pretooluse_hookのrecord nudgeからblock脅し文句削除、repeat分メッセージ繰り返し対応
- follow_up nudgeにmaterial漏れ・tag_notes転記確認の促しを追加

## Test plan
- [ ] harness_service単体テスト（条件#3/条件#4の発火・非発火パターン）
- [ ] stop_hook e2eテスト（record block廃止確認、nudge repeat=1/2/3、天井、リセット）
- [ ] pretooluse_hook e2eテスト（repeat増殖、後方互換、follow_upメッセージ文言）
- [ ] 実セッションでのnudge増殖動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)