### PR TITLE
feat: iTerm2ターミナルアダプタ + spawn時term_ref stdout取得

### DIFF
--- a/scripts/ow/adapters/iterm2.sh
+++ b/scripts/ow/adapters/iterm2.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# iTerm2 ターミナルアダプタ
+# 使い方:
+#   iterm2.sh spawn <cwd> <worker_cmd>   → 新タブ起動、セッションUUIDをstdoutに返す
+#   iterm2.sh close <term_ref>           → セッションUUIDでタブをクローズ
+set -euo pipefail
+
+ACTION="$1"
+
+case "$ACTION" in
+  spawn)
+    CWD="$2"
+    WORKER_CMD="$3"
+
+    SESSION_UUID=$(osascript <<APPLESCRIPT
+      tell application "iTerm2"
+        tell current window
+          set newTab to (create tab with default profile)
+          tell current session of newTab
+            set its name to "ow-worker"
+            write text "cd ${CWD} && ${WORKER_CMD}"
+            return id
+          end tell
+        end tell
+      end tell
+APPLESCRIPT
+    )
+    echo "$SESSION_UUID"
+    ;;
+
+  close)
+    TERM_REF="$2"
+
+    osascript <<APPLESCRIPT
+      tell application "iTerm2"
+        repeat with aWindow in windows
+          repeat with aTab in tabs of aWindow
+            repeat with aSession in sessions of aTab
+              if id of aSession is "${TERM_REF}" then
+                tell aSession to close
+                return
+              end if
+            end repeat
+          end repeat
+        end repeat
+      end tell
+APPLESCRIPT
+    ;;
+
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+esac

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -469,16 +469,19 @@ def ow_spawn_worker(
             "alias": alias,
         }
 
-    # アダプタ呼び出し
-    term_ref = str(uuid.uuid4())
+    # アダプタ呼び出し — stdoutから安定IDを取得する（D#2400）
     try:
-        subprocess.run(
-            ["bash", str(adapter_path), "spawn", cwd, worker_cmd, term_ref],
+        result = subprocess.run(
+            ["bash", str(adapter_path), "spawn", cwd, worker_cmd],
             check=True,
             capture_output=True,
             text=True,
             timeout=30,
         )
+        term_ref = result.stdout.strip()
+        if not term_ref:
+            term_ref = str(uuid.uuid4())
+            logger.warning("adapter returned empty term_ref, using fallback UUID: %s", term_ref)
     except subprocess.TimeoutExpired:
         logger.warning("adapter spawn timed out after 30s")
         return {

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -463,6 +463,64 @@ class TestOwSpawnWorkerManualFallback:
         assert "command" in result
 
 
+class TestOwSpawnWorkerAdapter:
+    """アダプタ経由でworkerを起動し、stdoutからterm_refを取得する"""
+
+    def test_adapter_returns_term_ref_from_stdout(self, tmp_path: Path, monkeypatch):
+        """アダプタのstdoutをterm_refとして使用する"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "iterm2")
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        adapter_script = tmp_path / "iterm2.sh"
+        adapter_script.write_text("#!/bin/bash\necho 'session-uuid-from-iterm2'\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", topic_id="99", task_n=1,
+        )
+        assert result.get("spawning") == "ok"
+        assert result["term_ref"] == "session-uuid-from-iterm2"
+
+    def test_adapter_empty_stdout_falls_back_to_uuid(self, tmp_path: Path, monkeypatch):
+        """アダプタがstdoutに何も返さない場合はUUIDフォールバック"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "iterm2")
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        adapter_script = tmp_path / "iterm2.sh"
+        adapter_script.write_text("#!/bin/bash\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-b", channel="ch2", cwd="/tmp", model="haiku",
+            task_title="test", acceptance="done", task_n=2,
+        )
+        assert result.get("spawning") == "ok"
+        assert len(result["term_ref"]) > 0  # UUID fallback
+
+    def test_adapter_failure_falls_back_to_manual(self, tmp_path: Path, monkeypatch):
+        """アダプタが失敗した場合はmanualフォールバック"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "iterm2")
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        adapter_script = tmp_path / "iterm2.sh"
+        adapter_script.write_text("#!/bin/bash\nexit 1\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-c", channel="ch3", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=3,
+        )
+        assert result.get("manual") is True
+        assert "adapter_error" in result
+
+
 class TestOwCloseWorkerTermRef:
     """ケース#17: term_ref(安定ID)で対象を特定"""
 


### PR DESCRIPTION
## Summary
- `scripts/ow/adapters/iterm2.sh` 新規追加: osascriptでiTerm2新タブ起動→セッションUUIDをstdout返却 / close時はUUIDで対象特定
- `ow_service.py` 修正: アダプタのstdoutからterm_refを取得するように変更（事前生成UUIDを廃止、D#2400準拠）
- テスト3件追加（stdout取得 / 空stdout時UUIDフォールバック / アダプタ失敗時manualフォールバック）

一回実験するのでそのまま通します。実機検証はマージ後にOW_TERMINAL=iterm2で実施。

## Test plan
- [x] ユニットテスト66件パス
- [ ] OW_TERMINAL=iterm2 でow_spawn_workerが新タブを開きセッションUUIDを返すこと（マージ後に実機検証）
- [ ] ow_close_workerでセッションUUIDを指定してタブがクローズされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)