### PR TITLE
feat: decisionにtitle追加とadd_decisionsの関連decision返却（migration 0037）

### DIFF
--- a/migrations/0037_add_decisions_title.sql
+++ b/migrations/0037_add_decisions_title.sql
@@ -1,0 +1,48 @@
+-- Migration 037: decisionsテーブルにtitleカラムを追加
+--
+-- depends: 0036_add_materials_updated_at
+--
+-- 背景:
+--   decisionは現状titleを持たず、表示時はdecision本文をそのまま見出しに使っている。
+--   要点を1行で表すtitleを持たせ、表示はtitle優先・decision本文fallbackにする。
+--   既存行はNULLのままとし、COALESCE(title, decision)で現行挙動を維持する。
+--
+-- 変更内容:
+--   - decisions.title を追加（NULL許容）。既存行はNULLのまま。
+--   - search_index投入トリガー（insert/update）を貼り直し、表示用titleが
+--     COALESCE(NEW.title, NEW.decision) になるようにする。
+--     FTSインデックス（search_index_fts: マッチ用）はNEW.decision/NEW.reasonの
+--     ままで変更しないため、全文検索の挙動は不変。
+--     既存行のtitleはNULL → COALESCE で decision本文と一致するため、
+--     search_indexの既存行に対するバックフィルは不要。
+
+ALTER TABLE decisions ADD COLUMN title TEXT;
+
+-- search_index投入トリガーを title優先のdisplay title に貼り直す
+-- （FTSのtitle/bodyは従来通り decision本文/reason のまま）
+DROP TRIGGER IF EXISTS trg_search_decisions_insert;
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_insert
+AFTER INSERT ON decisions
+BEGIN
+  INSERT INTO search_index (source_type, source_id, title, created_at)
+  VALUES ('decision', NEW.id, COALESCE(NEW.title, NEW.decision), NEW.created_at);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.decision, NEW.reason);
+END;
+
+DROP TRIGGER IF EXISTS trg_search_decisions_update;
+CREATE TRIGGER IF NOT EXISTS trg_search_decisions_update
+AFTER UPDATE ON decisions
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  UPDATE search_index
+  SET title = COALESCE(NEW.title, NEW.decision)
+  WHERE source_type = 'decision' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = NEW.id),
+    NEW.decision, NEW.reason);
+END;

--- a/src/main.py
+++ b/src/main.py
@@ -220,6 +220,7 @@ def add_decisions(items: list[dict], ctx: Context) -> dict:
         - topic_id (int, 必須): 関連するトピックのID
         - decision (str, 必須): 決定内容
         - reason (str, 必須): 決定の理由
+        - title (str, optional): 決定の要点を表す1行。**付けることを強く推奨**。check-in・timeline・search等の一覧表示でdecision本文の代わりに見出しとして使われ、可読性が大きく上がる。省略時はdecision本文にfallbackする
         - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
         - propagate_to (dict, optional): 決定事項を注入先に伝搬する。
             - type: "habit" | "tag_note"
@@ -227,6 +228,8 @@ def add_decisions(items: list[dict], ctx: Context) -> dict:
             - tag: タグ文字列（type="tag_note"の場合のみ必須）
 
     Returns: {created: [...], errors: [{index, error}]}
+        created各要素には related_decisions（同topic内の類似decision上位3件 [{id, title, distance}]）が付く。
+        既存decisionとの矛盾・重複に気づくための導線。embeddingサーバー未起動時は空配列。
     """
     result = decision_service.add_decisions(items)
     if "error" not in result:

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -92,7 +92,7 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
     placeholders = ",".join("?" * len(topic_ids))
     rows = conn.execute(
         f"""
-        SELECT id, decision
+        SELECT id, decision, title
         FROM decisions
         WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
         ORDER BY id DESC
@@ -103,7 +103,8 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
 
     decisions = []
     for row in rows:
-        decisions.append({"id": row["id"], "title": row["decision"]})
+        # title優先・decision本文fallback
+        decisions.append({"id": row["id"], "title": row["title"] or row["decision"]})
     return decisions
 
 
