### PR TITLE
feat: ow基盤 — MCPツール群・recvスクリプト・launcherトグルフィルタ

### DIFF
--- a/scripts/ow/recv.sh
+++ b/scripts/ow/recv.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SSE購読 + recv_filter + 自動再接続
+# 使い方: recv.sh <channel_code> <handle>
+# SSE切断時に1秒間隔で自動再接続する（M#219 §2.5）
+
+RELAY_URL="${RELAY_URL:-http://127.0.0.1:8765}"
+CHANNEL="$1"
+HANDLE="$2"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -z "$CHANNEL" ] || [ -z "$HANDLE" ]; then
+    echo "Usage: recv.sh <channel_code> <handle>" >&2
+    exit 1
+fi
+
+while true; do
+    curl -sN "${RELAY_URL}/stream?channel=${CHANNEL}&handle=${HANDLE}" \
+        | python3 -u "${SCRIPT_DIR}/recv_filter.py" "${HANDLE}"
+    sleep 1
+done

--- a/scripts/ow/recv.sh
+++ b/scripts/ow/recv.sh
@@ -14,7 +14,10 @@ if [ -z "$CHANNEL" ] || [ -z "$HANDLE" ]; then
 fi
 
 while true; do
-    curl -sN "${RELAY_URL}/stream?channel=${CHANNEL}&handle=${HANDLE}" \
+    curl -sN --get \
+        --data-urlencode "channel=${CHANNEL}" \
+        --data-urlencode "handle=${HANDLE}" \
+        "${RELAY_URL}/stream" \
         | python3 -u "${SCRIPT_DIR}/recv_filter.py" "${HANDLE}"
     sleep 1
 done

--- a/scripts/ow/recv_filter.py
+++ b/scripts/ow/recv_filter.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3 -u
+"""SSEストリームから自分宛メッセージのみをstdoutに出力する。
+
+使い方:
+    curl -sN "${RELAY_URL}/stream?channel=${CHANNEL}&handle=${HANDLE}" \\
+        | python3 -u recv_filter.py "${HANDLE}"
+
+自分宛（to=自分のhandle）またはbroadcast（to="*"）のメッセージのみ出力する。
+不正なJSON行はスキップ（クラッシュしない）。
+python -u + 行ごとflushでMonitorへの遅延なし（D#2393）。
+"""
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: recv_filter.py <my_handle>", file=sys.stderr)
+        sys.exit(1)
+
+    my_handle = sys.argv[1]
+
+    for line in sys.stdin:
+        line = line.rstrip("\n")
+        if not line or not line.startswith("data: "):
+            continue
+        try:
+            msg = json.loads(line[6:])
+            body_raw = msg.get("body", "{}")
+            body = json.loads(body_raw) if isinstance(body_raw, str) else body_raw
+            to = body.get("to")
+            if to == my_handle or to == "*":
+                print(line, flush=True)
+        except (json.JSONDecodeError, TypeError, KeyError):
+            continue
+
+
+if __name__ == "__main__":
+    main()

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -361,6 +361,7 @@ def main() -> None:
         except Exception as e:
             # anyioのExceptionGroupによりServerDisconnectedが直接キャッチできない
             # ケースがあるため、例外の種類を問わず統一的にリトライする
+            _pending_tools_list_ids.clear()
             if attempt >= MAX_RETRIES:
                 logger.error("Bridge failed, max retries (%d) exceeded: %s", MAX_RETRIES, e)
                 break

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 # リトライ設定
 MAX_RETRIES = 3
 
+# ow ON/OFFトグル（M#219 §2.6）
+# CCM_OW=1またはOW_ROLE=workerのセッションのみow_*ツールを可視にする
+_OW_ENABLED = os.environ.get("CCM_OW") == "1" or os.environ.get("OW_ROLE") == "worker"
+
+# tools/listリクエストIDのトラッキング（フィルタ対象の特定に使用）
+_pending_tools_list_ids: set = set()
+
 
 class ServerDisconnected(Exception):
     """サーバー側の切断を示す例外。stdin EOFとの区別に使用する。"""
@@ -235,6 +242,16 @@ async def _bridge() -> None:
                         if not line:
                             continue
                         try:
+                            # ow_*フィルタ: tools/listリクエストのIDをトラッキング（OW無効時のみ）
+                            if not _OW_ENABLED:
+                                try:
+                                    parsed = json.loads(line)
+                                    if parsed.get("method") == "tools/list":
+                                        req_id = parsed.get("id")
+                                        if req_id is not None:
+                                            _pending_tools_list_ids.add(req_id)
+                                except (json.JSONDecodeError, AttributeError):
+                                    pass
                             message = types.JSONRPCMessage.model_validate_json(line)
                             session_msg = SessionMessage(message)
                             await write_stream.send(session_msg)
@@ -256,6 +273,8 @@ async def _bridge() -> None:
 
             read_streamが終了したとき、stdin_eofがFalseならサーバー側切断と判断し
             ServerDisconnectedをraiseしてtask group全体をキャンセルする。
