### PR TITLE
feat: workerスキルフルスコープ化（worker-sync・escalation/fallback・hooks改修）

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -4,6 +4,7 @@
 レガシー関数（Phase 3で廃止予定）を含む。
 """
 import json
+import os
 import re
 from pathlib import Path
 
@@ -23,6 +24,21 @@ def _is_cc_memory_tool(name: str) -> bool:
 def _extract_short_name(name: str) -> str:
     """ツール名からshort_name（check_in, add_logs等）を取り出す。"""
     return name.split(_CC_MEMORY_MARKER, 1)[1]
+
+# --- ow worker判定 ---
+
+_ORCH_MANAGED_TAG = "orch-managed"
+
+
+def _is_worker_session() -> bool:
+    """ow workerとして起動されたセッションかを判定する（D#2409）。
+
+    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
+    workerはtask fileとcheck_inで文脈を得るため、個人フロー用の
+    アクティビティ一覧注入・check-inブロック・nudgeは適用しない。
+    """
+    return os.environ.get("OW_ROLE") == "worker"
+
 
 # --- 記録ツール ---
 

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -6,6 +6,7 @@
 - コンテキスト取得フロー・補助ツール認知（静的テキスト）
 """
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,6 +28,20 @@ from scripts.snapshot import health_check, should_take_snapshot, take_snapshot
 
 # description先頭の切り出し文字数
 _DESCRIPTION_SNIPPET_LENGTH = 100
+
+# orchが管理するアクティビティに付与される素タグ（D#2410）。
+# 個人フローのアクティビティ一覧・スコアリングから除外する。
+_ORCH_MANAGED_TAG = "orch-managed"
+
+
+def _is_worker_session() -> bool:
+    """ow workerとして起動されたセッションかを判定する（D#2409）。
+
+    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
+    worker は task file と check_in で文脈を得るため、個人フロー用の
+    アクティビティ一覧注入は不要・ノイズになる。
+    """
+    return os.environ.get("OW_ROLE") == "worker"
 
 
 
@@ -128,7 +143,14 @@ def _build_activities_section(conn) -> str:
 
     heartbeat中は別セクション表示。非heartbeatは番号付きフラットリストで出力し、
     AIスコアリング指示を末尾に追加する。
