### PR TITLE
feat: pinned列撤去とcheck-in注入の新pinsテーブル移行

### DIFF
--- a/migrations/0035_drop_pinned_columns.sql
+++ b/migrations/0035_drop_pinned_columns.sql
@@ -1,0 +1,14 @@
+-- Migration 035: pinned列の撤去（pins有向関係への移行完了）
+--
+-- depends: 0034_pins_directed_relation
+--
+-- 背景:
+--   0034でpinsテーブルへの有向関係移行が完了した。
+--   従来の discussion_logs / decisions / materials の pinned 列は不要になるため DROP する。
+--
+-- NOTE: 不可逆（down無し）。データ移行は0034で完了済みのため本migrationはDROPのみ。
+--   SQLite 3.35+ で ALTER TABLE ... DROP COLUMN が使用可能。
+
+ALTER TABLE discussion_logs DROP COLUMN pinned;
+ALTER TABLE decisions DROP COLUMN pinned;
+ALTER TABLE materials DROP COLUMN pinned;

--- a/skills/check-in/SKILL.md
+++ b/skills/check-in/SKILL.md
@@ -16,6 +16,18 @@ description: アクティビティにcheck-inして関連情報を集約取得�
 5. check-in結果に含まれるタグ一覧を見て、明らかな表記揺れや重複に気づいたらユーザーにサジェストする。分析ツール（`analyze_tags`）は呼ばない
 6. 把握した内容を以下の2セクション構成でユーザーに伝える
 
