### PR TITLE
feat: pins有向関係拡張の基盤（migration 0034 + add_pin/remove_pin）

### DIFF
--- a/migrations/0034_pins_directed_relation.sql
+++ b/migrations/0034_pins_directed_relation.sql
@@ -1,0 +1,30 @@
+-- Migration 034: pins有向関係拡張 — pinsテーブル新設 + 既存pinned=1 material移行
+--
+-- depends: 0033_relation_expansion
+--
+-- 背景:
+--   従来のpin機構は material/decision/log の pinned カラムで管理していたが、
+--   「source→target」の有向関係として表現できるよう pinsテーブルに移行する。
+--   source（tag/activity等）から target（任意エンティティ）へのpinを格納する。
+--
+-- NOTE: pinned列のDROPは0035で行う（checkin_service改修と同一PRに同梱するため）
+
+CREATE TABLE pins (
+    source_type TEXT NOT NULL CHECK(source_type IN ('tag','activity','topic','decision','log','material')),
+    source_id   INTEGER NOT NULL,
+    target_type TEXT NOT NULL CHECK(target_type IN ('tag','activity','topic','decision','log','material')),
+    target_id   INTEGER NOT NULL,
+    created_at  TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (source_type, source_id, target_type, target_id)
+);
+-- 注入クエリは source(type,id) で引くが、PKが (source_type, source_id, ...) 先頭一致のため追加indexは不要。
+-- target逆引き（A#733のsupersedes引き継ぎ）が必要になった時点で idx_pins_target を追加する。
+
+-- 既存pinned=1 material（M#145, M#152）を source='activity' で移行（D#2103）。
+-- materialとactivityの紐付けは relations（0033で統合済み, source_type='activity' target_type='material'）から引く。
+INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id, created_at)
+SELECT 'activity', r.source_id, 'material', m.id, m.created_at
+FROM materials m
+JOIN relations r
+  ON r.source_type = 'activity' AND r.target_type = 'material' AND r.target_id = m.id
+WHERE m.pinned = 1;

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 import logging
 import random
 from fastmcp import FastMCP, Context
-from typing import Optional
+from typing import Optional, Union
 from src.services import (
     topic_service,
     discussion_log_service,
@@ -839,9 +839,9 @@ def update_habit(habit_id: int, content: Optional[str] = None, active: Optional[
 @mcp.tool()
 def add_pin(
     source_type: str,
-    source_ref,
+    source_ref: Union[int, str],
     target_type: str,
-    target_ref,
+    target_ref: Union[int, str],
 ) -> dict:
     """有向pinを追加する（source → target）。
 
@@ -871,9 +871,9 @@ def add_pin(
 @mcp.tool()
 def remove_pin(
     source_type: str,
-    source_ref,
+    source_ref: Union[int, str],
     target_type: str,
-    target_ref,
+    target_ref: Union[int, str],
 ) -> dict:
     """有向pinを削除する（source → target）。
 

--- a/src/main.py
+++ b/src/main.py
@@ -837,28 +837,61 @@ def update_habit(habit_id: int, content: Optional[str] = None, active: Optional[
 
 
 @mcp.tool()
-def update_pin(entity_type: str, entity_id: int, pinned: bool) -> dict:
-    """エンティティのpinを切り替える。
+def add_pin(
+    source_type: str,
+    source_ref,
+    target_type: str,
+    target_ref,
+) -> dict:
+    """有向pinを追加する（source → target）。
 
-    pin基準: 「これを知らずに着手したら間違った方向に進む」レベルの情報。
-    unpin基準: 「もう知らなくてもいい状態になったか」。
+    pinはsourceエンティティからtargetエンティティへの有向関係として記録される。
+    check-in時にsourceに対応するpinのtargetが自動注入される。
 
-    pinすべき例:
-    - 方向転換を記録したログ（以前の方針と異なる判断をした経緯）
-    - プロジェクトの根幹に関わるdecision（アーキテクチャ選定、命名規約など）
-    - 必読のmaterial（設計ドキュメント、仕様書など）
+    source/target の種別は tag / activity / topic / decision / log / material のいずれか。
+    tagのrefはID（整数）またはnamespace:name形式の文字列（例: "domain:cc-memory"）で指定できる。
+    それ以外の種別のrefはIDを整数で指定する。
 
-    pinしない例:
-    - 進捗報告ログ（読まなくても方向を間違えない）
-    - 独立した小さな決定（他の作業に影響しない）
-    - 一時的な調査メモ（役目を終えた情報）
+    重複追加は冪等（エラーにならない）。自己参照（source==target）は拒否される。
+    source/targetが存在しない場合はNOT_FOUNDエラーを返す。
 
     Args:
-        entity_type: "decision" | "log" | "material"
-        entity_id: エンティティのID
-        pinned: True=pin, False=unpin
+        source_type: 起点エンティティ種別（"tag" | "activity" | "topic" | "decision" | "log" | "material"）
+        source_ref: 起点エンティティのID（int）またはtag名文字列（tag種別のみ）
+        target_type: 終点エンティティ種別（"tag" | "activity" | "topic" | "decision" | "log" | "material"）
+        target_ref: 終点エンティティのID（int）またはtag名文字列（tag種別のみ）
+
+    Returns:
+        成功時: {"source_type": str, "source_id": int, "target_type": str, "target_id": int}
+        失敗時: {"error": {"code": str, "message": str}}
     """
-    return pin_service.update_pin(entity_type, entity_id, pinned)
+    return pin_service.add_pin(source_type, source_ref, target_type, target_ref)
+
+
+@mcp.tool()
+def remove_pin(
+    source_type: str,
+    source_ref,
+    target_type: str,
+    target_ref,
+) -> dict:
+    """有向pinを削除する（source → target）。
+
+    add_pinで追加したpinを削除する。対象pinが存在しない場合はremoved=0を返す（エラーにならない）。
+
+    tagのrefはID（整数）またはnamespace:name形式の文字列（例: "domain:cc-memory"）で指定できる。
+
+    Args:
+        source_type: 起点エンティティ種別（"tag" | "activity" | "topic" | "decision" | "log" | "material"）
+        source_ref: 起点エンティティのID（int）またはtag名文字列（tag種別のみ）
+        target_type: 終点エンティティ種別（"tag" | "activity" | "topic" | "decision" | "log" | "material"）
+        target_ref: 終点エンティティのID（int）またはtag名文字列（tag種別のみ）
+
+    Returns:
+        成功時: {"removed": int}（実際に削除された件数）
+        失敗時: {"error": {"code": str, "message": str}}
+    """
+    return pin_service.remove_pin(source_type, source_ref, target_type, target_ref)
 
 
 @mcp.tool()

--- a/src/main.py
+++ b/src/main.py
@@ -843,10 +843,22 @@ def add_pin(
     target_type: str,
     target_ref: Union[int, str],
 ) -> dict:
-    """有向pinを追加する（source → target）。
+    """pinを追加する（source → target）。
 
-    pinはsourceエンティティからtargetエンティティへの有向関係として記録される。
+    pinはsourceエンティティからtargetエンティティへの関係として記録される。
     check-in時にsourceに対応するpinのtargetが自動注入される。
+
+    pin基準: 「これを知らずに着手したら間違った方向に進む」レベルの情報。
+
+    pinすべき例:
+    - 方向転換を記録したログ（以前の方針と異なる判断をした経緯）
+    - プロジェクトの根幹に関わるdecision（アーキテクチャ選定、命名規約など）
+    - 必読のmaterial（設計ドキュメント、仕様書など）
+
+    pinしない例:
+    - 進捗報告ログ（読まなくても方向を間違えない）
+    - 独立した小さな決定（他の作業に影響しない）
+    - 一時的な調査メモ（役目を終えた情報）
 
     source/target の種別は tag / activity / topic / decision / log / material のいずれか。
     tagのrefはID（整数）またはnamespace:name形式の文字列（例: "domain:cc-memory"）で指定できる。
@@ -875,9 +887,12 @@ def remove_pin(
     target_type: str,
     target_ref: Union[int, str],
 ) -> dict:
-    """有向pinを削除する（source → target）。
+    """pinを削除する（source → target）。
+
+    unpin基準: 「もう知らなくてもいい状態になったか」。
 
     add_pinで追加したpinを削除する。対象pinが存在しない場合はremoved=0を返す（エラーにならない）。
+    tag refを文字列で渡して該当tagが存在しなかった場合も removed=0 を返す（冪等）。
 
     tagのrefはID（整数）またはnamespace:name形式の文字列（例: "domain:cc-memory"）で指定できる。
 

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -1,8 +1,10 @@
-"""エンティティのpin/unpin管理サービス"""
+"""エンティティのpin管理サービス（有向関係版）"""
 import logging
 import sqlite3
+from typing import Union
 
 from src.db import get_connection
+from src.services.tag_service import parse_tag, resolve_tag_ids
 
 logger = logging.getLogger(__name__)
 
@@ -10,58 +12,214 @@ ENTITY_TABLE_MAP = {
     "decision": "decisions",
     "log": "discussion_logs",
     "material": "materials",
+    "topic": "discussion_topics",
+    "activity": "activities",
+    "tag": "tags",
 }
 
 
-def update_pin(entity_type: str, entity_id: int, pinned: bool) -> dict:
-    """エンティティのpinを切り替える。
+def _resolve_ref(
+    conn: sqlite3.Connection, entity_type: str, ref: Union[int, str]
+) -> Union[int, dict]:
+    """entity_type と ref から entity_id を解決する。
 
-    Args:
-        entity_type: エンティティ種別 ("decision" | "log" | "material")
-        entity_id: エンティティのID
-        pinned: True=pin, False=unpin
+    tag かつ str の場合は parse_tag → resolve_tag_ids で解決する。
+    それ以外は ref を int として返す（存在性チェックは後段で行う）。
 
     Returns:
-        更新結果 {"entity_type": str, "entity_id": int, "pinned": bool}
-        またはエラー {"error": {"code": str, "message": str}}
+        解決できた場合: int (entity_id)
+        tag が存在しない場合: {"error": {"code": "NOT_FOUND", ...}}
+        int変換失敗の場合: {"error": {"code": "VALIDATION_ERROR", ...}}
     """
-    # entity_type検証
-    if entity_type not in ENTITY_TABLE_MAP:
+    if entity_type == "tag" and isinstance(ref, str):
+        parsed = parse_tag(ref)
+        ids = resolve_tag_ids(conn, [parsed])
+        if not ids:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"tag '{ref}' not found",
+                }
+            }
+        return ids[0]
+    else:
+        try:
+            return int(ref)
+        except (ValueError, TypeError):
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"ref must be an integer for entity_type '{entity_type}', got: {ref!r}",
+                }
+            }
+
+
+def add_pin(
+    source_type: str,
+    source_ref: Union[int, str],
+    target_type: str,
+    target_ref: Union[int, str],
+) -> dict:
+    """有向pinを追加する（source → target）。
+
+    Args:
+        source_type: 起点エンティティ種別
+        source_ref: 起点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+        target_type: 終点エンティティ種別
+        target_ref: 終点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+
+    Returns:
+        成功時: {"source_type": str, "source_id": int, "target_type": str, "target_id": int}
+        失敗時: {"error": {"code": str, "message": str}}
+    """
+    # source_type / target_type の検証
+    if source_type not in ENTITY_TABLE_MAP:
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": f"Invalid entity_type: {entity_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
+                "message": f"Invalid source_type: {source_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
+            }
+        }
+    if target_type not in ENTITY_TABLE_MAP:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid target_type: {target_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
             }
         }
 