+
+    worker セッション（OW_ROLE=worker）では一覧注入自体を抑制する（D#2409）。
+    通常セッションでは orch-managed タグ付きアクティビティを除外する（D#2410）。
     """
+    # worker セッションはアクティビティ一覧を注入しない
+    if _is_worker_session():
+        return ""
+
     domains = get_active_domains_with_conn(conn)
 
     if not domains:
@@ -151,12 +173,26 @@ def _build_activities_section(conn) -> str:
             else:
                 normal_activities.append(a)
 
+    # 収集した全アクティビティのタグを一括取得し、orch-managedを除外する。
+    # heartbeat/normal両セクションが対象（個人フローからorchフローを分離）。
+    collected_ids = [a["id"] for a in heartbeat_activities + normal_activities]
+    tags_map = get_entity_tags_batch(
+        conn, "activity_tags", "activity_id", collected_ids
+    )
+    heartbeat_activities = [
+        a for a in heartbeat_activities
+        if _ORCH_MANAGED_TAG not in tags_map.get(a["id"], [])
+    ]
+    normal_activities = [
+        a for a in normal_activities
+        if _ORCH_MANAGED_TAG not in tags_map.get(a["id"], [])
+    ]
+
     if not heartbeat_activities and not normal_activities:
         return ""
 
-    # メタデータ一括取得
+    # メタデータ一括取得（tags_mapは収集時に取得済み・全idを網羅）
     all_ids = [a["id"] for a in normal_activities]
-    tags_map = get_entity_tags_batch(conn, "activity_tags", "activity_id", all_ids)
     unresolved_deps = _get_unresolved_deps(conn, all_ids)
     descriptions = _get_descriptions(conn, all_ids)
     created_ats = _get_created_ats(conn, all_ids)

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -25,24 +25,10 @@ from src.services.activity_service import (
 from src.services.habit_service import get_active_habit_contents_with_conn
 from src.services.tag_service import get_entity_tags_batch
 from scripts.snapshot import health_check, should_take_snapshot, take_snapshot
+from hooks.hook_transcript import _ORCH_MANAGED_TAG, _is_worker_session
 
 # description先頭の切り出し文字数
 _DESCRIPTION_SNIPPET_LENGTH = 100
-
-# orchが管理するアクティビティに付与される素タグ（D#2410）。
-# 個人フローのアクティビティ一覧・スコアリングから除外する。
-_ORCH_MANAGED_TAG = "orch-managed"
-
-
-def _is_worker_session() -> bool:
-    """ow workerとして起動されたセッションかを判定する（D#2409）。
-
-    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
-    worker は task file と check_in で文脈を得るため、個人フロー用の
-    アクティビティ一覧注入は不要・ノイズになる。
-    """
-    return os.environ.get("OW_ROLE") == "worker"
-
 
 
 def _calc_elapsed_days(updated_at_str: str) -> int:

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -35,6 +35,44 @@ _CHECKIN_DEFER_TURNS = 2
 _MAX_SKILL_SPAN_TURNS = 20
 _NUDGE_INTERVAL = 2
 
+# orchが管理するアクティビティに付与される素タグ（D#2410）
+_ORCH_MANAGED_TAG = "orch-managed"
+
+
+def _is_worker_session() -> bool:
+    """ow workerとして起動されたセッションかを判定する（D#2409）。
+
+    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
+    workerはworkerスキル・worker-syncの記録規律に従うため、個人フロー用の
+    check-inブロック・nudgeは適用しない。
+    """
+    return os.environ.get("OW_ROLE") == "worker"
+
+
+def _is_orch_managed_activity(activity_id) -> bool:
+    """指定アクティビティが orch-managed タグを持つかを判定する（D#2410）。
+
+    orchが管理するアクティビティにcheck-in済みのセッションは個人フローでなく
+    orchフローなので、check-inブロック・nudgeの対象外とする。
+    DB参照に失敗した場合はフェイルオープン（False=通常フロー扱い）。
+    """
+    if not activity_id:
+        return False
+    try:
+        from src.db import get_connection
+        from src.services.tag_service import get_entity_tags_batch
+
+        conn = get_connection()
+        try:
+            tags_map = get_entity_tags_batch(
+                conn, "activity_tags", "activity_id", [int(activity_id)]
+            )
+        finally:
+            conn.close()
+        return _ORCH_MANAGED_TAG in tags_map.get(int(activity_id), [])
+    except Exception:
+        return False
+
 
 def _output(decision: str, reason: str = "") -> None:
     result = {"decision": decision}
@@ -104,22 +142,31 @@ def main() -> None:
         if has_checkin:
             # activity_idを抽出して保存
             _update_checked_in_activity(state, all_events, transcript_path)
-        elif current_turn == _CHECKIN_DEFER_TURNS:
-            # one-shot block: 正確にdefer turnで1回だけblock
-            state.increment_block_count()
-            _output(
-                "block",
-                "アクティビティにcheck-inしてください。"
-                "該当するものがなければadd_activityで作成してください。",
-            )
-            return
+
+        # orchフロー（worker セッション or orch-managedアクティビティ）では
+        # 個人フロー用のcheck-inブロック・nudgeを抑制する（D#2409/D#2410）。
+        suppress_personal_flow = (
+            _is_worker_session()
+            or _is_orch_managed_activity(state.get_checked_in_activity())
+        )
+
+        if not has_checkin and not suppress_personal_flow:
+            if current_turn == _CHECKIN_DEFER_TURNS:
+                # one-shot block: 正確にdefer turnで1回だけblock
+                state.increment_block_count()
+                _output(
+                    "block",
+                    "アクティビティにcheck-inしてください。"
+                    "該当するものがなければadd_activityで作成してください。",
+                )
+                return
 
         # 7. nudge判定 + 状態更新 + approve
         state.reset_block_count()
         _output("approve")
         _safe_post_approve(
             state, all_events, transcript_path, current_turn,
-            run_nudges=True,
+            run_nudges=not suppress_personal_flow,
         )
 
     except Exception as e:

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -24,7 +24,9 @@ from hooks.heartbeat import update_heartbeat
 from hooks.hook_state import HookState
 from hooks.hook_transcript import (
     _CHECKIN_TOOLS,
+    _ORCH_MANAGED_TAG,
     _RECORDING_TOOLS,
+    _is_worker_session,
     extract_events,
     extract_last_activity_id,
     read_transcript_from_offset,
@@ -34,19 +36,6 @@ _BLOCK_LIMIT = 1
 _CHECKIN_DEFER_TURNS = 2
 _MAX_SKILL_SPAN_TURNS = 20
 _NUDGE_INTERVAL = 2
-
-# orchが管理するアクティビティに付与される素タグ（D#2410）
-_ORCH_MANAGED_TAG = "orch-managed"
-
-
-def _is_worker_session() -> bool:
-    """ow workerとして起動されたセッションかを判定する（D#2409）。
-
-    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
-    workerはworkerスキル・worker-syncの記録規律に従うため、個人フロー用の
-    check-inブロック・nudgeは適用しない。
-    """
-    return os.environ.get("OW_ROLE") == "worker"
 
 
 def _is_orch_managed_activity(activity_id) -> bool:

--- a/skills/worker-sync/SKILL.md
+++ b/skills/worker-sync/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: worker-sync
+description: owフレームワークのworkerが退場時に実行する簡易sync。ユーザー対話なしで作業経緯log・生データmaterialを記録し、decisionはorchへ提案する
+---
+
+# worker-sync
+
+owフレームワークの **worker** が退場処理（`cmd:close` 受信時）に実行する記録スキル。
+通常の `sync-memory` のworker版で、**会話相手（ユーザー）がいない**前提で設計されている（D#2397 / 設計M#219 §4.4）。
+
+`worker` スキルの §退場処理 から呼び出される。worker以外のセッションでは使わない（通常セッションは `sync-memory` を使う）。
+
+## sync-memoryとの差分
+
+| 項目 | sync-memory（通常） | worker-sync |
+|------|---------------------|-------------|
+| ユーザー対話（AskUserQuestion） | あり | **なし** |
+| topic作成 | あり | **なし** |
+| activity作成 | あり | **なし** |
+| log記録 | あり | あり（実装経緯・障害・orchやり取り） |
+| material記録 | あり | あり（生データ・related=担当activity） |
+| decision記録 | 直接記録 | **原則しない**（decision_proposalsでorchに提案） |
+| 棚卸し・remember・ふりかえり | あり | **なし** |
+
+workerは記録ストア上をorchフローとして走るため、知識層への書き込み権限はorchに集約する。workerが勝手にtopic/activity/decisionを量産すると、orchの認知漏れとrelay履歴からの監査欠落を招く（D#2397）。
+
+## 実行手順
+
+### 前提の確認
+
+このスキルは `worker` スキルの退場処理から、`cmd:close` 受信後・`state:closed` 送信前に呼ばれる。
+task fileの `topic_id` / `activity_id` を記録の紐づけ先に使う。
+
+### 1. log記録（必須） — add_logs
+
+セッション中の作業経緯を **1件のログ** として記録する。`state:done` のsummaryより詳細に残す。次に来るセッション（同一workerの再spawnや、orchによる別worker割り当て）が経緯を引き継げることが目的。
+
+- **title**: `worker <alias> T<task_n>: <タスク名>` の形式
+- **content**: 以下を含める
+  - 何をやったか（実装内容）
+  - どういうアプローチ・設計判断を取ったか
+  - 途中で迷った点・blockedやエスカレーションをした点とその結末
+  - ハマったポイント・障害
+  - orchとの重要なやり取り（差し戻し・追加指示等）
+- **topic_id**: task fileの `topic_id`
+- **tags**: `["worker-log", "domain:<topic_domain>"]` ＋ タスク内容に応じた素タグ
+- **related**: 担当activity（`activity_id`）に紐づける
+
+### 2. material記録（該当時のみ） — add_material
+
+`state:done` の `materials[]` で報告済み以外に、保存すべき中間成果物（調査結果・分析・ドラフト・設計メモ等）があれば保存する。なければスキップする。
+
+- 要約・整理はせず、**生データをそのまま** 保存する
+- `related` で担当activity（`activity_id`）・topic（`topic_id`）に紐づける
+- tags: `domain:<topic_domain>` ＋ 内容を表す素タグ
+
+### 3. decisionの扱い — 原則 add_decisions しない
+
+workerは決定事項を **直接記録しない**。`state:done` の `decision_proposals[]` でorchに提案済みのはずなので、ここで `add_decisions` を呼ぶ必要はない。
+
+- done時に提案し忘れた決定事項があることに気づいた場合は、`add_decisions` ではなく、その内容を `state` メッセージ（`working` のnote等）でorchに伝える
+- **例外**: エスカレーションで人間がこのworkerセッション内で **直接合意** した決定事項は、すでにエスカレーション処理時にworkerが記録済みのはずである（worker スキル §エスカレーション）。その記録漏れがあればここで `add_decisions`（タグ `escalation`・`user-decision`・`domain:<topic_domain>`）し、記録したD#を退場後のorch通知に含める
+
+### 4. 完了
+
+記録が完了したら `worker` スキルの退場処理に戻り、`state:closed` を送信する。
+
+## 禁止事項
+
+- ユーザーへの確認・質問（AskUserQuestion）をしない
+- topic・activityを新規作成しない
+- decisionを直接記録しない（エスカレーション例外を除く）
+- 棚卸し・remember・ふりかえりをしない

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -7,10 +7,31 @@ description: owフレームワークのworkerとして動作する。orchから�
 
 owフレームワークのworkerとして動作する。orchからの指示を受けてタスクを実行し、結果を報告する。
 
+このスキルは**ステートマシン**として記述されている。workerの全メッセージは「現在状態の宣言」（`state`）であり、各状態の遷移条件と送信メッセージを以下に定義する。
+
+## 状態一覧
+
+| state | 意味 | 主なdata |
+|-------|------|---------|
+| `ready` | 起動完了・assign待ち | `session_id`, `alias`, `cwd` |
+| `working` | assign受諾・作業中 | `phase`, `note`（assignへの初回は`in_reply_to`必須） |
+| `blocked` | 判断要請（orchに回答 or エスカレーション判断を仰ぐ） | `question`, `options`, `context_refs`（`needs_reply`） |
+| `escalated` | 人間へのエスカレーション中 | `report_md`（解決時は`summary`/`decision_ids`/`log_ids`を添えて`working`へ戻る） |
+| `done` | 作業完了・検証待ち | `summary`, `evidence`, `synced`, `materials[]`, `decision_proposals[]`（`needs_reply`） |
+| `closed` | 退場処理完了・終了 | （なし） |
+| `dead` | 起動失敗（task file不在等） | `message` |
+| `fallback` | orch通信不能・人間対話モードへ移行 | `reason` |
+
+メッセージ共通形式:
+```json
+{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"<state>", "data":{...}}
+```
+
 ## 起動
 
 1. task fileを読み込む: orchのbootstrapプロンプトで渡されたパスからJSONを読む
-2. task fileから `channel_code`, `alias`, `task_n`, `activity_id`, `topic_id`, `acceptance`, `context`, `playbook`, `timeout_min` を取得する
+   - **task fileが存在しない/読めない場合は `state:dead`（data: `{"message":"task file not found: <path>"}`）を送信して終了する**
+2. task fileから `channel`(channel_code), `alias`, `task`(task_n), `activity_id`, `topic_id`, `acceptance`, `context`, `playbook`, `timeout_min` を取得する
 3. Monitorを起動する: `Monitor recv.sh <channel_code> <alias> (persistent)`
    - `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
 4. `check_in(activity_id)` でアクティビティの関連情報を取得する
@@ -20,7 +41,7 @@ owフレームワークのworkerとして動作する。orchからの指示を�
    ```
 6. **ready送信直後に `ow_history(channel=<channel_code>, since=<ready_msg_id>)` を実行する**。orchがready受信後にすぐ送ったcmd:assignをSSE接続完了前に取りこぼす場合があるため、自分でpullして補完する。
 
-## cmd:assign の受信
+## cmd:assign の受信 → working
 
 orchから `cmd:assign` が届いたら:
 1. 内容を確認し、`state:working` を送信する（**in_reply_toにassignのmsg_idを指定 — 必須**）:
@@ -29,56 +50,146 @@ orchから `cmd:assign` が届いたら:
    ```
 2. タスクの作業を開始する
 
-## 作業中
+## 作業中（working）
 
 - 通常の実装作業を行う（コーディング、テスト作成、PR作成等）
 - 節目ごとに `state:working` を送信してorchに進捗を知らせる:
   ```json
   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working", "data":{"phase":"<phase>", "note":"<進捗メモ>"}}
   ```
-- cc-memoryへの記録（add_logs, add_decisions, add_material）は通常通り行う
+- cc-memoryへの記録方針はworker専用の規律に従う（§記録規律）
 - SAを使う場合のモデル選択: 機械的作業→haiku/sonnet、通常実装→sonnet/opus、設計・複雑推論→opus以上
 
-## 完了
+## 判断に迷ったら → blocked
+
+タスクスコープ内で判断がつかない（仕様の解釈が割れる、前提が矛盾している、設計判断が必要等）場合は、独断で進めず `state:blocked` を送信してorchに判断を仰ぐ:
+```json
+{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"blocked",
+ "data":{"question":"<判断を仰ぎたい点>", "options":["<選択肢A>","<選択肢B>"], "context_refs":["T<task_n>","A#<activity_id>","msg_id:<n>"]}}
+```
+（`needs_reply=true` で送信する）
+
+orchの応答:
+- `cmd:answer` が届いたら、その回答に従って作業を再開し `state:working` を送信する
+- orchが「エスカレーションせよ」と判断した場合は §エスカレーション へ進む
+
+## エスカレーション（escalated）
+
+orchが人間へのエスカレーションを指示したら、以下の**エスカレーションフォーマット**をmarkdownで組み立て、`state:escalated`（data: `{"report_md":"<下記フォーマット>"}`）を送信する:
+
+```markdown
+## エスカレーション: <1行サマリ>
+
+### 質問
+<人間に判断してほしいこと>
+
+### 自分の推奨と理由
+<workerとしての推奨案。なぜそう考えるかの理由>
+
+### 選択肢
+- A: <選択肢A>（メリット/デメリット）
+- B: <選択肢B>（メリット/デメリット）
+
+### 文脈要約
+<ここまでの作業経緯・判断に至った背景の要約>
+
+### 関連ID
+- task: T<task_n> / activity: A#<activity_id> / topic: #<topic_id>
+- 関連msg_id: <blocked等のmsg_id>
+- 関連decision/material: D#... / M#...
+```
+
+その後の流れ:
+1. orchが人間に `term_ref`（workerセッション）を提示し、人間がこのworkerセッションで直接対話して解決する
+2. 人間と合意した内容を記録する（**エスカレーション時の例外: workerがその場でdecisionを記録してよい**）:
+   - **log必須**（経緯）。タグに `escalation`・`user-decision`・`domain:<topic_domain>` を付ける
+   - 合意した決定事項は `add_decisions` で記録してよい（同タグ）
+3. 記録した `decision_ids` / `log_ids` を添えて `state:working` に戻り、orchへ必ず通知する（監査保全・D#2397）:
+   ```json
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working",
+    "data":{"phase":"escalation_resolved", "note":"<解決内容>", "decision_ids":[...], "log_ids":[...]}}
+   ```
+
+エスカレーション中（escalated）はorchのタイムアウト・クローズ対象外になる。
+
+## フォールバック（fallback）
+
+orchとの通信が途絶した場合の縮退動作（D#2384 / D#2399）:
+
+1. `needs_reply=true` で送ったメッセージに **10分** 応答がなければ同じメッセージを再送する
+2. 再送後さらに **10分** 応答がなければ `state:fallback`（data: `{"reason":"orch unreachable: <状況>"}`）を宣言し、**人間対話モード**へ移行する（以降はこのセッションのユーザーと直接対話して作業を進める）
+
+復帰規則:
+- フォールバック後、**人間の入力が一度もなければ**、orchからの復帰メッセージ（`cmd`）受信で自動的にworkerモードへ復帰する
+- **人間の入力が一度でもあれば**、自動復帰せず、人間に復帰可否を確認してから復帰する（人間の作業を中断・上書きしないため）
+
+## 完了 → done
 
 作業が完了したら:
-1. cc-memoryへの記録が完了していることを確認する（`synced: true` の前提）
-2. `state:done` を送信する:
+1. acceptanceを満たしていることを確認し、証拠（evidence: テスト結果・PR URL等）を揃える
+2. worker専用の記録規律（§記録規律）に従い、material保存・decision_proposalsの準備を済ませる
+3. `state:done` を送信する（`needs_reply=true`）:
    ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"done", "data":{"summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[], "decision_proposals":[]}}
+   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"done",
+    "data":{"summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[<material_id...>], "decision_proposals":[{"decision":"...","reason":"..."}]}}
    ```
-3. orchからの応答を待つ。`cmd:close` が届いたら退場処理（§退場処理）を行ってから `state:closed` を送信して終了する
+   - `synced:true` は「material保存済み・decision_proposals本メッセージに添付済みでorchが検証可能な状態」を意味する。最終的な作業経緯ログの確定はcmd:close時のworker-syncで行う（§退場処理・D#2446）
+4. orchからの応答を待つ（§完了後の待機）
+
+## 完了後の待機
+
+done送信後はcloseを受けるまで**読み取り専用**で待機する:
+- 新しい作業を始めない
+- cc-memoryへの追記もしない（退場処理を除く）
+- `state:closed` 以外のstateを送らない（`cmd:ping`への応答を除く）
+
+orchの応答:
+- `cmd:close` → §退場処理 を実行してから `state:closed` を送信して終了
+- `cmd:answer` 等で差し戻し（done検証NG）→ 指示に従い `state:working` に戻って作業を再開
 
 ## 退場処理（cmd:close受信時）
 
-`cmd:close` を受信したら、`state:closed` を送信する**前に**以下を実行する。セッション終了でコンテキストが失われるため、次のセッションが引き継げる情報を残すことが目的。
+`cmd:close` を受信したら、`state:closed` を送信する**前に** `worker-sync` スキルを実行する（D#2446: done時点ではなくclose確定後にsyncする。orchが差し戻す可能性があるため）。
 
-1. **ログ記録** (`add_logs`): セッション中の作業経緯を1件のログとして記録する
-   - title: `worker <alias> T<task_n>: <タスク名>` の形式
-   - content: 何をやったか、どういうアプローチを取ったか、途中で判断した点、ハマったポイントなど。state:doneのsummaryより詳細に残す
-   - topic_id: task fileの `topic_id` を使う
-   - tags: `["worker-log", "domain:<topic_domain>"]` + タスク内容に応じた素タグ
+`worker-sync` スキルは以下を行う（詳細はworker-syncスキル参照）:
+- **log記録**: セッション中の作業経緯（実装アプローチ・障害・orchとのやり取り）を1件のログとして記録
+- **material記録**: state:doneで報告済み以外の中間成果物があれば保存（related=担当activity）
+- **decisionは原則記録しない**: workerはdecisionを直接書かず、done時の `decision_proposals` でorchに提案する（D書き込み権限のorch集約・D#2397）。エスカレーションで人間と直接合意した分は例外として記録済み
 
-2. **決定事項記録** (`add_decisions`): セッション中にworkerが判断・合意した事項があれば記録する（なければスキップ）
-   - 実装上の設計判断、仕様解釈、トレードオフの選択など
+worker-syncスキル完了後に `state:closed` を送信して終了する:
+```json
+{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"closed", "data":{}}
+```
 
-3. **成果物記録** (`add_material`): state:doneで報告済みのmaterial以外に、記録すべき中間成果物があれば保存する（なければスキップ）
+## 記録規律（worker専用）
 
-4. 記録完了後に `state:closed` を送信する:
-   ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"closed", "data":{}}
-   ```
+workerは会話相手（ユーザー）がいないため、通常のsync-memoryではなく `worker-sync` スキルの規律に従う:
+- **log**: 実装経緯・障害・orchとのやり取りを記録（worker自身が直接記録してよい）
+- **material**: 生データをそのまま保存。`related` で担当activityに紐づける（worker自身が直接保存してよい）
+- **decision**: 原則 `decision_proposals` でorchに提案し、orchが採否・記録する（D集約）。**workerは直接 `add_decisions` しない**
+  - 例外: エスカレーションで人間がこのworkerセッション内で直接合意した内容はworkerが記録してよい。記録したD#/L#は `state` 遷移で必ずorchに通知する
+- **topic/activityの新規作成はしない**
+
+## 状態不明時の再導出（compaction後等）
+
+コンテキストが失われて現在状態が分からなくなった場合:
+1. `ow_history(channel=<channel_code>, since=0)` で全履歴を取得する
+2. 自分のhandle（alias）が `from` または `to` のメッセージだけにフィルタする
+3. 自分が最後に送った `state` 宣言を見つけ、そこから現在状態を再導出する
+4. orchから未処理のcmdがあれば対応する
 
 ## 受信処理
 
-SSE（Monitor）は起床信号専用。起床したら `ow_history(channel=<channel_code>, since=<last_seen_msg_id>)` で未処理メッセージを全件pull。自分宛（`to` が自分のaliasまたは `*`）のメッセージのみ処理する。
+SSE（Monitor）は起床信号専用。起床したら `ow_history(channel=<channel_code>, since=<last_seen_msg_id>)` で未処理メッセージを全件pull。自分宛（`to` が自分のaliasまたは `*`）のメッセージのみ処理する。処理後に `last_seen_msg_id` を最大msg_idに更新する。
 
 ## cmd:ping への応答
 
-orchから `cmd:ping` が届いたら、現在の状態を `state:working` で返す。
+orchから `cmd:ping` が届いたら、現在の状態を表す `state`（通常は `working`、完了後待機中なら直近のstate）で返す。
 
 ## 禁止事項
 
 - orchの指示なしにタスクスコープを拡張しない
+- topic/activityを新規作成しない
+- decisionを直接記録しない（エスカレーション例外を除く。原則decision_proposalsでorchに提案）
 - `state:closed` 送信後にツールを呼ばない
-- done送信後、closeを受けるまで新しい作業を始めない
+- done送信後、closeを受けるまで新しい作業を始めない・cc-memoryへ追記しない（退場処理を除く）

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""pytest共通フィクスチャ。
+
+ow workerセッション（OW_ROLE=worker）内でテストを実行すると、
+hookやサービス層がworkerフロー扱いになり、通常セッション前提のテストが
+非決定的に壊れる。テスト実行環境からow関連の環境変数を除去し、
+どの環境で実行してもテストが決定論的に振る舞うようにする。
+"""
+import os
+
+import pytest
+
+_OW_ENV_KEYS = ("OW_ROLE", "OW_ALIAS", "OW_CHANNEL", "OW_TASK_FILE")
+
+
+@pytest.fixture(autouse=True)
+def _clear_ow_env(monkeypatch):
+    """ow関連の環境変数をテストごとに除去する。
+
+    OW_ROLE=worker等が実行環境にリークしていても、テストは通常セッション
+    として振る舞う。worker挙動を検証するテストは個別にenvを設定すること。
+    """
+    for key in _OW_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -40,6 +40,8 @@ def _run_session_start_hook(
 ) -> dict:
     """session_start_hook.pyを実行してJSON出力を返す"""
     env = {**os.environ, "DISCUSSION_DB_PATH": db_path}