@@ -243,7 +244,7 @@ def _get_pinned_targets(conn: sqlite3.Connection, activity_id: int) -> dict:
         placeholders = ",".join("?" * len(ids))
         rows = conn.execute(
             f"""
-            SELECT id, decision, reason
+            SELECT id, decision, reason, title
             FROM decisions
             WHERE id IN ({placeholders}) AND retracted_at IS NULL
             """,
@@ -254,7 +255,8 @@ def _get_pinned_targets(conn: sqlite3.Connection, activity_id: int) -> dict:
         for did in ids:
             if did in row_map:
                 row = row_map[did]
-                decisions.append({"id": row["id"], "title": row["decision"], "reason": row["reason"]})
+                # title優先・decision本文fallback
+                decisions.append({"id": row["id"], "title": row["title"] or row["decision"], "reason": row["reason"]})
         if decisions:
             result["decisions"] = decisions
 

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -28,10 +28,12 @@ def add_decisions(items: list[dict]) -> dict:
             - topic_id (int, 必須): 関連するトピックのID
             - decision (str, 必須): 決定内容
             - reason (str, 必須): 決定の理由
+            - title (str, optional): 決定の要点を表す1行。省略時はNULL（表示はdecision本文にfallback）
             - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承
 
     Returns:
         {created: [...], errors: [{index, error}]}
+        created各要素には related_decisions（同topic内の類似decision上位N件）が付く。
     """
     # バリデーション: 1 <= len(items) <= 10
     if not items:
@@ -60,6 +62,10 @@ def add_decisions(items: list[dict]) -> dict:
                 topic_id = item.get("topic_id")
                 decision = item.get("decision", "")
                 reason = item.get("reason", "")
+                # 空文字・空白のみのtitleはNULLへ正規化する。表示fallbackは
+                # SQL側がCOALESCE(NULLのみfallback)・Python側が`or`(""もfallback)で
+                # 意味論が分かれるため、""をNULLに寄せて全箇所の挙動を一致させる。
+                title = (item.get("title") or "").strip() or None
                 tags = item.get("tags")
 
                 # タグのバリデーション（tagsが指定された場合のみ）
@@ -71,8 +77,8 @@ def add_decisions(items: list[dict]) -> dict:
 
                 # decisionをINSERT
                 cursor = conn.execute(
-                    "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
-                    (topic_id, decision, reason),
+                    "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
+                    (topic_id, decision, reason, title),
                 )
                 decision_id = cursor.lastrowid
 
@@ -145,15 +151,26 @@ def add_decisions(items: list[dict]) -> dict:
                 c["tags"] = tags_map.get(c["decision_id"], [])
                 c["created_at"] = created_at_map.get(c["decision_id"])
 
-            # embedding一括生成（created分のみ。失敗してもエラーにしない）
+            # embedding一括生成 + 同topic内の関連decision取得（created分のみ。失敗してもエラーにしない）
+            # 関連decisionは矛盾・重複への気づきを促す導線。embeddingサーバー未起動時は空リスト。
+            # search_serviceは関数内importでcircular import（decision→search→...）を回避する。
+            from src.services import search_service
             for c in created:
                 tag_text = " ".join(c["tags"]) if c["tags"] else ""
-                generate_and_store_embedding(
+                embedding = generate_and_store_embedding(
                     "decision", c["decision_id"],
                     build_embedding_text(c["decision"], c["reason"], tag_text),
                 )
+                related = []
+                if embedding is not None and c["topic_id"] is not None:
+                    related = search_service.find_similar_decisions(
+                        exclude_id=c["decision_id"],
+                        topic_id=c["topic_id"],
+                        embedding=embedding,
+                    )
+                c["related_decisions"] = related
 
-            # レスポンス軽量化: embedding生成後にdecision_id以外を除去
+            # レスポンス軽量化: embedding生成後はdecision_id/related_decisions以外を除去
             for c in created:
                 c.pop("decision", None)
                 c.pop("reason", None)

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -33,7 +33,7 @@ def add_decisions(items: list[dict]) -> dict:
 
     Returns:
         {created: [...], errors: [{index, error}]}
-        created各要素には related_decisions（同topic内の類似decision上位N件）が付く。
+        created各要素には related_decisions（同topic内の類似decision上位3件 [{id, title, distance}]）が付く。
     """
     # バリデーション: 1 <= len(items) <= 10
     if not items:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -2,6 +2,7 @@
 import logging
 import math
 import re
+import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -917,7 +918,7 @@ def find_similar_topics(
         results.sort(key=lambda x: x["distance"])
         return results[:limit]
 
-    except (ValueError, RuntimeError, OSError):
+    except (ValueError, RuntimeError, OSError, sqlite3.Error):
         logger.warning("find_similar_topics failed", exc_info=True)
         return []
 
@@ -1003,7 +1004,7 @@ def find_similar_decisions(
         results.sort(key=lambda x: x["distance"])
         return results[:limit]
 
-    except (ValueError, RuntimeError, OSError):
+    except (ValueError, RuntimeError, OSError, sqlite3.Error):
         logger.warning("find_similar_decisions failed", exc_info=True)
         return []
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -922,6 +922,92 @@ def find_similar_topics(
         return []
 
 
+def find_similar_decisions(
+    exclude_id: int,
+    topic_id: int,
+    text: str | None = None,
+    embedding: list[float] | None = None,
+    limit: int = 3,
+) -> list[dict]:
+    """同じtopic内でテキスト/embeddingに類似するdecisionをベクトル検索で取得する。
+
+    add_decisions のレスポンスに含める「関連decision」サジェスト用。
+    既存decisionのembedding（decision+reason+tagsで生成済み・vec_index格納済み）を
+    KNNし、search_index経由でsource_type='decision'に絞り、decisionsテーブルへJOINして
+    同一topic_id・retracted_at IS NULL・自身除外に限定する。
+    矛盾・重複への気づきを促す導線であり、embeddingサーバー未起動時は空リストを返す。
+
+    Args:
+        exclude_id: 除外するdecision ID（新規作成された自身）
+        topic_id: 関連decisionを絞り込む対象topic ID
+        text: 検索テキスト（embedding未指定時のみ使う）
+        embedding: 事前生成済みのembeddingベクトル（指定時はencode_queryをスキップ）
+        limit: 最大取得件数
+
+    Returns:
+        類似decisionのリスト [{id, title, distance}, ...]
+        title は title優先・decision本文fallback（COALESCE(title, decision)）。
+        distance は小さいほど類似度が高い。
+    """
+    try:
+        query_embedding = embedding if embedding is not None else (
+            embedding_service.encode_query(text) if text else None
+        )
+        if query_embedding is None:
+            return []
+
+        blob = serialize_float32(query_embedding)
+        # グローバルKNNで多めに取得してから decision型 + 同一topic + 自身除外 + retract除外 に
+        # post-filterする。find_similar_topicsより絞り込みが厳しい（種別＋topic）ため候補数を
+        # limit*20に増やす。本機能は矛盾・重複への気づき導線であり厳密なrecallは要求しない
+        # （DB規模が非常に大きくなり同一topicのdecisionが上位に来ない場合は取りこぼし得るが、
+        #  サジェストが減るだけで誤動作はしない）。将来はtopic絞り込み後KNNへの作り替え余地あり。
+        vec_rows = execute_query(
+            "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
+            (blob, limit * 20),
+        )
+        if not vec_rows:
+            return []
+
+        vec_data = {}
+        for row in vec_rows:
+            r = row_to_dict(row)
+            vec_data[r["rowid"]] = r["distance"]
+
+        rowids = list(vec_data.keys())
+        rowid_placeholders = ",".join("?" * len(rowids))
+
+        filter_rows = execute_query(
+            f"""
+            SELECT si.id, si.source_id, COALESCE(d.title, d.decision) AS title
+            FROM search_index si
+            JOIN decisions d ON d.id = si.source_id
+            WHERE si.id IN ({rowid_placeholders})
+              AND si.source_type = 'decision'
+              AND si.source_id != ?
+              AND d.topic_id = ?
+              AND d.retracted_at IS NULL
+            """,
+            (*rowids, exclude_id, topic_id),
+        )
+
+        results = []
+        for row in filter_rows:
+            r = row_to_dict(row)
+            results.append({
+                "id": r["source_id"],
+                "title": r["title"],
+                "distance": round(vec_data[r["id"]], 4),
+            })
+
+        results.sort(key=lambda x: x["distance"])
+        return results[:limit]
+
+    except (ValueError, RuntimeError, OSError):
+        logger.warning("find_similar_decisions failed", exc_info=True)
+        return []
+
+
 def _tag_like_search(
     keywords: list[str],
     tag_ids: Optional[list[int]],
@@ -1446,6 +1532,7 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
         result = {
             "id": data["id"],
             "topic_id": data["topic_id"],
+            "title": data.get("title"),
             "decision": data["decision"],
             "reason": data["reason"],
             "tags": tags,

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -146,7 +146,7 @@ def get_timeline(
             # decision_supersedesは多対多のスキーマだが、APIレスポンスのreplaces/replaced_byは
             # D#1874で{type, id}のスカラーと定義されているため、最新の1件のみ返す。
             union_parts.append(
-                f"SELECT d.id, 'decision' AS type, d.decision AS title, d.created_at,"
+                f"SELECT d.id, 'decision' AS type, COALESCE(d.title, d.decision) AS title, d.created_at,"
                 f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaces_id,"
                 f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaced_by_id"
                 f" FROM decisions d WHERE d.topic_id IN ({placeholders}) AND d.retracted_at IS NULL"

--- a/tests/test_migrations/test_0037_add_decisions_title.py
+++ b/tests/test_migrations/test_0037_add_decisions_title.py
@@ -1,0 +1,256 @@
+"""migration 0037_add_decisions_title のテスト
+
+0037適用後に decisions テーブルへ title列が追加されること、
+search_index投入トリガーが title優先（COALESCE(title, decision)）の
+display titleを格納するようになること、
+FTSインデックス（マッチ用）は decision本文/reason のまま不変であることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0037含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0037():
+    """0036までのmigrationを適用したDBを提供する。0037の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0037 = MigrationList([m for m in all_migs if m.id < "0037"])
+        with backend.lock():
+            backend.apply_migrations(pre_0037)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0037(db_path: str) -> None:
+    """db_pathに対してmigration 0037のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0037 = MigrationList([m for m in all_migs if m.id.startswith("0037")])
+    with backend.lock():
+        backend.apply_migrations(only_0037)
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    """指定テーブルのカラム名セットを返す。"""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _insert_topic(conn: sqlite3.Connection) -> int:
+    """テスト用トピックを1件INSERTしてIDを返す。"""
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("テストトピック", "説明"),
+    )
+    return cur.lastrowid
+
+
+class TestTitleColumnAdded:
+    """0037適用後にtitle列が追加されていることの確認"""
+
+    def test_decisions_has_title_column_after_0037(self, migrated_db):
+        """migration 0037適用後、decisionsテーブルにtitle列が存在する"""
+        conn = get_connection()
+        try:
+            assert "title" in _get_column_names(conn, "decisions"), (
+                "decisions.title が0037適用後に存在しない"
+            )
+        finally:
+            conn.close()
+
+    def test_decisions_has_no_title_column_before_0037(self, db_before_0037):
+        """0036適用時点では decisions に title列が存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            assert "title" not in _get_column_names(conn, "decisions"), (
+                "0037適用前のdecisionsにtitle列が既に存在している"
+            )
+        finally:
+            conn.close()
+
+    def test_other_columns_intact_after_0037(self, migrated_db):
+        """0037適用後、decisionsのid/topic_id/decision/reason/created_at/retracted_atが保持される"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "decisions")
+            for col in ["id", "topic_id", "decision", "reason", "created_at", "retracted_at"]:
+                assert col in column_names, (
+                    f"decisions.{col} が0037適用後に消えている"
+                )
+        finally:
+            conn.close()
+
+    def test_existing_rows_have_null_title(self, db_before_0037):
+        """0036時点のdecision行は、0037適用後にtitleがNULLのまま残る"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                (tid, "既存決定", "既存理由"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0037(db_before_0037)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT title FROM decisions WHERE decision='既存決定'"
+            ).fetchone()
+            assert row is not None, "対象のdecision行が見つからない"
+            assert row["title"] is None, (
+                f"0037適用後、既存decisionのtitleがNULLでない: {row['title']!r}"
+            )
+        finally:
+            conn.close()
+
+
+class TestSearchIndexTitleFallback:
+    """search_index投入トリガーが title優先のdisplay titleを格納する確認"""
+
+    def test_insert_decision_with_title_indexes_title(self, migrated_db):
+        """titleを指定したdecisionのsearch_index.titleがtitleになる"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
+                (tid, "長い決定本文がここに入る", "理由", "要点1行"),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                """
+                SELECT si.title FROM search_index si
+                JOIN decisions d ON d.id = si.source_id
+                WHERE si.source_type = 'decision' AND d.decision = '長い決定本文がここに入る'
+                """
+            ).fetchone()
+            assert row is not None, "search_indexにdecision行が無い"
+            assert row["title"] == "要点1行", (
+                f"search_index.title が title になっていない: {row['title']!r}"
+            )
+        finally:
+            conn.close()
+
+    def test_insert_decision_without_title_falls_back_to_decision(self, migrated_db):
+        """title未指定のdecisionのsearch_index.titleがdecision本文にfallbackする"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                (tid, "titleなし決定", "理由"),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                """
+                SELECT si.title FROM search_index si
+                JOIN decisions d ON d.id = si.source_id
+                WHERE si.source_type = 'decision' AND d.decision = 'titleなし決定'
+                """
+            ).fetchone()
+            assert row is not None
+            assert row["title"] == "titleなし決定", (
+                f"title未指定時にdecision本文へfallbackしていない: {row['title']!r}"
+            )
+        finally:
+            conn.close()
+
+    def test_update_decision_title_updates_search_index(self, migrated_db):
+        """decisionのtitleを後からUPDATEするとsearch_index.titleも追従する"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            cur = conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                (tid, "更新前決定", "理由"),
+            )
+            did = cur.lastrowid
+            conn.commit()
+
+            conn.execute(
+                "UPDATE decisions SET title = ? WHERE id = ?",
+                ("更新後の要点", did),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT title FROM search_index WHERE source_type = 'decision' AND source_id = ?",
+                (did,),
+            ).fetchone()
+            assert row is not None
+            assert row["title"] == "更新後の要点", (
+                f"UPDATE後にsearch_index.titleが追従していない: {row['title']!r}"
+            )
+        finally:
+            conn.close()
+
+    def test_fts_body_still_matches_decision_text(self, migrated_db):
+        """title指定decisionでも、FTSは decision本文/reason で全文検索できる（マッチ用indexは不変）"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
+                (tid, "ユニークキーワードzephyrを含む決定本文", "ユニーク理由quasar", "短い要点"),
+            )
+            conn.commit()
+
+            # decision本文中の語でFTSヒットする（title欄ではなくdecision本文がFTS title欄に入っている）
+            hit_decision = conn.execute(
+                """
+                SELECT si.source_id FROM search_index_fts
+                JOIN search_index si ON si.id = search_index_fts.rowid
+                WHERE search_index_fts MATCH 'zephyr' AND si.source_type = 'decision'
+                """
+            ).fetchall()
+            assert len(hit_decision) == 1, "decision本文の語でFTSヒットしない（FTS titleが壊れている）"
+
+            # reason中の語でFTSヒットする（FTS body）
+            hit_reason = conn.execute(
+                """
+                SELECT si.source_id FROM search_index_fts
+                JOIN search_index si ON si.id = search_index_fts.rowid
+                WHERE search_index_fts MATCH 'quasar' AND si.source_type = 'decision'
+                """
+            ).fetchall()
+            assert len(hit_reason) == 1, "reasonの語でFTSヒットしない（FTS bodyが壊れている）"
+        finally:
+            conn.close()

--- a/tests/unit/test_decision_title.py
+++ b/tests/unit/test_decision_title.py
@@ -1,0 +1,319 @@
+"""decision title + 関連decision返却 のテスト（migration 0037 で追加した機能）
+
+- add_decisions が optional title を受け取り decisions.title に保存する
+- add_decisions のレスポンス created各要素に related_decisions（同topic内の類似decision）が付く
+- find_similar_decisions が同一topic・自身除外・retract除外で類似decisionを返す
+- 表示箇所（check-in の recent_decisions / get_by_id）が title優先・decision本文fallback になる
+"""
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.topic_service import add_topic
+from src.services.decision_service import add_decisions
+from src.services.search_service import find_similar_decisions, get_by_id
+from src.services.checkin_service import _get_decisions_from_topics
+from src.services.tag_service import _injected_tags
+import src.services.embedding_service as emb
+
+
+EMBEDDING_DIM = 384
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic(temp_db):
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def topic2(temp_db):
+    return add_topic(title="テストトピック2", description="テスト用2", tags=["domain:test", "extra"])
+
+
+@pytest.fixture
+def mock_embedding_server(monkeypatch):
+    """embedding_serverへのHTTPリクエストをモック化（テキストごとに決定的なベクトルを返す）"""
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            np.random.seed(hash(prefix_str + text) % (2**32))
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    yield
+
+
+@pytest.fixture
+def mock_embedding_unavailable(monkeypatch):
+    """embeddingサーバーが利用不可（encode系がNoneを返す）状態をモック化する。
+
+    実環境でembedding_serverが起動しているか否かに依存せず、
+    embedding取得失敗時の挙動を決定的に検証するために使う。
+    """
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_encode_batch', lambda texts, prefix: None)
+    yield
+
+
+def _decision_title_in_db(decision_id: int):
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT title FROM decisions WHERE id = ?", (decision_id,)
+        ).fetchone()
+        return row["title"] if row else None
+    finally:
+        conn.close()
+
+
+class TestTitleStored:
+    """add_decisions が title を保存する"""
+
+    def test_title_persisted_when_provided(self, topic):
+        """titleを指定するとdecisions.titleに保存される"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文", "reason": "理由", "title": "要点1行"},
+        ])
+        assert "error" not in result
+        did = result["created"][0]["decision_id"]
+        assert _decision_title_in_db(did) == "要点1行"
+
+    def test_title_null_when_omitted(self, topic):
+        """title省略時はdecisions.titleがNULLになる"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文", "reason": "理由"},
+        ])
+        assert "error" not in result
+        did = result["created"][0]["decision_id"]
+        assert _decision_title_in_db(did) is None
+
+    def test_empty_or_whitespace_title_normalized_to_null(self, topic):
+        """空文字・空白のみのtitleはNULLに正規化される（表示fallbackを全箇所で一致させるため）"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文1", "reason": "理由", "title": ""},
+            {"topic_id": topic["topic_id"], "decision": "本文2", "reason": "理由", "title": "   "},
+        ])
+        assert "error" not in result
+        for c in result["created"]:
+            assert _decision_title_in_db(c["decision_id"]) is None
+
+
+class TestRelatedDecisionsResponse:
+    """add_decisions のレスポンスに related_decisions が付く"""
+
+    def test_created_has_related_decisions_key(self, topic, mock_embedding_server):
+        """created各要素に related_decisions キーが存在する"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "決定A", "reason": "理由A"},
+        ])
+        assert "error" not in result
+        assert "related_decisions" in result["created"][0]
+        assert isinstance(result["created"][0]["related_decisions"], list)
+
+    def test_related_includes_prior_same_topic_decision(self, topic, mock_embedding_server):
+        """同topicの既存decisionが related_decisions に含まれ、自身は除外される"""
+        first = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "既存決定", "reason": "理由", "title": "既存の要点"},
+        ])
+        first_id = first["created"][0]["decision_id"]
+
+        second = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "新しい決定", "reason": "理由"},
+        ])
+        second_id = second["created"][0]["decision_id"]
+        related = second["created"][0]["related_decisions"]
+
+        related_ids = [r["id"] for r in related]
+        assert first_id in related_ids, "同topicの既存decisionがrelated_decisionsに含まれない"
+        assert second_id not in related_ids, "自身がrelated_decisionsに含まれている"
+
+    def test_related_title_uses_fallback(self, topic, mock_embedding_server):
+        """related_decisions の title は title優先・decision本文fallback"""
+        # titleありの既存decision
+        add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文A", "reason": "理由", "title": "要点A"},
+        ])
+        # titleなしの既存decision
+        add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文B（titleなし）", "reason": "理由"},
+        ])
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "トリガー決定", "reason": "理由"},
+        ])
+        related = {r["title"] for r in result["created"][0]["related_decisions"]}
+        assert "要点A" in related, "titleありdecisionがtitleで表示されていない"
+        assert "本文B（titleなし）" in related, "titleなしdecisionがdecision本文にfallbackしていない"
+
+    def test_related_excludes_other_topic(self, topic, topic2, mock_embedding_server):
+        """別topicのdecisionは related_decisions に含まれない"""
+        other = add_decisions([
+            {"topic_id": topic2["topic_id"], "decision": "別topic決定", "reason": "理由"},
+        ])
+        other_id = other["created"][0]["decision_id"]
+
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "対象topic決定", "reason": "理由"},
+        ])
+        related_ids = [r["id"] for r in result["created"][0]["related_decisions"]]
+        assert other_id not in related_ids, "別topicのdecisionがrelated_decisionsに混入している"
+
+    def test_related_within_batch_respects_processing_order(self, topic, mock_embedding_server):
+        """同一バッチ内では、後続decisionのrelatedに先行decisionが現れ、逆は現れない。
+
+        add_decisionsはcreated順に「embedding生成→find_similar_decisions」を行う。
+        後続要素のfind時点では先行要素のembeddingが既にvec_index格納済みだが、
+        先行要素のfind時点では後続要素のembeddingが未格納であることに由来する挙動。
+        """
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "バッチ先行", "reason": "理由"},
+            {"topic_id": topic["topic_id"], "decision": "バッチ後続", "reason": "理由"},
+        ])
+        first_id = result["created"][0]["decision_id"]
+        second_id = result["created"][1]["decision_id"]
+
+        first_related = [r["id"] for r in result["created"][0]["related_decisions"]]
+        second_related = [r["id"] for r in result["created"][1]["related_decisions"]]
+
+        assert first_id in second_related, "後続decisionのrelatedに先行decisionが現れていない"
+        assert second_id not in first_related, "先行decisionのrelatedに後続decisionが現れている（処理順序の前提が崩れている）"
+
+    def test_related_capped_at_limit(self, topic, mock_embedding_server):
+        """同topicに4件以上の先行decisionがあっても related_decisions は上位3件に絞られる"""
+        for i in range(4):
+            add_decisions([
+                {"topic_id": topic["topic_id"], "decision": f"先行決定{i}", "reason": "理由"},
+            ])
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "トリガー決定", "reason": "理由"},
+        ])
+        related = result["created"][0]["related_decisions"]
+        assert len(related) == 3, f"related_decisionsがlimit(3)で絞られていない: {len(related)}件"
+
+    def test_related_empty_when_embedding_unavailable(self, topic, mock_embedding_unavailable):
+        """embeddingが取得できない場合は related_decisions が空配列になる"""
+        # 既存decisionを1件作成（embeddingは生成されない）
+        add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "既存決定", "reason": "理由"},
+        ])
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "新決定", "reason": "理由"},
+        ])
+        assert result["created"][0]["related_decisions"] == []
+
+
+class TestFindSimilarDecisions:
+    """find_similar_decisions の単体挙動"""
+
+    def test_excludes_retracted(self, topic, mock_embedding_server):
+        """retract済みdecisionは結果に含まれない"""
+        retracted = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "撤回される決定", "reason": "理由"},
+        ])
+        retracted_id = retracted["created"][0]["decision_id"]
+
+        # retractフラグを立てる
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE decisions SET retracted_at = '2026-01-01 00:00:00' WHERE id = ?",
+                (retracted_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        anchor = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "アンカー決定", "reason": "理由"},
+        ])
+        anchor_id = anchor["created"][0]["decision_id"]
+
+        results = find_similar_decisions(
+            exclude_id=anchor_id,
+            topic_id=topic["topic_id"],
+            text="アンカー決定",
+        )
+        result_ids = [r["id"] for r in results]
+        assert retracted_id not in result_ids, "retract済みdecisionが結果に含まれている"
+
+    def test_returns_empty_when_embedding_unavailable(self, topic, mock_embedding_unavailable):
+        """embeddingが取得できない場合は空リストを返す"""
+        add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "既存", "reason": "理由"},
+        ])
+        results = find_similar_decisions(
+            exclude_id=99999,
+            topic_id=topic["topic_id"],
+            text="何か",
+        )
+        assert results == []
+
+
+class TestDisplayFallback:
+    """表示箇所の title優先・decision本文fallback"""
+
+    def test_checkin_recent_decisions_title_fallback(self, topic):
+        """_get_decisions_from_topics が title優先・decision本文fallbackで返す"""
+        with_title = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文X", "reason": "理由", "title": "要点X"},
+        ])
+        without_title = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文Y（titleなし）", "reason": "理由"},
+        ])
+        with_id = with_title["created"][0]["decision_id"]
+        without_id = without_title["created"][0]["decision_id"]
+
+        conn = get_connection()
+        try:
+            decisions = _get_decisions_from_topics(conn, [topic["topic_id"]])
+        finally:
+            conn.close()
+
+        by_id = {d["id"]: d["title"] for d in decisions}
+        assert by_id[with_id] == "要点X", "titleありdecisionがtitleで表示されない"
+        assert by_id[without_id] == "本文Y（titleなし）", "titleなしdecisionがdecision本文にfallbackしない"
+
+    def test_get_by_id_decision_includes_title(self, topic):
+        """get_by_id(decision) のレスポンスに title フィールドが含まれる"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文", "reason": "理由", "title": "要点Z"},
+        ])
+        did = result["created"][0]["decision_id"]
+
+        res = get_by_id("decision", did)
+        assert "error" not in res
+        data = res["data"]
+        assert data["title"] == "要点Z"
+        # decision本文も従来通り含まれる
+        assert data["decision"] == "本文"
+
+    def test_get_by_id_decision_title_none_when_omitted(self, topic):
+        """title未指定decisionのget_by_idはtitle=Noneを返す"""
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "本文", "reason": "理由"},
+        ])
+        did = result["created"][0]["decision_id"]
+
+        res = get_by_id("decision", did)
+        assert res["data"]["title"] is None


