### PR TITLE
fix: queueファイルのauto-memory frontmatter書き換え問題を解消

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -16,7 +16,7 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 ## 起動フロー
 
-1. **queue走査**: `<auto-memory>/orch/queue-t<topic_id>.md` を走査する。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
+1. **queue走査**: `~/.cc-memory-ow/orch/queue-t<topic_id>.md` を走査する（auto-memory管理外のディレクトリ。パス変更は `OW_QUEUE_DIR` 環境変数で可能）。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
 2. **relay疎通確認**: `ow_status()` を呼ぶ（ow_*ツール内蔵のensure-server処理が自動実行）。channelがなければ作成し、channel_codeをqueueのfrontmatterに記録する
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージをpullし処理する（初回起動時はskip）
 4. **cc-memory check-in**: `check_in(orch_activity_id)` でアクティビティに紐づく情報を取得する
@@ -98,11 +98,11 @@ on Monitor発火 or 自発的タイミング:
 
 ## タスクキュー
 
-### ファイルパスとMEMORY.md
+### ファイルパス
 
-- パス: `<auto-memory>/orch/queue-t<topic_id>.md`
-- MEMORY.mdに1行ポインタを追記し「orchセッション専用」と明記する
-- task fileは `<auto-memory>/orch/tasks/T<n>.json`
+- パス: `~/.cc-memory-ow/orch/queue-t<topic_id>.md`（auto-memory管理外）
+- task fileは `~/.cc-memory-ow/orch/tasks/T<n>.json`
+- パスは `OW_QUEUE_DIR` 環境変数で変更可能（変更する場合もauto-memory管理外のディレクトリを指定すること）
 
 ### frontmatterフォーマット
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -16,7 +16,7 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 ## 起動フロー
 
-1. **queue走査**: `~/.cc-memory-ow/orch/queue-t<topic_id>.md` を走査する（auto-memory管理外のディレクトリ。パス変更は `OW_QUEUE_DIR` 環境変数で可能）。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
+1. **queue走査**: `~/.cc-memory/ow/orch/queue-t<topic_id>.md` を走査する（auto-memory管理外のディレクトリ。パス変更は `OW_QUEUE_DIR` 環境変数で可能）。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
 2. **relay疎通確認**: `ow_status()` を呼ぶ（ow_*ツール内蔵のensure-server処理が自動実行）。channelがなければ作成し、channel_codeをqueueのfrontmatterに記録する
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージをpullし処理する（初回起動時はskip）
 4. **cc-memory check-in**: `check_in(orch_activity_id)` でアクティビティに紐づく情報を取得する
@@ -100,8 +100,8 @@ on Monitor発火 or 自発的タイミング:
 
 ### ファイルパス
 
-- パス: `~/.cc-memory-ow/orch/queue-t<topic_id>.md`（auto-memory管理外）
-- task fileは `~/.cc-memory-ow/orch/tasks/T<n>.json`
+- パス: `~/.cc-memory/ow/orch/queue-t<topic_id>.md`（auto-memory管理外）
+- task fileは `~/.cc-memory/ow/orch/tasks/T<n>.json`
 - パスは `OW_QUEUE_DIR` 環境変数で変更可能（変更する場合もauto-memory管理外のディレクトリを指定すること）
 
 ### frontmatterフォーマット

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -240,12 +240,12 @@ def _get_queue_dir() -> Path:
     """queueディレクトリパスを返す。
 
     OW_QUEUE_DIR環境変数が設定されていればそのパスを使用する。
-    未設定の場合は~/.cc-memory-ow/orchをデフォルトとして返す。
+    未設定の場合は~/.cc-memory/ow/orchをデフォルトとして返す。
     いずれもauto-memory管理外ディレクトリに配置する（frontmatter書き換え防止）。
     """
     if OW_QUEUE_DIR:
         return Path(OW_QUEUE_DIR).expanduser()
