### PR TITLE
fix: iterm2.shのAppleScript変数インジェクション対策

### DIFF
--- a/scripts/ow/adapters/iterm2.sh
+++ b/scripts/ow/adapters/iterm2.sh
@@ -12,6 +12,10 @@ case "$ACTION" in
     CWD="$2"
     WORKER_CMD="$3"
 
+    # AppleScriptインジェクション対策: base64エンコードしてheredoc展開時の特殊文字混入を防ぐ
+    CWD_B64=$(printf '%s' "$CWD" | base64 | tr -d '\n')
+    CMD_B64=$(printf '%s' "$WORKER_CMD" | base64 | tr -d '\n')
+
     SESSION_UUID=$(osascript <<APPLESCRIPT
       tell application "iTerm2"
         tell current window
@@ -19,7 +23,9 @@ case "$ACTION" in
           set newTab to (create tab with default profile)
           tell current session of newTab
             set its name to "ow-worker"
-            write text "cd ${CWD} && ${WORKER_CMD}"
+            set theCwd to do shell script "echo ${CWD_B64} | base64 --decode"
+            set theCmd to do shell script "echo ${CMD_B64} | base64 --decode"
+            write text "cd " & quoted form of theCwd & " && " & theCmd
             set newSessionId to id
           end tell
           select originalTab
@@ -34,12 +40,16 @@ APPLESCRIPT
   close)
     TERM_REF="$2"
 
+    # AppleScriptインジェクション対策: base64エンコードしてheredoc展開時の特殊文字混入を防ぐ
+    TERM_REF_B64=$(printf '%s' "$TERM_REF" | base64 | tr -d '\n')
+
     osascript <<APPLESCRIPT
       tell application "iTerm2"
+        set theRef to do shell script "echo ${TERM_REF_B64} | base64 --decode"
         repeat with aWindow in windows
           repeat with aTab in tabs of aWindow
             repeat with aSession in sessions of aTab
-              if id of aSession is "${TERM_REF}" then
+              if id of aSession is theRef then
                 tell aSession to close
                 return
               end if

--- a/tests/unit/test_iterm2_adapter.py
+++ b/tests/unit/test_iterm2_adapter.py
@@ -7,8 +7,6 @@ import os
 import subprocess
 from pathlib import Path
 
-import pytest
-
 ADAPTER = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "adapters" / "iterm2.sh"
 MOCK_UUID = "mock-uuid-0000-1111-2222-333333333333"
 
@@ -111,22 +109,18 @@ class TestIterm2AdapterClose:
         result, _ = _run_adapter(["close", "uuid with spaces"], tmp_path)
         assert result.returncode == 0
 
+    def test_close_applescript_contains_base64(self, tmp_path):
+        """closeで生成されたAppleScriptにTERM_REFのbase64エンコード文字列が含まれる。"""
+        import base64
+        term_ref = "ABCD1234-5678-90EF-ABCD-EF0123456789"
+        expected_b64 = base64.b64encode(term_ref.encode()).decode()
+        _, captured = _run_adapter(["close", term_ref], tmp_path)
+        assert expected_b64 in captured
+
 
 class TestIterm2AdapterErrors:
     def test_unknown_action_exits_nonzero(self, tmp_path):
         """未知のactionはゼロ以外のexit codeとエラーメッセージを返す。"""