### PR DESCRIPTION
## 概要

decisionに要点1行を表す`title`を持たせ、`add_decisions`のレスポンスに同topic内の類似decisionを返す。矛盾・重複への気づきを促す導線（大掛かりな矛盾検知インフラではなく、気づきやすくする軽量な仕組み）。recomposeナッジhint + decision title改善の機能2にあたる（機能1のナッジhintはPR#339でマージ済み）。

## 変更内容

### migration 0037
- `decisions.title`（nullable）を追加。既存行はNULLのまま、表示は`COALESCE(title, decision)`で現行挙動を維持（バックフィル不要）
- `search_index`投入トリガー（insert/update）を貼り直し、表示用titleを`COALESCE(NEW.title, NEW.decision)`に。FTSインデックス（マッチ用）は`decision`本文/`reason`のまま変更せず、**全文検索の挙動は不変**

### add_decisions（decision_service / main.py）
- itemsにoptional `title`を追加。空文字・空白のみは`NULL`へ正規化
- docstringで「要点1行を付けることを強く推奨」と明記
- レスポンスの`created`各要素に`related_decisions`（同topic内の類似decision上位3件 `[{id, title, distance}]`）を付与

### find_similar_decisions（search_service 新設）
- 既存decisionのembedding（decision+reason+tagsで生成済み・vec_index格納済み）でKNN → `source_type='decision'` → decisionsへJOINで**同一topic_id・retracted_at IS NULL・自身除外**に絞る
- embeddingサーバー未起動時は空リストを返す

### 表示fallback（title優先・decision本文fallback）
- check-inの`recent_decisions` / pinned decision
- timeline
- `get_by_id(decision)`に`title`フィールド追加
- search結果（search_indexトリガー経由で自動追従）

## テスト
- `tests/test_migrations/test_0037_add_decisions_title.py`: title列追加・NULL維持・search_indexのtitle優先/fallback・FTS不変
- `tests/unit/test_decision_title.py`: title保存/正規化・related_decisions（同topic限定・自身除外・retract除外・別topic除外・バッチ内順序・limit上限・embedding不在時空配列）・表示fallback
- **全1382件通過**（新規23件含む）

## レビュー
opusサブエージェントによる事前レビューでBlocker/Criticalなし。指摘されたMinor（空文字title正規化・KNN候補数の根拠コメント・テスト3件追加）は本PRに反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)