+    # runnerのOW_ROLEを継承しない（テストの決定性確保。worker抑制テストはextra_envで明示設定する）
+    env.pop("OW_ROLE", None)
     if extra_env:
         env.update(extra_env)
     if env_remove:
@@ -90,6 +92,31 @@ def _seed_activity(title: str, status: str = "pending", domain: str = "test") ->
         )
         conn.commit()
         return activity_id
+    finally:
+        conn.close()
+
+
+def _tag_activity_bare(activity_id: int, tag_name: str) -> None:
+    """アクティビティに素タグ（namespaceなし）を付与する"""
+    conn = get_connection()
+    try:
+        tag_row = conn.execute(
+            "SELECT id FROM tags WHERE namespace = '' AND name = ?",
+            (tag_name,),
+        ).fetchone()
+        if tag_row:
+            tag_id = tag_row["id"]
+        else:
+            cursor = conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES ('', ?)",
+                (tag_name,),
+            )
+            tag_id = cursor.lastrowid
+        conn.execute(
+            "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+            (activity_id, tag_id),
+        )
+        conn.commit()
     finally:
         conn.close()
 
@@ -288,6 +315,88 @@ class TestSessionStartHookHabits:
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "無効な振る舞い" not in context
+
+
+class TestSessionStartHookWorkerSuppression:
+    """OW_ROLE=worker セッションでのアクティビティ一覧抑制テスト（D#2409）"""
+
+    def test_worker_session_suppresses_activity_list(self, temp_db):
+        """OW_ROLE=worker時はアクティビティがあってもアクティビティ一覧セクションが出ない"""
+        _seed_activity("[作業] worker抑制テスト", status="in_progress")
+
+        result = _run_session_start_hook(temp_db, extra_env={"OW_ROLE": "worker"})
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "# アクティビティ一覧" not in context
+        assert "worker抑制テスト" not in context
+
+    def test_worker_session_keeps_habits_and_guide(self, temp_db):
+        """OW_ROLE=worker時もアクティビティ以外（振る舞い・取得フローガイド）は注入される"""
+        _seed_habit("worker向け振る舞い")
+
+        result = _run_session_start_hook(temp_db, extra_env={"OW_ROLE": "worker"})
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "コンテキスト取得フロー" in context
+        assert "# 振る舞い" in context
+        assert "worker向け振る舞い" in context
+
+    def test_non_worker_session_shows_activity_list(self, temp_db):
+        """OW_ROLE未設定（通常セッション）ではアクティビティ一覧が出る"""
+        _seed_activity("[作業] 通常表示テスト", status="in_progress")
+
+        result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "# アクティビティ一覧" in context
+        assert "通常表示テスト" in context
+
+
+class TestSessionStartHookOrchManagedExclusion:
+    """orch-managedタグ付きアクティビティの除外テスト（D#2410）"""
+
+    def test_orch_managed_activity_excluded(self, temp_db):
+        """orch-managedタグ付きアクティビティはアクティビティ一覧に出ない"""
+        activity_id = _seed_activity("[作業] orch管理タスク", status="in_progress")
+        _tag_activity_bare(activity_id, "orch-managed")
+
+        result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "orch管理タスク" not in context
+        assert f"[{activity_id}]" not in context
+
+    def test_non_orch_managed_activity_still_shown(self, temp_db):
+        """orch-managedタグのない通常アクティビティは引き続き表示される"""
+        normal_id = _seed_activity("[作業] 個人タスク", status="in_progress")
+        orch_id = _seed_activity("[作業] orch管理タスク", status="in_progress")
+        _tag_activity_bare(orch_id, "orch-managed")
+
+        result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "個人タスク" in context
+        assert f"[{normal_id}]" in context
+        assert "orch管理タスク" not in context
+        assert f"[{orch_id}]" not in context
+
+    def test_all_orch_managed_yields_no_activity_section(self, temp_db):
+        """全アクティビティがorch-managedなら一覧セクション自体が出ない"""
+        activity_id = _seed_activity("[作業] orch管理のみ", status="in_progress")
+        _tag_activity_bare(activity_id, "orch-managed")
+
+        # 初期振る舞いを削除してアクティビティ一覧の有無を純粋に判定
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM habits")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "# アクティビティ一覧" not in context
 
 
 class TestSessionStartHookErrorHandling:

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -728,13 +728,13 @@ class TestRecordNudgeMultiplication:
         assert result["decision"] == "approve"
 
 
