### PR TITLE
fix: ow_send/ow_spawn_workerのchannel未存在時を自動作成で対応

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -158,16 +158,20 @@ def ensure_channel(channel_code: str) -> bool:
     """channelが存在しなければrelayに作成する（idempotent）。
 
     POST /createにchannel_codeを指定して送信する。relayサーバー側で
-    既存なら何もせず、未存在なら作成する（D#2xxx）。
+    既存なら何もせず、未存在なら作成する（D#2453）。
 
     Args:
         channel_code: 存在を保証したいchannel_code
 
     Returns:
         True: channelが存在する（作成成功・既存どちらも）
-        False: 作成失敗
+        False: 作成失敗（4xx・5xx・接続断すべて含む）
     """
-    result = _relay_request("POST", "/create", {"channel_code": channel_code})
+    try:
+        result = _relay_request("POST", "/create", {"channel_code": channel_code})
+    except Exception as e:
+        logger.warning("ensure_channel failed for %s: %s", channel_code, e)
+        return False
     if "error" in result:
         logger.warning("ensure_channel failed for %s: %s", channel_code, result["error"])
         return False

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -154,6 +154,27 @@ def ensure_relay_server() -> bool:
     return False
 
 
+def ensure_channel(channel_code: str) -> bool:
+    """channelが存在しなければrelayに作成する（idempotent）。
+
+    POST /createにchannel_codeを指定して送信する。relayサーバー側で
+    既存なら何もせず、未存在なら作成する（D#2xxx）。
+
+    Args:
+        channel_code: 存在を保証したいchannel_code
+
+    Returns:
+        True: channelが存在する（作成成功・既存どちらも）
+        False: 作成失敗
+    """
+    result = _relay_request("POST", "/create", {"channel_code": channel_code})
+    if "error" in result:
+        logger.warning("ensure_channel failed for %s: %s", channel_code, result["error"])
+        return False
+    logger.info("ensure_channel: channel %s is ready", channel_code)
+    return True
+
+
 # ----------------------------
 # T1: ow_send
 # ----------------------------