-    table = ENTITY_TABLE_MAP[entity_type]
-
     conn = get_connection()
     try:
-        # 存在確認
+        # ref解決
+        source_id = _resolve_ref(conn, source_type, source_ref)
+        if isinstance(source_id, dict):
+            return source_id
+
+        target_id = _resolve_ref(conn, target_type, target_ref)
+        if isinstance(target_id, dict):
+            return target_id
+
+        # 自己参照拒否（D#2147）
+        if source_type == target_type and source_id == target_id:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"Self-reference is not allowed: {source_type}#{source_id} → {target_type}#{target_id}",
+                }
+            }
+
+        # 存在性チェック（D#2152）
+        source_table = ENTITY_TABLE_MAP[source_type]
         row = conn.execute(
-            f"SELECT id FROM {table} WHERE id = ?", (entity_id,)
+            f"SELECT id FROM {source_table} WHERE id = ?", (source_id,)
         ).fetchone()
         if not row:
             return {
                 "error": {
                     "code": "NOT_FOUND",
-                    "message": f"{entity_type} with id {entity_id} not found",
+                    "message": f"{source_type} with id {source_id} not found",
                 }
             }
 
-        # UPDATE実行
+        target_table = ENTITY_TABLE_MAP[target_type]
+        row = conn.execute(
+            f"SELECT id FROM {target_table} WHERE id = ?", (target_id,)
+        ).fetchone()
+        if not row:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"{target_type} with id {target_id} not found",
+                }
+            }
+
+        # INSERT OR IGNORE（D#2154 冪等）
         conn.execute(
-            f"UPDATE {table} SET pinned = ? WHERE id = ?",
-            (1 if pinned else 0, entity_id),
+            "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+            (source_type, source_id, target_type, target_id),
         )
         conn.commit()
 
         return {
-            "entity_type": entity_type,
-            "entity_id": entity_id,
-            "pinned": pinned,
+            "source_type": source_type,
+            "source_id": source_id,
+            "target_type": target_type,
+            "target_id": target_id,
         }
+
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "CONSTRAINT_VIOLATION",
+                "message": str(e),
+            }
+        }
+    except Exception as e:
+        conn.rollback()
+        return {
+            "error": {
+                "code": "DATABASE_ERROR",
+                "message": str(e),
+            }
+        }
+    finally:
+        conn.close()
+
+
+def remove_pin(
+    source_type: str,
+    source_ref: Union[int, str],
+    target_type: str,
+    target_ref: Union[int, str],
+) -> dict:
+    """有向pinを削除する（source → target）。
+
+    Args:
+        source_type: 起点エンティティ種別
+        source_ref: 起点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+        target_type: 終点エンティティ種別
+        target_ref: 終点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+
+    Returns:
+        成功時: {"removed": int}（実際に削除された件数）
+        失敗時: {"error": {"code": str, "message": str}}
+    """
+    # source_type / target_type の検証
+    if source_type not in ENTITY_TABLE_MAP:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid source_type: {source_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
+            }
+        }
+    if target_type not in ENTITY_TABLE_MAP:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid target_type: {target_type}. Must be one of: {', '.join(sorted(ENTITY_TABLE_MAP.keys()))}",
+            }
+        }
+
+    conn = get_connection()
+    try:
+        # ref解決
+        source_id = _resolve_ref(conn, source_type, source_ref)
+        if isinstance(source_id, dict):
+            return source_id
+
+        target_id = _resolve_ref(conn, target_type, target_ref)
+        if isinstance(target_id, dict):
+            return target_id
+
+        # DELETE実行
+        cursor = conn.execute(
+            "DELETE FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
+            (source_type, source_id, target_type, target_id),
+        )
+        conn.commit()
+
+        return {"removed": cursor.rowcount}
 
     except sqlite3.IntegrityError as e:
         conn.rollback()

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -1,7 +1,7 @@
-"""エンティティのpin管理サービス（有向関係版）"""
+"""エンティティのpin管理サービス"""
 import logging
 import sqlite3