+
+            OW無効時はtools/listレスポンスからow_*ツールを除外する（M#219 §2.6）。
             """
             try:
                 async for session_msg_or_exc in read_stream:
@@ -266,6 +285,27 @@ async def _bridge() -> None:
                     json_bytes = message.model_dump_json(
                         by_alias=True, exclude_none=True
                     ).encode("utf-8")
+
+                    # ow_*フィルタ: tools/listレスポンスからow_*を除外（OW無効時のみ）
+                    if not _OW_ENABLED and _pending_tools_list_ids:
+                        try:
+                            parsed = json.loads(json_bytes)
+                            resp_id = parsed.get("id")
+                            if resp_id in _pending_tools_list_ids:
+                                _pending_tools_list_ids.discard(resp_id)
+                                tools = (
+                                    parsed.get("result", {}).get("tools", [])
+                                )
+                                if tools:
+                                    filtered = [
+                                        t for t in tools
+                                        if not t.get("name", "").startswith("ow_")
+                                    ]
+                                    parsed["result"]["tools"] = filtered
+                                    json_bytes = json.dumps(parsed, ensure_ascii=False).encode("utf-8")
+                        except (json.JSONDecodeError, AttributeError, KeyError):
+                            pass
+
                     sys.stdout.buffer.write(json_bytes + b"\n")
                     sys.stdout.buffer.flush()
             except anyio.ClosedResourceError:

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from src.services import (
     retract_service,
     timeline_service,
     harness_service,
+    ow_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -968,6 +969,151 @@ def get_config() -> dict:
 def roll_dice(sides: int = 10) -> dict:
     """指定面数のダイスを振る。デフォルト1d10。"""
     return {"result": random.randint(1, sides)}
+
+
+# ----------------------------
+# ow（orch/worker）ツール群
+# CCM_OW=1またはOW_ROLE=workerのセッションのみ可視（launcher.pyでフィルタ）
+# ----------------------------
+
+
+@mcp.tool()
+def ow_send(
+    channel: str,
+    handle: str,
+    body: dict,
+    needs_reply: bool = False,
+    in_reply_to: int | None = None,
+) -> dict:
+    """ow channelにメッセージを送信する。
+
+    bodyはow固有JSONを格納するdict（{"v":1, "kind":"cmd"|"state", ...}）。
+    4xx即失敗、5xx/接続断のみ3回指数バックオフ。
+
+    Args:
+        channel: channelコード
+        handle: 送信者handle（例: "orch", "w-a"）
+        body: ow固有JSON。relayのbody内に格納される
+        needs_reply: 返信を期待するか（デフォルト: False）
+        in_reply_to: 返信先のmsg_id（optional）
+
+    Returns:
+        成功時: {"msg_id": int}
+        失敗時: {"error": {...}}
+    """
+    return ow_service.ow_send(channel, handle, body, needs_reply, in_reply_to)
+
+
+@mcp.tool()
+def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+    """ow channelの履歴を取得する。受信処理の本体。
+
+    since自身を含まない（msg_id > since）。
+    SSEは起床信号専用。起床後はこのツールで未処理メッセージを全件pull（D#2392）。
+
+    Args:
+        channel: channelコード
+        since: このmsg_idより大きいものを返す（0=全件）
+        limit: 最大取得件数（デフォルト: 100）
+
+    Returns:
+        {"messages": [{"msg_id": int, "handle": str, "body": dict, ...}, ...]}
+        失敗時: {"error": {...}}
+    """
+    return ow_service.ow_history(channel, since, limit)
+
+
+@mcp.tool()
+def ow_spawn_worker(
+    alias: str,
+    channel: str,
+    cwd: str,
+    model: str,
+    permission: str = "acceptEdits",
+    task_title: str = "",
+    acceptance: str = "",
+    context: str = "",
+    playbook: str = "",
+    timeout_min: int = 60,
+    activity_id: int | None = None,
+    topic_id: str | None = None,
+    task_n: int = 1,
+) -> dict:
+    """workerセッションを起動する。
+
+    処理順: queueへspawning write-ahead → task file書き出し → アダプタ起動 → 安定ID返却。
+    relay疎通確認・起動（ensure-server処理）も内包。
+
+    OW_TERMINAL環境変数でアダプタを選択（iterm2/tmux/manual。manualは起動コマンド表示のフォールバック）。
+
+    Args:
+        alias: workerのhandle（例: "w-a"）
+        channel: channelコード
+        cwd: workerの作業ディレクトリ
+        model: 使用モデル（例: "sonnet", "opus"）
+        permission: permission_mode（デフォルト: "acceptEdits"）
+        task_title: タスクタイトル
+        acceptance: 完了条件
+        context: タスクコンテキスト
+        playbook: プレイブック抜粋（assignのplaybookフィールド）
+        timeout_min: タイムアウト（分、デフォルト: 60）
+        activity_id: 対応するアクティビティID（optional）
+        topic_id: 対応するトピックID（optional）
+        task_n: タスク番号（T<n>）
+
+    Returns:
+        成功時: {"term_ref": str, "task_file": str, "spawning": "ok", "alias": str}
+        manualフォールバック時: {"command": str, "manual": True, "task_file": str, "alias": str}
+        失敗時: {"error": {...}}
+    """
+    return ow_service.ow_spawn_worker(
+        alias=alias,
+        channel=channel,
+        cwd=cwd,
+        model=model,
+        permission=permission,
+        task_title=task_title,
+        acceptance=acceptance,
+        context=context,
+        playbook=playbook,
+        timeout_min=timeout_min,
+        activity_id=activity_id,
+        topic_id=topic_id,
+        task_n=task_n,
+    )
+
+
+@mcp.tool()
+def ow_close_worker(term_ref: str) -> dict:
+    """アダプタ経由でworkerセッションをクローズする。
+
+    OW_TERMINAL環境変数でアダプタを選択。アダプタ不在時はmanualフォールバック（手動クローズ案内）。
+
+    Args:
+        term_ref: 安定ID（iTerm2のsession UUID、tmuxのpane ID等。タブindexは不安定なため使用しない）
+
+    Returns:
+        成功時: {"closed": True, "term_ref": str}
+        manualフォールバック時: {"manual": True, "message": str}
+        失敗時: {"error": {...}}
+    """
+    return ow_service.ow_close_worker(term_ref)
+
+
+@mcp.tool()
+def ow_status(channel: str, topic_id: str | None = None) -> dict:
+    """queueサマリ＋GetPresence（worker死活）の合成ビュー。
+
+    queueの論理状態とrelayのpresence（物理接続）を統合して、orchが判断に使える単一ビューを返す。
+
+    Args:
+        channel: channelコード（presence取得に使用）
+        topic_id: queueファイル特定に使用（OW_QUEUE_DIRと組み合わせ）
+
+    Returns:
+        {"tasks": [...], "presence": [...], "summary": {"total_tasks": int, "status_counts": dict, "online_workers": [...]}}
+    """
+    return ow_service.ow_status(channel, topic_id)
 
 
 # セッションエンドポイント（HTTPモード用カスタムルート）

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1,0 +1,569 @@
+"""ow（orch/worker）基盤サービス
+
+relay HTTPサーバーとのやり取り、worker spawn/close、ステータス管理を担う。
+外部HTTPのためcc-memory DBのconn共有パターンは不要。urllib.requestベース（サードパーティ依存なし）。
+"""
+import json
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------
+# 設定定数
+# ----------------------------
+
+RELAY_URL = os.environ.get("RELAY_URL", "http://127.0.0.1:8765")
+RELAY_DIR = os.environ.get("RELAY_DIR", str(Path.home() / "workspace" / "powwow"))
+OW_QUEUE_DIR = os.environ.get("OW_QUEUE_DIR", "")
+
+_MAX_RETRIES = 3
+
+
+# ----------------------------
+# relay HTTPヘルパー
+# ----------------------------
+
+
+def _relay_request(method: str, path: str, data: dict | None = None) -> dict:
+    """relay HTTPリクエストの共通ヘルパー。4xx即失敗、5xx/接続断のみリトライ。
+
+    Args:
+        method: "GET" or "POST"
+        path: relayエンドポイントパス（例: "/send", "/history?channel=...&since=0"）
+        data: POSTボディ（Noneの場合はGET）
+
+    Returns:
+        レスポンスJSON dictまたは {"error": ...}
+    """
+    url = f"{RELAY_URL}{path}"
+    body_bytes = json.dumps(data).encode("utf-8") if data is not None else None
+
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body_bytes,
+                headers={"Content-Type": "application/json"} if body_bytes else {},
+                method=method,
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code < 500:
+                # 4xx: クライアントエラー → 即失敗（リトライしない）
+                try:
+                    err_body = json.loads(e.read())
+                except Exception:
+                    err_body = {"message": str(e)}
+                return {"error": {"code": e.code, "message": err_body}}
+            if attempt >= _MAX_RETRIES:
+                raise
+            sleep_secs = 2 ** attempt
+            logger.warning(
+                "relay %s %s returned %d, retrying in %ds (%d/%d)",
+                method, path, e.code, sleep_secs, attempt + 1, _MAX_RETRIES,
+            )
+            time.sleep(sleep_secs)
+        except (urllib.error.URLError, ConnectionError, OSError) as e:
+            if attempt >= _MAX_RETRIES:
+                raise
+            sleep_secs = 2 ** attempt
+            logger.warning(
+                "relay %s %s failed: %s, retrying in %ds (%d/%d)",
+                method, path, e, sleep_secs, attempt + 1, _MAX_RETRIES,
+            )
+            time.sleep(sleep_secs)
+
+    # ここには到達しない（ループ内でraiseされる）
+    raise RuntimeError("unreachable")
+
+
+# ----------------------------
+# relayサーバー起動確認
+# ----------------------------
+
+
+def _is_relay_running() -> bool:
+    """relayサーバーの生存確認。"""
+    try:
+        req = urllib.request.Request(
+            f"{RELAY_URL}/presence?channel=__health__",
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            return resp.status == 200
+    except urllib.error.HTTPError as e:
+        # 404でもサーバー起動済みと判定可能
+        return e.code in (404, 400)
+    except Exception:
+        return False
+
+
+def _start_relay_server() -> bool:
+    """relayサーバーをバックグラウンドで起動する。"""
+    relay_dir = Path(RELAY_DIR).expanduser()
+    server_py = relay_dir / "server.py"
+    if not server_py.exists():
+        logger.warning("relay server.py not found at %s", server_py)
+        return False
+    try:
+        subprocess.Popen(
+            [sys.executable, str(server_py)],
+            cwd=str(relay_dir),
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        logger.info("relay server process started")
+        return True
+    except OSError as e:
+        logger.warning("Failed to start relay server: %s", e)
+        return False
+
+
+def ensure_relay_server() -> bool:
+    """relayサーバーの起動確認 → 未起動なら自動起動 → 待機。
+
+    Returns:
+        Trueなら接続可能、Falseなら起動失敗またはタイムアウト
+    """
+    if _is_relay_running():
+        return True
+    if not _start_relay_server():
+        return False
+    # 最大10秒待機（0.5秒間隔 x 20回）
+    for _ in range(20):
+        time.sleep(0.5)
+        if _is_relay_running():
+            logger.info("relay server is ready")
+            return True
+    logger.warning("relay server failed to start within 10 seconds")
+    return False
+
+
+# ----------------------------
+# T1: ow_send
+# ----------------------------
+
+
+def ow_send(
+    channel: str,
+    handle: str,
+    body: dict,
+    needs_reply: bool = False,
+    in_reply_to: int | None = None,
+) -> dict:
+    """ow channelにメッセージを送信する。
+
+    bodyはow固有JSONを格納するdict（relay schemaは無改修）。
+    4xx即失敗、5xx/接続断のみ3回指数バックオフ。
+
+    Args:
+        channel: channelコード
+        handle: 送信者handle（例: "orch", "w-a"）
+        body: ow固有JSON（{"v":1, "kind":"cmd"|"state", ...}）
+        needs_reply: 返信を期待するか
+        in_reply_to: 返信先のmsg_id
+
+    Returns:
+        成功時: {"msg_id": int}
+        失敗時: {"error": {...}}
+    """
+    payload: dict = {
+        "channel": channel,
+        "handle": handle,
+        "body": json.dumps(body),
+        "needs_reply": needs_reply,
+    }
+    if in_reply_to is not None:
+        payload["in_reply_to"] = in_reply_to
+
+    return _relay_request("POST", "/send", payload)
+
+
+# ----------------------------
+# T2: ow_history
+# ----------------------------
+
+
+def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+    """GET /history。受信処理の本体。
+
+    since自身を含まない（msg_id > since）。
+
+    Args:
+        channel: channelコード
+        since: このmsg_idより大きいものを返す（0=全件）
+        limit: 最大取得件数
+
+    Returns:
+        {"messages": [{"msg_id": int, "handle": str, "body": dict, ...}, ...]}
+        失敗時: {"error": {...}}
+    """
+    path = f"/history?channel={channel}&since={since}&limit={limit}"
+    result = _relay_request("GET", path)
+    if "error" in result:
+        return result
+
+    # bodyがJSON文字列の場合はパースする
+    messages = result.get("messages", [])
+    for msg in messages:
+        if isinstance(msg.get("body"), str):
+            try:
+                msg["body"] = json.loads(msg["body"])
+            except (json.JSONDecodeError, TypeError):
+                pass  # パース失敗はそのまま文字列で返す
+
+    return {"messages": messages}
+
+
+# ----------------------------
+# T3: ow_spawn_worker / ow_close_worker
+# ----------------------------
+
+
+def _get_queue_dir() -> Path | None:
+    """queueディレクトリパスを返す（OW_QUEUE_DIR環境変数）。"""
+    if OW_QUEUE_DIR:
+        return Path(OW_QUEUE_DIR).expanduser()
+    return None
+
+
+def _write_queue_spawning(
+    queue_dir: Path,
+    topic_id: str,
+    alias: str,
+    task_n: int,
+    cwd: str,
+) -> None:
+    """queueファイルにspawning write-aheadを記録する（孤児worker対策）。"""
+    queue_file = queue_dir / f"queue-t{topic_id}.md"
+    now = datetime.now(timezone.utc).isoformat()
+
+    spawning_entry = (
+        f"\n## T{task_n} | spawning | spawning\n"
+        f"- worker: {alias} / term_ref: (pending) / session: (pending)\n"
+        f"- spawning: {now}\n"
+    )
+
+    queue_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(queue_file, "a", encoding="utf-8") as f:
+        f.write(spawning_entry)
+
+
+def _write_task_file(
+    task_dir: Path,
+    task_n: int,
+    alias: str,
+    channel: str,
+    cwd: str,
+    model: str,
+    permission: str,
+    task_title: str,
+    acceptance: str,
+    context: str,
+    playbook: str,
+    timeout_min: int,
+    activity_id: int | None,
+    topic_id: str | None,
+) -> Path:
+    """task fileを書き出す。"""
+    task_file = task_dir / f"T{task_n}.json"
+    task_file.parent.mkdir(parents=True, exist_ok=True)
+
+    task_data = {
+        "v": 1,
+        "task": f"T{task_n}",
+        "alias": alias,
+        "channel": channel,
+        "cwd": cwd,
+        "model": model,
+        "permission_mode": permission,
+        "title": task_title,
+        "acceptance": acceptance,
+        "context": context,
+        "playbook": playbook,
+        "timeout_min": timeout_min,
+        "activity_id": activity_id,
+        "topic_id": topic_id,
+    }
+
+    with open(task_file, "w", encoding="utf-8") as f:
+        json.dump(task_data, f, ensure_ascii=False, indent=2)
+
+    return task_file
+
+
+def _get_adapter_path(terminal: str) -> Path | None:
+    """アダプタスクリプトのパスを返す（不在ならNone）。"""
+    scripts_dir = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "adapters"
+    adapter = scripts_dir / f"{terminal}.sh"
+    if adapter.exists():
+        return adapter
+    return None
+
+
+def ow_spawn_worker(
+    alias: str,
+    channel: str,
+    cwd: str,
+    model: str,
+    permission: str = "acceptEdits",
+    task_title: str = "",
+    acceptance: str = "",
+    context: str = "",
+    playbook: str = "",
+    timeout_min: int = 60,
+    activity_id: int | None = None,
+    topic_id: str | None = None,
+    task_n: int = 1,
+) -> dict:
+    """workerセッションを起動する。
+
+    処理順: queueへspawning write-ahead → task file書き出し → アダプタ呼び出し → 安定ID返却
+
+    Args:
+        alias: workerのhandle（例: "w-a"）
+        channel: channelコード
+        cwd: workerの作業ディレクトリ
+        model: 使用モデル（例: "sonnet", "opus"）
+        permission: permission_mode（デフォルト: "acceptEdits"）
+        task_title: タスクタイトル
+        acceptance: 完了条件
+        context: タスクコンテキスト
+        playbook: プレイブック抜粋
+        timeout_min: タイムアウト（分）
+        activity_id: 対応するアクティビティID
+        topic_id: 対応するトピックID
+        task_n: タスク番号（Tn）
+
+    Returns:
+        {"term_ref": str, "task_file": str, "spawning": "ok"}
+        manualフォールバック時: {"command": str, "manual": True, "task_file": str}
+    """
+    # relayサーバー確認
+    if not ensure_relay_server():
+        return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
+
+    # task file書き出し先の決定
+    queue_dir = _get_queue_dir()
+    if queue_dir is None:
+        # OW_QUEUE_DIR未設定の場合は一時的なパスを使用
+        queue_dir = Path.home() / ".cc-memory-ow" / "orch"
+
+    task_dir = queue_dir / "tasks"
+
+    # queueへspawning write-ahead（孤児worker対策 D#2395）
+    if topic_id is not None:
+        _write_queue_spawning(queue_dir, str(topic_id), alias, task_n, cwd)
+
+    # task fileを書き出す
+    task_file = _write_task_file(
+        task_dir=task_dir,
+        task_n=task_n,
+        alias=alias,
+        channel=channel,
+        cwd=cwd,
+        model=model,
+        permission=permission,
+        task_title=task_title,
+        acceptance=acceptance,
+        context=context,
+        playbook=playbook,
+        timeout_min=timeout_min,
+        activity_id=activity_id,
+        topic_id=topic_id,
+    )
+
+    # アダプタ起動
+    terminal = os.environ.get("OW_TERMINAL", "manual")
+    adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
+
+    worker_cmd = (
+        f'env OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
+        f'OW_TASK_FILE={shlex.quote(str(task_file))} '
+        f'claude --model {shlex.quote(model)} --permission-mode {shlex.quote(permission)} '
+        f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
+    )
+
+    if adapter_path is None:
+        # manualフォールバック: 起動コマンドを返す
+        return {
+            "command": worker_cmd,
+            "manual": True,
+            "task_file": str(task_file),
+            "alias": alias,
+        }
+
+    # アダプタ呼び出し
+    term_ref = str(uuid.uuid4())
+    try:
+        subprocess.run(
+            ["bash", str(adapter_path), "spawn", cwd, worker_cmd, term_ref],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.warning("adapter spawn failed: %s", e.stderr)
+        # アダプタ失敗時はmanualフォールバック
+        return {
+            "command": worker_cmd,
+            "manual": True,
+            "task_file": str(task_file),
+            "alias": alias,
+            "adapter_error": e.stderr,
+        }
+
+    return {
+        "term_ref": term_ref,
+        "task_file": str(task_file),
+        "spawning": "ok",
+        "alias": alias,
+    }
+
+
+def ow_close_worker(term_ref: str) -> dict:
+    """アダプタ経由でworkerセッションをクローズする。
+
+    Args:
+        term_ref: 安定ID（iterm2のsession UUID、tmuxのpane ID等）
+
+    Returns:
+        {"closed": True} または {"error": ...}
+    """
+    terminal = os.environ.get("OW_TERMINAL", "manual")
+    adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
+
+    if adapter_path is None:
+        return {
+            "manual": True,
+            "message": f"手動でterm_ref={term_ref}のセッションをクローズしてください",
+        }
+
+    try:
+        subprocess.run(
+            ["bash", str(adapter_path), "close", term_ref],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return {"closed": True, "term_ref": term_ref}
+    except subprocess.CalledProcessError as e:
+        logger.warning("adapter close failed: %s", e.stderr)
+        return {
+            "error": {"code": "ADAPTER_CLOSE_FAILED", "message": e.stderr},
+            "term_ref": term_ref,
+        }
+
+
+# ----------------------------
+# T4: ow_status
+# ----------------------------
+
+
+def _parse_queue_file(queue_file: Path) -> list[dict]:
+    """queueファイルをパースしてタスク一覧を返す。"""
+    if not queue_file.exists():
+        return []
+
+    tasks = []
+    current_task: dict | None = None
+
+    try:
+        content = queue_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    for line in content.splitlines():
+        line = line.strip()
+        # タスクヘッダー: ## T1 | タイトル | status
+        if line.startswith("## T") and " | " in line:
+            if current_task is not None:
+                tasks.append(current_task)
+            parts = line.lstrip("# ").split(" | ")
+            task_id = parts[0].strip() if len(parts) > 0 else "?"
+            task_title = parts[1].strip() if len(parts) > 1 else ""
+            task_status = parts[2].strip() if len(parts) > 2 else "unknown"
+            current_task = {
+                "task": task_id,
+                "title": task_title,
+                "status": task_status,
+                "worker": None,
+                "term_ref": None,
+            }
+        elif current_task is not None and line.startswith("- worker:"):
+            # "- worker: w-a / term_ref: iterm2:xxx / session: <uuid>"
+            worker_info = line[len("- worker:"):].strip()
+            for part in worker_info.split("/"):
+                part = part.strip()
+                if part.startswith("term_ref:"):
+                    current_task["term_ref"] = part[len("term_ref:"):].strip()
+                elif not part.startswith("session:"):
+                    current_task["worker"] = part
+
+    if current_task is not None:
+        tasks.append(current_task)
+
+    return tasks
+
+
+def ow_status(channel: str, topic_id: str | None = None) -> dict:
+    """queueサマリ＋GetPresence（worker死活）の合成ビュー。
+
+    Args:
+        channel: channelコード（presence取得に使用）
+        topic_id: queueファイル特定に使用（OW_QUEUE_DIRと組み合わせ）
+
+    Returns:
+        {"tasks": [...], "presence": [...], "summary": {...}}
+    """
+    # presenceを取得
+    presence_result = _relay_request("GET", f"/presence?channel={channel}")
+    if "error" in presence_result:
+        handles = []
+    else:
+        handles = presence_result.get("handles", [])
+
+    # queueファイルをパース
+    tasks: list[dict] = []
+    queue_dir = _get_queue_dir()
+    if queue_dir is not None and topic_id is not None:
+        queue_file = queue_dir / f"queue-t{topic_id}.md"
+        tasks = _parse_queue_file(queue_file)
+    elif queue_dir is not None:
+        # topic_id未指定の場合は存在する全queueファイルを読む
+        for queue_file in sorted(queue_dir.glob("queue-t*.md")):
+            tasks.extend(_parse_queue_file(queue_file))
+
+    # presenceとqueueの統合
+    for task in tasks:
+        worker = task.get("worker")
+        if worker:
+            task["online"] = worker in handles
+
+    # サマリ
+    status_counts: dict[str, int] = {}
+    for task in tasks:
+        s = task.get("status", "unknown")
+        status_counts[s] = status_counts.get(s, 0) + 1
+
+    return {
+        "tasks": tasks,
+        "presence": handles,
+        "summary": {
+            "total_tasks": len(tasks),
+            "status_counts": status_counts,
+            "online_workers": [h for h in handles if h.startswith("w-")],
+        },
+    }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 import urllib.error
 import uuid
@@ -210,7 +211,8 @@ def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
         {"messages": [{"msg_id": int, "handle": str, "body": dict, ...}, ...]}
         失敗時: {"error": {...}}
     """
