### PR TITLE
refactor: nudge注入をPreToolUseからUserPromptSubmitに移行

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -26,13 +26,13 @@
         ]
       }
     ],
-    "PreToolUse": [
+    "UserPromptSubmit": [
       {
         "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/pretooluse_hook.py"
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/user_prompt_submit_hook.py"
           }
         ]
       }

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -216,7 +216,7 @@ def _update_state_on_approve(
 def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> None:
     """nudge判定: events.jsonlから直接判定してnudgeイベントを追記する。
 
-    pretooluse_hookがevents.jsonlを読んでnudge注入を判定するため、
+    user_prompt_submit_hookがevents.jsonlを読んでnudge注入を判定するため、
     nudgeフラグの代わりにnudgeイベントをevents.jsonlに追記する。
     """
     nudge_events: list[dict] = []

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -232,7 +232,7 @@ def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> N
         )
         if not has_recent_record:
             turns_since = _turns_since_last_recording(events, current_turn)
-            repeat = max(1, min(turns_since // _NUDGE_INTERVAL, 3))
+            repeat = max(1, min(turns_since // _NUDGE_INTERVAL, 5))
             nudge_events.append({
                 "e": "nudge",
                 "type": "record",

--- a/hooks/user_prompt_submit_hook.py
+++ b/hooks/user_prompt_submit_hook.py
@@ -1,4 +1,4 @@
-"""PreToolUse hook: nudgeリマインダー注入（イベント駆動版）
+"""UserPromptSubmit hook: nudgeリマインダー注入（イベント駆動版）
 
 処理フロー:
 1. stdin読み込み → JSON parse（session_id取得）
@@ -6,6 +6,9 @@
 3. events.jsonl全読み
 4. 未消費のnudgeイベント判定 → system-reminder注入
 5. 何もなし → 空JSON出力
+
+Stop hookでnudge判定とevents.jsonl追記を行い、本hookで消費して注入する。
+注入タイミングが「ユーザーの次の発言時」になるため、文面もその文脈に合わせている。
 """
 import json
 import os
@@ -21,10 +24,10 @@ from hooks.hook_state import HookState
 
 
 def _make_hook_output(message: str) -> dict:
-    """PreToolUse hookのsystem-reminder注入用JSON構造を返す"""
+    """UserPromptSubmit hookのsystem-reminder注入用JSON構造を返す"""
     return {
         "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
+            "hookEventName": "UserPromptSubmit",
             "additionalContext": message,
         }
     }
@@ -32,17 +35,17 @@ def _make_hook_output(message: str) -> dict:
 
 _FOLLOW_UP_NUDGE_MESSAGE = (
     "<system-reminder>"
-    "決定事項を記録しました。以下を確認してください:\n"
-    "- 関連するエンティティ（topic・logs・activity）の作成や更新\n"
-    "- 資材（material）として残すべき成果物がないか\n"
-    "- tag_notesへ転記すべき運用ルールや設計指針がないか\n"
-    "該当しなければ無視してください。"
+    "直近で add_decisions を呼んだものの、関連エンティティ（topic/logs/activity/material/tag_notes）"
+    "の更新が行われていません。応答に入る前に、補完すべき記録がないか確認してください。"
+    "該当なしなら無視してOK。"
     "</system-reminder>"
 )
 
 _RECORD_NUDGE_MESSAGE = (
     "<system-reminder>"
-    "記録が遅れています。議論の途中でもいいので add_logs / add_decisions / add_topic で記録してください。"
+    "直近の応答で記録ツール（add_logs/add_decisions/add_topic）が呼ばれていません。"
+    "ユーザーの今回の発言に応答する前に、これまでの議論で残すべき事項がないか振り返ってください。"
+    "該当があれば応答冒頭で記録してから本題に入ってください。"
     "</system-reminder>"
 )
 
@@ -97,7 +100,7 @@ def main() -> None:
 
     except Exception as e:
         # フェイルオープン: 例外時は空JSON + stderrログ
-        print(f"pretooluse_hook.py error: {e}", file=sys.stderr)
+        print(f"user_prompt_submit_hook.py error: {e}", file=sys.stderr)
         print("{}")
 
 

--- a/hooks/user_prompt_submit_hook.py
+++ b/hooks/user_prompt_submit_hook.py
@@ -13,6 +13,7 @@ Stop hookでnudge判定とevents.jsonl追記を行い、本hookで消費して�
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 # プロジェクトルートをパスに追加
@@ -106,10 +107,9 @@ def main() -> None:
 
 def _rewrite_events(state: HookState, events: list[dict]) -> None:
     """events.jsonlを全書き換えする（nudge消費マーク用）。
-    tempfile + os.replace()でアトミックに書き換える。"""
-    import os
-    import tempfile
-
+    tempfile + os.replace()でアトミックに書き換える。
+    Note: stop_hookのappend_eventsと同じファイルを操作するが、
+    発火順（Stop→ユーザー入力→UserPromptSubmit）上は通常競合しない。"""
     dir_ = state.events_path.parent
     with tempfile.NamedTemporaryFile("w", dir=dir_, delete=False, suffix=".tmp", encoding="utf-8") as f:
         tmp = f.name

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -607,8 +607,55 @@ class TestRecordNudgeMultiplication:
         assert len(record_nudges) >= 1
         assert record_nudges[-1]["repeat"] == 1
 
-    def test_6_turns_without_recording_nudge_repeat_3_ceiling(self, env_setup):
-        """6ターン記録なし → nudge repeat=3（天井）"""
+    def test_10_turns_without_recording_nudge_repeat_5_ceiling(self, env_setup):
+        """10ターン記録なし → nudge repeat=5（天井）。turns_since//2が5を超えても5で頭打ち"""
+        state_dir = env_setup["state_dir"]
+        _write_events(
+            [
+                {"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1},
+            ],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "checked_in_activity_test-session").write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("turn2"),
+                _make_assistant_entry(text="response 2"),
+                _make_user_entry("turn3"),
+                _make_assistant_entry(text="response 3"),
+                _make_user_entry("turn4"),
+                _make_assistant_entry(text="response 4"),
+                _make_user_entry("turn5"),
+                _make_assistant_entry(text="response 5"),
+                _make_user_entry("turn6"),
+                _make_assistant_entry(text="response 6"),
+                _make_user_entry("turn7"),
+                _make_assistant_entry(text="response 7"),
+                _make_user_entry("turn8"),
+                _make_assistant_entry(text="response 8"),
+                _make_user_entry("turn9"),
+                _make_assistant_entry(text="response 9"),
+                _make_user_entry("turn10"),
+                _make_assistant_entry(text="response 10"),
+            ],
+            transcript,
+        )
+
+        result = _run_stop_hook(
+            str(transcript), "test-session", env_setup["env_override"],
+        )
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) >= 1
+        assert record_nudges[-1]["repeat"] == 5
+
+    def test_6_turns_without_recording_nudge_repeat_3(self, env_setup):
+        """6ターン記録なし → nudge repeat=3（6//2=3、天井5には未達）"""
         state_dir = env_setup["state_dir"]
         _write_events(
             [

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -1,6 +1,6 @@
-"""hooks/pretooluse_hook.py のE2Eテスト（イベント駆動アーキテクチャ版）
+"""hooks/user_prompt_submit_hook.py のE2Eテスト（イベント駆動アーキテクチャ版）
 
-subprocess.runでpretooluse_hook.pyを呼び出し、stdin→stdoutの入出力をテスト。
+subprocess.runでuser_prompt_submit_hook.pyを呼び出し、stdin→stdoutの入出力をテスト。
 nudge判定はevents.jsonl内のnudgeイベントに基づく。
 """
 import json
@@ -25,9 +25,9 @@ def state_dir(tmp_path, monkeypatch):
 
 
 def _run_hook(input_data: dict, state_dir: Path) -> subprocess.CompletedProcess:
-    """pretooluse_hook.pyをサブプロセスで実行する"""
+    """user_prompt_submit_hook.pyをサブプロセスで実行する"""
     return subprocess.run(
-        [sys.executable, "hooks/pretooluse_hook.py"],
+        [sys.executable, "hooks/user_prompt_submit_hook.py"],
         input=json.dumps(input_data),
         capture_output=True,
         text=True,
@@ -64,7 +64,7 @@ class TestNoNudge:
 
 
 class TestRecordNudge:
-    """record nudgeイベント → system-reminder注入"""
+    """record nudgeイベント → system-reminder注入（hookEventName="UserPromptSubmit"）"""
 
     def test_record_nudge_injection(self, state_dir):
         _write_events(
@@ -77,11 +77,11 @@ class TestRecordNudge:
 
         output = json.loads(result.stdout)
         assert "hookSpecificOutput" in output
-        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
 
         ctx = output["hookSpecificOutput"]["additionalContext"]
         assert "<system-reminder>" in ctx
-        assert "記録が遅れています" in ctx
+        assert "直近の応答で記録ツール" in ctx
         assert "add_decisions" in ctx
 
     def test_nudge_consumed_after_injection(self, state_dir):
@@ -111,22 +111,22 @@ class TestRecordNudgeMultiplication:
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         output = json.loads(result.stdout)
         ctx = output["hookSpecificOutput"]["additionalContext"]
-        assert ctx.count("記録が遅れています") == 2
+        assert ctx.count("直近の応答で記録ツール") == 2
 
-    def test_repeat_3_triples_message(self, state_dir):
-        """repeat=3 → メッセージが3回注入される"""
+    def test_repeat_5_quintuples_message(self, state_dir):
+        """repeat=5 → メッセージが5回注入される（上限到達）"""
         _write_events(
-            [{"e": "nudge", "type": "record", "turn": 6, "repeat": 3}],
+            [{"e": "nudge", "type": "record", "turn": 10, "repeat": 5}],
             state_dir,
         )
 
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         output = json.loads(result.stdout)
         ctx = output["hookSpecificOutput"]["additionalContext"]
-        assert ctx.count("記録が遅れています") == 3
+        assert ctx.count("直近の応答で記録ツール") == 5
 
     def test_no_repeat_field_defaults_to_1(self, state_dir):
-        """repeatフィールドなし → メッセージ1回（後方互換）"""
+        """repeatフィールドなし → メッセージ1回（デフォルト値）"""
         _write_events(
             [{"e": "nudge", "type": "record", "turn": 2}],
             state_dir,
@@ -135,7 +135,7 @@ class TestRecordNudgeMultiplication:
         result = _run_hook({"session_id": _SESSION_ID}, state_dir)
         output = json.loads(result.stdout)
         ctx = output["hookSpecificOutput"]["additionalContext"]
-        assert ctx.count("記録が遅れています") == 1
+        assert ctx.count("直近の応答で記録ツール") == 1
 
 
 class TestFollowUpNudge:
@@ -152,8 +152,9 @@ class TestFollowUpNudge:
 
         output = json.loads(result.stdout)
         assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
         ctx = output["hookSpecificOutput"]["additionalContext"]
-        assert "決定事項" in ctx
+        assert "add_decisions" in ctx
         assert "topic" in ctx
         assert "material" in ctx
         assert "tag_notes" in ctx
@@ -172,13 +173,13 @@ class TestFollowUpNudge:
         output = json.loads(result.stdout)
         ctx = output["hookSpecificOutput"]["additionalContext"]
         # follow_up nudgeが注入される（最新のnudgeが先に消費される）
-        assert "決定事項" in ctx
+        assert "補完すべき記録" in ctx
 
         # record nudgeはまだ残っている
         result2 = _run_hook({"session_id": _SESSION_ID}, state_dir)
         output2 = json.loads(result2.stdout)
         ctx2 = output2["hookSpecificOutput"]["additionalContext"]
-        assert "記録が遅れています" in ctx2
+        assert "直近の応答で記録ツール" in ctx2
 
 
 class TestEmptySessionId:
@@ -200,7 +201,7 @@ class TestFailOpen:
 
     def test_invalid_json_input(self, state_dir):
         proc = subprocess.run(
-            [sys.executable, "hooks/pretooluse_hook.py"],
+            [sys.executable, "hooks/user_prompt_submit_hook.py"],
             input="not valid json",
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- nudge注入タイミングを **PreToolUse → UserPromptSubmit** に変更。PreToolUseのたびに繰り返し注入される挙動（ユーザー報告: 「nudgeの増殖」）を、ユーザー発言時1回の注入に集約
- record nudgeの`repeat`上限を **3→5** に引き上げ。注入頻度低下による「圧」の低下を補う代替手段
- 注入文面を「ユーザー発言を読む直前」という文脈に合わせて書き換え
- Stop hookでのnudge判定とevents.jsonl追記ロジックは維持

## 変更ファイル
- `hooks/hooks.json`: PreToolUseセクション削除、UserPromptSubmitセクション追加
- `hooks/user_prompt_submit_hook.py`: 新規（旧pretooluse_hook.pyを移行）
- `hooks/pretooluse_hook.py`: 削除
- `hooks/stop_hook.py`: repeat上限 3→5
- `tests/e2e/test_user_prompt_submit_hook.py`: 新規（旧test_pretooluse_hook.pyを移行・文面マッチ更新）
- `tests/e2e/test_pretooluse_hook.py`: 削除
- `tests/e2e/test_stop_hook.py`: 10ターン→repeat=5天井テスト追加、6ターン→repeat=3テストを天井扱いから外す

## 設計経緯
cc-memory: A#781 / T#451 / D#2351-2356 / L#2501 参照

## Test plan
- [x] `uv run pytest` 全1203件 PASS
- [ ] マージ後、Claude Codeセッション再起動して record nudge / follow_up nudge が UserPromptSubmit時に注入されることを手動確認
- [ ] PreToolUseでは一切注入されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)