### PR TITLE
feat: orch起動フローの自動化（relay自動起動・channel自動作成・queueパス統一）

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -16,8 +16,8 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 ## 起動フロー
 
-1. **queue走査**: `<auto-memory>/orch/queue-t<topic_id>.md` を走査する。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
-2. **relay疎通確認**: `ow_status()` を呼ぶ（ow_*ツール内蔵のensure-server処理が自動実行）。channelがなければ作成し、channel_codeをqueueのfrontmatterに記録する
+1. **queue走査**: `~/.cc-memory-ow/orch/queue-t<topic_id>.md` を走査する。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
+2. **relay疎通確認**: `ow_status(channel_code, topic_id)` を呼ぶ。relayサーバーの自動起動・channel自動作成（idempotent）が内部で実行される。queueファイルのfrontmatterを確認し、channel_codeを記録する（初回起動時）
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージをpullし処理する（初回起動時はskip）
 4. **cc-memory check-in**: `check_in(orch_activity_id)` でアクティビティに紐づく情報を取得する
 5. **特化版プレイブック取得**: `search(tags=["playbook", "domain:<topic_domain>"])` で特化版プレイブックを取得する（§プレイブック参照 参照）
@@ -100,9 +100,9 @@ on Monitor発火 or 自発的タイミング:
 
 ### ファイルパスとMEMORY.md
 
-- パス: `<auto-memory>/orch/queue-t<topic_id>.md`
+- パス: `~/.cc-memory-ow/orch/queue-t<topic_id>.md`
 - MEMORY.mdに1行ポインタを追記し「orchセッション専用」と明記する
-- task fileは `<auto-memory>/orch/tasks/T<n>.json`
+- task fileは `~/.cc-memory-ow/orch/tasks/T<n>.json`
 
 ### frontmatterフォーマット
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -158,14 +158,16 @@ def ensure_channel(channel_code: str) -> bool:
     """channelが存在しなければrelayに作成する（idempotent）。
 
     POST /createにchannel_codeを指定して送信する。relayサーバー側で
-    既存なら何もせず、未存在なら作成する（D#2xxx）。
+    既存なら何もせず、未存在なら作成する（D#2453）。
 
     Args:
         channel_code: 存在を保証したいchannel_code
 
     Returns:
         True: channelが存在する（作成成功・既存どちらも）
-        False: 作成失敗
+        False: 作成失敗（4xxエラー）
+    Raises:
+        urllib.error.HTTPError: relayが5xxを返した場合（_relay_requestが再raise）
     """
     result = _relay_request("POST", "/create", {"channel_code": channel_code})
     if "error" in result:
@@ -694,7 +696,8 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
 
     # channel指定があればensure_channel（idempotent）
     if channel:
-        ensure_channel(channel)
+        if not ensure_channel(channel):
+            return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
 
     # presenceを取得
     presence_result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -266,11 +266,11 @@ def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
 # ----------------------------
 
 
-def _get_queue_dir() -> Path | None:
-    """queueディレクトリパスを返す（OW_QUEUE_DIR環境変数）。"""
+def _get_queue_dir() -> Path:
+    """queueディレクトリパスを返す（OW_QUEUE_DIR環境変数、またはデフォルト ~/.cc-memory-ow/orch）。"""
     if OW_QUEUE_DIR:
         return Path(OW_QUEUE_DIR).expanduser()