-    path = f"/history?channel={channel}&since={since}&limit={limit}"
+    params = urllib.parse.urlencode({"channel": channel, "since": since, "limit": limit})
+    path = f"/history?{params}"
     result = _relay_request("GET", path)
     if "error" in result:
         return result
@@ -253,6 +255,7 @@ def _write_queue_spawning(
     spawning_entry = (
         f"\n## T{task_n} | spawning | spawning\n"
         f"- worker: {alias} / term_ref: (pending) / session: (pending)\n"
+        f"- cwd: {cwd}\n"
         f"- spawning: {now}\n"
     )
 
@@ -413,10 +416,19 @@ def ow_spawn_worker(
             check=True,
             capture_output=True,
             text=True,
+            timeout=30,
         )
+    except subprocess.TimeoutExpired:
+        logger.warning("adapter spawn timed out after 30s")
+        return {
+            "command": worker_cmd,
+            "manual": True,
+            "task_file": str(task_file),
+            "alias": alias,
+            "adapter_error": "adapter spawn timed out",
+        }
     except subprocess.CalledProcessError as e:
         logger.warning("adapter spawn failed: %s", e.stderr)
-        # アダプタ失敗時はmanualフォールバック
         return {
             "command": worker_cmd,
             "manual": True,
@@ -457,8 +469,15 @@ def ow_close_worker(term_ref: str) -> dict:
             check=True,
             capture_output=True,
             text=True,
+            timeout=15,
         )
         return {"closed": True, "term_ref": term_ref}
+    except subprocess.TimeoutExpired:
+        logger.warning("adapter close timed out after 15s")
+        return {
+            "error": {"code": "ADAPTER_CLOSE_TIMEOUT", "message": "adapter close timed out"},
+            "term_ref": term_ref,
+        }
     except subprocess.CalledProcessError as e:
         logger.warning("adapter close failed: %s", e.stderr)
         return {
@@ -493,8 +512,8 @@ def _parse_queue_file(queue_file: Path) -> list[dict]:
                 tasks.append(current_task)
             parts = line.lstrip("# ").split(" | ")
             task_id = parts[0].strip() if len(parts) > 0 else "?"
-            task_title = parts[1].strip() if len(parts) > 1 else ""
-            task_status = parts[2].strip() if len(parts) > 2 else "unknown"
+            task_status = parts[-1].strip() if len(parts) > 2 else "unknown"
+            task_title = " | ".join(parts[1:-1]).strip() if len(parts) > 2 else (parts[1].strip() if len(parts) > 1 else "")
             current_task = {
                 "task": task_id,
                 "title": task_title,
@@ -529,7 +548,7 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
         {"tasks": [...], "presence": [...], "summary": {...}}
     """
     # presenceを取得
-    presence_result = _relay_request("GET", f"/presence?channel={channel}")
+    presence_result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")
     if "error" in presence_result:
         handles = []
     else:

--- a/tests/unit/test_ow_launcher_filter.py
+++ b/tests/unit/test_ow_launcher_filter.py
@@ -1,0 +1,168 @@
+"""launcherのtools/listフィルタのユニットテスト（M#219 §2.6）
+
+エッジケース:
+- CCM_OW未設定&OW_ROLE未設定 → tools/list応答からow_*を除外
+- CCM_OW=1 → ow_*を含めた全ツールを返す
+- OW_ROLE=worker → ow_*を含めた全ツールを返す
+- ow_*以外のツールは常に全て返す
+"""
+import json
+import os
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _reload_launcher_with_env(env_vars: dict) -> Any:
+    """環境変数を設定してlauncher.pyを再ロードする"""
+    env_patch: dict = {"CC_MEMORY_URL": ""}
+    for key in ("CCM_OW", "OW_ROLE"):
+        env_patch[key] = ""  # デフォルトは空（未設定相当）
+    env_patch.update(env_vars)
+
+    with patch.dict(os.environ, env_patch):
+        if "src.launcher" in sys.modules:
+            del sys.modules["src.launcher"]
+        import src.launcher as launcher
+        return launcher
+
+
+ALL_TOOLS = [
+    {"name": "search", "description": "検索"},
+    {"name": "add_topic", "description": "トピック追加"},
+    {"name": "ow_send", "description": "OW送信"},
+    {"name": "ow_history", "description": "OW履歴"},
+    {"name": "ow_spawn_worker", "description": "OWワーカー起動"},
+    {"name": "ow_close_worker", "description": "OWワーカー終了"},
+    {"name": "ow_status", "description": "OWステータス"},
+]
+
+NON_OW_TOOLS = [t for t in ALL_TOOLS if not t["name"].startswith("ow_")]
+OW_TOOLS = [t for t in ALL_TOOLS if t["name"].startswith("ow_")]
+
+
+def _make_response(tools: list, resp_id: int = 1) -> dict:
+    return {"jsonrpc": "2.0", "id": resp_id, "result": {"tools": tools}}
+
+
+def _apply_filter(m: Any, response: dict, req_id: int) -> dict:
+    """ブリッジロジックのフィルタ部分を再現する"""
+    json_bytes = json.dumps(response).encode("utf-8")
+
+    if not m._OW_ENABLED and m._pending_tools_list_ids:
+        try:
+            parsed = json.loads(json_bytes)
+            rid = parsed.get("id")
+            if rid in m._pending_tools_list_ids:
+                m._pending_tools_list_ids.discard(rid)
+                tools = parsed.get("result", {}).get("tools", [])
+                if tools:
+                    filtered = [t for t in tools if not t.get("name", "").startswith("ow_")]
+                    parsed["result"]["tools"] = filtered
+                    json_bytes = json.dumps(parsed, ensure_ascii=False).encode("utf-8")
+        except (json.JSONDecodeError, AttributeError, KeyError):
+            pass
+
+    return json.loads(json_bytes)
+
+
+class TestOwEnabled:
+    """CCM_OW=1またはOW_ROLE=workerの場合はow_*を含めた全ツールを返す"""
+
+    def test_ccm_ow_1_is_enabled(self):
+        """CCM_OW=1のとき _OW_ENABLED=True"""
+        launcher = _reload_launcher_with_env({"CCM_OW": "1"})
+        assert launcher._OW_ENABLED is True
+
+    def test_ow_role_worker_is_enabled(self):
+        """OW_ROLE=workerのとき _OW_ENABLED=True"""
+        launcher = _reload_launcher_with_env({"OW_ROLE": "worker"})
+        assert launcher._OW_ENABLED is True
+
+    def test_ow_role_orch_is_disabled(self):
+        """OW_ROLE=orch など worker以外は _OW_ENABLED=False"""
+        launcher = _reload_launcher_with_env({"OW_ROLE": "orch"})
+        assert launcher._OW_ENABLED is False
+
+    def test_ow_role_empty_is_disabled(self):
+        """OW_ROLE=（空文字）は _OW_ENABLED=False"""
+        launcher = _reload_launcher_with_env({"OW_ROLE": ""})
+        assert launcher._OW_ENABLED is False
+
+
+class TestOwDisabled:
+    """CCM_OW未設定&OW_ROLE未設定の場合はow_*を除外"""
+
+    def test_no_env_is_disabled(self):
+        """環境変数なしのとき _OW_ENABLED=False"""
+        launcher = _reload_launcher_with_env({})
+        assert launcher._OW_ENABLED is False
+
+    def test_ccm_ow_0_is_disabled(self):
+        """CCM_OW=0のとき _OW_ENABLED=False"""
+        launcher = _reload_launcher_with_env({"CCM_OW": "0"})
+        assert launcher._OW_ENABLED is False
+
+
+class TestFilterLogic:
+    """tools/listレスポンスのフィルタロジックを検証する"""
+
+    def test_disabled_filters_ow_tools(self):
+        """OW無効時はtools/listレスポンスからow_*を除外する"""
+        m = _reload_launcher_with_env({})
+        assert m._OW_ENABLED is False
+        m._pending_tools_list_ids.add(42)
+        result = _apply_filter(m, _make_response(ALL_TOOLS, 42), 42)
+        names = [t["name"] for t in result["result"]["tools"]]
+        for t in OW_TOOLS:
+            assert t["name"] not in names
+        for t in NON_OW_TOOLS:
+            assert t["name"] in names
+
+    def test_enabled_returns_all_tools(self):
+        """OW有効時はow_*を含めた全ツールを返す（フィルタしない）"""
+        m = _reload_launcher_with_env({"CCM_OW": "1"})
+        assert m._OW_ENABLED is True
+        # OW有効時はIDをトラッキングしないのでpending_idsは空のまま
+        result = _apply_filter(m, _make_response(ALL_TOOLS, 43), 43)
+        names = [t["name"] for t in result["result"]["tools"]]
+        for t in ALL_TOOLS:
+            assert t["name"] in names
+
+    def test_non_ow_tools_always_returned(self):
+        """ow_*以外のツールは常に全て返す"""
+        m = _reload_launcher_with_env({})
+        assert m._OW_ENABLED is False
+        m._pending_tools_list_ids.add(44)
+        result = _apply_filter(m, _make_response(NON_OW_TOOLS, 44), 44)
+        names = [t["name"] for t in result["result"]["tools"]]
+        for t in NON_OW_TOOLS:
+            assert t["name"] in names
+
+    def test_untracked_id_not_filtered(self):
+        """トラッキングされていないIDのレスポンスはフィルタしない"""
+        m = _reload_launcher_with_env({})
+        assert m._OW_ENABLED is False
+        m._pending_tools_list_ids.clear()
+        result = _apply_filter(m, _make_response(ALL_TOOLS, 99), 99)
+        names = [t["name"] for t in result["result"]["tools"]]
+        for t in OW_TOOLS:
+            assert t["name"] in names
+
+    def test_id_discarded_after_filter(self):
+        """フィルタ後はpending_tools_list_idsからIDが除去される"""
+        m = _reload_launcher_with_env({})
+        m._pending_tools_list_ids.add(55)
+        _apply_filter(m, _make_response(ALL_TOOLS, 55), 55)
+        assert 55 not in m._pending_tools_list_ids
+
+    def test_ow_role_worker_returns_all_tools(self):
+        """OW_ROLE=workerのときもow_*を含めた全ツールを返す"""
+        m = _reload_launcher_with_env({"OW_ROLE": "worker"})
+        assert m._OW_ENABLED is True
+        result = _apply_filter(m, _make_response(ALL_TOOLS, 77), 77)
+        names = [t["name"] for t in result["result"]["tools"]]
+        for t in ALL_TOOLS:
+            assert t["name"] in names

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -61,6 +61,16 @@ class TestParseQueueFile:
         tasks = ow_service._parse_queue_file(queue_file)
         assert tasks == []
 
+    def test_handles_pipe_in_title(self, tmp_path: Path):
+        """タイトルに ' | ' が含まれていてもstatusが正しくパースされる"""
+        content = "## T1 | fix: A | B問題 | in_progress\n- worker: w-a / term_ref: uuid-1 / session: s1\n"
+        queue_file = tmp_path / "queue-t1.md"
+        queue_file.write_text(content, encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        assert len(tasks) == 1
+        assert tasks[0]["title"] == "fix: A | B問題"
+        assert tasks[0]["status"] == "in_progress"
+
     def test_handles_spawning_status(self, tmp_path: Path):
         """spawningステータスのwrite-aheadエントリをパースできる"""
         content = "## T3 | new task | spawning\n- worker: w-b / term_ref: (pending) / session: (pending)\n"

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -1,0 +1,242 @@
+"""queueファイルのパース/シリアライズのユニットテスト（M#219 §3.2）"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+SAMPLE_QUEUE_CONTENT = """\
+---
+topic_id: 454
+channel_code: AbCdEfGh
+---
+
+## T1 | pin引き継ぎUI実装 | in_progress
+- worker: w-a / term_ref: iterm2:8CDF1801-ABCD / session: sess-1
+- activity: 801
+
+## T2 | データ移行スクリプト作成 | queued
+"""
+
+
+class TestParseQueueFile:
+    def test_parses_basic_queue(self, tmp_path: Path):
+        """基本的なqueueファイルをパースできる"""
+        queue_file = tmp_path / "queue-t454.md"
+        queue_file.write_text(SAMPLE_QUEUE_CONTENT, encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        assert len(tasks) == 2
+
+    def test_parses_task_fields(self, tmp_path: Path):
+        """タスクのフィールドが正しくパースされる"""
+        queue_file = tmp_path / "queue-t454.md"
+        queue_file.write_text(SAMPLE_QUEUE_CONTENT, encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        t1 = tasks[0]
+        assert t1["task"] == "T1"
+        assert t1["title"] == "pin引き継ぎUI実装"
+        assert t1["status"] == "in_progress"
+        assert t1["term_ref"] == "iterm2:8CDF1801-ABCD"
+
+    def test_parses_queued_task(self, tmp_path: Path):
+        """queuedステータスのタスクもパースできる"""
+        queue_file = tmp_path / "queue-t454.md"
+        queue_file.write_text(SAMPLE_QUEUE_CONTENT, encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        t2 = tasks[1]
+        assert t2["task"] == "T2"
+        assert t2["status"] == "queued"
+
+    def test_returns_empty_for_nonexistent_file(self, tmp_path: Path):
+        """存在しないファイルは空リストを返す"""
+        queue_file = tmp_path / "queue-t999.md"
+        tasks = ow_service._parse_queue_file(queue_file)
+        assert tasks == []
+
+    def test_returns_empty_for_empty_file(self, tmp_path: Path):
+        """空のファイルは空リストを返す"""
+        queue_file = tmp_path / "queue-t0.md"
+        queue_file.write_text("", encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        assert tasks == []
+
+    def test_handles_spawning_status(self, tmp_path: Path):
+        """spawningステータスのwrite-aheadエントリをパースできる"""
+        content = "## T3 | new task | spawning\n- worker: w-b / term_ref: (pending) / session: (pending)\n"
+        queue_file = tmp_path / "queue-t1.md"
+        queue_file.write_text(content, encoding="utf-8")
+        tasks = ow_service._parse_queue_file(queue_file)
+        assert len(tasks) == 1
+        assert tasks[0]["status"] == "spawning"
+
+
+class TestWriteQueueSpawning:
+    def test_creates_queue_file(self, tmp_path: Path):
+        """queueファイルにspawning write-aheadエントリが作成される"""
+        ow_service._write_queue_spawning(tmp_path, "454", "w-a", 1, "/tmp")
+        queue_file = tmp_path / "queue-t454.md"
+        assert queue_file.exists()
+        content = queue_file.read_text(encoding="utf-8")
+        assert "spawning" in content
+        assert "T1" in content
+
+    def test_appends_to_existing_file(self, tmp_path: Path):
+        """既存のqueueファイルにspawning write-aheadエントリを追記する"""
+        queue_file = tmp_path / "queue-t100.md"
+        queue_file.write_text("## T1 | 既存タスク | done\n")
+        ow_service._write_queue_spawning(tmp_path, "100", "w-b", 2, "/tmp")
+        content = queue_file.read_text(encoding="utf-8")
+        assert "既存タスク" in content
+        assert "T2" in content
+
+
+class TestOwSpawnWorkerManualFallback:
+    """ケース#14: アダプタ不在時にmanualフォールバックで起動コマンドを返す"""
+
+    def test_manual_fallback_when_ow_terminal_unset(self, tmp_path: Path, monkeypatch):
+        """OW_TERMINAL未設定 → manual=True + commandキーを返す"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", topic_id="99", task_n=1,
+        )
+        assert result.get("manual") is True
+        assert "command" in result
+        assert "OW_ROLE=worker" in result["command"]
+        assert "task_file" in result
+
+    def test_manual_fallback_when_ow_terminal_manual(self, tmp_path: Path, monkeypatch):
+        """OW_TERMINAL=manual → manual=True"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "manual")
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-b", channel="ch2", cwd="/tmp", model="haiku",
+            task_title="manual", acceptance="ok", task_n=2,
+        )
+        assert result.get("manual") is True
+        assert "command" in result
+
+
+class TestOwStatusIntegration:
+    """ケース#16: queueパース + /presence合成 → 統合ビューを返す"""
+
+    def test_status_merges_queue_and_presence(self, tmp_path: Path, monkeypatch):
+        """queue内のworkerとpresenceの突合でonlineフラグが付く"""
+        queue_content = (
+            "## T1 | タスクA | in_progress\n"
+            "- worker: w-a / term_ref: uuid-1 / session: s1\n\n"
+            "## T2 | タスクB | queued\n"
+        )
+        queue_file = tmp_path / "queue-t100.md"
+        queue_file.write_text(queue_content, encoding="utf-8")
+
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+
+        def fake_relay_request(method, path, data=None):
+            if "/presence" in path:
+                return {"handles": ["orch", "w-a"]}
+            return {"error": "unexpected"}
+
+        monkeypatch.setattr(ow_service, "_relay_request", fake_relay_request)
+
+        result = ow_service.ow_status(channel="ch", topic_id="100")
+
+        assert len(result["tasks"]) == 2
+        assert result["tasks"][0]["online"] is True
+        assert result["presence"] == ["orch", "w-a"]
+        assert result["summary"]["total_tasks"] == 2
+        assert "w-a" in result["summary"]["online_workers"]
+
+    def test_status_with_empty_queue(self, tmp_path: Path, monkeypatch):
+        """queueファイルなし + presence取得 → タスク0件の統合ビュー"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+
+        def fake_relay_request(method, path, data=None):
+            return {"handles": ["orch"]}
+
+        monkeypatch.setattr(ow_service, "_relay_request", fake_relay_request)
+
+        result = ow_service.ow_status(channel="ch", topic_id="999")
+        assert result["tasks"] == []
+        assert result["summary"]["total_tasks"] == 0
+
+
+class TestOwCloseWorkerTermRef:
+    """ケース#17: term_ref(安定ID)で対象を特定"""
+
+    def test_close_passes_term_ref_to_adapter(self, tmp_path: Path, monkeypatch):
+        """アダプタにterm_refが正しく渡される"""
+        adapter_script = tmp_path / "adapters" / "iterm2.sh"
+        adapter_script.parent.mkdir(parents=True, exist_ok=True)
+        adapter_script.write_text("#!/bin/bash\nexit 0\n")
+        adapter_script.chmod(0o755)
+
+        monkeypatch.setenv("OW_TERMINAL", "iterm2")
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        captured_args = []
+        original_run = ow_service.subprocess.run
+
+        def fake_run(args, **kwargs):
+            captured_args.extend(args)
+            from unittest.mock import MagicMock
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+
+        result = ow_service.ow_close_worker(term_ref="8CDF1801-ABCD-1234")
+
+        assert result.get("closed") is True
+        assert "8CDF1801-ABCD-1234" in captured_args
+        assert result["term_ref"] == "8CDF1801-ABCD-1234"
+
+    def test_close_manual_fallback(self, monkeypatch):
+        """アダプタ不在時はmanualフォールバック"""
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        result = ow_service.ow_close_worker(term_ref="some-uuid")
+        assert result.get("manual") is True
+        assert "some-uuid" in result.get("message", "")
+
+
+class TestWriteTaskFile:
+    def test_creates_task_json(self, tmp_path: Path):
+        """task fileがJSONとして作成される"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path, task_n=1, alias="w-a", channel="AbCdEfGh",
+            cwd="/tmp", model="sonnet", permission="acceptEdits",
+            task_title="Test", acceptance="pass", context="ctx",
+            playbook="", timeout_min=60, activity_id=1, topic_id="10"
+        )
+        assert task_file.exists()
+        data = json.loads(task_file.read_text(encoding="utf-8"))
+        assert data["task"] == "T1"
+        assert data["alias"] == "w-a"
+        assert data["v"] == 1
+
+    def test_task_file_name(self, tmp_path: Path):
+        """task fileの名前がT{n}.json形式になる"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path, task_n=5, alias="w-e", channel="ch1",
+            cwd="/tmp", model="haiku", permission="default",
+            task_title="", acceptance="", context="", playbook="",
+            timeout_min=30, activity_id=None, topic_id=None
+        )
+        assert task_file.name == "T5.json"
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        """親ディレクトリが存在しなくても作成する"""
+        nested_dir = tmp_path / "deep" / "nested" / "tasks"
+        task_file = ow_service._write_task_file(
+            task_dir=nested_dir, task_n=1, alias="w-a", channel="ch",
+            cwd="/tmp", model="sonnet", permission="acceptEdits",
+            task_title="", acceptance="", context="", playbook="",
+            timeout_min=60, activity_id=None, topic_id=None
+        )
+        assert task_file.exists()

--- a/tests/unit/test_ow_recv_filter.py
+++ b/tests/unit/test_ow_recv_filter.py
@@ -1,0 +1,150 @@
+"""recv_filter.pyのユニットテスト
+
+エッジケース:
+- 自分宛（to=自分のhandle）→ stdout出力
+- broadcast（to="*"）→ stdout出力
+- 他者宛 → 出力しない
+- 不正JSON行 → スキップ（クラッシュしない）
+"""
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+RECV_FILTER = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "recv_filter.py"
+
+
+def _make_sse_line(body_dict: dict) -> str:
+    """SSEのdata行を作成する（bodyはJSON文字列化してmsgに格納）"""
+    msg = {"msg_id": 1, "handle": "orch", "body": json.dumps(body_dict)}
+    return f"data: {json.dumps(msg)}"
+
+
+def _run_filter(handle: str, stdin_lines: list[str]) -> list[str]:
+    """recv_filter.pyを実行してstdout行を返す"""
+    result = subprocess.run(
+        [sys.executable, str(RECV_FILTER), handle],
+        input="\n".join(stdin_lines) + "\n",
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+class TestRecvFilterDirect:
+    """recv_filter.pyのmain()をサブプロセスで直接テストする"""
+
+    def test_outputs_message_addressed_to_me(self):
+        """自分宛メッセージ（to=自分のhandle）はstdoutに出力される"""
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"})
+        output = _run_filter("orch", [line])
+        assert len(output) == 1
+        assert "data: " in output[0]
+
+    def test_outputs_broadcast_message(self):
+        """broadcast（to="*"）はstdoutに出力される"""
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "*", "from": "w-a"})
+        output = _run_filter("orch", [line])
+        assert len(output) == 1
+
+    def test_skips_message_to_others(self):
+        """他者宛メッセージはstdoutに出力されない"""
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "w-b", "from": "orch"})
+        output = _run_filter("orch", [line])
+        assert len(output) == 0
+
+    def test_skips_invalid_json(self):
+        """不正なJSON行はスキップ（クラッシュしない）"""
+        lines = [
+            "data: not-json-at-all",
+            "data: {broken",
+            _make_sse_line({"v": 1, "kind": "state", "to": "orch", "from": "w-a"}),
+        ]
+        output = _run_filter("orch", lines)
+        # 有効な1件のみ出力される
+        assert len(output) == 1
+
+    def test_skips_non_data_lines(self):
+        """SSEのkeep-alive等、data:で始まらない行はスキップ"""
+        lines = [
+            ": ping",
+            "",
+            "event: message",
+            _make_sse_line({"v": 1, "kind": "state", "to": "orch", "from": "w-a"}),
+        ]
+        output = _run_filter("orch", lines)
+        assert len(output) == 1
+
+    def test_handles_multiple_messages(self):
+        """複数行が混在する場合、自分宛のみ出力される"""
+        lines = [
+            _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"}),  # 自分宛
+            _make_sse_line({"v": 1, "kind": "state", "to": "w-b", "from": "orch"}),  # 他者宛
+            _make_sse_line({"v": 1, "kind": "state", "to": "*", "from": "w-a"}),  # broadcast
+        ]
+        output = _run_filter("orch", lines)
+        assert len(output) == 2
+
+    def test_skips_message_with_no_to_field(self):
+        """toフィールドがない場合はスキップ"""
+        line = _make_sse_line({"v": 1, "kind": "cmd", "from": "w-a"})
+        output = _run_filter("orch", [line])
+        assert len(output) == 0
+
+
+class TestRecvFilterModule:
+    """recv_filter.pyのロジックをモジュールとして直接テストする"""
+
+    def _call_filter(self, my_handle: str, lines: list[str]) -> list[str]:
+        """sys.stdin/stdoutをモックしてmain()を実行する"""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("recv_filter", RECV_FILTER)
+        mod = importlib.util.module_from_spec(spec)
+
+        captured_output: list[str] = []
+
+        original_argv = sys.argv
+        original_stdin = sys.stdin
+        original_stdout = sys.stdout
+        try:
+            sys.argv = ["recv_filter.py", my_handle]
+            sys.stdin = io.StringIO("\n".join(lines) + "\n")
+
+            class CapturingWriter(io.StringIO):
+                def write(self, s: str) -> int:
+                    if s.strip():
+                        captured_output.append(s.rstrip("\n"))
+                    return len(s)
+
+            sys.stdout = CapturingWriter()
+            spec.loader.exec_module(mod)
+            mod.main()
+        finally:
+            sys.argv = original_argv
+            sys.stdin = original_stdin
+            sys.stdout = original_stdout
+
+        return captured_output
+
+    def test_outputs_addressed_to_me(self):
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"})
+        output = self._call_filter("orch", [line])
+        assert len(output) == 1
+
+    def test_outputs_broadcast(self):
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "*", "from": "w-a"})
+        output = self._call_filter("orch", [line])
+        assert len(output) == 1
+
+    def test_skips_others(self):
+        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "w-b", "from": "orch"})
+        output = self._call_filter("orch", [line])
+        assert len(output) == 0
+
+    def test_skips_invalid_json(self):
+        lines = ["data: {broken", "data: not-json"]
+        output = self._call_filter("orch", lines)
+        assert len(output) == 0

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -1,0 +1,248 @@
+"""ow_send()のユニットテスト（リトライ区分）
+
+エッジケース:
+- 4xx レスポンス → 即座にエラー返却（リトライしない）
+- 5xx/接続断 → 指数バックオフ後にリトライ → 最終的にエラー
+- 成功時 → {"msg_id": int}を返す
+"""
+import json
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services import ow_service
+
+
+def _make_http_error(code: int, message: str = "error") -> urllib.error.HTTPError:
+    """urllib.error.HTTPErrorを作成するヘルパー"""
+    return urllib.error.HTTPError(
+        url="http://127.0.0.1:8765/send",
+        code=code,
+        msg=message,
+        hdrs={},
+        fp=None,
+    )
+
+
+class TestOwSend4xx:
+    """4xxレスポンスは即座に失敗（リトライなし）"""
+
+    def test_404_returns_error_immediately(self, monkeypatch):
+        """404 Not Found → リトライなしで即エラー"""
+        call_count = 0
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise _make_http_error(404, "channel not found")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service._relay_request("POST", "/send", {"channel": "xxx", "handle": "orch", "body": "{}"})
+
+        assert "error" in result
+        assert result["error"]["code"] == 404
+        # 4xxはリトライしないので1回のみ呼ばれる
+        assert call_count == 1
+
+    def test_400_returns_error_immediately(self, monkeypatch):
+        """400 Bad Request → リトライなしで即エラー"""
+        call_count = 0
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise _make_http_error(400, "missing required fields")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service._relay_request("POST", "/send", {"channel": "xxx", "handle": "orch", "body": "{}"})
+
+        assert "error" in result
+        assert result["error"]["code"] == 400
+        assert call_count == 1
+
+    def test_403_returns_error_immediately(self, monkeypatch):
+        """403 Forbidden → リトライなしで即エラー"""
+        call_count = 0
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise _make_http_error(403, "forbidden")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service._relay_request("POST", "/send", {})
+        assert "error" in result
+        assert call_count == 1
+
+
+class TestOwSend5xx:
+    """5xx/接続断は指数バックオフでリトライ"""
+
+    def test_500_retries_and_raises(self, monkeypatch):
+        """500 Server Error → MAX_RETRIES回リトライ後にraiseされる"""
+        call_count = 0
+        max_retries = ow_service._MAX_RETRIES
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise _make_http_error(500, "internal server error")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        # sleepを無効化してテストを高速化
+        monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            ow_service._relay_request("POST", "/send", {})
+
+        assert exc_info.value.code == 500
+        # MAX_RETRIES+1回（初回 + リトライ回数）呼ばれる
+        assert call_count == max_retries + 1
+
+    def test_connection_error_retries_and_raises(self, monkeypatch):
+        """接続断（URLError）→ MAX_RETRIES回リトライ後にraiseされる"""
+        call_count = 0
+        max_retries = ow_service._MAX_RETRIES
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
+
+        with pytest.raises(urllib.error.URLError):
+            ow_service._relay_request("POST", "/send", {})
+
+        assert call_count == max_retries + 1
+
+    def test_5xx_eventually_succeeds_after_retry(self, monkeypatch):
+        """最初に5xxでも、2回目で成功すれば結果を返す"""
+        call_count = 0
+
+        class FakeResponse:
+            def __init__(self):
+                self._data = json.dumps({"msg_id": 42}).encode()
+
+            def read(self):
+                return self._data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _make_http_error(503, "service unavailable")
+            return FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
+
+        result = ow_service._relay_request("POST", "/send", {"channel": "ch", "handle": "orch", "body": "{}"})
+
+        assert result.get("msg_id") == 42
+        assert call_count == 2
+
+
+class TestOwSendSuccess:
+    """正常系"""
+
+    def test_success_returns_msg_id(self, monkeypatch):
+        """正常時は {"msg_id": int} を返す"""
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"msg_id": 10}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_send(
+            channel="AbCdEfGh",
+            handle="orch",
+            body={"v": 1, "kind": "cmd", "to": "w-a", "verb": "ping"},
+        )
+        assert result.get("msg_id") == 10
+
+    def test_ow_history_since_passed_in_url(self, monkeypatch):
+        """ow_history: since値がURLクエリパラメータとして正しく渡される（ケース#3）"""
+        captured_urls = []
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"messages": [
+                    {"msg_id": 5, "handle": "w-a", "body": '{"v":1}'},
+                    {"msg_id": 6, "handle": "w-a", "body": '{"v":1}'},
+                ]}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_history(channel="AbCd", since=4, limit=50)
+
+        assert "since=4" in captured_urls[0]
+        assert "limit=50" in captured_urls[0]
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["msg_id"] == 5
+
+    def test_body_serialized_as_json_string(self, monkeypatch):
+        """bodyはJSON文字列としてrelayに送信される（D#2405）"""
+        sent_data = {}
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"msg_id": 1}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            sent_data.update(json.loads(req.data))
+            return FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        ow_body = {"v": 1, "kind": "cmd", "to": "w-a", "verb": "ping"}
+        ow_service.ow_send(channel="ch", handle="orch", body=ow_body)
+
+        # bodyはJSON文字列として格納されている
+        assert isinstance(sent_data["body"], str)
+        parsed_body = json.loads(sent_data["body"])
+        assert parsed_body == ow_body


