### PR TITLE
feat: sync-memory SKILL.mdにupdate_material/update_habitステップ追加

### DIFF
--- a/skills/sync-memory/SKILL.md
+++ b/skills/sync-memory/SKILL.md
@@ -99,7 +99,7 @@ transcriptを解析し、議論されたテーマを特定する。
 
 **アクション:**
 - セッション中の生データを洗い出し、`add_material` でタグ付きで保存する（タグ必須）
-- 既存 material（ガイド・設計仕様・一覧表など、更新されうる素材）の内容と矛盾・古い情報がある場合は `update_material(material_id, ...)` で更新する
+- 既存 material（ガイド・設計仕様・一覧表など、更新されうる素材）の内容と矛盾・古い情報がある場合は、`search()` で対象 material を特定してから `update_material(material_id, ...)` で更新する
 - `related` で関連するアクティビティやトピックとリレーションを張る
 - 保存した material ID は Step 4 の log で参照する
 
@@ -261,9 +261,9 @@ description: "「sync-memory改善」トピックで議論中。ステップ4の
 
 **habits の手順:**
 1. `get_habits` で既存 habits を確認する
-2. 新規ルールは `add_habit` で追加する
-3. 既存 habit と矛盾・改善がある場合は `update_habit(habit_id, content)` で更新する（内容を保持しつつ改訂）
-4. ステップ9cでユーザーに提案し、承認後に書き込む
+2. 新規ルールか、既存 habit の改善・修正かを判定する
+3. 登録・更新する内容のドラフトを準備する（この時点では API 呼び出ししない）
+4. ステップ9cでユーザーに提案し、承認後に `add_habit` または `update_habit(habit_id, content)` で書き込む
 
 **auto-memory の記録先判断（エージェント裁量）:**
 - 短い（数行）→ MEMORY.mdに直接追記
@@ -310,12 +310,12 @@ options:
 ```
 header: "habits"
 question: |
-  habitsに登録する？（check-in時にAIへ毎回注入される）
-  - {ルールの概要}
+  habitsを登録／更新する？（check-in時にAIへ毎回注入される）
+  - {ルールの概要}（新規 or 既存habit id:XX の更新）
 options:
-  - label: 登録する
+  - label: 登録／更新する
     markdown: |
-      {登録するhabitsの全文}
+      {登録・更新するhabitsの全文}
   - label: 不要
 ```
 

--- a/skills/sync-memory/SKILL.md
+++ b/skills/sync-memory/SKILL.md
@@ -99,6 +99,7 @@ transcriptを解析し、議論されたテーマを特定する。
 
 **アクション:**
 - セッション中の生データを洗い出し、`add_material` でタグ付きで保存する（タグ必須）
+- 既存 material（ガイド・設計仕様・一覧表など、更新されうる素材）の内容と矛盾・古い情報がある場合は `update_material(material_id, ...)` で更新する
 - `related` で関連するアクティビティやトピックとリレーションを張る
 - 保存した material ID は Step 4 の log で参照する
 
@@ -250,13 +251,19 @@ description: "「sync-memory改善」トピックで議論中。ステップ4の
 
 **振り分け — 収集したネタを2軸で保存先に判定する:**
 - 特定のタグ文脈でだけ必要 → tag notes（`update_tag`で記録）
-- どの文脈でも常に適用 + 「従え」系の制約・ルール → habits（`add_habit`で記録）
+- どの文脈でも常に適用 + 「従え」系の制約・ルール → habits（新規は`add_habit`、既存を改善・修正するなら`update_habit`で記録）
 - どの文脈でも常に適用 + 「知っとけ」系の文脈・tips → auto-memory
 
 **tag notes の手順:**
 1. `search_tags` で対象タグの現在の notes を確認する（include_notes=True）
 2. 既存 notes がある場合は内容を保持しつつマージ（上書き方式なので全文を書く）
 3. ステップ9cでユーザーに提案し、承認後に `update_tag` で書き込む
+
+**habits の手順:**
+1. `get_habits` で既存 habits を確認する
+2. 新規ルールは `add_habit` で追加する
+3. 既存 habit と矛盾・改善がある場合は `update_habit(habit_id, content)` で更新する（内容を保持しつつ改訂）
+4. ステップ9cでユーザーに提案し、承認後に書き込む
 
 **auto-memory の記録先判断（エージェント裁量）:**
 - 短い（数行）→ MEMORY.mdに直接追記
@@ -331,7 +338,7 @@ options:
 **ユーザーの回答に応じて処理:**
 - 棚卸し: ユーザーの指示に従って処理（completed、削除、そのまま残す等）
 - tag notes: ユーザーが承認した場合 `update_tag(tag, notes)` で書き込む
-- habits: ユーザーが承認した場合 `add_habit(content)` で登録する
+- habits: ユーザーが承認した場合 `add_habit(content)` で登録する（既存を改善・修正するなら `update_habit(habit_id, content)` で更新する）
 - auto memory: ユーザーが承認した項目をauto memoryに書き込む
 
 ## 10. 完了報告

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -420,6 +420,8 @@ class TestOwStatusIntegration:
         nonexistent = tmp_path / "does_not_exist"
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", "")
         monkeypatch.setattr(ow_service, "_get_queue_dir", lambda: nonexistent)
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda channel: True)
         monkeypatch.setattr(ow_service, "_relay_request", lambda *a, **k: {"handles": []})
         result = ow_service.ow_status(channel="ch", topic_id=None)
         assert result["tasks"] == []


### PR DESCRIPTION
## Summary

- Step 3（資材の保存）に`update_material`の手順を追加。既存material（ガイド・設計仕様・一覧表など）の内容と矛盾・古い情報がある場合に更新する
- Step 9b（remember）にhabits更新手順を追加。`get_habits`で既存を確認し、矛盾・改善がある場合は`update_habit`で更新する
- Step 9c（ユーザーへの処理応答）のhabits行に`update_habit`使用ケースを追記

## 背景

sync-memoryのSKILL.mdには新規作成（add_*）ステップはあったが、既存エンティティの更新（update_material/update_habit）のステップが欠けていた。doc洗練（既存materialの最新化、habitの更新・統合）が起きない根本原因の一つを修正する。

## Test plan

- [x] テスト全通過（1355 passed）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)