-def _seed_orch_managed_db(db_path: str, activity_id: int) -> None:
+def _seed_orch_managed_db(db_path: str, activity_id: int, monkeypatch) -> None:
     """テスト用DBを初期化し、orch-managed素タグ付きアクティビティを作成する"""
     import src.config
     from src.db import init_database, get_connection
 
-    os.environ["DISCUSSION_DB_PATH"] = db_path
-    src.config.DB_PATH = db_path
+    monkeypatch.setenv("DISCUSSION_DB_PATH", db_path)
+    monkeypatch.setattr(src.config, "DB_PATH", db_path)
     init_database()
 
     conn = get_connection()
@@ -754,8 +754,6 @@ def _seed_orch_managed_db(db_path: str, activity_id: int) -> None:
         conn.commit()
     finally:
         conn.close()
-    src.config.DB_PATH = None
-    del os.environ["DISCUSSION_DB_PATH"]
 
 
 class TestOrchFlowSuppression:
@@ -810,11 +808,11 @@ class TestOrchFlowSuppression:
         record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
         assert len(record_nudges) == 0
 
-    def test_orch_managed_activity_no_record_nudge(self, env_setup):
+    def test_orch_managed_activity_no_record_nudge(self, env_setup, monkeypatch):
         """orch-managedアクティビティにcheck-in済みなら記録なしでもrecord nudgeを生成しない"""
         state_dir = env_setup["state_dir"]
         db_path = str(env_setup["tmp_path"] / "orch.db")