### PR DESCRIPTION
## Summary
- orch/worker拡張（ow）の実装第1弾。後続のorchスキル(A#798)・workerスキル(A#799)・ターミナルアダプタ(A#800)が依存する基盤
- relay HTTP直結MCPツール5本: `ow_send` / `ow_history` / `ow_spawn_worker` / `ow_close_worker` / `ow_status`
- SSE宛先フィルタ: `scripts/ow/recv_filter.py` + `scripts/ow/recv.sh`（Monitor監視対象、自分宛 or broadcast のみ出力、1秒間隔自動再接続）
- launcherトグル: `CCM_OW=1` または `OW_ROLE=worker` セッションのみ ow_* ツール可視。通常セッションはデフォルト非表示

## Design references
- 設計書: M#219 v1.2 FIX §2
- 関連decisions: D#2391, D#2392, D#2393, D#2395, D#2400, D#2403-D#2406
- cc-memory activity: A#797

## Test plan
- [x] ow_send 4xx即失敗 / 5xxリトライ / 成功（9テスト）
- [x] recv_filter 自分宛・broadcast・他者宛・不正JSON（11テスト）
- [x] launcherフィルタ CCM_OW / OW_ROLE / 無効時のow_*除外（12テスト）
- [x] queueパーサ / write-ahead / spawn manual fallback / ow_status統合 / close term_ref（17テスト）
- [x] 全ユニットテスト 916+49 passed, 既存テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)