### PR TITLE
fix: worker spawn時のUX改善（フォーカス維持+auto permission）

### DIFF
--- a/scripts/ow/adapters/iterm2.sh
+++ b/scripts/ow/adapters/iterm2.sh
@@ -15,12 +15,15 @@ case "$ACTION" in
     SESSION_UUID=$(osascript <<APPLESCRIPT
       tell application "iTerm2"
         tell current window
+          set originalTab to current tab
           set newTab to (create tab with default profile)
           tell current session of newTab
             set its name to "ow-worker"
             write text "cd ${CWD} && ${WORKER_CMD}"
-            return id
+            set newSessionId to id
           end tell
+          select originalTab
+          return newSessionId
         end tell
       end tell
 APPLESCRIPT

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -47,7 +47,24 @@ orchから `cmd:assign` が届いたら:
    ```json
    {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"done", "data":{"summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[], "decision_proposals":[]}}
    ```
-3. orchからの応答を待つ。`cmd:close` が届いたら `state:closed` を送信して終了:
+3. orchからの応答を待つ。`cmd:close` が届いたら退場処理（§退場処理）を行ってから `state:closed` を送信して終了する
+
+## 退場処理（cmd:close受信時）
+
+`cmd:close` を受信したら、`state:closed` を送信する**前に**以下を実行する。セッション終了でコンテキストが失われるため、次のセッションが引き継げる情報を残すことが目的。
+
+1. **ログ記録** (`add_logs`): セッション中の作業経緯を1件のログとして記録する
+   - title: `worker <alias> T<task_n>: <タスク名>` の形式
+   - content: 何をやったか、どういうアプローチを取ったか、途中で判断した点、ハマったポイントなど。state:doneのsummaryより詳細に残す
+   - topic_id: task fileの `topic_id` を使う
+   - tags: `["worker-log", "domain:<topic_domain>"]` + タスク内容に応じた素タグ
+
+2. **決定事項記録** (`add_decisions`): セッション中にworkerが判断・合意した事項があれば記録する（なければスキップ）
+   - 実装上の設計判断、仕様解釈、トレードオフの選択など
+
+3. **成果物記録** (`add_material`): state:doneで報告済みのmaterial以外に、記録すべき中間成果物があれば保存する（なければスキップ）
+
+4. 記録完了後に `state:closed` を送信する:
    ```json
    {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"closed", "data":{}}
    ```

--- a/src/main.py
+++ b/src/main.py
@@ -1029,7 +1029,7 @@ def ow_spawn_worker(
     channel: str,
     cwd: str,
     model: str,
-    permission: str = "acceptEdits",
+    permission: str = "auto",
     task_title: str = "",
     acceptance: str = "",
     context: str = "",
@@ -1051,7 +1051,7 @@ def ow_spawn_worker(
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "acceptEdits"）
+        permission: permission_mode（デフォルト: "auto"）
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト

--- a/src/main.py
+++ b/src/main.py
@@ -1051,7 +1051,7 @@ def ow_spawn_worker(
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "auto"）
+        permission: permission_mode（デフォルト: "auto"）。autoは全操作を自動承認するため、orchが管理する信頼されたタスクでの使用を前提とする
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -365,7 +365,7 @@ def ow_spawn_worker(
     channel: str,
     cwd: str,
     model: str,
-    permission: str = "acceptEdits",
+    permission: str = "auto",
     task_title: str = "",
     acceptance: str = "",
     context: str = "",
@@ -384,7 +384,7 @@ def ow_spawn_worker(
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "acceptEdits"）
+        permission: permission_mode（デフォルト: "auto"）
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -384,7 +384,7 @@ def ow_spawn_worker(
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "auto"）
+        permission: permission_mode（デフォルト: "auto"）。autoは全操作を自動承認するため、orchが管理する信頼されたタスクでの使用を前提とする
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -564,7 +564,7 @@ class TestWriteTaskFile:
         """task fileがJSONとして作成される"""
         task_file = ow_service._write_task_file(
             task_dir=tmp_path, task_n=1, alias="w-a", channel="AbCdEfGh",
-            cwd="/tmp", model="sonnet", permission="acceptEdits",
+            cwd="/tmp", model="sonnet", permission="auto",
             task_title="Test", acceptance="pass", context="ctx",
             playbook="", timeout_min=60, activity_id=1, topic_id="10"
         )
@@ -589,7 +589,7 @@ class TestWriteTaskFile:
         nested_dir = tmp_path / "deep" / "nested" / "tasks"
         task_file = ow_service._write_task_file(
             task_dir=nested_dir, task_n=1, alias="w-a", channel="ch",
-            cwd="/tmp", model="sonnet", permission="acceptEdits",
+            cwd="/tmp", model="sonnet", permission="auto",
             task_title="", acceptance="", context="", playbook="",
             timeout_min=60, activity_id=None, topic_id=None
         )


### PR DESCRIPTION
## Summary
- iTerm2で新タブをspawnした際、元タブにフォーカスを戻すようAppleScriptを修正
- workerのデフォルトpermission_modeを`acceptEdits`→`auto`に変更（task fileのRead等で権限プロンプトが出てworkerが止まる問題を解消）

## Test plan
- [x] test_ow_queue.py 34 passed
- [ ] 手動確認: spawn後にorchタブのフォーカスが維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)