+## pinnedフィールドの扱い
+
+check-in結果に `pinned` フィールドがある場合、その内容はタスクに常に意識してほしい情報としてpinされたエンティティ群である。以下の5種が含まれることがある（0件キーは省略される）:
+
+- `pinned.decisions`: 重要な決定事項（id, title, reason付き）
+- `pinned.logs`: 重要な議事録・ログ（id, title, content付き）
+- `pinned.materials`: 重要な参考資材（id, title, content, source付き）
+- `pinned.topics`: 関連トピック（id, title）
+- `pinned.activities`: 関連アクティビティ（id, title, status）
+
+pinned情報は進捗把握の最初に確認し、概要・進捗の説明に反映すること。
+
 ## 出力フォーマット
 
 ```

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -76,9 +76,9 @@ def _get_activities_overview(conn: sqlite3.Connection, activity_ids: list[int]) 
 
 
 def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
-    """複数トピックの非pinnedのdecisionsを横断取得し、新しい順にフラット化する。
+    """複数トピックのdecisionsを横断取得し、新しい順にフラット化する。
 
-    上位DECISIONS_FULL_LIMIT件はid+title。pinnedは除外される（別途取得）。
+    上位DECISIONS_FULL_LIMIT件はid+title。retractedは除外される。
     """
     if not topic_ids:
         return []
@@ -87,7 +87,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
         f"""
         SELECT id, decision
         FROM decisions
-        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL
+        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
         ORDER BY id DESC
         LIMIT {DECISIONS_FULL_LIMIT}
         """,
@@ -101,7 +101,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
 
 
 def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> int:
-    """複数トピックのdecisionsの総件数を取得する（pinned含む、retracted除外、coverage分母用）。"""
+    """複数トピックのdecisionsの総件数を取得する（retracted除外、coverage分母用）。"""
     if not topic_ids:
         return 0
     placeholders = ",".join("?" * len(topic_ids))
@@ -116,7 +116,7 @@ def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int])
 def _get_logs_catalog_from_topics(
     conn: sqlite3.Connection, topic_ids: list[int]
 ) -> tuple[dict | None, list[dict]]:
-    """複数トピックの非pinnedのlogsを横断取得し、新しい順にフラット化する。
+    """複数トピックのlogsを横断取得し、新しい順にフラット化する。
 
     最新1件はcontent付き、残りはid + titleのカタログとして返す。
 
@@ -134,7 +134,7 @@ def _get_logs_catalog_from_topics(
         f"""
         SELECT id, title, content
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL
+        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
         ORDER BY id DESC
         LIMIT 1
         """,
@@ -151,7 +151,7 @@ def _get_logs_catalog_from_topics(
         f"""
         SELECT id, title
         FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 0 AND retracted_at IS NULL AND id != ?
+        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL AND id != ?
         ORDER BY id DESC
         """,
         params + (latest_row["id"],),
@@ -161,54 +161,177 @@ def _get_logs_catalog_from_topics(
     return latest_log, catalog
 
 
-def _get_pinned_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
-    """関連トピックのpinned decisionsをcontent付きで取得する。"""
-    if not topic_ids:
-        return []
-    placeholders = ",".join("?" * len(topic_ids))
-    rows = conn.execute(
-        f"""
-        SELECT id, decision, reason
-        FROM decisions
-        WHERE topic_id IN ({placeholders}) AND pinned = 1 AND retracted_at IS NULL
-        ORDER BY id DESC
-        """,
-        tuple(topic_ids),
-    ).fetchall()
-    return [{"id": row["id"], "title": row["decision"], "reason": row["reason"]} for row in rows]
+def _get_pinned_targets(conn: sqlite3.Connection, activity_id: int) -> dict:
+    """新pinsテーブル経由でpinされたtargetをcontent付きで取得する。
 
+    1. activity自身のtag_idを取得する（activity_tags経由）
+    2. source=tag（activity自身のtagsのみ）と source=activity のpinsをUNIONで取得する
+    3. (target_type, target_id) でDISTINCT化し、created_at降順で並べる
+    4. target_type別にcontent fetchする（decision/logはretracted_at IS NULLでフィルタ）
+    5. {decisions, logs, materials, topics, activities} に振り分けて返す（0件キーは省略）
 
-def _get_pinned_logs_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -> list[dict]:
-    """関連トピックのpinned logsをcontent付きで取得する。"""
-    if not topic_ids:
-        return []
-    placeholders = ",".join("?" * len(topic_ids))
-    rows = conn.execute(
-        f"""
-        SELECT id, title, content
-        FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND pinned = 1 AND retracted_at IS NULL
-        ORDER BY id DESC
-        """,
-        tuple(topic_ids),
-    ).fetchall()
-    return [{"id": row["id"], "title": row["title"], "content": row["content"]} for row in rows]
+    NOTE: retracted_at カラムは decisions と discussion_logs にのみ存在する（migration 0031）。
+    materials / discussion_topics / activities には存在しないため、
+    retracted_at IS NULL フィルタは decision/log のクエリにのみ付ける。
 
-
-def _get_pinned_materials_for_activity(conn: sqlite3.Connection, activity_id: int) -> list[dict]:
-    """アクティビティに紐づくpinned materialsをcontent付きで取得する。"""
-    rows = conn.execute(
-        """
-        SELECT m.id, m.title, m.content, m.source
-        FROM materials m
-        JOIN relations r ON r.source_type = 'activity' AND r.source_id = ?
-                        AND r.target_type = 'material' AND r.target_id = m.id
-        WHERE m.pinned = 1
-        ORDER BY m.created_at ASC
-        """,
+    Returns:
+        0件キーを省略したdict。全種0件の場合は空dict。
+    """
+    # 1. activity自身のtag_idを取得
+    tag_rows = conn.execute(
+        "SELECT tag_id FROM activity_tags WHERE activity_id = ?",
         (activity_id,),
     ).fetchall()
-    return [{"id": row["id"], "title": row["title"], "content": row["content"], "source": row["source"]} for row in rows]
+    tag_ids = [row["tag_id"] for row in tag_rows]
+
+    # 2. source=tag（activity自身のtagsのみ）と source=activity のpinsをUNIONで取得
+    if tag_ids:
+        tag_placeholders = ",".join("?" * len(tag_ids))
+        raw_rows = conn.execute(
+            f"""
+            SELECT target_type, target_id, created_at
+            FROM pins
+            WHERE (source_type = 'tag' AND source_id IN ({tag_placeholders}))
+               OR (source_type = 'activity' AND source_id = ?)
+            """,
+            tuple(tag_ids) + (activity_id,),
+        ).fetchall()
+    else:
+        raw_rows = conn.execute(
+            """
+            SELECT target_type, target_id, created_at
+            FROM pins
+            WHERE source_type = 'activity' AND source_id = ?
+            """,
+            (activity_id,),
+        ).fetchall()
+
+    # 3. (target_type, target_id) でDISTINCT化し、created_at降順で並べる
+    seen: set[tuple[str, int]] = set()
+    distinct_rows: list[tuple[str, int]] = []
+    # created_at降順にするため、ソートしてから処理（SQLiteのdatetimeはISO8601文字列なのでstr比較OK）
+    sorted_rows = sorted(raw_rows, key=lambda r: r["created_at"] or "", reverse=True)
+    for row in sorted_rows:
+        key = (row["target_type"], row["target_id"])
+        if key not in seen:
+            seen.add(key)
+            distinct_rows.append(key)
+
+    if not distinct_rows:
+        return {}
+
+    # target_type別にIDをグルーピング
+    by_type: dict[str, list[int]] = {}
+    for target_type, target_id in distinct_rows:
+        by_type.setdefault(target_type, []).append(target_id)
+
+    result: dict[str, list[dict]] = {}
+
+    # 4. target_type別にcontent fetch（target_type別に順序を保つためID→rowをmapして変換）
+    if "decision" in by_type:
+        ids = by_type["decision"]
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            SELECT id, decision, reason
+            FROM decisions
+            WHERE id IN ({placeholders}) AND retracted_at IS NULL
+            """,
+            tuple(ids),
+        ).fetchall()
+        row_map = {row["id"]: row for row in rows}
+        decisions = []
+        for did in ids:
+            if did in row_map:
+                row = row_map[did]
+                decisions.append({"id": row["id"], "title": row["decision"], "reason": row["reason"]})
+        if decisions:
+            result["decisions"] = decisions
+
+    if "log" in by_type:
+        ids = by_type["log"]
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            SELECT id, title, content
+            FROM discussion_logs
+            WHERE id IN ({placeholders}) AND retracted_at IS NULL
+            """,
+            tuple(ids),
+        ).fetchall()
+        row_map = {row["id"]: row for row in rows}
+        logs = []
+        for lid in ids:
+            if lid in row_map:
+                row = row_map[lid]
+                logs.append({"id": row["id"], "title": row["title"], "content": row["content"]})
+        if logs:
+            result["logs"] = logs
+
+    if "material" in by_type:
+        # materialsにはretracted_atカラムが存在しない（migration 0031参照）
+        ids = by_type["material"]
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            SELECT id, title, content, source
+            FROM materials
+            WHERE id IN ({placeholders})
+            """,
+            tuple(ids),
+        ).fetchall()
+        row_map = {row["id"]: row for row in rows}
+        materials = []
+        for mid in ids:
+            if mid in row_map:
+                row = row_map[mid]
+                materials.append({"id": row["id"], "title": row["title"], "content": row["content"], "source": row["source"]})
+        if materials:
+            result["materials"] = materials
+
+    if "topic" in by_type:
+        # discussion_topicsにはretracted_atカラムが存在しない
+        ids = by_type["topic"]
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            SELECT id, title
+            FROM discussion_topics
+            WHERE id IN ({placeholders})
+            """,
+            tuple(ids),
+        ).fetchall()
+        row_map = {row["id"]: row for row in rows}
+        topics = []
+        for tid in ids:
+            if tid in row_map:
+                row = row_map[tid]
+                topics.append({"id": row["id"], "title": row["title"]})
+        if topics:
+            result["topics"] = topics
+
+    if "activity" in by_type:
+        # activitiesにはretracted_atカラムが存在しない
+        ids = by_type["activity"]
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            SELECT id, title, status
+            FROM activities
+            WHERE id IN ({placeholders})
+            """,
+            tuple(ids),
+        ).fetchall()
+        row_map = {row["id"]: row for row in rows}
+        activities = []
+        for aid in ids:
+            if aid in row_map:
+                row = row_map[aid]
+                activities.append({"id": row["id"], "title": row["title"], "status": row["status"]})
+        if activities:
+            result["activities"] = activities
+
+    return result
 
 
 def _extract_intent_tag(tags: list[str]) -> str:
@@ -257,6 +380,11 @@ def check_in(activity_id: int) -> dict:
     - always_inject_namespaces対象タグ（例: intent:）: 毎回注入される。
       _injected_tagsによるフィルタをスキップし、check-inのたびにnotesを返す。
 
+    pinsテーブル経由のpinned targets注入:
+    - activity自身のtag（source=tag）と activity自身（source=activity）のpinsを取得する
+    - (target_type, target_id) でDISTINCT化してレスポンスのpinnedキーに注入する
+    - retracted済みのdecision/logはpins経由でも注入されない（retracted_at IS NULL除外）
+
     Args:
         activity_id: アクティビティID
 
@@ -282,16 +410,19 @@ def check_in(activity_id: int) -> dict:
         activity = row_to_dict(row)
         tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
 
-        # 2. 直接関連エンティティ取得（1次）
+        # 2. tag_notes収集（collect_tag_notes_for_injectionは変更なし）
+        tag_notes = collect_tag_notes_for_injection(conn, tags, always_inject_namespaces=["intent"]) or []
+
+        # 3. 直接関連エンティティ取得（1次）
         direct = _get_direct_relations(conn, "activity", activity_id)
 
-        # 2a. 関連トピック情報
+        # 3a. 関連トピック情報
         related_topics = _get_topics_info(conn, direct["topic"])
 
-        # 2b. 関連アクティビティ概要
+        # 3b. 関連アクティビティ概要
         related_activities = _get_activities_overview(conn, direct["activity"])
 
-        # 2c. depends_on情報取得
+        # 3c. depends_on情報取得
         dep_rows = conn.execute(
             """SELECT a.id, a.title, a.status
                FROM activity_dependencies ad
@@ -301,45 +432,38 @@ def check_in(activity_id: int) -> dict:
         ).fetchall()
         dependencies = [{"id": r["id"], "title": r["title"], "status": r["status"]} for r in dep_rows]
 
-        # 3. tag_notes収集
-        tag_notes = collect_tag_notes_for_injection(conn, tags, always_inject_namespaces=["intent"]) or []
+        # 4. pinsテーブル経由のpinned targets取得（新pinsテーブル経由）
+        pinned_targets = _get_pinned_targets(conn, activity_id)
 
-        # 4. pinnedエンティティ取得（content付き）
-        pinned_decisions = _get_pinned_decisions_from_topics(conn, direct["topic"])
-        pinned_logs = _get_pinned_logs_from_topics(conn, direct["topic"])
-        pinned_materials = _get_pinned_materials_for_activity(conn, activity_id)
-        pinned_material_ids = {m["id"] for m in pinned_materials}
+        # 5. materials取得（リレーション経由、カタログ形式）
+        materials = get_materials_by_relation_with_conn(conn, activity_id)
 
-        # 5. materials取得（リレーション経由、カタログ形式、pinnedを除外）
-        all_materials = get_materials_by_relation_with_conn(conn, activity_id)
-        materials = [m for m in all_materials if m["id"] not in pinned_material_ids]
-
-        # 6. recent_decisions取得（関連topic横断、フラット15件、pinnedを除外）
+        # 5a. recent_decisions取得（関連topic横断、フラット15件）
         recent_decisions = _get_decisions_from_topics(conn, direct["topic"])
 
-        # 7. logs取得（最新1件はcontent付き、残りはカタログ、pinnedを除外）
+        # 5b. logs取得（最新1件はcontent付き、残りはカタログ）
         latest_log, logs_catalog = _get_logs_catalog_from_topics(conn, direct["topic"])
 
-        # 8. coverage算出（pinned件数・最新ログを分子に加算）
+        # 6. coverage算出（pins注入targetsは含めない）
         total_decisions = _count_decisions_from_topics(conn, direct["topic"])
         total_materials_row = conn.execute(
             "SELECT COUNT(*) FROM relations WHERE source_type = 'activity' AND source_id = ? AND target_type = 'material'",
             (activity_id,),
         ).fetchone()
         total_materials = total_materials_row[0] if total_materials_row else 0
-        total_logs = (1 if latest_log else 0) + len(logs_catalog) + len(pinned_logs)
-        loaded_logs = len(pinned_logs) + (1 if latest_log else 0)
+        total_logs = (1 if latest_log else 0) + len(logs_catalog)
+        loaded_logs = 1 if latest_log else 0
 
         coverage = {
-            "decisions": f"{len(pinned_decisions) + len(recent_decisions)}/{total_decisions}",
-            "materials": f"{len(pinned_materials) + len(materials)}/{total_materials}",
+            "decisions": f"{len(recent_decisions)}/{total_decisions}",
+            "materials": f"{len(materials)}/{total_materials}",
             "logs": f"{loaded_logs}/{total_logs}",
         }
 
-        # 9. 2次カタログ取得（depth 1-2）
+        # 7. 2次カタログ取得（depth 1-2）
         catalog = _get_map_with_conn(conn, "activity", activity_id, min_depth=1, max_depth=2)
 
-        # 10. status自動更新（in_progress以外ならin_progressに変更）
+        # 8. status自動更新（in_progress以外ならin_progressに変更）
         # NOTE: update_activityは内部で別コネクションを使用する（既存APIの制約）。
         # check_inのトランザクションとは独立してコミットされる。
         if activity["status"] != "in_progress":
@@ -353,7 +477,7 @@ def check_in(activity_id: int) -> dict:
             else:
                 activity["status"] = "in_progress"
 
-        # 11. summary生成
+        # 9. summary生成
         summary = _build_summary(activity, tags)
 
         # 戻り値組み立て（coverageをトップレベルの最初のキーに）
@@ -379,12 +503,8 @@ def check_in(activity_id: int) -> dict:
         if dependencies:
             result["dependencies"] = dependencies
 
-        if pinned_decisions or pinned_logs or pinned_materials:
-            result["pinned"] = {
-                "decisions": pinned_decisions,
-                "logs": pinned_logs,
-                "materials": pinned_materials,
-            }
+        if pinned_targets:
+            result["pinned"] = pinned_targets
 
         result["tag_notes"] = tag_notes
         result["materials"] = materials

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -170,6 +170,9 @@ def _get_pinned_targets(conn: sqlite3.Connection, activity_id: int) -> dict:
     4. target_type別にcontent fetchする（decision/logはretracted_at IS NULLでフィルタ）
     5. {decisions, logs, materials, topics, activities} に振り分けて返す（0件キーは省略）
 
+    NOTE: target_type='tag' のpinは処理しない（tagにはcontent表現がないため）。
+    pinsテーブルのCHECK制約では'tag'が許容されるが、注入対象は上記5種に限定する。
+
     NOTE: retracted_at カラムは decisions と discussion_logs にのみ存在する（migration 0031）。
     materials / discussion_topics / activities には存在しないため、
     retracted_at IS NULL フィルタは decision/log のクエリにのみ付ける。

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,34 +4,9 @@ add_logs / add_decisions のバッチAPIを単件呼び出し形式でラップ�
 旧 add_log / add_decision と同じインターフェースを提供する。
 """
 from typing import Optional
-from src.db import get_connection
 from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.retract_service import retract
-
-
-_PINNED_ENTITY_TABLE = {
-    "decision": "decisions",
-    "log": "discussion_logs",
-    "material": "materials",
-}
-
-
-def set_pinned(entity_type: str, entity_id: int, pinned: bool = True) -> None:
-    """テスト用: 旧 pinned 列を直接更新する。
-
-    PR-b で pinned 列が DROP されるまでの暫定ヘルパー。
-    """
-    table = _PINNED_ENTITY_TABLE[entity_type]
-    conn = get_connection()
-    try:
-        conn.execute(
-            f"UPDATE {table} SET pinned = ? WHERE id = ?",
-            (1 if pinned else 0, entity_id),
-        )
-        conn.commit()
-    finally:
-        conn.close()
 
 
 def add_log(

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -4,8 +4,9 @@ import tempfile
 import pytest
 from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
-from tests.helpers import add_decision, add_log, retract_decision, set_pinned as _set_pinned
+from tests.helpers import add_decision, add_log, retract_decision
 from src.services.material_service import add_material
+from src.services.pin_service import add_pin
 from src.services.relation_service import add_relation
 from src.services.topic_service import add_topic
 from src.services.checkin_service import check_in, DECISIONS_FULL_LIMIT
@@ -537,6 +538,27 @@ class TestCheckInCoverage:
         assert result["coverage"]["materials"] == "0/0"
         assert result["coverage"]["logs"] == "0/0"
 
+    def test_coverage_not_affected_by_pinned_targets(self, temp_db):
+        """pinsテーブル経由で注入されたpinned targetsはcoverageの分子に加算されない"""
+        # activityに関連するtopic（coverageの分母・分子に計上される）
+        related_topic = add_topic(title="関連トピック", description="Desc", tags=DEFAULT_TAGS)
+        add_decision(decision="通常の決定", reason="理由", topic_id=related_topic["topic_id"])
+        # activityに関連しないtopic（coverage対象外）にdecisionを作成
+        unrelated_topic = add_topic(title="無関係トピック", description="Desc", tags=DEFAULT_TAGS)
+        unrelated_d = add_decision(decision="pin用決定", reason="理由", topic_id=unrelated_topic["topic_id"])
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [related_topic["topic_id"]]}])
+        # 無関係topicのdecisionをpin → pins注入されるがcoverageには含まれないはず
+        add_pin("activity", a["activity_id"], "decision", unrelated_d["decision_id"])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert len(result["pinned"]["decisions"]) == 1
+        # coverageは関連topic配下のdecisionのみ: 通常1件/全体1件。pin注入分は加算されない
+        assert result["coverage"]["decisions"] == "1/1"
+
 
 class TestCheckInLogsCatalog:
     """logsカタログのテスト"""
@@ -714,10 +736,10 @@ class TestCheckInDependencies:
 
 
 class TestCheckInPinned:
-    """pinnedエンティティのcheck-in注入テスト"""
+    """pinsテーブル経由のpinned target注入テスト"""
 
     def test_no_pinned_field_when_nothing_pinned(self, temp_db):
-        """pinnedエンティティが0件の場合、pinnedフィールドは省略される"""
+        """pinsテーブルに対象activity向けのpinがない場合、pinnedフィールドは省略される"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         add_decision(decision="通常の決定", reason="理由", topic_id=topic["topic_id"])
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
@@ -728,163 +750,234 @@ class TestCheckInPinned:
         assert "error" not in result
         assert "pinned" not in result
 
-    def test_pinned_decision_in_pinned_field(self, temp_db):
-        """pinされたdecisionがpinned.decisionsにcontent付きで返る"""
+    def test_activity_source_pin_injects_decision(self, temp_db):
+        """source=activityのpinsテーブルエントリが、check-in時にpinned.decisionsにcontent付きで注入される"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
         d = add_decision(decision="重要な決定", reason="根本的な理由", topic_id=topic["topic_id"])
-        _set_pinned("decision", d["decision_id"], True)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        # pinsにsource=activityでdecisionをpin
+        add_pin("activity", a["activity_id"], "decision", d["decision_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
         assert "pinned" in result
+        assert "decisions" in result["pinned"]
         assert len(result["pinned"]["decisions"]) == 1
         assert result["pinned"]["decisions"][0]["title"] == "重要な決定"
         assert result["pinned"]["decisions"][0]["reason"] == "根本的な理由"
 
-    def test_pinned_decision_excluded_from_recent_decisions(self, temp_db):
-        """pinされたdecisionはrecent_decisionsから除外される"""
+    def test_tag_source_pin_injects_decision(self, temp_db):
+        """source=tag（activity自身のtag）のpinsテーブルエントリが、check-in時にpinned.decisionsに注入される"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
-        d1 = add_decision(decision="pinされた決定", reason="理由1", topic_id=topic["topic_id"])
-        add_decision(decision="通常の決定", reason="理由2", topic_id=topic["topic_id"])
-        _set_pinned("decision", d1["decision_id"], True)
+        d = add_decision(decision="タグ経由重要決定", reason="根拠", topic_id=topic["topic_id"])
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
-
-        result = check_in(a["activity_id"])
-
-        assert "error" not in result
-        # recent_decisionsにはpinされていないものだけ
-        assert len(result["recent_decisions"]) == 1
-        assert result["recent_decisions"][0]["title"] == "通常の決定"
-        # pinnedにはpinされたものだけ
-        assert len(result["pinned"]["decisions"]) == 1
-        assert result["pinned"]["decisions"][0]["title"] == "pinされた決定"
-
-    def test_pinned_log_in_pinned_field(self, temp_db):
-        """pinされたlogがpinned.logsにcontent付きで返る"""
-        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
-        log = add_log(topic_id=topic["topic_id"], title="方向転換ログ", content="## 経緯\n重要な方向転換")
-        _set_pinned("log", log["log_id"], True)
-        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        # pinsにsource=tagでdecisionをpin（domain:testタグ）
+        add_pin("tag", "domain:test", "decision", d["decision_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
         assert "pinned" in result
+        assert "decisions" in result["pinned"]
+        assert len(result["pinned"]["decisions"]) == 1
+        assert result["pinned"]["decisions"][0]["title"] == "タグ経由重要決定"
+
+    def test_pinned_decisions_included_in_recent_decisions(self, temp_db):
+        """pinsテーブルでpinされたdecisionはrecent_decisionsにも通常通り含まれる（除外されない）"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d = add_decision(decision="ピン済み決定", reason="理由", topic_id=topic["topic_id"])
+        add_decision(decision="通常の決定", reason="理由", topic_id=topic["topic_id"])
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        # decisionをpinする
+        add_pin("activity", a["activity_id"], "decision", d["decision_id"])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # recent_decisionsにはピン済み・非ピンの両方が含まれる（pinned列による除外なし）
+        assert len(result["recent_decisions"]) == 2
+        titles = {dec["title"] for dec in result["recent_decisions"]}
+        assert "ピン済み決定" in titles
+        assert "通常の決定" in titles
+
+    def test_activity_source_pin_injects_log(self, temp_db):
+        """source=activityのpinsテーブルエントリが、check-in時にpinned.logsにcontent付きで注入される"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        log = add_log(topic_id=topic["topic_id"], title="方向転換ログ", content="## 経緯\n重要な方向転換")
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_pin("activity", a["activity_id"], "log", log["log_id"])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert "logs" in result["pinned"]
         assert len(result["pinned"]["logs"]) == 1
         assert result["pinned"]["logs"][0]["title"] == "方向転換ログ"
         assert result["pinned"]["logs"][0]["content"] == "## 経緯\n重要な方向転換"
 
-    def test_pinned_log_excluded_from_logs_catalog(self, temp_db):
-        """pinされたlogはlogsカタログとlatest_logから除外される"""
+    def test_pinned_log_also_appears_in_latest_log(self, temp_db):
+        """pinsテーブルでpinされたlogはlatest_logにも通常通り含まれる（除外されない）"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
-        log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
-        add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
-        _set_pinned("log", log1["log_id"], True)
+        log1 = add_log(topic_id=topic["topic_id"], title="ピン済みログ", content="内容1")
+        add_log(topic_id=topic["topic_id"], title="新しいログ", content="内容2")
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        # log1をpinするが、IDが小さい（古い）ため latest_log には新しい方が来る
+        add_pin("activity", a["activity_id"], "log", log1["log_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
-        # 非pinの1件がlatest_logに入り、logsカタログは空
-        assert result["latest_log"]["title"] == "通常ログ"
-        assert result["logs"] == []
+        # latest_logには最新のログが入る（pinned列による除外なし）
+        assert result["latest_log"]["title"] == "新しいログ"
+        # logsカタログにはpinされたログが残る
+        assert len(result["logs"]) == 1
+        assert result["logs"][0]["title"] == "ピン済みログ"
 
-    def test_pinned_material_in_pinned_field(self, temp_db):
-        """pinされたmaterialがpinned.materialsにcontent付きで返る"""
+    def test_activity_source_pin_injects_material(self, temp_db):
+        """source=activityのpinsテーブルエントリが、check-in時にpinned.materialsにcontent付きで注入される"""
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
         m = add_material("設計書", "# 設計\n詳細な内容", DEFAULT_TAGS, "テスト用データ",
                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        _set_pinned("material", m["material_id"], True)
+        add_pin("activity", a["activity_id"], "material", m["material_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
         assert "pinned" in result
+        assert "materials" in result["pinned"]
         assert len(result["pinned"]["materials"]) == 1
         assert result["pinned"]["materials"][0]["title"] == "設計書"
         assert result["pinned"]["materials"][0]["content"] == "# 設計\n詳細な内容"
         assert result["pinned"]["materials"][0]["source"] == "テスト用データ"
 
-    def test_pinned_material_excluded_from_materials(self, temp_db):
-        """pinされたmaterialは通常のmaterialsフィールドから除外される"""
+    def test_pinned_material_also_appears_in_materials(self, temp_db):
+        """pinsテーブルでpinされたmaterialはmaterialsフィールドにも通常通り含まれる（除外されない）"""
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        m1 = add_material("pin資材", "内容1", DEFAULT_TAGS, "テスト用データ",
+        m1 = add_material("ピン資材", "内容1", DEFAULT_TAGS, "テスト用データ",
                           related=[{"type": "activity", "ids": [a["activity_id"]]}])
         add_material("通常資材", "内容2", DEFAULT_TAGS, "テスト用データ",
                      related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        _set_pinned("material", m1["material_id"], True)
+        add_pin("activity", a["activity_id"], "material", m1["material_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
-        # materialsにはpinされていないものだけ
-        assert len(result["materials"]) == 1
-        assert result["materials"][0]["title"] == "通常資材"
+        # materialsにはpin済みも非ピンも両方含まれる（pinned列による除外なし）
+        assert len(result["materials"]) == 2
+        titles = {m["title"] for m in result["materials"]}
+        assert "ピン資材" in titles
+        assert "通常資材" in titles
 
-    def test_coverage_includes_pinned_decisions(self, temp_db):
-        """coverageのdecisions分子にpinned件数が加算される"""
-        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
-        d1 = add_decision(decision="pin決定", reason="理由", topic_id=topic["topic_id"])
-        add_decision(decision="通常決定1", reason="理由", topic_id=topic["topic_id"])
-        add_decision(decision="通常決定2", reason="理由", topic_id=topic["topic_id"])
-        _set_pinned("decision", d1["decision_id"], True)
+    def test_activity_source_pin_injects_topic(self, temp_db):
+        """source=activityのpinsテーブルエントリが、check-in時にpinned.topicsに注入される"""
+        topic = add_topic(title="重要トピック", description="Desc", tags=DEFAULT_TAGS)
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        add_pin("activity", a["activity_id"], "topic", topic["topic_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
-        # pinned 1件 + 通常 2件 = 3件, 全体 3件
-        assert result["coverage"]["decisions"] == "3/3"
+        assert "pinned" in result
+        assert "topics" in result["pinned"]
+        assert len(result["pinned"]["topics"]) == 1
+        assert result["pinned"]["topics"][0]["id"] == topic["topic_id"]
+        assert result["pinned"]["topics"][0]["title"] == "重要トピック"
 
-    def test_coverage_includes_pinned_logs(self, temp_db):
-        """coverageのlogs分子にpinned件数が加算される"""
+    def test_activity_source_pin_injects_activity(self, temp_db):
+        """source=activityのpinsテーブルエントリが、check-in時にpinned.activitiesに注入される"""
+        a1 = add_activity(title="メインタスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        a2 = add_activity(title="重要参照タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_pin("activity", a1["activity_id"], "activity", a2["activity_id"])
+
+        result = check_in(a1["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert "activities" in result["pinned"]
+        assert len(result["pinned"]["activities"]) == 1
+        assert result["pinned"]["activities"][0]["id"] == a2["activity_id"]
+        assert result["pinned"]["activities"][0]["title"] == "重要参照タスク"
+        assert result["pinned"]["activities"][0]["status"] == "pending"
+
+    def test_distinct_deduplication_when_multiple_routes(self, temp_db):
+        """同一targetがtagソースとactivityソースの両方からpinされても、pinned結果に1件だけ注入される"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
-        log1 = add_log(topic_id=topic["topic_id"], title="pinログ", content="内容1")
-        add_log(topic_id=topic["topic_id"], title="通常ログ", content="内容2")
-        _set_pinned("log", log1["log_id"], True)
+        d = add_decision(decision="重複テスト決定", reason="理由", topic_id=topic["topic_id"])
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
+        # activityソースとtagソースの両方からdecisionをpin
+        add_pin("activity", a["activity_id"], "decision", d["decision_id"])
+        add_pin("tag", "domain:test", "decision", d["decision_id"])
 
         result = check_in(a["activity_id"])
 
         assert "error" not in result
-        # pinned 1件 + latest_log 1件 / 全体 2件
-        assert result["coverage"]["logs"] == "2/2"
+        assert "pinned" in result
+        # (target_type, target_id) でDISTINCTされ、1件のみ
+        assert len(result["pinned"]["decisions"]) == 1
+        assert result["pinned"]["decisions"][0]["title"] == "重複テスト決定"
 
-    def test_coverage_includes_pinned_materials(self, temp_db):
-        """coverageのmaterials分子にpinned件数が加算される"""
-        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        m1 = add_material("pin資材", "内容1", DEFAULT_TAGS, "テスト用データ",
-                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        add_material("通常資材", "内容2", DEFAULT_TAGS, "テスト用データ",
-                     related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        _set_pinned("material", m1["material_id"], True)
-
-        result = check_in(a["activity_id"])
-
-        assert "error" not in result
-        # pinned 1件 + 通常 1件 = 2件, 全体 2件
-        assert result["coverage"]["materials"] == "2/2"
-
-    def test_all_types_pinned_together(self, temp_db):
-        """decision, log, materialすべてpinされた場合、pinnedフィールドに3種とも含まれる"""
+    def test_retracted_decision_excluded_from_pinned(self, temp_db):
+        """retractされたdecisionはpinsテーブル経由でもpinned.decisionsに注入されない"""
         topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d = add_decision(decision="取り消し済み決定", reason="理由", topic_id=topic["topic_id"])
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_pin("activity", a["activity_id"], "decision", d["decision_id"])
+        # decisionをretract
+        retract_decision(d["decision_id"])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        # retractされているためpinnedキー自体が省略される（または decisions が空）
+        assert "pinned" not in result or "decisions" not in result.get("pinned", {})
+
+    def test_tag_source_only_uses_activity_own_tags(self, temp_db):
+        """tagソースのpinは、check-in対象activityが持つtagのみが使用される（他activityのtagは無視される）"""
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        d = add_decision(decision="他タグ経由決定", reason="理由", topic_id=topic["topic_id"])
+        a1 = add_activity(title="メインタスク", description="Desc", tags=["domain:test"], check_in=False)
+        # a1が持たないタグ（domain:other）をsourceとしてdecisionをpin
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES ('domain', 'other')",
+            )
+            other_tag_row = conn.execute(
+                "SELECT id FROM tags WHERE namespace='domain' AND name='other'"
+            ).fetchone()
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) VALUES ('tag', ?, 'decision', ?)",
+                (other_tag_row["id"], d["decision_id"]),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = check_in(a1["activity_id"])
+
+        assert "error" not in result
+        # a1はdomain:otherタグを持たないため、そのpinは注入されない
+        assert "pinned" not in result
+
+    def test_all_five_target_types_in_pinned(self, temp_db):
+        """decision/log/material/topic/activityの5種すべてがpinnedフィールドに含まれる"""
+        topic = add_topic(title="重要トピック", description="Desc", tags=DEFAULT_TAGS)
         d = add_decision(decision="重要決定", reason="理由", topic_id=topic["topic_id"])
         log = add_log(topic_id=topic["topic_id"], title="重要ログ", content="内容")
         a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
-        add_relation("activity", a["activity_id"], [{"type": "topic", "ids": [topic["topic_id"]]}])
         m = add_material("重要資材", "内容", DEFAULT_TAGS, "テスト用データ",
                          related=[{"type": "activity", "ids": [a["activity_id"]]}])
-        _set_pinned("decision", d["decision_id"], True)
-        _set_pinned("log", log["log_id"], True)
-        _set_pinned("material", m["material_id"], True)
+        a2 = add_activity(title="参照タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+
+        add_pin("activity", a["activity_id"], "decision", d["decision_id"])
+        add_pin("activity", a["activity_id"], "log", log["log_id"])
+        add_pin("activity", a["activity_id"], "material", m["material_id"])
+        add_pin("activity", a["activity_id"], "topic", topic["topic_id"])
+        add_pin("activity", a["activity_id"], "activity", a2["activity_id"])
 
         result = check_in(a["activity_id"])
 
@@ -893,3 +986,23 @@ class TestCheckInPinned:
         assert len(result["pinned"]["decisions"]) == 1
         assert len(result["pinned"]["logs"]) == 1
         assert len(result["pinned"]["materials"]) == 1
+        assert len(result["pinned"]["topics"]) == 1
+        assert len(result["pinned"]["activities"]) == 1
+
+    def test_zero_key_omission_in_pinned(self, temp_db):
+        """pinned結果で0件のキーは省略される"""
+        a = add_activity(title="タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        topic = add_topic(title="トピック", description="Desc", tags=DEFAULT_TAGS)
+        # topicのみをpin（他のtypeはピンなし）
+        add_pin("activity", a["activity_id"], "topic", topic["topic_id"])
+
+        result = check_in(a["activity_id"])
+
+        assert "error" not in result
+        assert "pinned" in result
+        assert "topics" in result["pinned"]
+        # 0件のキーは省略される
+        assert "decisions" not in result["pinned"]
+        assert "logs" not in result["pinned"]
+        assert "materials" not in result["pinned"]
+        assert "activities" not in result["pinned"]

--- a/tests/test_migrations/test_0034_pins_directed_relation.py
+++ b/tests/test_migrations/test_0034_pins_directed_relation.py
@@ -214,13 +214,15 @@ class TestPinsMigrationData:
         conn.commit()
         return activity_id, material_id
 
-    def test_pinned_column_still_exists_after_0034(self, migrated_db):
-        """migration 0034適用後もmaterialsテーブルにpinned列が残っている（0035でDROP予定）"""
+    def test_pinned_column_still_exists_after_0034_before_0035(self, db_before_0034):
+        """0033までのDBに0034を適用するとmaterialsテーブルにpinned列が存在する（0035適用前の状態確認）"""
+        _apply_migration_0034(db_before_0034)
+
         conn = get_connection()
         try:
             rows = conn.execute("PRAGMA table_info(materials)").fetchall()
             column_names = {row["name"] for row in rows}
-            assert "pinned" in column_names, "pinned列がmaterialsから削除されている（0035はまだ適用していないはず）"
+            assert "pinned" in column_names, "0034適用後（0035適用前）にpinned列がmaterialsから削除されている"
         finally:
             conn.close()
 

--- a/tests/test_migrations/test_0035_drop_pinned_columns.py
+++ b/tests/test_migrations/test_0035_drop_pinned_columns.py
@@ -1,0 +1,277 @@
+"""migration 0035_drop_pinned_columns のテスト
+
+0035適用後に discussion_logs / decisions / materials の pinned列が存在しないことを確認する。
+SQLite 3.35+ で ALTER TABLE ... DROP COLUMN が使用可能なことを前提とする。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0035含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0035():
+    """0034までのmigrationを適用したDBを提供する。0035の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0035 = MigrationList([m for m in all_migs if m.id < "0035"])
+        with backend.lock():
+            backend.apply_migrations(pre_0035)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0035(db_path: str) -> None:
+    """db_pathに対してmigration 0035のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0035 = MigrationList([m for m in all_migs if m.id.startswith("0035")])
+    with backend.lock():
+        backend.apply_migrations(only_0035)
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    """指定テーブルのカラム名セットを返す。"""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+class TestSQLiteVersion:
+    """DROP COLUMN サポートの前提確認"""
+
+    def test_sqlite_supports_drop_column(self, migrated_db):
+        """実行環境のSQLiteが3.35以上でDROP COLUMNをサポートしている"""
+        conn = get_connection()
+        try:
+            version_row = conn.execute("SELECT sqlite_version()").fetchone()
+            version_str = version_row[0]
+            major, minor, *_ = [int(x) for x in version_str.split(".")]
+            assert (major, minor) >= (3, 35), (
+                f"SQLite {version_str} は DROP COLUMN をサポートしていない（3.35+ が必要）"
+            )
+        finally:
+            conn.close()
+
+
+class TestPinnedColumnsDropped:
+    """0035適用後にpinned列が削除されていることの確認"""
+
+    def test_discussion_logs_has_no_pinned_column_after_0035(self, migrated_db):
+        """migration 0035適用後、discussion_logsテーブルにpinned列が存在しない"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "discussion_logs")
+            assert "pinned" not in column_names, (
+                "discussion_logs.pinned が0035適用後も残っている"
+            )
+        finally:
+            conn.close()
+
+    def test_decisions_has_no_pinned_column_after_0035(self, migrated_db):
+        """migration 0035適用後、decisionsテーブルにpinned列が存在しない"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "decisions")
+            assert "pinned" not in column_names, (
+                "decisions.pinned が0035適用後も残っている"
+            )
+        finally:
+            conn.close()
+
+    def test_materials_has_no_pinned_column_after_0035(self, migrated_db):
+        """migration 0035適用後、materialsテーブルにpinned列が存在しない"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "materials")
+            assert "pinned" not in column_names, (
+                "materials.pinned が0035適用後も残っている"
+            )
+        finally:
+            conn.close()
+
+    def test_pinned_columns_present_before_0035(self, db_before_0035):
+        """0034適用時点では discussion_logs / decisions / materials に pinned列が存在する（前提確認）"""
+        conn = get_connection()
+        try:
+            assert "pinned" in _get_column_names(conn, "discussion_logs"), (
+                "0035適用前のdiscussion_logsにpinned列がない"
+            )
+            assert "pinned" in _get_column_names(conn, "decisions"), (
+                "0035適用前のdecisionsにpinned列がない"
+            )
+            assert "pinned" in _get_column_names(conn, "materials"), (
+                "0035適用前のmaterialsにpinned列がない"
+            )
+        finally:
+            conn.close()
+
+    def test_pinned_columns_removed_after_applying_0035(self, db_before_0035):
+        """0034までのDBに0035を適用すると、3テーブルのpinned列がすべて削除される"""
+        _apply_migration_0035(db_before_0035)
+
+        conn = get_connection()
+        try:
+            assert "pinned" not in _get_column_names(conn, "discussion_logs"), (
+                "0035適用後もdiscussion_logs.pinned が残っている"
+            )
+            assert "pinned" not in _get_column_names(conn, "decisions"), (
+                "0035適用後もdecisions.pinned が残っている"
+            )
+            assert "pinned" not in _get_column_names(conn, "materials"), (
+                "0035適用後もmaterials.pinned が残っている"
+            )
+        finally:
+            conn.close()
+
+
+class TestOtherColumnsUnaffected:
+    """0035でDROPされるべきでないカラムへの影響がないことの確認"""
+
+    def test_discussion_logs_other_columns_intact(self, migrated_db):
+        """0035適用後、discussion_logsのid/title/content/topic_id/retracted_atカラムが保持される"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "discussion_logs")
+            for col in ["id", "title", "content", "topic_id", "retracted_at"]:
+                assert col in column_names, (
+                    f"discussion_logs.{col} が0035適用後に消えている"
+                )
+        finally:
+            conn.close()
+
+    def test_decisions_other_columns_intact(self, migrated_db):
+        """0035適用後、decisionsのid/decision/reason/topic_id/retracted_atカラムが保持される"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "decisions")
+            for col in ["id", "decision", "reason", "topic_id", "retracted_at"]:
+                assert col in column_names, (
+                    f"decisions.{col} が0035適用後に消えている"
+                )
+        finally:
+            conn.close()
+
+    def test_materials_other_columns_intact(self, migrated_db):
+        """0035適用後、materialsのid/title/content/sourceカラムが保持される"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "materials")
+            for col in ["id", "title", "content", "source"]:
+                assert col in column_names, (
+                    f"materials.{col} が0035適用後に消えている"
+                )
+        finally:
+            conn.close()
+
+    def test_pins_table_still_exists_after_0035(self, migrated_db):
+        """0035適用後もpinsテーブルが存在する（0034で作成されたもの）"""
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='pins'"
+            ).fetchone()
+            assert row is not None, "pinsテーブルが0035適用後に消えている"
+        finally:
+            conn.close()
+
+
+class TestDataIntegrity:
+    """0035適用後のデータ操作確認"""
+
+    def test_insert_discussion_log_without_pinned(self, migrated_db):
+        """0035適用後、discussion_logsにpinned列なしでINSERTできる"""
+        conn = get_connection()
+        try:
+            # topicを先に作成
+            conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("テストトピック", "説明"),
+            )
+            topic_id = conn.execute(
+                "SELECT id FROM discussion_topics WHERE title='テストトピック'"
+            ).fetchone()["id"]
+
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, ?, ?)",
+                (topic_id, "テストログ", "内容"),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT title FROM discussion_logs WHERE title='テストログ'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_insert_decision_without_pinned(self, migrated_db):
+        """0035適用後、decisionsにpinned列なしでINSERTできる"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("テストトピック2", "説明"),
+            )
+            topic_id = conn.execute(
+                "SELECT id FROM discussion_topics WHERE title='テストトピック2'"
+            ).fetchone()["id"]
+
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                (topic_id, "テスト決定", "テスト根拠"),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT decision FROM decisions WHERE decision='テスト決定'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_insert_material_without_pinned(self, migrated_db):
+        """0035適用後、materialsにpinned列なしでINSERTできる"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO materials (title, content) VALUES (?, ?)",
+                ("テスト資材", "内容"),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT title FROM materials WHERE title='テスト資材'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()

--- a/tests/unit/test_retract_filter.py
+++ b/tests/unit/test_retract_filter.py
@@ -16,7 +16,7 @@ from src.services.checkin_service import check_in
 from src.services.activity_service import add_activity
 from src.services.relation_service import add_relation
 from src.services.tag_service import _injected_tags
-from tests.helpers import set_pinned
+from src.services.pin_service import add_pin
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -167,7 +167,7 @@ class TestCheckInFilter:
             assert checkin["latest_log"]["id"] != retracted_id
 
     def test_pinned_retracted_decision_excluded_from_checkin(self, activity_with_topic):
-        """pinned + retractedのdecisionはcheck-inのpinnedに含まれない"""
+        """pinsテーブルでpinされたdecisionをretractすると、check-inのpinnedに含まれない"""
         tid = activity_with_topic["topic_id"]
         aid = activity_with_topic["activity_id"]
 
@@ -176,20 +176,20 @@ class TestCheckInFilter:
         ])
         decision_id = result["created"][0]["decision_id"]
 
-        # pin（DBのpinned列を直接設定）→ retract
-        set_pinned("decision", decision_id, True)
+        # pinsテーブルに登録 → retract
+        add_pin("activity", aid, "decision", decision_id)
         retract("decision", [decision_id])
 
         checkin = check_in(aid)
         assert "error" not in checkin
 
-        # pinnedセクションに含まれないこと
+        # retractされているためpinnedセクションに含まれない
         pinned = checkin.get("pinned", {})
         pinned_decision_ids = [d["id"] for d in pinned.get("decisions", [])]
         assert decision_id not in pinned_decision_ids
 
     def test_pinned_retracted_log_excluded_from_checkin(self, activity_with_topic):
-        """pinned + retractedのlogはcheck-inのpinnedに含まれない"""
+        """pinsテーブルでpinされたlogをretractすると、check-inのpinnedに含まれない"""
         tid = activity_with_topic["topic_id"]
         aid = activity_with_topic["activity_id"]
 
@@ -198,13 +198,14 @@ class TestCheckInFilter:
         ])
         log_id = result["created"][0]["log_id"]
 
-        # pin（DBのpinned列を直接設定）→ retract
-        set_pinned("log", log_id, True)
+        # pinsテーブルに登録 → retract
+        add_pin("activity", aid, "log", log_id)
         retract("log", [log_id])
 
         checkin = check_in(aid)
         assert "error" not in checkin
 
+        # retractされているためpinnedセクションに含まれない
         pinned = checkin.get("pinned", {})
         pinned_log_ids = [l["id"] for l in pinned.get("logs", [])]
         assert log_id not in pinned_log_ids

--- a/tests/unit/test_retract_service.py
+++ b/tests/unit/test_retract_service.py
@@ -13,7 +13,8 @@ from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.retract_service import retract
 from src.services.tag_service import _injected_tags
-from tests.helpers import set_pinned
+from src.services.pin_service import add_pin
+from src.services.activity_service import add_activity
 
 
 DEFAULT_TAGS = ["domain:test"]
@@ -229,30 +230,38 @@ class TestRetractValidationErrors:
 
 
 class TestRetractWithPin:
-    """pinned + retractの組み合わせ"""
+    """pinsテーブルでpinされたエンティティのretractテスト"""
 
     def test_retract_pinned_decision(self, topic):
-        """pinされたdecisionもretractできる"""
+        """pinsテーブルでpinされたdecisionもretractできる（pinsエントリが残りretracted_atが設定される）"""
         tid = topic["topic_id"]
         result = add_decisions([
             {"topic_id": tid, "decision": "pinされた決定", "reason": "理由"},
         ])
         decision_id = result["created"][0]["decision_id"]
 
-        # pin（DBのpinned列を直接設定）→ retract
-        set_pinned("decision", decision_id, True)
+        # activityを作成してpinsテーブルにpin登録 → retract
+        act = add_activity(title="テストタスク", description="テスト用", tags=["domain:test"], check_in=False)
+        aid = act["activity_id"]
+        add_pin("activity", aid, "decision", decision_id)
         retract_result = retract("decision", [decision_id])
 
         assert "error" not in retract_result
         assert decision_id in retract_result["success"]
 
-        # pinned=1かつretracted_atが設定されていることを確認
+        # pinsエントリが残りつつretracted_atが設定されていることを確認
         conn = get_connection()
         try:
             row = conn.execute(
-                "SELECT pinned, retracted_at FROM decisions WHERE id = ?", (decision_id,)
+                "SELECT retracted_at FROM decisions WHERE id = ?", (decision_id,)
             ).fetchone()
-            assert row["pinned"] == 1
             assert row["retracted_at"] is not None
+
+            # pinsテーブルのエントリはそのまま残る（D#2149: retract時pins残置）
+            pin_row = conn.execute(
+                "SELECT * FROM pins WHERE source_type='activity' AND source_id=? AND target_type='decision' AND target_id=?",
+                (aid, decision_id),
+            ).fetchone()
+            assert pin_row is not None
         finally:
             conn.close()


### PR DESCRIPTION
## Summary
- migration 0035でdiscussion_logs/decisions/materialsのpinned列をDROP
- check-in時のpinned注入を旧pinned列ベースから新pinsテーブル経由に全面切り替え
- レスポンスのpinnedフィールドを5キー化（decisions/logs/materials/topics/activities）
- coverageからpins注入分を除外しシンプル化

## 関連
- PR #334（PR-a: migration 0034 + add_pin/remove_pin）の後続PR
- A#757 plan-b: pins有向関係拡張の実装
- 設計: D#2135-2137, D#2142-2145, D#2178

## 変更内容

### Migration
- `0035_drop_pinned_columns.sql`: 3テーブルからpinned列をDROP COLUMN

### checkin_service.py
- 旧pinned取得3関数（`_get_pinned_*`）を削除
- `AND pinned = 0` フィルタを撤去
- `_get_pinned_targets(conn, activity_id)` を新設: activity自身のtag + activity自体をソースとするpinsからtargetを取得し、種別ごとにcontent fetch
- `check_in()` のstep構造を再構成、レスポンスを5キー化

### テスト
- `TestCheckInPinned` を全面書き換え（15テスト、新pinsテーブル経由）
- `test_0035_drop_pinned_columns.py` 新規（13テスト）
- 既存テストの`set_pinned`依存を`add_pin`に書き換え

## Test plan
- [ ] `uv run pytest tests/integration/test_checkin_service.py -v` → 60 passed
- [ ] `uv run pytest tests/test_migrations/test_0035_drop_pinned_columns.py -v` → 13 passed
- [ ] `uv run pytest -n auto` → 1240 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)