### PR TITLE
fix: _injected_tagsをセッション別に分離

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 import logging
 import random
 from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_context
 from typing import Optional, Union
 from src.services import (
     topic_service,
@@ -129,9 +130,14 @@ def _maybe_inject_tag_notes(result: dict, tag_strings: list[str], mark: bool = T
     Args:
         mark: False の場合、_injected_tags を参照も更新もしない（読み取り経路用）。
     """
+    try:
+        ctx = get_context()
+        session_id = ctx.session_id
+    except RuntimeError:
+        session_id = None
     conn = get_connection()
     try:
-        notes = collect_tag_notes_for_injection(conn, tag_strings, mark=mark)
+        notes = collect_tag_notes_for_injection(conn, tag_strings, session_id=session_id, mark=mark)
     finally:
         conn.close()
     if notes:
@@ -726,7 +732,12 @@ def check_in(
     Returns:
         check-in結果（coverage, activity, related_topics, related_activities, pinned, tag_notes, materials, recent_decisions, latest_log, logs, catalog, summary）
     """
-    return _check_in(activity_id)
+    try:
+        ctx = get_context()
+        session_id = ctx.session_id
+    except RuntimeError:
+        session_id = None
+    return _check_in(activity_id, session_id=session_id)
 
 
 

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -486,7 +486,7 @@ def _build_summary(
     return f"{line1}\n{line2}"
 
 
-def check_in(activity_id: int) -> dict:
+def check_in(activity_id: int, session_id: str | None = None) -> dict:
     """アクティビティにcheck-inする。
 
     関連情報（tag_notes, materials, decisions, logs catalog, catalog）を集約取得し、
@@ -536,8 +536,8 @@ def check_in(activity_id: int) -> dict:
         activity = row_to_dict(row)
         tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
 
-        # 2. tag_notes収集（collect_tag_notes_for_injectionは変更なし）
-        tag_notes = collect_tag_notes_for_injection(conn, tags, always_inject_namespaces=["intent"]) or []
+        # 2. tag_notes収集
+        tag_notes = collect_tag_notes_for_injection(conn, tags, session_id=session_id, always_inject_namespaces=["intent"]) or []
 
         # 3. 直接関連エンティティ取得（1次）
         direct = _get_direct_relations(conn, "activity", activity_id)

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -518,6 +518,13 @@ def check_in(activity_id: int, session_id: str | None = None) -> dict:
         check-in結果（coverage, activity, related_topics, related_activities, pinned,
         tag_notes, materials, recent_decisions, logs, catalog, summary）
     """
+    if session_id is None:
+        try:
+            from fastmcp.server.dependencies import get_context
+            ctx = get_context()
+            session_id = ctx.session_id
+        except (RuntimeError, ImportError):
+            pass
     conn = get_connection()
     try:
         # 1. activity取得

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1014,13 +1014,14 @@ def get_available_intents() -> list[dict]:
 # 遭遇時注入（Tag Notes Injection）
 # ========================================
 
-# モジュールレベルのグローバル変数（MCPサーバープロセスのライフサイクル = セッション）
-_injected_tags: set[str] = set()
+# セッション別の注入済みタグ追跡（ctx.session_idキー）
+_injected_tags: dict[str, set[str]] = {}
 
 
 def collect_tag_notes_for_injection(
     conn: sqlite3.Connection,
     tag_strings: list[str],
+    session_id: str | None = None,
     always_inject_namespaces: list[str] | None = None,
     mark: bool = True,
 ) -> list[dict] | None:
@@ -1029,6 +1030,7 @@ def collect_tag_notes_for_injection(
     Args:
         conn: DB接続
         tag_strings: タグ文字列リスト（例: ["domain:cc-memory", "intent:design"]）
+        session_id: MCPセッションID。セッション別に注入済みを管理する
         always_inject_namespaces: 常時注入するnamespaceのリスト（例: ["intent"]）。
             このnamespaceに属するタグは _injected_tags チェックをスキップし、
             毎回 notes を返す。_injected_tags には登録しない。
@@ -1039,6 +1041,7 @@ def collect_tag_notes_for_injection(
         notes があるタグの一覧。なければ None
         [{"tag": "domain:cc-memory", "notes": "..."}, ...]
     """
+    session_key = session_id or "__default__"
     always_ns = set(always_inject_namespaces) if always_inject_namespaces else set()
 
     # always_inject対象とそれ以外を分離（パース結果も保持）
@@ -1054,13 +1057,12 @@ def collect_tag_notes_for_injection(
             normal_parsed.append((ns, name))
 
     if mark:
-        # 通常タグ: 未注入のもののみ
+        session_set = _injected_tags.setdefault(session_key, set())
         new_normal = [
             (t, p) for t, p in zip(normal_tags, normal_parsed)
-            if t not in _injected_tags
+            if t not in session_set
         ]
-        # 通常タグをすべてマーク（notes の有無に関わらず）
-        _injected_tags.update(t for t, _ in new_normal)
+        session_set.update(t for t, _ in new_normal)
     else:
         # mark=False: 全タグをクエリ対象にし、_injected_tags は更新しない
         new_normal = list(zip(normal_tags, normal_parsed))

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -408,6 +408,7 @@ class TestOwStatusIntegration:
         nonexistent = tmp_path / "does_not_exist"
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
         monkeypatch.setattr(ow_service, "_get_queue_dir", lambda: nonexistent)
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "_relay_request", lambda *a, **k: {"handles": []})
         result = ow_service.ow_status(channel="ch", topic_id=None)
         assert result["tasks"] == []

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -249,7 +249,7 @@ class TestAlwaysInjectNamespaces:
             collect_tag_notes_for_injection(
                 conn, ["intent:design"], always_inject_namespaces=["intent"]
             )
-            assert "intent:design" not in _injected_tags
+            assert "intent:design" not in _injected_tags.get("__default__", set())
         finally:
             conn.close()
 
@@ -625,7 +625,7 @@ class TestResultBasedInjectionDoesNotMark:
             assert result[0]["tag"] == "domain:test"
 
             # _injected_tags に登録されていないことを確認
-            assert "domain:test" not in _injected_tags
+            assert "domain:test" not in _injected_tags.get("__default__", set())
 
             # mark=True（書き込み経路）でも notes が注入されることを確認
             result2 = collect_tag_notes_for_injection(conn, ["domain:test"])
@@ -645,7 +645,7 @@ class TestResultBasedInjectionDoesNotMark:
         try:
             # まず mark=True で domain:test をマーク
             collect_tag_notes_for_injection(conn, ["domain:test"])
-            assert "domain:test" in _injected_tags
+            assert "domain:test" in _injected_tags.get("__default__", set())
 
             # mark=False では domain:test もクエリ対象になる
             result = collect_tag_notes_for_injection(
@@ -706,7 +706,7 @@ class TestHandlerGetTopicsInjection:
         update_tag("domain:handler", "ハンドラ経由テスト")
 
         get_topics()
-        assert "domain:handler" not in _injected_tags
+        assert "domain:handler" not in _injected_tags.get("__default__", set())
 
 
 class TestHandlerGetActivitiesInjection:
@@ -738,7 +738,7 @@ class TestHandlerGetActivitiesInjection:
         update_tag("domain:handler", "ハンドラ経由テスト")
 
         get_activities()
-        assert "domain:handler" not in _injected_tags
+        assert "domain:handler" not in _injected_tags.get("__default__", set())
 
 
 class TestHandlerGetLogsInjection:
@@ -776,7 +776,7 @@ class TestHandlerGetLogsInjection:
         update_tag("domain:handler", "ハンドラ経由テスト")
 
         get_logs("topic", topic_id)
-        assert "domain:handler" not in _injected_tags
+        assert "domain:handler" not in _injected_tags.get("__default__", set())
 
 
 class TestHandlerGetDecisionsInjection:
@@ -814,4 +814,87 @@ class TestHandlerGetDecisionsInjection:
         update_tag("domain:handler", "ハンドラ経由テスト")
 
         get_decisions("topic", topic_id)
-        assert "domain:handler" not in _injected_tags
+        assert "domain:handler" not in _injected_tags.get("__default__", set())
+
+
+# ========================================
+# マルチセッション分離テスト
+# ========================================
+
+
+class TestMultiSessionIsolation:
+    """異なるセッションIDで _injected_tags が独立管理されるテスト"""
+
+    def test_different_sessions_inject_independently(self, temp_db):
+        """セッションAの注入済みタグがセッションBの注入を阻害しない"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        conn = get_connection()
+        try:
+            result_a = collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-A"
+            )
+            assert result_a is not None
+            assert result_a[0]["tag"] == "domain:test"
+
+            result_b = collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-B"
+            )
+            assert result_b is not None
+            assert result_b[0]["tag"] == "domain:test"
+        finally:
+            conn.close()
+
+    def test_same_session_deduplicates(self, temp_db):
+        """同一セッション内では2回目の注入が抑制される"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        conn = get_connection()
+        try:
+            result1 = collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-X"
+            )
+            assert result1 is not None
+
+            result2 = collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-X"
+            )
+            assert result2 is None
+        finally:
+            conn.close()
+
+    def test_session_sets_are_isolated(self, temp_db):
+        """各セッションの注入済みセットが他セッションに影響しない"""
+        add_topic(title="Test", description="Desc", tags=["domain:test", "domain:other"])
+        update_tag("domain:test", "テスト教訓")
+        update_tag("domain:other", "その他の教訓")
+
+        conn = get_connection()
+        try:
+            collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-1"
+            )
+            assert "domain:test" in _injected_tags["session-1"]
+            assert "session-2" not in _injected_tags
+
+            collect_tag_notes_for_injection(
+                conn, ["domain:other"], session_id="session-2"
+            )
+            assert "domain:other" in _injected_tags["session-2"]
+            assert "domain:other" not in _injected_tags["session-1"]
+        finally:
+            conn.close()
+
+    def test_no_session_id_uses_default_key(self, temp_db):
+        """session_id=Noneの場合は__default__キーが使われる"""
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "テスト教訓")
+
+        conn = get_connection()
+        try:
+            collect_tag_notes_for_injection(conn, ["domain:test"])
+            assert "domain:test" in _injected_tags["__default__"]
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
- `_injected_tags`がプロセスグローバルな`set[str]`だったため、複数セッションが同一MCPサーバーを共有すると、一方のセッションで素タグ/domain:タグのtag-notesが注入済みマークされると他方のセッションでは注入されなかった
- `dict[str, set[str]]`（session_idキー）に変更し、`fastmcp.server.dependencies.get_context()`でsession_idを取得してセッション別に管理する
- `checkin_service.check_in`にも`get_context()`フォールバックを追加（`activity_service.add_activity`経由の呼び出しでもsession_idが取れるようにする）

## Test plan
- [x] 既存テスト45件（`test_tag_notes.py`）全パス
- [x] マルチセッション分離テスト4件追加（独立注入・同一セッション重複抑制・セット分離・デフォルトキー）
- [x] 全テスト1355件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)