-    return Path.home() / ".cc-memory-ow" / "orch"
+    return Path.home() / ".cc-memory" / "ow" / "orch"
 
 
 def _build_queue_frontmatter(

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -236,11 +236,16 @@ def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
 # ----------------------------
 
 
-def _get_queue_dir() -> Path | None:
-    """queueディレクトリパスを返す（OW_QUEUE_DIR環境変数）。"""
+def _get_queue_dir() -> Path:
+    """queueディレクトリパスを返す。
+
+    OW_QUEUE_DIR環境変数が設定されていればそのパスを使用する。
+    未設定の場合は~/.cc-memory-ow/orchをデフォルトとして返す。
+    いずれもauto-memory管理外ディレクトリに配置する（frontmatter書き換え防止）。
+    """
     if OW_QUEUE_DIR:
         return Path(OW_QUEUE_DIR).expanduser()
-    return None
+    return Path.home() / ".cc-memory-ow" / "orch"
 
 
 def _build_queue_frontmatter(
@@ -402,12 +407,7 @@ def ow_spawn_worker(
     if not ensure_relay_server():
         return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
 
-    # task file書き出し先の決定
     queue_dir = _get_queue_dir()
-    if queue_dir is None:
-        # OW_QUEUE_DIR未設定の場合は一時的なパスを使用
-        queue_dir = Path.home() / ".cc-memory-ow" / "orch"
-
     task_dir = queue_dir / "tasks"
 
     # queueへspawning write-ahead（孤児worker対策 D#2395）
@@ -669,10 +669,10 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
     tasks: list[dict] = []
     frontmatter: dict = {}
     queue_dir = _get_queue_dir()
-    if queue_dir is not None and topic_id is not None:
+    if topic_id is not None:
         queue_file = queue_dir / f"queue-t{topic_id}.md"
         frontmatter, tasks = _parse_queue_file(queue_file)
-    elif queue_dir is not None:
+    else:
         # topic_id未指定の場合は存在する全queueファイルを読む
         for queue_file in sorted(queue_dir.glob("queue-t*.md")):
             fm, file_tasks = _parse_queue_file(queue_file)

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -674,13 +674,14 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
         frontmatter, tasks = _parse_queue_file(queue_file)
     else:
         # topic_id未指定の場合は存在する全queueファイルを読む
-        for queue_file in sorted(queue_dir.glob("queue-t*.md")):
-            fm, file_tasks = _parse_queue_file(queue_file)
-            tasks.extend(file_tasks)
-            if fm and not frontmatter:
-                # 1 orch = 1 topic（D#2383）のためtopic_id指定が原則。
-                # topic_id未指定の全件走査は診断用途のみ想定し、最初のfrontmatterを代表とする。
-                frontmatter = fm
+        if queue_dir.exists():
+            for queue_file in sorted(queue_dir.glob("queue-t*.md")):
+                fm, file_tasks = _parse_queue_file(queue_file)
+                tasks.extend(file_tasks)
+                if fm and not frontmatter:
+                    # 1 orch = 1 topic（D#2383）のためtopic_id指定が原則。
+                    # topic_id未指定の全件走査は診断用途のみ想定し、最初のfrontmatterを代表とする。
+                    frontmatter = fm
 
     # presenceとqueueの統合
     for task in tasks:

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -559,6 +559,28 @@ class TestOwCloseWorkerTermRef:
         assert "some-uuid" in result.get("message", "")
 
 
+class TestGetQueueDir:
+    def test_returns_env_var_path(self, tmp_path: Path, monkeypatch):
+        """OW_QUEUE_DIRが設定されている場合はその値をPathとして返す"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service._get_queue_dir()
+        assert result == tmp_path
+
+    def test_default_path_is_not_auto_memory(self, monkeypatch):
+        """OW_QUEUE_DIR未設定の場合、~/.cc-memory-ow/orch を返す（auto-memory管理外）"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
+        result = ow_service._get_queue_dir()
+        assert result == Path.home() / ".cc-memory-ow" / "orch"
+        # auto-memoryが管理する~/.claude/projects/配下でないことを確認
+        assert ".claude" not in str(result)
+
+    def test_default_path_never_returns_none(self, monkeypatch):
+        """OW_QUEUE_DIR未設定でもNoneは返さない（ow_statusがNoneチェック不要）"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
+        result = ow_service._get_queue_dir()
+        assert result is not None
+
+
 class TestWriteTaskFile:
     def test_creates_task_json(self, tmp_path: Path):
         """task fileがJSONとして作成される"""

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -403,6 +403,15 @@ class TestOwStatusIntegration:
         assert result["summary"]["total_tasks"] == 0
 
 
+    def test_status_no_queue_dir_returns_empty(self, monkeypatch, tmp_path):
+        """OW_QUEUE_DIR未設定かつデフォルトディレクトリが存在しない場合、tasks=[]を返す（初回起動シナリオ）"""
+        nonexistent = tmp_path / "does_not_exist"
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
+        monkeypatch.setattr(ow_service, "_get_queue_dir", lambda: nonexistent)
+        monkeypatch.setattr(ow_service, "_relay_request", lambda *a, **k: {"handles": []})
+        result = ow_service.ow_status(channel="ch", topic_id=None)
+        assert result["tasks"] == []
+
     def test_status_multi_queue_uses_first_frontmatter(self, tmp_path: Path, monkeypatch):
         """topic_id未指定の全件走査時、ソート順で最初のfrontmatterを代表として返す"""
         q1 = tmp_path / "queue-t100.md"
@@ -573,13 +582,6 @@ class TestGetQueueDir:
         assert result == Path.home() / ".cc-memory-ow" / "orch"
         # auto-memoryが管理する~/.claude/projects/配下でないことを確認
         assert ".claude" not in str(result)
-
-    def test_default_path_never_returns_none(self, monkeypatch):
-        """OW_QUEUE_DIR未設定でもNoneは返さない（ow_statusがNoneチェック不要）"""
-        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
-        result = ow_service._get_queue_dir()
-        assert result is not None
-
 
 class TestWriteTaskFile:
     def test_creates_task_json(self, tmp_path: Path):

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -576,10 +576,10 @@ class TestGetQueueDir:
         assert result == tmp_path
 
     def test_default_path_is_not_auto_memory(self, monkeypatch):
-        """OW_QUEUE_DIR未設定の場合、~/.cc-memory-ow/orch を返す（auto-memory管理外）"""
+        """OW_QUEUE_DIR未設定の場合、~/.cc-memory/ow/orch を返す（auto-memory管理外）"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
         result = ow_service._get_queue_dir()
-        assert result == Path.home() / ".cc-memory-ow" / "orch"
+        assert result == Path.home() / ".cc-memory" / "ow" / "orch"
         # auto-memoryが管理する~/.claude/projects/配下でないことを確認
         assert ".claude" not in str(result)
 


### PR DESCRIPTION
## Summary

- SKILL.mdで`<auto-memory>/orch/`という曖昧なパス記述を使っていたため、AIがauto-memory管理ディレクトリ(`~/.claude/projects/.../memory/`)にqueueファイルを配置し、auto-memoryシステムにfrontmatterが書き換えられる問題が発生していた
- queueファイルの正しい置き場所は`~/.cc-memory-ow/orch/`（auto-memory管理外）だが、コードと記述が乖離していた
- `_get_queue_dir()`がOW_QUEUE_DIR未設定時にNoneを返していたため、`ow_status`がキューファイルを読めないバグも存在した

## Changes

- `skills/orch/SKILL.md`: `<auto-memory>/orch/`→`~/.cc-memory-ow/orch/`に明示、MEMORY.mdポインタ追記指示を削除
- `src/services/ow_service.py`: `_get_queue_dir()`のデフォルトを関数本体に統合し戻り値型を`Path`に変更、`ow_spawn_worker`と`ow_status`の冗長なNoneチェックを削除
- `tests/unit/test_ow_queue.py`: `TestGetQueueDir`クラス追加でデフォルトパスがauto-memory管理外であることを保証

## Test plan

- [ ] `uv run pytest tests/unit/test_ow_queue.py` が全37件PASS
- [ ] `_get_queue_dir()`がOW_QUEUE_DIR未設定でも`~/.cc-memory-ow/orch`を返す（TestGetQueueDir::test_default_path_is_not_auto_memory）
- [ ] queueファイルが`~/.claude/`配下に作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)