-        _seed_orch_managed_db(db_path, activity_id=1)
+        _seed_orch_managed_db(db_path, activity_id=1, monkeypatch=monkeypatch)
 
         _write_events(
             [{"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1}],
@@ -846,15 +844,15 @@ class TestOrchFlowSuppression:
         record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
         assert len(record_nudges) == 0
 
-    def test_normal_activity_still_nudges(self, env_setup):
+    def test_normal_activity_still_nudges(self, env_setup, monkeypatch):
         """orch-managedでない通常アクティビティでは従来通りrecord nudgeを生成する"""
         state_dir = env_setup["state_dir"]
         db_path = str(env_setup["tmp_path"] / "normal.db")
         # 通常アクティビティ（orch-managedタグなし）のDBを作る
         import src.config
         from src.db import init_database, get_connection
-        os.environ["DISCUSSION_DB_PATH"] = db_path
-        src.config.DB_PATH = db_path
+        monkeypatch.setenv("DISCUSSION_DB_PATH", db_path)
+        monkeypatch.setattr(src.config, "DB_PATH", db_path)
         init_database()
         conn = get_connection()
         try:
@@ -865,8 +863,6 @@ class TestOrchFlowSuppression:
             conn.commit()
         finally:
             conn.close()
-        src.config.DB_PATH = None
-        del os.environ["DISCUSSION_DB_PATH"]
 
         _write_events(
             [{"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1}],

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -95,6 +95,8 @@ def _run_stop_hook(
     })
 
     env = {**os.environ}
+    # runnerのOW_ROLEを継承しない（テストの決定性確保。worker抑制テストはenv_overrideで明示設定する）
+    env.pop("OW_ROLE", None)
     if env_override:
         env.update(env_override)
 
@@ -126,6 +128,9 @@ def env_setup(tmp_path):
 
     env_override = {
         "HOOK_STATE_DIR": state_dir,
+        # orch-managed判定が本番DBへ接続しないよう隔離DBを指す。
+        # 未初期化の空パスのため接続/クエリは失敗し、フェイルオープン（False）になる。
+        "DISCUSSION_DB_PATH": str(tmp_path / "isolated.db"),
     }
 
     yield {
@@ -721,3 +726,173 @@ class TestRecordNudgeMultiplication:
             str(transcript), "test-session", env_setup["env_override"],
         )
         assert result["decision"] == "approve"
+
+
+def _seed_orch_managed_db(db_path: str, activity_id: int) -> None:
+    """テスト用DBを初期化し、orch-managed素タグ付きアクティビティを作成する"""
+    import src.config
+    from src.db import init_database, get_connection
+
+    os.environ["DISCUSSION_DB_PATH"] = db_path
+    src.config.DB_PATH = db_path
+    init_database()
+
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO activities (id, title, description, status) VALUES (?, ?, ?, ?)",
+            (activity_id, "[作業] orch管理タスク", "desc", "in_progress"),
+        )
+        cursor = conn.execute(
+            "INSERT INTO tags (namespace, name) VALUES ('', 'orch-managed')"
+        )
+        tag_id = cursor.lastrowid
+        conn.execute(
+            "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+            (activity_id, tag_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    src.config.DB_PATH = None
+    del os.environ["DISCUSSION_DB_PATH"]
+
+
+class TestOrchFlowSuppression:
+    """orchフロー（worker セッション・orch-managedアクティビティ）でのcheck-inブロック/nudge抑制（D#2409/D#2410）"""
+
+    def test_worker_session_no_checkin_block(self, env_setup):
+        """OW_ROLE=worker時はcheck-in未呼出でもturn>=2でblockしない"""
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("hi"),
+                CONTEXT_RETRIEVAL_ENTRY,
+                _make_assistant_entry(text="response 1"),
+                _make_user_entry("continue"),
+                _make_assistant_entry(text="response 2"),
+            ],
+            transcript,
+        )
+
+        env_override = {**env_setup["env_override"], "OW_ROLE": "worker"}
+        result = _run_stop_hook(str(transcript), "test-session", env_override)
+        assert result["decision"] == "approve"
+
+    def test_worker_session_no_record_nudge(self, env_setup):
+        """OW_ROLE=worker時は記録なしターンが続いてもrecord nudgeを生成しない"""
+        state_dir = env_setup["state_dir"]
+        _write_events(
+            [{"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1}],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "checked_in_activity_test-session").write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("turn2"),
+                _make_assistant_entry(text="response 2"),
+                _make_user_entry("turn3"),
+                _make_assistant_entry(text="response 3"),
+                _make_user_entry("turn4"),
+                _make_assistant_entry(text="response 4"),
+            ],
+            transcript,
+        )
+
+        env_override = {**env_setup["env_override"], "OW_ROLE": "worker"}
+        result = _run_stop_hook(str(transcript), "test-session", env_override)
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) == 0
+
+    def test_orch_managed_activity_no_record_nudge(self, env_setup):
+        """orch-managedアクティビティにcheck-in済みなら記録なしでもrecord nudgeを生成しない"""
+        state_dir = env_setup["state_dir"]
+        db_path = str(env_setup["tmp_path"] / "orch.db")
+        _seed_orch_managed_db(db_path, activity_id=1)
+
+        _write_events(
+            [{"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1}],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "checked_in_activity_test-session").write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("turn2"),
+                _make_assistant_entry(text="response 2"),
+                _make_user_entry("turn3"),
+                _make_assistant_entry(text="response 3"),
+                _make_user_entry("turn4"),
+                _make_assistant_entry(text="response 4"),
+            ],
+            transcript,
+        )
+
+        env_override = {**env_setup["env_override"], "DISCUSSION_DB_PATH": db_path}
+        # OW_ROLEは設定しない（orch-managedタグのみで抑制されることを確認）
+        env_override.pop("OW_ROLE", None)
+        result = _run_stop_hook(str(transcript), "test-session", env_override)
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) == 0
+
+    def test_normal_activity_still_nudges(self, env_setup):
+        """orch-managedでない通常アクティビティでは従来通りrecord nudgeを生成する"""
+        state_dir = env_setup["state_dir"]
+        db_path = str(env_setup["tmp_path"] / "normal.db")
+        # 通常アクティビティ（orch-managedタグなし）のDBを作る
+        import src.config
+        from src.db import init_database, get_connection
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        src.config.DB_PATH = db_path
+        init_database()
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO activities (id, title, description, status) VALUES (?, ?, ?, ?)",
+                (1, "[作業] 個人タスク", "desc", "in_progress"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        src.config.DB_PATH = None
+        del os.environ["DISCUSSION_DB_PATH"]
+
+        _write_events(
+            [{"e": "tool", "name": "check_in", "turn": 1, "activity_id": 1}],
+            state_dir, "test-session",
+        )
+        Path(state_dir, "current_turn_test-session").write_text("1")
+        Path(state_dir, "checked_in_activity_test-session").write_text("1")
+
+        transcript = env_setup["tmp_path"] / "transcript.jsonl"
+        _write_transcript(
+            [
+                _make_user_entry("turn2"),
+                _make_assistant_entry(text="response 2"),
+                _make_user_entry("turn3"),
+                _make_assistant_entry(text="response 3"),
+                _make_user_entry("turn4"),
+                _make_assistant_entry(text="response 4"),
+            ],
+            transcript,
+        )
+
+        env_override = {**env_setup["env_override"], "DISCUSSION_DB_PATH": db_path}
+        env_override.pop("OW_ROLE", None)
+        result = _run_stop_hook(str(transcript), "test-session", env_override)
+        assert result["decision"] == "approve"
+
+        events = _read_events(state_dir, "test-session")
+        record_nudges = [e for e in events if e.get("e") == "nudge" and e.get("type") == "record"]
+        assert len(record_nudges) >= 1


### PR DESCRIPTION
## 概要

A#799/T8。owフレームワークのworkerスキルをフルスコープ化する。設計M#219 §4全体＋§5の実装。

T1で暫定配置した最小版workerスキルを、設計書通りのフルスコープ（ステートマシン化・worker-sync独立スキル・hooks改修）に拡張する。

## 変更内容

### skills/worker/SKILL.md — ステートマシン化
- 状態一覧テーブル（ready/working/blocked/escalated/done/closed/dead/fallback）
- `blocked`: 判断要請（question/options/context_refs、needs_reply）
- `escalated`: エスカレーションフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）出力、人間合意の記録とID通知（D#2397）
- フォールバック: needs_reply 10分無応答→再送→10分→`fallback`宣言・人間対話モード。復帰規則（人間入力ゼロ→自動復帰／入力あり→確認、D#2399）
- 退場処理は `worker-sync` スキル呼び出しに変更（D#2446）
- 状態不明時の履歴からの再導出、worker専用記録規律（D#2397）

### skills/worker-sync/SKILL.md（新規）
現行sync-memoryのworker版（D#2397 / §4.4）。ユーザー対話なし・topic/activity作成なし・log=実装経緯・material=生データ・decisionは原則decision_proposalsでorch提案（D集約）。エスカレーション人間合意は例外で記録可。

### hooks改修（D#2409/D#2410）
- `session_start_hook.py`: OW_ROLE=worker時にアクティビティ一覧注入を抑制、通常セッションでorch-managedタグ付きを除外
- `stop_hook.py`: workerセッション/orch-managedアクティビティでcheck-inブロック・nudgeを抑制

### tests/conftest.py（新規）
workerセッション（OW_ROLE=worker）内でテスト実行すると通常セッション前提のテストが非決定的に壊れるため、autouseでOW_*環境変数をクリアする。

## テスト
- 全1331件パス
- session_start: worker抑制3件・orch-managed除外3件を追加
- stop: orchフロー抑制4件を追加

## 設計判断（orch確認事項）
- T8 task fileの「worker-sync=§退場処理に記載済み」とM#219 §10/§4.4/§13-3・D#2397（worker-syncは独立skill）が食い違うため、ヘッドライン「A#799フルスコープ」を優先し設計通り独立skillとして実装した
- D#2446（sync at close）とdone schemaの`synced:true`（§2.2/§4.5）の整合: `synced:true`=「material保存済み・decision_proposals添付済みで検証可能」、最終作業経緯ログの確定はclose時のworker-syncで行う、と解釈

🤖 Generated with [Claude Code](https://claude.com/claude-code)