-from typing import Union
+from typing import Optional, Union
 
 from src.db import get_connection
 from src.services.tag_service import parse_tag, resolve_tag_ids
@@ -20,38 +20,32 @@ ENTITY_TABLE_MAP = {
 
 def _resolve_ref(
     conn: sqlite3.Connection, entity_type: str, ref: Union[int, str]
-) -> Union[int, dict]:
+) -> tuple[Optional[int], Optional[dict]]:
     """entity_type と ref から entity_id を解決する。
 
     tag かつ str の場合は parse_tag → resolve_tag_ids で解決する。
-    それ以外は ref を int として返す（存在性チェックは後段で行う）。
+    解決できなかった tag str は (None, None) を返し、呼び出し側で意味付けする
+    （add_pin → NOT_FOUND、remove_pin → 冪等な {"removed": 0} 短絡）。
+    int キャスト失敗のみエラーとして返す。
 
     Returns:
-        解決できた場合: int (entity_id)
-        tag が存在しない場合: {"error": {"code": "NOT_FOUND", ...}}
-        int変換失敗の場合: {"error": {"code": "VALIDATION_ERROR", ...}}
+        解決成功: (entity_id, None)
+        tag str 未存在: (None, None)
+        int 変換失敗: (None, {"error": {"code": "VALIDATION_ERROR", ...}})
     """
     if entity_type == "tag" and isinstance(ref, str):
         parsed = parse_tag(ref)
         ids = resolve_tag_ids(conn, [parsed])
-        if not ids:
-            return {
-                "error": {
-                    "code": "NOT_FOUND",
-                    "message": f"tag '{ref}' not found",
-                }
+        return (ids[0] if ids else None, None)
+    try:
+        return (int(ref), None)
+    except (ValueError, TypeError):
+        return (None, {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"ref must be an integer for entity_type '{entity_type}', got: {ref!r}",
             }
-        return ids[0]
-    else:
-        try:
-            return int(ref)
-        except (ValueError, TypeError):
-            return {
-                "error": {
-                    "code": "VALIDATION_ERROR",
-                    "message": f"ref must be an integer for entity_type '{entity_type}', got: {ref!r}",
-                }
-            }
+        })
 
 
 def add_pin(
@@ -60,7 +54,7 @@ def add_pin(
     target_type: str,
     target_ref: Union[int, str],
 ) -> dict:
-    """有向pinを追加する（source → target）。
+    """pinを追加する（source → target）。
 
     Args:
         source_type: 起点エンティティ種別
@@ -91,13 +85,27 @@ def add_pin(
     conn = get_connection()
     try:
         # ref解決
-        source_id = _resolve_ref(conn, source_type, source_ref)
-        if isinstance(source_id, dict):
-            return source_id
+        source_id, err = _resolve_ref(conn, source_type, source_ref)
+        if err:
+            return err
+        if source_id is None:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"tag '{source_ref}' not found",
+                }
+            }
 
-        target_id = _resolve_ref(conn, target_type, target_ref)
-        if isinstance(target_id, dict):
-            return target_id
+        target_id, err = _resolve_ref(conn, target_type, target_ref)
+        if err:
+            return err
+        if target_id is None:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"tag '{target_ref}' not found",
+                }
+            }
 
         # 自己参照拒否（D#2147）
         if source_type == target_type and source_id == target_id:
@@ -147,14 +155,6 @@ def add_pin(
             "target_id": target_id,
         }
 