-    return None
+    return Path.home() / ".cc-memory-ow" / "orch"
 
 
 def _build_queue_frontmatter(
@@ -438,10 +438,6 @@ def ow_spawn_worker(
 
     # task file書き出し先の決定
     queue_dir = _get_queue_dir()
-    if queue_dir is None:
-        # OW_QUEUE_DIR未設定の場合は一時的なパスを使用
-        queue_dir = Path.home() / ".cc-memory-ow" / "orch"
-
     task_dir = queue_dir / "tasks"
 
     # queueへspawning write-ahead（孤児worker対策 D#2395）
@@ -692,6 +688,14 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
             "summary": {"total_tasks": int, "status_counts": dict, "online_workers": [...]}
         }
     """
+    # relayサーバー確認 → 未起動なら自動起動
+    if not ensure_relay_server():
+        return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
+
+    # channel指定があればensure_channel（idempotent）
+    if channel:
+        ensure_channel(channel)
+
     # presenceを取得
     presence_result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")
     if "error" in presence_result:
@@ -703,10 +707,10 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
     tasks: list[dict] = []
     frontmatter: dict = {}
     queue_dir = _get_queue_dir()
-    if queue_dir is not None and topic_id is not None:
+    if topic_id is not None:
         queue_file = queue_dir / f"queue-t{topic_id}.md"
         frontmatter, tasks = _parse_queue_file(queue_file)
-    elif queue_dir is not None:
+    else:
         # topic_id未指定の場合は存在する全queueファイルを読む
         for queue_file in sorted(queue_dir.glob("queue-t*.md")):
             fm, file_tasks = _parse_queue_file(queue_file)

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -154,6 +154,27 @@ def ensure_relay_server() -> bool:
     return False
 
 
+def ensure_channel(channel_code: str) -> bool:
+    """channelが存在しなければrelayに作成する（idempotent）。
+
+    POST /createにchannel_codeを指定して送信する。relayサーバー側で
+    既存なら何もせず、未存在なら作成する（D#2xxx）。
+
+    Args:
+        channel_code: 存在を保証したいchannel_code
+
+    Returns:
+        True: channelが存在する（作成成功・既存どちらも）
+        False: 作成失敗
+    """
+    result = _relay_request("POST", "/create", {"channel_code": channel_code})
+    if "error" in result:
+        logger.warning("ensure_channel failed for %s: %s", channel_code, result["error"])
+        return False
+    logger.info("ensure_channel: channel %s is ready", channel_code)
+    return True
+
+
 # ----------------------------
 # T1: ow_send
 # ----------------------------
@@ -170,6 +191,7 @@ def ow_send(
 
     bodyはow固有JSONを格納するdict（relay schemaは無改修）。
     4xx即失敗、5xx/接続断のみ3回指数バックオフ。
+    channel未存在（404）の場合はensure_channelで自動作成してから再送する。
 
     Args:
         channel: channelコード
@@ -191,7 +213,15 @@ def ow_send(
     if in_reply_to is not None:
         payload["in_reply_to"] = in_reply_to
 
-    return _relay_request("POST", "/send", payload)
+    result = _relay_request("POST", "/send", payload)
+
+    # channel未存在による404 → 自動作成して再送（1回のみ）
+    if "error" in result and result["error"].get("code") == 404:
+        logger.info("ow_send: channel %s not found, attempting ensure_channel", channel)
+        if ensure_channel(channel):
+            result = _relay_request("POST", "/send", payload)
+
+    return result
 
 
 # ----------------------------
@@ -401,6 +431,10 @@ def ow_spawn_worker(
     # relayサーバー確認
     if not ensure_relay_server():
         return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
+
+    # channel存在確認 → 未存在なら自動作成
+    if not ensure_channel(channel):
+        return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
 
     # task file書き出し先の決定
     queue_dir = _get_queue_dir()

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -454,6 +454,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
@@ -469,6 +470,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "manual")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-b", channel="ch2", cwd="/tmp", model="haiku",
@@ -486,6 +488,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\necho 'session-uuid-from-iterm2'\n")
@@ -504,6 +507,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\n")
@@ -522,6 +526,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\nexit 1\n")

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -319,6 +319,9 @@ last_seen_msg_id: 42
 
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
 
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
+
         def fake_relay_request(method, path, data=None):
             if "/presence" in path:
                 return {"handles": ["orch", "w-a"]}
@@ -348,6 +351,9 @@ last_seen_msg_id: 42
 
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
 
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
+
         def fake_relay_request(method, path, data=None):
             return {"handles": ["orch", "w-a"]}
 
@@ -374,6 +380,9 @@ class TestOwStatusIntegration:
 
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
 
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
+
         def fake_relay_request(method, path, data=None):
             if "/presence" in path:
                 return {"handles": ["orch", "w-a"]}
@@ -392,6 +401,9 @@ class TestOwStatusIntegration:
     def test_status_with_empty_queue(self, tmp_path: Path, monkeypatch):
         """queueファイルなし + presence取得 → タスク0件の統合ビュー"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         def fake_relay_request(method, path, data=None):
             return {"handles": ["orch"]}
@@ -419,6 +431,9 @@ class TestOwStatusIntegration:
         )
 
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
 
         def fake_relay_request(method, path, data=None):
             return {"handles": []}

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -271,8 +271,8 @@ class TestEnsureChannel:
         result = ow_service.ensure_channel("TestCh01")
         assert result is True
 