@@ -170,6 +191,7 @@ def ow_send(
 
     bodyはow固有JSONを格納するdict（relay schemaは無改修）。
     4xx即失敗、5xx/接続断のみ3回指数バックオフ。
+    channel未存在（404）の場合はensure_channelで自動作成してから再送する。
 
     Args:
         channel: channelコード
@@ -191,7 +213,15 @@ def ow_send(
     if in_reply_to is not None:
         payload["in_reply_to"] = in_reply_to
 
-    return _relay_request("POST", "/send", payload)
+    result = _relay_request("POST", "/send", payload)
+
+    # channel未存在による404 → 自動作成して再送（1回のみ）
+    if "error" in result and result["error"].get("code") == 404:
+        logger.info("ow_send: channel %s not found, attempting ensure_channel", channel)
+        if ensure_channel(channel):
+            result = _relay_request("POST", "/send", payload)
+
+    return result
 
 
 # ----------------------------
@@ -401,6 +431,10 @@ def ow_spawn_worker(
     # relayサーバー確認
     if not ensure_relay_server():
         return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
+
+    # channel存在確認 → 未存在なら自動作成
+    if not ensure_channel(channel):
+        return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
 
     # task file書き出し先の決定
     queue_dir = _get_queue_dir()

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -439,6 +439,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
@@ -454,6 +455,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "manual")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-b", channel="ch2", cwd="/tmp", model="haiku",
@@ -471,6 +473,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\necho 'session-uuid-from-iterm2'\n")
@@ -489,6 +492,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\n")
@@ -507,6 +511,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\nexit 1\n")
@@ -519,6 +524,44 @@ class TestOwSpawnWorkerAdapter:
         )
         assert result.get("manual") is True
         assert "adapter_error" in result
+
+
+class TestOwSpawnWorkerEnsureChannel:
+    """ow_spawn_worker: ensure_channel呼び出しの動作確認"""
+
+    def test_ensure_channel_called_before_spawn(self, tmp_path: Path, monkeypatch):
+        """ensure_channelが成功すれば通常通りspawnが進む"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+
+        called_channels = []
+
+        def fake_ensure_channel(c):
+            called_channels.append(c)
+            return True
+
+        monkeypatch.setattr(ow_service, "ensure_channel", fake_ensure_channel)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="TestCh01", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=1,
+        )
+        assert called_channels == ["TestCh01"]
+        assert result.get("manual") is True  # OW_TERMINAL未設定なのでmanual
+
+    def test_ensure_channel_failure_returns_error(self, tmp_path: Path, monkeypatch):
+        """ensure_channelが失敗するとCHANNEL_UNAVAILABLEエラーを返す"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: False)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="BadCh01", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=1,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "CHANNEL_UNAVAILABLE"
 
 
 class TestOwCloseWorkerTermRef:

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -246,3 +246,121 @@ class TestOwSendSuccess:
         assert isinstance(sent_data["body"], str)
         parsed_body = json.loads(sent_data["body"])
         assert parsed_body == ow_body
+
+
+class TestEnsureChannel:
+    """ensure_channel: channel未存在時の自動作成"""
+
+    def test_ensure_channel_success(self, monkeypatch):
+        """POST /createが成功すればTrueを返す"""
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"channel_code": "TestCh01"}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ensure_channel("TestCh01")
+        assert result is True
+
+    def test_ensure_channel_failure_returns_false(self, monkeypatch):
+        """POST /createが失敗（5xx）すればFalseを返す（raiseは外に出ない）"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url="http://127.0.0.1:8765/create",
+                code=500,
+                msg="internal server error",
+                hdrs={},
+                fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
+
+        with pytest.raises(urllib.error.HTTPError):
+            ow_service.ensure_channel("TestCh01")
+
+
+class TestOwSendEnsureChannel:
+    """ow_send: channel未存在時のensure_channel自動作成フロー"""
+
+    def test_404_triggers_ensure_channel_and_resend(self, monkeypatch):
+        """ow_sendでchannel 404 → ensure_channelが呼ばれ再送が成功する"""
+        call_log = []
+
+        class FakeCreateResponse:
+            def read(self):
+                return json.dumps({"channel_code": "AbCdEfGh"}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        class FakeSendResponse:
+            def read(self):
+                return json.dumps({"msg_id": 99}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            url = req.full_url
+            call_log.append(url)
+            if "/send" in url and len([u for u in call_log if "/send" in u]) == 1:
+                # 1回目のsendは404
+                raise urllib.error.HTTPError(
+                    url=url, code=404, msg="channel not found", hdrs={}, fp=None
+                )
+            elif "/create" in url:
+                return FakeCreateResponse()
+            else:
+                # 2回目のsend（再送）は成功
+                return FakeSendResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_send(
+            channel="AbCdEfGh",
+            handle="orch",
+            body={"v": 1, "kind": "cmd", "to": "w-a", "verb": "ping"},
+        )
+
+        assert result.get("msg_id") == 99
+        # /createと2回目の/sendが呼ばれている
+        assert any("/create" in u for u in call_log)
+        assert len([u for u in call_log if "/send" in u]) == 2
+
+    def test_404_ensure_channel_fails_returns_error(self, monkeypatch):
+        """ow_sendでchannel 404 → ensure_channel失敗 → 元の404エラーを返す"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=404, msg="not found", hdrs={}, fp=None
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_send(
+            channel="NoExist1",
+            handle="orch",
+            body={"v": 1, "kind": "state", "state": "ready"},
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == 404

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -271,7 +271,7 @@ class TestEnsureChannel:
         assert result is True
 
     def test_ensure_channel_failure_returns_false(self, monkeypatch):
-        """POST /createが失敗（5xx）すればFalseを返す（raiseは外に出ない）"""
+        """POST /createが5xxで失敗してもFalseを返す（例外は外に出ない）"""
 
         def fake_urlopen(req, timeout=None):
             raise urllib.error.HTTPError(
@@ -286,8 +286,8 @@ class TestEnsureChannel:
         monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
         monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
 
-        with pytest.raises(urllib.error.HTTPError):
-            ow_service.ensure_channel("TestCh01")
+        result = ow_service.ensure_channel("TestCh01")
+        assert result is False
 
 
 class TestOwSendEnsureChannel:


### PR DESCRIPTION
## Summary

- `ow_service.py`に`ensure_channel(channel_code)`を追加。`POST /create`にchannel_codeを指定して呼ぶことでidempotentにchannelを作成する
- `ow_send()`でchannel不在による404を検出した場合、`ensure_channel`で自動作成→再送する
- `ow_spawn_worker()`でも事前に`ensure_channel`を呼び、channel存在を保証してからworkerを起動する
- relay/server.pyも`POST /create`をchannel_code指定対応に拡張（別途relayリポにコミット済み）

## Test plan

- [ ] `TestEnsureChannel::test_ensure_channel_success` — POST /createが成功すればTrueを返す
- [ ] `TestEnsureChannel::test_ensure_channel_failure_returns_false` — 5xx時はraiseが伝播する
- [ ] `TestOwSendEnsureChannel::test_404_triggers_ensure_channel_and_resend` — channel 404→ensure_channel→再送成功
- [ ] `TestOwSendEnsureChannel::test_404_ensure_channel_fails_returns_error` — ensure_channel失敗→元の404エラーを返す
- [ ] 既存テスト944件がすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)