-        capture_file = tmp_path / "capture.txt"
-        capture_file.write_text("")
-        mock_dir = _make_mock_osascript(tmp_path, capture_file)
-
-        env = os.environ.copy()
-        env["PATH"] = str(mock_dir) + ":" + env["PATH"]
-
-        result = subprocess.run(
-            [str(ADAPTER), "unknown_action"],
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+        result, _ = _run_adapter(["unknown_action"], tmp_path)
         assert result.returncode != 0
         assert "Unknown action" in result.stderr

--- a/tests/unit/test_iterm2_adapter.py
+++ b/tests/unit/test_iterm2_adapter.py
@@ -1,0 +1,132 @@
+"""iterm2.sh ターミナルアダプタのユニットテスト
+
+osascriptをモックして、CWD/WORKER_CMD/TERM_REFに特殊文字が含まれても
+AppleScriptインジェクションが発生しないことを確認する。
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "adapters" / "iterm2.sh"
+MOCK_UUID = "mock-uuid-0000-1111-2222-333333333333"
+
+
+def _make_mock_osascript(tmp_path: Path, capture_file: Path) -> Path:
+    """osascriptをモックするシェルスクリプトを作成する。
+
+    stdinで受け取ったAppleScriptをcapture_fileに追記し、モックUUIDを返す。
+    """
+    mock_dir = tmp_path / "mock_bin"
+    mock_dir.mkdir(exist_ok=True)
+    mock = mock_dir / "osascript"
+    mock.write_text(f'#!/usr/bin/env bash\ncat >> "{capture_file}"\necho "{MOCK_UUID}"\n')
+    mock.chmod(0o755)
+    return mock_dir
+
+
+def _run_adapter(args: list[str], tmp_path: Path) -> tuple[subprocess.CompletedProcess, str]:
+    """iterm2.shをモックosascript環境で実行し、(result, captured_applescript)を返す。"""
+    capture_file = tmp_path / "applescript_capture.txt"
+    capture_file.write_text("")
+    mock_dir = _make_mock_osascript(tmp_path, capture_file)
+
+    env = os.environ.copy()
+    env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+
+    result = subprocess.run(
+        [str(ADAPTER)] + args,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, capture_file.read_text()
+
+
+class TestIterm2AdapterSpawn:
+    def test_spawn_returns_session_uuid(self, tmp_path):
+        """通常のCWD/WORKER_CMDでspawnが正常終了し、osascriptの出力を返す。"""
+        result, _ = _run_adapter(["spawn", "/tmp/normal", "claude"], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_UUID in result.stdout
+
+    def test_spawn_cwd_with_spaces(self, tmp_path):
+        """CWDにスペースが含まれてもspawnが正常終了し、AppleScriptに生の値が直接埋め込まれない。"""
+        cwd = "/Users/John Doe/my project"
+        result, captured = _run_adapter(["spawn", cwd, "claude"], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_UUID in result.stdout
+        assert cwd not in captured
+
+    def test_spawn_worker_cmd_with_double_quotes(self, tmp_path):
+        """WORKER_CMDにダブルクォートが含まれてもspawnが正常終了し、AppleScriptに生の値が直接埋め込まれない。"""
+        cmd = 'claude --arg "value with spaces"'
+        result, captured = _run_adapter(["spawn", "/tmp/work", cmd], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_UUID in result.stdout
+        assert cmd not in captured
+
+    def test_spawn_cwd_with_single_quotes(self, tmp_path):
+        """CWDにシングルクォートが含まれてもspawnが正常終了し、AppleScriptに生の値が直接埋め込まれない。"""
+        cwd = "/Users/O'Brien/work"
+        result, captured = _run_adapter(["spawn", cwd, "claude"], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_UUID in result.stdout
+        assert cwd not in captured
+
+    def test_spawn_worker_cmd_with_backslash(self, tmp_path):
+        """WORKER_CMDにバックスラッシュが含まれてもspawnが正常終了する。"""
+        cmd = r'claude --path C:\Users\foo'
+        result, _ = _run_adapter(["spawn", "/tmp/work", cmd], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_UUID in result.stdout
+
+    def test_spawn_applescript_contains_base64(self, tmp_path):
+        """spawnで生成されたAppleScriptにbase64エンコード文字列が含まれる（インジェクション対策の確認）。"""
+        import base64
+        cwd = "/Users/John Doe/my project"
+        expected_b64 = base64.b64encode(cwd.encode()).decode()
+        _, captured = _run_adapter(["spawn", cwd, "claude"], tmp_path)
+        assert expected_b64 in captured
+
+
+class TestIterm2AdapterClose:
+    def test_close_normal_uuid(self, tmp_path):
+        """通常のUUID形式でcloseが正常終了する。"""
+        result, _ = _run_adapter(
+            ["close", "ABCD1234-5678-90EF-ABCD-EF0123456789"], tmp_path
+        )
+        assert result.returncode == 0
+
+    def test_close_term_ref_with_double_quotes(self, tmp_path):
+        """TERM_REFにダブルクォートが含まれてもcloseが正常終了し、AppleScriptに生の値が直接埋め込まれない。"""
+        term_ref = 'uuid-with-"quotes"'
+        result, captured = _run_adapter(["close", term_ref], tmp_path)
+        assert result.returncode == 0
+        assert term_ref not in captured
+
+    def test_close_term_ref_with_spaces(self, tmp_path):
+        """TERM_REFにスペースが含まれてもcloseが正常終了する。"""
+        result, _ = _run_adapter(["close", "uuid with spaces"], tmp_path)
+        assert result.returncode == 0
+
+
+class TestIterm2AdapterErrors:
+    def test_unknown_action_exits_nonzero(self, tmp_path):
+        """未知のactionはゼロ以外のexit codeとエラーメッセージを返す。"""
+        capture_file = tmp_path / "capture.txt"
+        capture_file.write_text("")
+        mock_dir = _make_mock_osascript(tmp_path, capture_file)
+
+        env = os.environ.copy()
+        env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+
+        result = subprocess.run(
+            [str(ADAPTER), "unknown_action"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode != 0
+        assert "Unknown action" in result.stderr


### PR DESCRIPTION
## Summary
- `scripts/ow/adapters/iterm2.sh` の `spawn` / `close` でCWD・WORKER_CMD・TERM_REFをbase64エンコードしてからheredocに埋め込むよう修正
- AppleScript内では `do shell script "echo BASE64 | base64 --decode"` でデコードし、`quoted form of` でシェルコマンドを安全に構築
- テスト10件追加（`tests/unit/test_iterm2_adapter.py`）

## Background
PR#343のレビューで指摘された既存問題。bashのheredoc展開でCWD/WORKER_CMDがAppleScript文字列に直接埋め込まれており、スペースや引用符を含む値でパース失敗が発生していた。

## Test plan
- [x] `uv run pytest tests/unit/test_iterm2_adapter.py -v` で10件全パス確認済み
- [x] スペース含みCWD・ダブルクォート含みWORKER_CMD・シングルクォート含みCWDのケースをカバー
- [x] close時のTERM_REF特殊文字ケースもカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)