### PR TITLE
feat: workerスキル最小版 + orchスキルMonitorコマンド修正

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -21,7 +21,7 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージをpullし処理する（初回起動時はskip）
 4. **cc-memory check-in**: `check_in(orch_activity_id)` でアクティビティに紐づく情報を取得する
 5. **特化版プレイブック取得**: `search(tags=["playbook", "domain:<topic_domain>"])` で特化版プレイブックを取得する（§プレイブック参照 参照）
-6. **Monitor起動**: `Monitor recv.sh --me orch (persistent)` を起動する。Monitorはスキル指示でClaude自身に起動させる。`recv.sh` は `scripts/ow/recv.sh` にあり、1秒自動再接続付き
+6. **Monitor起動**: `Monitor recv.sh <channel_code> orch (persistent)` を起動する。Monitorはスキル指示でClaude自身に起動させる。`recv.sh` は `scripts/ow/recv.sh` にあり、引数は `<channel_code> <handle>` の位置引数。1秒自動再接続付き
 
 **起動cwd規約**: orchは作業ルート（例: `~/workspace`）で起動し、workerにはリポジトリ/worktreeのcwdを割り当てる。auto-memoryのslug依存を回避し、orch/workerのauto-memoryを構造分離する。queueのfrontmatterに `orch_cwd` を記録し、復旧は同一cwdで行う。
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: worker
+description: owフレームワークのworkerとして動作する。orchからの指示を受けてタスクを実行し、結果を報告する
+---
+
+# worker
+
+owフレームワークのworkerとして動作する。orchからの指示を受けてタスクを実行し、結果を報告する。
+
+## 起動
+
+1. task fileを読み込む: orchのbootstrapプロンプトで渡されたパスからJSONを読む
+2. task fileから `channel_code`, `alias`, `task_n`, `activity_id`, `topic_id`, `acceptance`, `context`, `playbook`, `timeout_min` を取得する
+3. Monitorを起動する: `Monitor recv.sh <channel_code> <alias> (persistent)`
+   - `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
+4. `check_in(activity_id)` でアクティビティの関連情報を取得する
+5. `ow_send` で `state:ready` を送信する:
+   ```json
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"ready", "data":{"session_id":"<session_id>", "alias":"<alias>", "cwd":"<cwd>"}}
+   ```
+6. **ready送信直後に `ow_history(channel=<channel_code>, since=<ready_msg_id>)` を実行する**。orchがready受信後にすぐ送ったcmd:assignをSSE接続完了前に取りこぼす場合があるため、自分でpullして補完する。
+
+## cmd:assign の受信
+
+orchから `cmd:assign` が届いたら:
+1. 内容を確認し、`state:working` を送信する（**in_reply_toにassignのmsg_idを指定 — 必須**）:
+   ```json
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working", "data":{"phase":"starting", "note":"assign received, beginning work"}}
+   ```
+2. タスクの作業を開始する
+
+## 作業中
+
+- 通常の実装作業を行う（コーディング、テスト作成、PR作成等）
+- 節目ごとに `state:working` を送信してorchに進捗を知らせる:
+  ```json
+  {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working", "data":{"phase":"<phase>", "note":"<進捗メモ>"}}
+  ```
+- cc-memoryへの記録（add_logs, add_decisions, add_material）は通常通り行う
+- SAを使う場合のモデル選択: 機械的作業→haiku/sonnet、通常実装→sonnet/opus、設計・複雑推論→opus以上
+
+## 完了
+
+作業が完了したら:
+1. cc-memoryへの記録が完了していることを確認する（`synced: true` の前提）
+2. `state:done` を送信する:
+   ```json
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"done", "data":{"summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[], "decision_proposals":[]}}
+   ```
+3. orchからの応答を待つ。`cmd:close` が届いたら `state:closed` を送信して終了:
+   ```json
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"closed", "data":{}}
+   ```
+
+## 受信処理
+
+SSE（Monitor）は起床信号専用。起床したら `ow_history(channel=<channel_code>, since=<last_seen_msg_id>)` で未処理メッセージを全件pull。自分宛（`to` が自分のaliasまたは `*`）のメッセージのみ処理する。
+
+## cmd:ping への応答
+
+orchから `cmd:ping` が届いたら、現在の状態を `state:working` で返す。
+
+## 禁止事項
+
+- orchの指示なしにタスクスコープを拡張しない
+- `state:closed` 送信後にツールを呼ばない
+- done送信後、closeを受けるまで新しい作業を始めない


### PR DESCRIPTION
## Summary
- workerスキル最小版（skills/worker/SKILL.md）を追加。owプロトコルの基本フロー（ready→working→done→closed）をカバー
- ready送信直後のow_history即時pullステップを含む（SSE接続前のassign取りこぼし対策）
- orchスキルのMonitor起動コマンドを `recv.sh --me orch` → `recv.sh <channel_code> orch` に修正（recv.shの実際の引数形式に合わせる）

## Test plan
- [ ] workerセッションを手動起動し、task file読込→state:ready→cmd:assign受信→state:working→state:doneの基本フローが完走すること
- [ ] ready送信直後のow_history pullで、SSE接続前に送られたcmd:assignを拾えること
- [ ] orchセッションで `recv.sh <channel_code> orch` 形式のMonitorが正常にSSEイベントを受信すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)