-    def test_ensure_channel_failure_returns_false(self, monkeypatch):
-        """POST /createが失敗（5xx）すればFalseを返す（raiseは外に出ない）"""
+    def test_ensure_channel_5xx_propagates_exception(self, monkeypatch):
+        """POST /createが5xxのとき_relay_request経由で例外が伝播する"""
 
         def fake_urlopen(req, timeout=None):
             raise urllib.error.HTTPError(

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -246,3 +246,121 @@ class TestOwSendSuccess:
         assert isinstance(sent_data["body"], str)
         parsed_body = json.loads(sent_data["body"])
         assert parsed_body == ow_body
+
+
+class TestEnsureChannel:
+    """ensure_channel: channel未存在時の自動作成"""
+
+    def test_ensure_channel_success(self, monkeypatch):
+        """POST /createが成功すればTrueを返す"""
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"channel_code": "TestCh01"}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ensure_channel("TestCh01")
+        assert result is True
+
+    def test_ensure_channel_failure_returns_false(self, monkeypatch):
+        """POST /createが失敗（5xx）すればFalseを返す（raiseは外に出ない）"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url="http://127.0.0.1:8765/create",
+                code=500,
+                msg="internal server error",
+                hdrs={},
+                fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        monkeypatch.setattr(ow_service.time, "sleep", lambda _: None)
+
+        with pytest.raises(urllib.error.HTTPError):
+            ow_service.ensure_channel("TestCh01")
+
+
+class TestOwSendEnsureChannel:
+    """ow_send: channel未存在時のensure_channel自動作成フロー"""
+
+    def test_404_triggers_ensure_channel_and_resend(self, monkeypatch):
+        """ow_sendでchannel 404 → ensure_channelが呼ばれ再送が成功する"""
+        call_log = []
+
+        class FakeCreateResponse:
+            def read(self):
+                return json.dumps({"channel_code": "AbCdEfGh"}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        class FakeSendResponse:
+            def read(self):
+                return json.dumps({"msg_id": 99}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            url = req.full_url
+            call_log.append(url)
+            if "/send" in url and len([u for u in call_log if "/send" in u]) == 1:
+                # 1回目のsendは404
+                raise urllib.error.HTTPError(
+                    url=url, code=404, msg="channel not found", hdrs={}, fp=None
+                )
+            elif "/create" in url:
+                return FakeCreateResponse()
+            else:
+                # 2回目のsend（再送）は成功
+                return FakeSendResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_send(
+            channel="AbCdEfGh",
+            handle="orch",
+            body={"v": 1, "kind": "cmd", "to": "w-a", "verb": "ping"},
+        )
+
+        assert result.get("msg_id") == 99
+        # /createと2回目の/sendが呼ばれている
+        assert any("/create" in u for u in call_log)
+        assert len([u for u in call_log if "/send" in u]) == 2
+
+    def test_404_ensure_channel_fails_returns_error(self, monkeypatch):
+        """ow_sendでchannel 404 → ensure_channel失敗 → 元の404エラーを返す"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=404, msg="not found", hdrs={}, fp=None
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+        result = ow_service.ow_send(
+            channel="NoExist1",
+            handle="orch",
+            body={"v": 1, "kind": "state", "state": "ready"},
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == 404

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -8,6 +8,7 @@
 import json
 import urllib.error
 import urllib.request
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -364,3 +365,47 @@ class TestOwSendEnsureChannel:
 
         assert "error" in result
         assert result["error"]["code"] == 404
+
+
+class TestGetQueueDir:
+    """_get_queue_dir: OW_QUEUE_DIR設定の有無でパスが変わる"""
+
+    def test_default_returns_cc_memory_ow_path(self, monkeypatch):
+        """OW_QUEUE_DIR未設定時は ~/.cc-memory-ow/orch を返す"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
+        result = ow_service._get_queue_dir()
+        assert result == Path.home() / ".cc-memory-ow" / "orch"
+
+    def test_env_var_overrides_default(self, monkeypatch, tmp_path):
+        """OW_QUEUE_DIR設定時はその値を展開して返す"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service._get_queue_dir()
+        assert result == tmp_path
+
+
+class TestOwStatusEnsure:
+    """ow_status: relay起動 + channel作成の自動化"""
+
+    def test_ow_status_calls_ensure_relay_and_channel(self, monkeypatch, tmp_path):
+        """ow_statusはensure_relay_serverとensure_channelを自動実行する"""
+        ensure_relay_called = []
+        ensure_channel_called = []
+
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: ensure_relay_called.append(True) or True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: ensure_channel_called.append(ch) or True)
+        monkeypatch.setattr(ow_service, "_relay_request", lambda *args, **kwargs: {"handles": []})
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+
+        ow_service.ow_status(channel="TestCh01", topic_id="454")
+
+        assert len(ensure_relay_called) == 1
+        assert ensure_channel_called == ["TestCh01"]
+
+    def test_ow_status_relay_unavailable_returns_error(self, monkeypatch):
+        """relayが起動できない場合はエラーを返す"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: False)
+
+        result = ow_service.ow_status(channel="TestCh01")
+
+        assert "error" in result
+        assert result["error"]["code"] == "RELAY_UNAVAILABLE"


### PR DESCRIPTION
## Summary

- `ow_status()` に relay自動起動・channel自動作成を内包し、orch起動時に手動curl/mkdirが不要に
- `_get_queue_dir()` のデフォルトを `None` → `~/.cc-memory-ow/orch` に変更（D#2452）
- `skills/orch/SKILL.md` の起動フロー§の `<auto-memory>` 曖昧パスを `~/.cc-memory-ow/orch` に修正（D#2451）

## 関連

- PR#346 (`fix/spawn-ensure-channel`) を先行マージしてから作業した
- T4 (orch: topic 454 ow実装の進捗管理)

## Test plan

- [ ] `uv run pytest tests/unit/test_ow_send.py tests/unit/test_ow_queue.py -q` → 全件パス
- [ ] `ow_status()` を呼ぶだけで relay未起動→自動起動・channel未存在→自動作成が走ることを確認
- [ ] OW_QUEUE_DIR未設定時に `~/.cc-memory-ow/orch` が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)