-    except sqlite3.IntegrityError as e:
-        conn.rollback()
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         conn.rollback()
         return {
@@ -173,7 +173,7 @@ def remove_pin(
     target_type: str,
     target_ref: Union[int, str],
 ) -> dict:
-    """有向pinを削除する（source → target）。
+    """pinを削除する（source → target）。
 
     Args:
         source_type: 起点エンティティ種別
@@ -203,14 +203,18 @@ def remove_pin(
 
     conn = get_connection()
     try:
-        # ref解決
-        source_id = _resolve_ref(conn, source_type, source_ref)
-        if isinstance(source_id, dict):
-            return source_id
+        # ref解決。tag str 未存在は冪等な {"removed": 0} で短絡（D#2347）
+        source_id, err = _resolve_ref(conn, source_type, source_ref)
+        if err:
+            return err
+        if source_id is None:
+            return {"removed": 0}
 
-        target_id = _resolve_ref(conn, target_type, target_ref)
-        if isinstance(target_id, dict):
-            return target_id
+        target_id, err = _resolve_ref(conn, target_type, target_ref)
+        if err:
+            return err
+        if target_id is None:
+            return {"removed": 0}
 
         # DELETE実行（pinsテーブルに外部キー制約はないためIntegrityErrorは発生しない）
         cursor = conn.execute(

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -212,7 +212,7 @@ def remove_pin(
         if isinstance(target_id, dict):
             return target_id
 
-        # DELETE実行
+        # DELETE実行（pinsテーブルに外部キー制約はないためIntegrityErrorは発生しない）
         cursor = conn.execute(
             "DELETE FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
             (source_type, source_id, target_type, target_id),
@@ -221,14 +221,6 @@ def remove_pin(
 
         return {"removed": cursor.rowcount}
 
-    except sqlite3.IntegrityError as e:
-        conn.rollback()
-        return {
-            "error": {
-                "code": "CONSTRAINT_VIOLATION",
-                "message": str(e),
-            }
-        }
     except Exception as e:
         conn.rollback()
         return {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,9 +4,34 @@ add_logs / add_decisions のバッチAPIを単件呼び出し形式でラップ�
 旧 add_log / add_decision と同じインターフェースを提供する。
 """
 from typing import Optional
+from src.db import get_connection
 from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.retract_service import retract
+
+
+_PINNED_ENTITY_TABLE = {
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "material": "materials",
+}
+
+
+def set_pinned(entity_type: str, entity_id: int, pinned: bool = True) -> None:
+    """テスト用: 旧 pinned 列を直接更新する。
+
+    PR-b で pinned 列が DROP されるまでの暫定ヘルパー。
+    """
+    table = _PINNED_ENTITY_TABLE[entity_type]
+    conn = get_connection()
+    try:
+        conn.execute(
+            f"UPDATE {table} SET pinned = ? WHERE id = ?",
+            (1 if pinned else 0, entity_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def add_log(

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
-from tests.helpers import add_decision, add_log, retract_decision
+from tests.helpers import add_decision, add_log, retract_decision, set_pinned as _set_pinned
 from src.services.material_service import add_material
 from src.services.relation_service import add_relation
 from src.services.topic_service import add_topic
@@ -13,23 +13,6 @@ from src.services.tag_service import _injected_tags
 
 
 DEFAULT_TAGS = ["domain:test"]
-
-_ENTITY_TABLE = {
-    "decision": "decisions",
-    "log": "discussion_logs",
-    "material": "materials",
-}
-
-
-def _set_pinned(entity_type: str, entity_id: int, pinned: bool = True) -> None:
-    """テスト用: DBのpinned列を直接設定する。"""
-    table = _ENTITY_TABLE[entity_type]
-    conn = get_connection()
-    try:
-        conn.execute(f"UPDATE {table} SET pinned = ? WHERE id = ?", (1 if pinned else 0, entity_id))
-        conn.commit()
-    finally:
-        conn.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -6,7 +6,6 @@ from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
 from tests.helpers import add_decision, add_log, retract_decision
 from src.services.material_service import add_material
-from src.services.pin_service import update_pin
 from src.services.relation_service import add_relation
 from src.services.topic_service import add_topic
 from src.services.checkin_service import check_in, DECISIONS_FULL_LIMIT
@@ -14,6 +13,23 @@ from src.services.tag_service import _injected_tags
 
 
 DEFAULT_TAGS = ["domain:test"]
+
+_ENTITY_TABLE = {
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "material": "materials",
+}
+
+
+def _set_pinned(entity_type: str, entity_id: int, pinned: bool = True) -> None:
+    """テスト用: DBのpinned列を直接設定する。"""
+    table = _ENTITY_TABLE[entity_type]
+    conn = get_connection()
+    try:
+        conn.execute(f"UPDATE {table} SET pinned = ? WHERE id = ?", (1 if pinned else 0, entity_id))
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture
@@ -733,7 +749,7 @@ class TestCheckInPinned:
         """pinされたdecisionがpinned.decisionsにcontent付きで返る"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         d = add_decision(decision="重要な決定", reason="根本的な理由", topic_id=topic["topic_id"])
-        update_pin("decision", d["decision_id"], True)
+        _set_pinned("decision", d["decision_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -750,7 +766,7 @@ class TestCheckInPinned:
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         d1 = add_decision(decision="pinされた決定", reason="理由1", topic_id=topic["topic_id"])
         add_decision(decision="通常の決定", reason="理由2", topic_id=topic["topic_id"])
-        update_pin("decision", d1["decision_id"], True)
+        _set_pinned("decision", d1["decision_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -768,7 +784,7 @@ class TestCheckInPinned:
         """pinされたlogがpinned.logsにcontent付きで返る"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         log = add_log(topic_id=topic["topic_id"], title="方向転換ログ", content="## 経緯\n重要な方向転換")
-        update_pin("log", log["log_id"], True)
+        _set_pinned("log", log["log_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -785,7 +801,7 @@ class TestCheckInPinned:
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
         add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
-        update_pin("log", log1["log_id"], True)
+        _set_pinned("log", log1["log_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -801,7 +817,7 @@ class TestCheckInPinned:
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         m = add_material("設計書", "# 設計\n詳細な内容", DEFAULT_TAGS, "テスト用データ",
                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        update_pin("material", m["material_id"], True)
+        _set_pinned("material", m["material_id"], True)
 
         result = check_in(a["activity_id"])
 
@@ -819,7 +835,7 @@ class TestCheckInPinned:
                           related=[{"type": "activity", "ids": [a["activity_id"]]}])
         add_material("通常資材", "内容2", DEFAULT_TAGS, "テスト用データ",
                      related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        update_pin("material", m1["material_id"], True)
+        _set_pinned("material", m1["material_id"], True)
 
         result = check_in(a["activity_id"])
 
@@ -834,7 +850,7 @@ class TestCheckInPinned:
         d1 = add_decision(decision="pin決定", reason="理由", topic_id=topic["topic_id"])
         add_decision(decision="通常決定1", reason="理由", topic_id=topic["topic_id"])
         add_decision(decision="通常決定2", reason="理由", topic_id=topic["topic_id"])
-        update_pin("decision", d1["decision_id"], True)
+        _set_pinned("decision", d1["decision_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -849,7 +865,7 @@ class TestCheckInPinned:
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
         add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
-        update_pin("log", log1["log_id"], True)
+        _set_pinned("log", log1["log_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
 
@@ -866,7 +882,7 @@ class TestCheckInPinned:
                           related=[{"type": "activity", "ids": [a["activity_id"]]}])
         add_material("通常資材", "内容2", DEFAULT_TAGS, "テスト用データ",
                      related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        update_pin("material", m1["material_id"], True)
+        _set_pinned("material", m1["material_id"], True)
 
         result = check_in(a["activity_id"])
 
@@ -883,9 +899,9 @@ class TestCheckInPinned:
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
         m = add_material("重要資材", "内容", DEFAULT_TAGS, "テスト用データ",
                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        update_pin("decision", d["decision_id"], True)
-        update_pin("log", log["log_id"], True)
-        update_pin("material", m["material_id"], True)
+        _set_pinned("decision", d["decision_id"], True)
+        _set_pinned("log", log["log_id"], True)
+        _set_pinned("material", m["material_id"], True)
 
         result = check_in(a["activity_id"])
 

--- a/tests/test_migrations/test_0034_pins_directed_relation.py
+++ b/tests/test_migrations/test_0034_pins_directed_relation.py
@@ -1,0 +1,352 @@
+"""migration 0034_pins_directed_relation のテスト
+
+0034適用後のスキーマと、pinned=1のmaterialがsource='activity'のpinsレコードに
+移行されることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags, ensure_tag_ids
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0034含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0034():
+    """0033までのmigrationを適用したDBを提供する。0034の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0034 = MigrationList([m for m in all_migs if m.id < "0034"])
+        with backend.lock():
+            backend.apply_migrations(pre_0034)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0034(db_path: str) -> None:
+    """db_pathに対してmigration 0034のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0034 = MigrationList([m for m in all_migs if m.id.startswith("0034")])
+    with backend.lock():
+        backend.apply_migrations(only_0034)
+
+
+class TestPinsTableSchema:
+    """pinsテーブルのスキーマ確認"""
+
+    def test_pins_table_exists(self, migrated_db):
+        """0034適用後にpinsテーブルが存在する"""
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='pins'"
+            ).fetchone()
+            assert row is not None, "pinsテーブルが存在しない"
+        finally:
+            conn.close()
+
+    def test_pins_table_columns(self, migrated_db):
+        """pinsテーブルが必要なカラムを持つ"""
+        conn = get_connection()
+        try:
+            rows = conn.execute("PRAGMA table_info(pins)").fetchall()
+            column_names = {row["name"] for row in rows}
+            assert "source_type" in column_names
+            assert "source_id" in column_names
+            assert "target_type" in column_names
+            assert "target_id" in column_names
+            assert "created_at" in column_names
+        finally:
+            conn.close()
+
+    def test_pins_table_primary_key(self, migrated_db):
+        """pinsテーブルのPKが (source_type, source_id, target_type, target_id) である"""
+        conn = get_connection()
+        try:
+            rows = conn.execute("PRAGMA table_info(pins)").fetchall()
+            pk_columns = [row["name"] for row in rows if row["pk"] > 0]
+            # PKの存在と4カラムであることを確認
+            assert len(pk_columns) == 4
+            assert set(pk_columns) == {"source_type", "source_id", "target_type", "target_id"}
+        finally:
+            conn.close()
+
+
+class TestPinsCheckConstraints:
+    """pinsテーブルのCHECK制約"""
+
+    def test_source_type_check_constraint_rejects_invalid(self, migrated_db):
+        """source_typeに 'invalid_type' を入れると IntegrityError でINSERTが拒否される"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                    ("invalid_type", 1, "material", 1),
+                )
+                conn.commit()
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_target_type_check_constraint_rejects_invalid(self, migrated_db):
+        """target_typeに 'invalid_type' を入れると IntegrityError でINSERTが拒否される"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                    ("activity", 1, "invalid_type", 1),
+                )
+                conn.commit()
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_all_valid_source_types_accepted(self, migrated_db):
+        """source_typeに6種（tag/activity/topic/decision/log/material）を入れると6行すべてが実際にpinsに挿入される"""
+        valid_types = ["tag", "activity", "topic", "decision", "log", "material"]
+        conn = get_connection()
+        try:
+            for i, entity_type in enumerate(valid_types, start=1):
+                conn.execute(
+                    "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                    (entity_type, i, "material", i + 100),
+                )
+            conn.commit()
+            inserted = conn.execute(
+                "SELECT source_type FROM pins WHERE target_type='material' AND target_id BETWEEN 101 AND 106"
+            ).fetchall()
+            assert {row["source_type"] for row in inserted} == set(valid_types)
+        finally:
+            conn.close()
+
+    def test_all_valid_target_types_accepted(self, migrated_db):
+        """target_typeに6種（tag/activity/topic/decision/log/material）を入れると6行すべてが実際にpinsに挿入される"""
+        valid_types = ["tag", "activity", "topic", "decision", "log", "material"]
+        conn = get_connection()
+        try:
+            for i, entity_type in enumerate(valid_types, start=1):
+                conn.execute(
+                    "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                    ("activity", i, entity_type, i + 200),
+                )
+            conn.commit()
+            inserted = conn.execute(
+                "SELECT target_type FROM pins WHERE source_type='activity' AND source_id BETWEEN 1 AND 6"
+            ).fetchall()
+            assert {row["target_type"] for row in inserted} == set(valid_types)
+        finally:
+            conn.close()
+
+
+class TestPinsMigrationData:
+    """既存pinned=1 materialの移行確認"""
+
+    def _setup_pinned_material_with_activity_relation(self, conn, material_title="テスト資材"):
+        """pinned=1のmaterialをactivityとのrelationつきで作成する。
+
+        0034の移行クエリは relations テーブル経由で紐づきを引くため、
+        activityとmaterialをrelationsに登録した上でmaterial.pinned=1にする。
+        """
+        # activityを作成
+        tag_ids = ensure_tag_ids(conn, [("domain", "test")])
+        cursor = conn.execute(
+            "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+            ("テストアクティビティ", "説明", "completed"),
+        )
+        activity_id = cursor.lastrowid
+        for tag_id in tag_ids:
+            conn.execute(
+                "INSERT OR IGNORE INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+                (activity_id, tag_id),
+            )
+
+        # materialを作成（pinned=1）
+        cursor = conn.execute(
+            "INSERT INTO materials (title, content, pinned) VALUES (?, ?, 1)",
+            (material_title, "テスト内容"),
+        )
+        material_id = cursor.lastrowid
+        for tag_id in tag_ids:
+            conn.execute(
+                "INSERT OR IGNORE INTO material_tags (material_id, tag_id) VALUES (?, ?)",
+                (material_id, tag_id),
+            )
+
+        # activity → material の relation を追加（0033以降の形式）
+        # activity < material のアルファベット順制約（relations.CHECK）に注意:
+        # 'activity' < 'material' は True なので source=activity, target=material で格納
+        conn.execute(
+            "INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES (?, ?, ?, ?, ?)",
+            ("activity", activity_id, "material", material_id, "related"),
+        )
+
+        conn.commit()
+        return activity_id, material_id
+
+    def test_pinned_column_still_exists_after_0034(self, migrated_db):
+        """migration 0034適用後もmaterialsテーブルにpinned列が残っている（0035でDROP予定）"""
+        conn = get_connection()
+        try:
+            rows = conn.execute("PRAGMA table_info(materials)").fetchall()
+            column_names = {row["name"] for row in rows}
+            assert "pinned" in column_names, "pinned列がmaterialsから削除されている（0035はまだ適用していないはず）"
+        finally:
+            conn.close()
+
+    def test_pinned_material_with_relation_migrated_to_pins_on_0034_apply(self, db_before_0034):
+        """0033まで適用したDBにpinned=1 material + activity relationをseedし、0034を適用するとpinsに('activity', activity_id, 'material', material_id)レコードが1件作られる"""
+        conn = get_connection()
+        try:
+            activity_id, material_id = self._setup_pinned_material_with_activity_relation(
+                conn, material_title="移行対象資材"
+            )
+        finally:
+            conn.close()
+
+        _apply_migration_0034(db_before_0034)
+
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT source_type, source_id, target_type, target_id FROM pins WHERE target_type='material' AND target_id=?",
+                (material_id,),
+            ).fetchall()
+            assert len(rows) == 1, "移行後のpinsレコードは1件であるべき"
+            row = rows[0]
+            assert row["source_type"] == "activity"
+            assert row["source_id"] == activity_id
+            assert row["target_type"] == "material"
+            assert row["target_id"] == material_id
+        finally:
+            conn.close()
+
+    def test_pinned_material_without_relation_skipped_during_0034_migration(self, db_before_0034):
+        """0033まで適用したDBにpinned=1 materialのみ（relations欠落）をseedし、0034を適用してもpinsに該当materialのレコードは作られない"""
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, pinned) VALUES (?, ?, 1)",
+                ("孤立した資材", "content"),
+            )
+            material_id = cursor.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0034(db_before_0034)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='material' AND target_id=?",
+                (material_id,),
+            ).fetchone()
+            assert row is None, "activityとのrelationが無いpinned=1 materialは移行スコープ外"
+        finally:
+            conn.close()
+
+    def test_unpinned_material_not_migrated_on_0034_apply(self, db_before_0034):
+        """0033まで適用したDBにpinned=0 material + activity relationをseedし、0034を適用してもpinsには移行されない（移行条件はpinned=1のみ）"""
+        conn = get_connection()
+        try:
+            tag_ids = ensure_tag_ids(conn, [("domain", "test")])
+            cursor = conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                ("テストアクティビティ", "説明", "completed"),
+            )
+            activity_id = cursor.lastrowid
+            for tag_id in tag_ids:
+                conn.execute(
+                    "INSERT OR IGNORE INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+                    (activity_id, tag_id),
+                )
+
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, pinned) VALUES (?, ?, 0)",
+                ("ピンなし資材", "content"),
+            )
+            material_id = cursor.lastrowid
+            for tag_id in tag_ids:
+                conn.execute(
+                    "INSERT OR IGNORE INTO material_tags (material_id, tag_id) VALUES (?, ?)",
+                    (material_id, tag_id),
+                )
+
+            conn.execute(
+                "INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES (?, ?, ?, ?, ?)",
+                ("activity", activity_id, "material", material_id, "related"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0034(db_before_0034)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='material' AND target_id=?",
+                (material_id,),
+            ).fetchone()
+            assert row is None, "pinned=0 materialは0034の移行対象外"
+        finally:
+            conn.close()
+
+
+class TestPinsInsertOrIgnore:
+    """pinsテーブルの重複挿入挙動"""
+
+    def test_insert_or_ignore_duplicate(self, migrated_db):
+        """同一の (source_type, source_id, target_type, target_id) を重複挿入してもエラーにならない"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                ("activity", 1, "material", 1),
+            )
+            conn.commit()
+
+            # 同じキーを再度 INSERT OR IGNORE
+            conn.execute(
+                "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+                ("activity", 1, "material", 1),
+            )
+            conn.commit()
+
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pins WHERE source_type='activity' AND source_id=1 AND target_type='material' AND target_id=1"
+            ).fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -341,11 +341,10 @@ class TestRemovePin:
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
 
-    def test_remove_pin_nonexistent_tag_string(self, activity, temp_db):
-        """存在しないtag名文字列でNOT_FOUNDエラーを返す"""
+    def test_remove_pin_nonexistent_tag_string_is_idempotent(self, activity, temp_db):
+        """存在しないtag名文字列で remove しても {"removed": 0} を返し冪等になる（D#2347）"""
         activity_id = activity["activity_id"]
 
         result = remove_pin("tag", "domain:nonexistent", "activity", activity_id)
 
-        assert "error" in result
-        assert result["error"]["code"] == "NOT_FOUND"
+        assert result == {"removed": 0}

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -1,7 +1,7 @@
-"""pin_service のテスト
+"""pin_service の単体テスト
 
-エンティティ（decision, log, material）のpin/unpin操作と
-バリデーションエラーをカバーする。
+pinsテーブルへの有向関係（source → target）の追加・削除と
+バリデーションエラー・エッジケースをカバーする。
 """
 import os
 import tempfile
@@ -12,8 +12,9 @@ from src.services.topic_service import add_topic
 from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.material_service import add_material
-from src.services.pin_service import update_pin
-from src.services.tag_service import _injected_tags
+from src.services.activity_service import add_activity
+from src.services.pin_service import add_pin, remove_pin
+from src.services.tag_service import _injected_tags, ensure_tag_ids
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -38,230 +39,313 @@ def topic(temp_db):
     return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
 
 
-class TestPinDecision:
-    """decisionのpin/unpin"""
+@pytest.fixture
+def activity(temp_db):
+    """テスト用アクティビティを作成する"""
+    return add_activity(title="テストアクティビティ", description="テスト用", tags=DEFAULT_TAGS)
 
-    def test_pin_decision(self, topic):
-        """decisionをpinできる"""
-        tid = topic["topic_id"]
+
+@pytest.fixture
+def material(temp_db):
+    """テスト用資材を作成する"""
+    return add_material(
+        title="テスト資材",
+        content="テスト資材の内容",
+        tags=DEFAULT_TAGS,
+        source="テスト用データ",
+    )
+
+
+class TestAddPinBasic:
+    """add_pin の基本動作"""
+
+    def test_add_pin_activity_to_material(self, activity, material):
+        """activityからmaterialへのpinを追加できる"""
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        result = add_pin("activity", activity_id, "material", material_id)
+
+        assert "error" not in result
+        assert result["source_type"] == "activity"
+        assert result["source_id"] == activity_id
+        assert result["target_type"] == "material"
+        assert result["target_id"] == material_id
+
+        # DB上にpinsレコードが作成されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
+                ("activity", activity_id, "material", material_id),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_add_pin_topic_to_decision(self, topic):
+        """topicからdecisionへのpinを追加できる"""
+        topic_id = topic["topic_id"]
         result = add_decisions([
-            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
+            {"topic_id": topic_id, "decision": "テスト決定", "reason": "テスト理由"},
         ])
         decision_id = result["created"][0]["decision_id"]
 
-        pin_result = update_pin("decision", decision_id, True)
+        pin_result = add_pin("topic", topic_id, "decision", decision_id)
+
         assert "error" not in pin_result
-        assert pin_result["entity_type"] == "decision"
-        assert pin_result["entity_id"] == decision_id
-        assert pin_result["pinned"] is True
+        assert pin_result["source_type"] == "topic"
+        assert pin_result["source_id"] == topic_id
+        assert pin_result["target_type"] == "decision"
+        assert pin_result["target_id"] == decision_id
 
-        # DB上でもpinned=1であることを確認
-        conn = get_connection()
-        try:
-            row = conn.execute(
-                "SELECT pinned FROM decisions WHERE id = ?", (decision_id,)
-            ).fetchone()
-            assert row["pinned"] == 1
-        finally:
-            conn.close()
-
-    def test_unpin_decision(self, topic):
-        """decisionをunpinできる"""
-        tid = topic["topic_id"]
-        result = add_decisions([
-            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
-        ])
-        decision_id = result["created"][0]["decision_id"]
-
-        # pin → unpin
-        update_pin("decision", decision_id, True)
-        unpin_result = update_pin("decision", decision_id, False)
-
-        assert "error" not in unpin_result
-        assert unpin_result["pinned"] is False
-
-        # DB上でもpinned=0であることを確認
-        conn = get_connection()
-        try:
-            row = conn.execute(
-                "SELECT pinned FROM decisions WHERE id = ?", (decision_id,)
-            ).fetchone()
-            assert row["pinned"] == 0
-        finally:
-            conn.close()
-
-
-class TestPinLog:
-    """logのpin/unpin"""
-
-    def test_pin_log(self, topic):
-        """logをpinできる"""
-        tid = topic["topic_id"]
+    def test_add_pin_topic_to_log(self, topic):
+        """topicからlogへのpinを追加できる"""
+        topic_id = topic["topic_id"]
         result = add_logs([
-            {"topic_id": tid, "content": "テストログ内容", "title": "テストログ"},
+            {"topic_id": topic_id, "content": "テストログ内容", "title": "テストログ"},
         ])
         log_id = result["created"][0]["log_id"]
 
-        pin_result = update_pin("log", log_id, True)
+        pin_result = add_pin("topic", topic_id, "log", log_id)
+
         assert "error" not in pin_result
-        assert pin_result["entity_type"] == "log"
-        assert pin_result["entity_id"] == log_id
-        assert pin_result["pinned"] is True
+        assert pin_result["target_type"] == "log"
+        assert pin_result["target_id"] == log_id
 
+
+class TestAddPinTagRef:
+    """add_pin の tag ref 解決"""
+
+    def test_add_pin_with_tag_ref_string(self, activity, temp_db):
+        """tagのrefをnamespace:name形式の文字列で指定できる"""
+        activity_id = activity["activity_id"]
+
+        # tagを作成する
         conn = get_connection()
         try:
-            row = conn.execute(
-                "SELECT pinned FROM discussion_logs WHERE id = ?", (log_id,)
-            ).fetchone()
-            assert row["pinned"] == 1
+            tag_ids = ensure_tag_ids(conn, [("domain", "cc-memory")])
+            conn.commit()
+            tag_id = tag_ids[0]
         finally:
             conn.close()
 
-    def test_unpin_log(self, topic):
-        """logをunpinできる"""
-        tid = topic["topic_id"]
-        result = add_logs([
-            {"topic_id": tid, "content": "テストログ内容", "title": "テストログ"},
-        ])
-        log_id = result["created"][0]["log_id"]
+        result = add_pin("tag", "domain:cc-memory", "activity", activity_id)
 
-        update_pin("log", log_id, True)
-        unpin_result = update_pin("log", log_id, False)
+        assert "error" not in result
+        assert result["source_type"] == "tag"
+        assert result["source_id"] == tag_id
+        assert result["target_type"] == "activity"
+        assert result["target_id"] == activity_id
 
-        assert "error" not in unpin_result
-        assert unpin_result["pinned"] is False
+    def test_add_pin_with_tag_ref_int(self, activity, temp_db):
+        """tagのrefをIDの整数で指定できる"""
+        activity_id = activity["activity_id"]
 
         conn = get_connection()
         try:
-            row = conn.execute(
-                "SELECT pinned FROM discussion_logs WHERE id = ?", (log_id,)
-            ).fetchone()
-            assert row["pinned"] == 0
+            tag_ids = ensure_tag_ids(conn, [("domain", "cc-memory")])
+            conn.commit()
+            tag_id = tag_ids[0]
         finally:
             conn.close()
 
+        result = add_pin("tag", tag_id, "activity", activity_id)
 
-class TestPinMaterial:
-    """materialのpin/unpin"""
+        assert "error" not in result
+        assert result["source_type"] == "tag"
+        assert result["source_id"] == tag_id
 
-    def test_pin_material(self, temp_db):
-        """materialをpinできる"""
-        result = add_material(
-            title="テスト資材",
-            content="テスト資材の内容",
-            tags=DEFAULT_TAGS,
-            source="テスト用データ",
-        )
-        material_id = result["material_id"]
+    def test_add_pin_with_nonexistent_tag_string(self, activity, temp_db):
+        """存在しないtag名文字列でNOT_FOUNDエラーを返す"""
+        activity_id = activity["activity_id"]
 
-        pin_result = update_pin("material", material_id, True)
-        assert "error" not in pin_result
-        assert pin_result["entity_type"] == "material"
-        assert pin_result["entity_id"] == material_id
-        assert pin_result["pinned"] is True
+        result = add_pin("tag", "domain:nonexistent", "activity", activity_id)
 
-        conn = get_connection()
-        try:
-            row = conn.execute(
-                "SELECT pinned FROM materials WHERE id = ?", (material_id,)
-            ).fetchone()
-            assert row["pinned"] == 1
-        finally:
-            conn.close()
-
-    def test_unpin_material(self, temp_db):
-        """materialをunpinできる"""
-        result = add_material(
-            title="テスト資材",
-            content="テスト資材の内容",
-            tags=DEFAULT_TAGS,
-            source="テスト用データ",
-        )
-        material_id = result["material_id"]
-
-        update_pin("material", material_id, True)
-        unpin_result = update_pin("material", material_id, False)
-
-        assert "error" not in unpin_result
-        assert unpin_result["pinned"] is False
-
-        conn = get_connection()
-        try:
-            row = conn.execute(
-                "SELECT pinned FROM materials WHERE id = ?", (material_id,)
-            ).fetchone()
-            assert row["pinned"] == 0
-        finally:
-            conn.close()
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+        assert "domain:nonexistent" in result["error"]["message"]
 
 
-class TestPinIdempotent:
-    """pin操作の冪等性"""
+class TestAddPinIdempotent:
+    """add_pin の冪等性"""
 
-    def test_pin_twice_no_error(self, topic):
-        """既にpinされた状態でpinしてもエラーにならない"""
-        tid = topic["topic_id"]
-        result = add_decisions([
-            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
-        ])
-        decision_id = result["created"][0]["decision_id"]
+    def test_add_pin_duplicate_is_idempotent(self, activity, material):
+        """同じpinを2回追加してもエラーにならない"""
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
 
-        result1 = update_pin("decision", decision_id, True)
-        result2 = update_pin("decision", decision_id, True)
+        result1 = add_pin("activity", activity_id, "material", material_id)
+        result2 = add_pin("activity", activity_id, "material", material_id)
 
         assert "error" not in result1
         assert "error" not in result2
-        assert result2["pinned"] is True
 
-    def test_unpin_twice_no_error(self, topic):
-        """既にunpinされた状態でunpinしてもエラーにならない"""
-        tid = topic["topic_id"]
-        result = add_decisions([
-            {"topic_id": tid, "decision": "テスト決定", "reason": "テスト理由"},
-        ])
-        decision_id = result["created"][0]["decision_id"]
-
-        # デフォルトでpinned=0なので、unpinを2回呼ぶ
-        result1 = update_pin("decision", decision_id, False)
-        result2 = update_pin("decision", decision_id, False)
-
-        assert "error" not in result1
-        assert "error" not in result2
-        assert result2["pinned"] is False
+        # DB上のpinsレコードは1件のみ
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
+                ("activity", activity_id, "material", material_id),
+            ).fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
 
 
-class TestPinValidationErrors:
-    """バリデーションエラー"""
+class TestAddPinSelfReference:
+    """add_pin の自己参照拒否"""
 
-    def test_invalid_entity_type(self, temp_db):
-        """不正なentity_typeでエラーが返る"""
-        result = update_pin("topic", 1, True)
+    def test_add_pin_self_reference_rejected(self, activity):
+        """同一エンティティへのself-referenceはVALIDATION_ERRORを返す"""
+        activity_id = activity["activity_id"]
+
+        result = add_pin("activity", activity_id, "activity", activity_id)
 
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
-        assert "Invalid entity_type" in result["error"]["message"]
+        assert "Self-reference" in result["error"]["message"]
 
-    def test_nonexistent_decision_id(self, topic):
-        """存在しないdecision IDでエラーが返る"""
-        result = update_pin("decision", 99999, True)
+    def test_add_pin_different_types_allowed(self, topic, material):
+        """source_typeとtarget_typeが異なれば同じIDでもpinできる"""
+        topic_id = topic["topic_id"]
+
+        # materialのIDがtopic_idと一致するとは限らないが、
+        # topic → material は source_type != target_type なので自己参照ではない
+        material_id = material["material_id"]
+
+        # ID値が同じになるケースを人工的に作るのは困難なため、
+        # 異なる種別の組み合わせが通ることを確認するに留める
+        result = add_pin("topic", topic_id, "material", material_id)
+        assert "error" not in result
+
+
+class TestAddPinNotFound:
+    """add_pin の存在性チェック"""
+
+    def test_add_pin_nonexistent_source_returns_not_found(self, material):
+        """存在しないsource IDでNOT_FOUNDエラーを返す"""
+        material_id = material["material_id"]
+
+        result = add_pin("activity", 99999, "material", material_id)
 
         assert "error" in result
         assert result["error"]["code"] == "NOT_FOUND"
-        assert "decision" in result["error"]["message"]
+        assert "activity" in result["error"]["message"]
         assert "99999" in result["error"]["message"]
 
-    def test_nonexistent_log_id(self, topic):
-        """存在しないlog IDでエラーが返る"""
-        result = update_pin("log", 99999, True)
+    def test_add_pin_nonexistent_target_returns_not_found(self, activity):
+        """存在しないtarget IDでNOT_FOUNDエラーを返す"""
+        activity_id = activity["activity_id"]
 
-        assert "error" in result
-        assert result["error"]["code"] == "NOT_FOUND"
-        assert "log" in result["error"]["message"]
-
-    def test_nonexistent_material_id(self, temp_db):
-        """存在しないmaterial IDでエラーが返る"""
-        result = update_pin("material", 99999, True)
+        result = add_pin("activity", activity_id, "material", 99999)
 
         assert "error" in result
         assert result["error"]["code"] == "NOT_FOUND"
         assert "material" in result["error"]["message"]
+        assert "99999" in result["error"]["message"]
+
+
+class TestAddPinValidationErrors:
+    """add_pin のバリデーションエラー"""
+
+    def test_invalid_source_type(self, material):
+        """不正なsource_typeでVALIDATION_ERRORを返す"""
+        material_id = material["material_id"]
+
+        result = add_pin("invalid_type", 1, "material", material_id)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "source_type" in result["error"]["message"]
+
+    def test_invalid_target_type(self, activity):
+        """不正なtarget_typeでVALIDATION_ERRORを返す"""
+        activity_id = activity["activity_id"]
+
+        result = add_pin("activity", activity_id, "invalid_type", 1)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "target_type" in result["error"]["message"]
+
+    def test_non_integer_ref_for_non_tag_type(self, activity):
+        """tag以外でstr形式のrefを指定するとVALIDATION_ERRORを返す"""
+        activity_id = activity["activity_id"]
+
+        result = add_pin("activity", "not_an_int", "activity", activity_id)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestRemovePin:
+    """remove_pin の動作"""
+
+    def test_remove_existing_pin(self, activity, material):
+        """追加済みpinを削除できる"""
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        add_pin("activity", activity_id, "material", material_id)
+        result = remove_pin("activity", activity_id, "material", material_id)
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+        # DB上のpinsレコードが削除されていることを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
+                ("activity", activity_id, "material", material_id),
+            ).fetchone()
+            assert row is None
+        finally:
+            conn.close()
+
+    def test_remove_nonexistent_pin_returns_zero(self, activity, material):
+        """存在しないpinの削除はremoved=0を返す（エラーにならない）"""
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        result = remove_pin("activity", activity_id, "material", material_id)
+
+        assert "error" not in result
+        assert result["removed"] == 0
+
+    def test_remove_pin_with_tag_ref_string(self, activity, temp_db):
+        """tagのrefをnamespace:name形式の文字列で削除できる"""
+        activity_id = activity["activity_id"]
+
+        conn = get_connection()
+        try:
+            tag_ids = ensure_tag_ids(conn, [("domain", "cc-memory")])
+            conn.commit()
+            tag_id = tag_ids[0]
+        finally:
+            conn.close()
+
+        add_pin("tag", "domain:cc-memory", "activity", activity_id)
+        result = remove_pin("tag", "domain:cc-memory", "activity", activity_id)
+
+        assert "error" not in result
+        assert result["removed"] == 1
+
+    def test_remove_pin_invalid_source_type(self, material):
+        """不正なsource_typeでVALIDATION_ERRORを返す"""
+        material_id = material["material_id"]
+
+        result = remove_pin("invalid_type", 1, "material", material_id)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_remove_pin_nonexistent_tag_string(self, activity, temp_db):
+        """存在しないtag名文字列でNOT_FOUNDエラーを返す"""
+        activity_id = activity["activity_id"]
+
+        result = remove_pin("tag", "domain:nonexistent", "activity", activity_id)
+
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"

--- a/tests/unit/test_retract_filter.py
+++ b/tests/unit/test_retract_filter.py
@@ -16,6 +16,7 @@ from src.services.checkin_service import check_in
 from src.services.activity_service import add_activity
 from src.services.relation_service import add_relation
 from src.services.tag_service import _injected_tags
+from tests.helpers import set_pinned
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -176,12 +177,7 @@ class TestCheckInFilter:
         decision_id = result["created"][0]["decision_id"]
 
         # pin（DBのpinned列を直接設定）→ retract
-        conn = get_connection()
-        try:
-            conn.execute("UPDATE decisions SET pinned = 1 WHERE id = ?", (decision_id,))
-            conn.commit()
-        finally:
-            conn.close()
+        set_pinned("decision", decision_id, True)
         retract("decision", [decision_id])
 
         checkin = check_in(aid)
@@ -203,12 +199,7 @@ class TestCheckInFilter:
         log_id = result["created"][0]["log_id"]
 
         # pin（DBのpinned列を直接設定）→ retract
-        conn = get_connection()
-        try:
-            conn.execute("UPDATE discussion_logs SET pinned = 1 WHERE id = ?", (log_id,))
-            conn.commit()
-        finally:
-            conn.close()
+        set_pinned("log", log_id, True)
         retract("log", [log_id])
 
         checkin = check_in(aid)

--- a/tests/unit/test_retract_filter.py
+++ b/tests/unit/test_retract_filter.py
@@ -11,7 +11,6 @@ from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
 from src.services.discussion_log_service import add_logs, get_logs
 from src.services.decision_service import add_decisions, get_decisions
-from src.services.pin_service import update_pin
 from src.services.retract_service import retract
 from src.services.checkin_service import check_in
 from src.services.activity_service import add_activity
@@ -176,8 +175,13 @@ class TestCheckInFilter:
         ])
         decision_id = result["created"][0]["decision_id"]
 
-        # pin → retract
-        update_pin("decision", decision_id, True)
+        # pin（DBのpinned列を直接設定）→ retract
+        conn = get_connection()
+        try:
+            conn.execute("UPDATE decisions SET pinned = 1 WHERE id = ?", (decision_id,))
+            conn.commit()
+        finally:
+            conn.close()
         retract("decision", [decision_id])
 
         checkin = check_in(aid)
@@ -198,8 +202,13 @@ class TestCheckInFilter:
         ])
         log_id = result["created"][0]["log_id"]
 
-        # pin → retract
-        update_pin("log", log_id, True)
+        # pin（DBのpinned列を直接設定）→ retract
+        conn = get_connection()
+        try:
+            conn.execute("UPDATE discussion_logs SET pinned = 1 WHERE id = ?", (log_id,))
+            conn.commit()
+        finally:
+            conn.close()
         retract("log", [log_id])
 
         checkin = check_in(aid)

--- a/tests/unit/test_retract_service.py
+++ b/tests/unit/test_retract_service.py
@@ -13,6 +13,7 @@ from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.retract_service import retract
 from src.services.tag_service import _injected_tags
+from tests.helpers import set_pinned
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -239,12 +240,7 @@ class TestRetractWithPin:
         decision_id = result["created"][0]["decision_id"]
 
         # pin（DBのpinned列を直接設定）→ retract
-        conn = get_connection()
-        try:
-            conn.execute("UPDATE decisions SET pinned = 1 WHERE id = ?", (decision_id,))
-            conn.commit()
-        finally:
-            conn.close()
+        set_pinned("decision", decision_id, True)
         retract_result = retract("decision", [decision_id])
 
         assert "error" not in retract_result

--- a/tests/unit/test_retract_service.py
+++ b/tests/unit/test_retract_service.py
@@ -11,7 +11,6 @@ from src.db import init_database, get_connection
 from src.services.topic_service import add_topic
 from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
-from src.services.pin_service import update_pin
 from src.services.retract_service import retract
 from src.services.tag_service import _injected_tags
 
@@ -239,8 +238,13 @@ class TestRetractWithPin:
         ])
         decision_id = result["created"][0]["decision_id"]
 
-        # pin → retract
-        update_pin("decision", decision_id, True)
+        # pin（DBのpinned列を直接設定）→ retract
+        conn = get_connection()
+        try:
+            conn.execute("UPDATE decisions SET pinned = 1 WHERE id = ?", (decision_id,))
+            conn.commit()
+        finally:
+            conn.close()
         retract_result = retract("decision", [decision_id])
 
         assert "error" not in retract_result


### PR DESCRIPTION
## Summary
- pin機構を「source→target」の有向関係に拡張する第一段。新pinsテーブルを作成し、既存 `pinned=1` material を `('activity', material)` のpinレコードとして移行
- `update_pin` を廃止し `add_pin`/`remove_pin` に分離。tag str ref（namespace:name）の内部解決・自己参照拒否・INSERT OR IGNOREによる冪等性
- `pinned` 列のDROP と check_in_service 改修は PR-b（後続）に委譲

## 関連
- アクティビティ: A#757（実装）/ A#740（設計）/ A#738（議論）
- topic: T#401「check-inレスポンスへのpinnedエンティティ導入」
- 確定decision: D#2102-2104, 2107-2109, 2118, 2120, 2147, 2152, 2154, 2178

## スコープ外
- D#2150 / D#2151 のCASCADE削除（呼び出し元不在のためデッドコード化を回避、D#2177）
- get_pins（D#2119）
- supersedes連鎖でのpin引き継ぎ（A#733）

## Test plan
- [x] `uv run pytest tests/unit/test_pin_service.py -v` → 19 passed
- [x] `uv run pytest tests/test_migrations/test_0034_pins_directed_relation.py -v` → 12 passed
- [x] `uv run pytest -n auto` → 1217 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)