### PR TITLE
fix: relay自己修復にport占有プロセスのkill経路追加

### DIFF
--- a/src/relay/server.py
+++ b/src/relay/server.py
@@ -29,7 +29,7 @@ from urllib.parse import parse_qs, urlparse
 
 from . import PROTOCOL_VERSION
 
-PORT = 8765
+PORT = int(os.environ.get("RELAY_PORT", "8765"))
 DB_PATH = os.environ.get(
     "RELAY_DB",
     str(Path.home() / ".cc-memory" / "ow" / "relay" / "relay.db"),

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -168,6 +168,10 @@ def _start_relay_server() -> bool:
     else:
         cmd = [sys.executable, str(server_py)]
         cwd = str(relay_dir)
+    env = os.environ.copy()
+    port = _get_relay_port()
+    if port:
+        env["RELAY_PORT"] = str(port)
     try:
         subprocess.Popen(
             cmd,
@@ -175,6 +179,7 @@ def _start_relay_server() -> bool:
             start_new_session=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=env,
         )
         logger.info("relay server process started (cmd=%s)", cmd)
         return True

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -196,6 +196,11 @@ def _get_relay_port() -> int | None:
         return None
 
 
+# `lsof unavailable` warningは ensure_relay_server 呼び出しの度に出ると煩いため、
+# プロセスライフタイムで1回だけ警告する（以降は debug ログに格下げ）。
+_lsof_unavailable_logged = False
+
+
 def _find_port_owners(port: int) -> list[int]:
     """指定ポートを LISTEN 中のプロセスPIDを返す（lsof経由）。
 
@@ -206,16 +211,31 @@ def _find_port_owners(port: int) -> list[int]:
 
     macOS/Linuxを想定し、`lsof -ti:<port> -sTCP:LISTEN` で LISTEN 限定のPIDのみ取得する
     （curl等のクライアント接続側PIDを含めないため）。
+
+    Note:
+        lsof必須。Alpine等のlsof不在環境ではこの自己修復経路は無効化され、
+        `ensure_relay_server` は `_start_relay_server` のbind失敗 → wait timeout → False
+        の従来挙動に落ちる（その場合 `RELAY_UNAVAILABLE` が呼び出し元に伝搬する）。
+        コンテナ運用する場合は `lsof` を含むベースイメージ（Debian slim等）の利用を推奨する。
     """
+    global _lsof_unavailable_logged
+    timeout_sec = 2  # lsofは通常ms単位、_wait_for_relay_healthのtimeout(10s)と接近させない
     try:
         result = subprocess.run(
             ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=timeout_sec,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
-        logger.warning("lsof unavailable for port %s: %s", port, e)
+        if not _lsof_unavailable_logged:
+            logger.warning(
+                "lsof unavailable for port %s: %s (relay self-heal port-clear disabled; further occurrences logged at debug)",
+                port, e,
+            )
+            _lsof_unavailable_logged = True
+        else:
+            logger.debug("lsof unavailable for port %s: %s", port, e)
         return []
 
     # lsof は該当プロセスがない場合 exit code 1 + 空 stdout
@@ -238,6 +258,13 @@ def _clear_relay_port() -> int:
     /health 非対応の旧版relayや無関係プロセスが居座っているケースを self-heal するための経路。
     `_kill_relay` がSIGTERM→SIGKILL fallbackと例外握り潰しを担うため、ここでは単純に列挙して
     順次killし、bind可能な状態を作るだけに専念する。
+
+    WARNING:
+        本関数は `RELAY_URL` のportを LISTEN 中の**任意の**プロセスを kill する。
+        プロセス種別の検証は行わない（lsofで返ってきたPIDをそのまま `_kill_relay` に渡す）。
+        したがって `RELAY_URL` の port は relay 専用の値（デフォルト 8765）を使うこと。
+        誤って他サービスと共有しているportを指定すると、そのサービスを巻き込んで kill する。
+        実害は kill 権限の範囲（同一ユーザー）に閉じるが、設計上の前提として明示しておく。
     """
     port = _get_relay_port()
     if port is None:
@@ -346,14 +373,18 @@ def ensure_relay_server() -> bool:
             health = _wait_for_relay_health()
             if health is None:
                 # 起動直後に/healthが揃わない原因の最頻ケースはbind失敗（並行起動・占有再発）。
-                # もう一度port占有を掃除して起動を試みる(self-heal 1回限り)。リトライしても揃わなければFalse。
-                if _clear_relay_port() > 0:
-                    logger.warning("relay /health did not converge — retrying after clearing port")
-                    if not _start_relay_server():
-                        return False
-                    health = _wait_for_relay_health()
+                # 一度だけport占有を再掃除→再起動する（self-heal 1回限り）。リトライしても揃わなければFalse。
+                # flock保持中なので別orch/workerからの並行起動は発生せず、無限ループにはならない。
+                # clear件数が0でもリトライする（_start_relay_serverが起動途中で死んだ等のレアケースを救うため）。
+                logger.warning(
+                    "relay /health did not converge — clearing port and retrying once (cleared=%d)",
+                    _clear_relay_port(),
+                )
+                if not _start_relay_server():
+                    return False
+                health = _wait_for_relay_health()
                 if health is None:
-                    logger.warning("relay server failed to start within timeout")
+                    logger.warning("relay server failed to start within timeout (after retry)")
                     return False
         elif health.get("protocol_version") != PROTOCOL_VERSION:
             # 版不一致: 古いrelayをkill→新版を起動

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -183,6 +183,77 @@ def _start_relay_server() -> bool:
         return False
 
 
+def _get_relay_port() -> int | None:
+    """RELAY_URL から待受ポート番号を抽出する。
+
+    `http://127.0.0.1:8765` のような形式から 8765 を取り出す。
+    解析失敗時は None（_find_port_owners 側でスキップ）。
+    """
+    try:
+        parsed = urllib.parse.urlparse(RELAY_URL)
+        return parsed.port
+    except (ValueError, TypeError):
+        return None
+
+
+def _find_port_owners(port: int) -> list[int]:
+    """指定ポートを LISTEN 中のプロセスPIDを返す（lsof経由）。
+
+    `/health` 404 を返す旧版relayや、何らかの別プロセスがポートを占有しているケースで、
+    `_start_relay_server` 前にそのPIDを特定してkillするために使う。
+    lsofが存在しない・実行失敗・占有プロセス無しはいずれも空リストを返し、呼び出し元は
+    そのまま起動を試みて従来挙動（bind失敗で起動失敗扱い）にフォールバックする。
+
+    macOS/Linuxを想定し、`lsof -ti:<port> -sTCP:LISTEN` で LISTEN 限定のPIDのみ取得する
+    （curl等のクライアント接続側PIDを含めないため）。
+    """
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.warning("lsof unavailable for port %s: %s", port, e)
+        return []
+
+    # lsof は該当プロセスがない場合 exit code 1 + 空 stdout
+    pids: list[int] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            pids.append(int(line))
+        except ValueError:
+            continue
+    return pids
+
+
+def _clear_relay_port() -> int:
+    """RELAY_URL のポート占有プロセスを全てkillする。killしたPID数を返す。
+
+    `ensure_relay_server` の `health is None` 枝で `_start_relay_server` 前に呼ばれる。
+    /health 非対応の旧版relayや無関係プロセスが居座っているケースを self-heal するための経路。
+    `_kill_relay` がSIGTERM→SIGKILL fallbackと例外握り潰しを担うため、ここでは単純に列挙して
+    順次killし、bind可能な状態を作るだけに専念する。
+    """
+    port = _get_relay_port()
+    if port is None:
+        return 0
+    pids = _find_port_owners(port)
+    if not pids:
+        return 0
+    logger.warning(
+        "clearing %d stale process(es) holding relay port %d (pids=%s) before restart",
+        len(pids), port, pids,
+    )
+    for pid in pids:
+        _kill_relay(pid)
+    return len(pids)
+
+
 def _kill_relay(pid: int) -> None:
     """relayプロセスにSIGTERM→数秒待機→SIGKILLでkillする。
 
@@ -266,13 +337,24 @@ def ensure_relay_server() -> bool:
     try:
         health = _get_relay_health()
         if health is None:
-            # 未起動 or 旧版404扱い: そのまま起動して/healthが揃うのを待つ
+            # 未起動 or 旧版404扱い。「/health 404 を返す旧版relayがport占有中」のケースでは
+            # 起動前にport占有プロセスをkillしないとEADDRINUSEで新版が起動できない。
+            # 占有が無い未起動ケースでは _clear_relay_port が0件で何もせず通過する。
+            _clear_relay_port()
             if not _start_relay_server():
                 return False
             health = _wait_for_relay_health()
             if health is None:
-                logger.warning("relay server failed to start within timeout")
-                return False
+                # 起動直後に/healthが揃わない原因の最頻ケースはbind失敗（並行起動・占有再発）。
+                # もう一度port占有を掃除して起動を試みる(self-heal 1回限り)。リトライしても揃わなければFalse。
+                if _clear_relay_port() > 0:
+                    logger.warning("relay /health did not converge — retrying after clearing port")
+                    if not _start_relay_server():
+                        return False
+                    health = _wait_for_relay_health()
+                if health is None:
+                    logger.warning("relay server failed to start within timeout")
+                    return False
         elif health.get("protocol_version") != PROTOCOL_VERSION:
             # 版不一致: 古いrelayをkill→新版を起動
             stale_pid = health.get("pid")

--- a/tests/integration/test_relay_health.py
+++ b/tests/integration/test_relay_health.py
@@ -16,15 +16,12 @@
 既存の8765上の本番relayと衝突しないようにするための処置。
 """
 import json
-import os
 import socket
 import subprocess
 import sys
-import threading
 import time
 import urllib.error
 import urllib.request
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -41,22 +38,6 @@ def _pick_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
-
-
-class _LegacyStubHandler(BaseHTTPRequestHandler):
-    """旧版relay相当のスタブ。あらゆるルートに404 + {"error":"not found"} を返す。"""
-
-    def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandlerの命名規約)
-        self.send_response(404)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(json.dumps({"error": "not found"}).encode("utf-8"))
-
-    def do_POST(self):  # noqa: N802
-        self.do_GET()
-
-    def log_message(self, format, *args):  # テスト出力を汚さない
-        return
 
 
 def _start_legacy_stub_subprocess(port: int) -> subprocess.Popen:
@@ -144,7 +125,10 @@ def isolated_relay(tmp_path, monkeypatch):
     monkeypatch.setattr(ow_service, "RELAY_URL", relay_url)
     monkeypatch.setattr(ow_service, "_RELAY_STATE_DIR", tmp_path)
     monkeypatch.setattr(ow_service, "_RELAY_LOCK_PATH", tmp_path / "relay.lock")
-    # _start_relay_server が起動する src.relay.server に env として伝播
+    # `_start_relay_server` は `subprocess.Popen` で env を明示せず親の os.environ を継承する
+    # 設計に依存して、ここで monkeypatch.setenv した RELAY_PORT/RELAY_DB が子プロセスに届く。
+    # 将来 _start_relay_server に `env={...}` 引数渡しのリファクタが入った場合は、ここで
+    # explicit env を渡す形式に追従する必要がある。
     monkeypatch.setenv("RELAY_PORT", str(port))
     monkeypatch.setenv("RELAY_DB", relay_db)
 

--- a/tests/integration/test_relay_health.py
+++ b/tests/integration/test_relay_health.py
@@ -16,6 +16,7 @@
 既存の8765上の本番relayと衝突しないようにするための処置。
 """
 import json
+import select
 import socket
 import subprocess
 import sys
@@ -80,11 +81,11 @@ srv.serve_forever()
     # "ready"が来るまで待つ（最大3秒）
     deadline = time.monotonic() + 3.0
     while time.monotonic() < deadline:
-        if proc.stdout and proc.stdout.readable():
+        r, _, _ = select.select([proc.stdout], [], [], 0.05)
+        if r:
             line = proc.stdout.readline()
             if line.strip() == "ready":
                 return proc
-        time.sleep(0.05)
     proc.kill()
     raise RuntimeError("legacy stub did not become ready in time")
 
@@ -125,10 +126,8 @@ def isolated_relay(tmp_path, monkeypatch):
     monkeypatch.setattr(ow_service, "RELAY_URL", relay_url)
     monkeypatch.setattr(ow_service, "_RELAY_STATE_DIR", tmp_path)
     monkeypatch.setattr(ow_service, "_RELAY_LOCK_PATH", tmp_path / "relay.lock")
-    # `_start_relay_server` は `subprocess.Popen` で env を明示せず親の os.environ を継承する
-    # 設計に依存して、ここで monkeypatch.setenv した RELAY_PORT/RELAY_DB が子プロセスに届く。
-    # 将来 _start_relay_server に `env={...}` 引数渡しのリファクタが入った場合は、ここで
-    # explicit env を渡す形式に追従する必要がある。
+    # `_start_relay_server` は os.environ.copy() に RELAY_PORT を明示してから Popen に渡す。
+    # monkeypatch.setenv はここで os.environ を書き換えるため、Popen 呼び出し時のコピーに反映される。
     monkeypatch.setenv("RELAY_PORT", str(port))
     monkeypatch.setenv("RELAY_DB", relay_db)
 

--- a/tests/integration/test_relay_health.py
+++ b/tests/integration/test_relay_health.py
@@ -1,0 +1,227 @@
+"""relay自己修復のE2E（実プロセスを伴う統合テスト）
+
+シナリオ:
+- /health を404で返す「旧版相当」のダミーHTTPサーバーを別ポートで起動して
+  ポートを占有させる
+- ow_service.RELAY_URL を同ポートに差し替える
+- ensure_relay_server() を呼ぶと
+  - _get_relay_health → None（ダミーが404を返すため）
+  - _clear_relay_port → lsofでダミーのPIDを特定して kill
+  - _start_relay_server → 本物の src/relay/server.py を同ポートで起動
+  - _wait_for_relay_health → 新版が PROTOCOL_VERSION 一致のhealth dictを返す
+  - 結果 True
+- 最終クリーンアップとして起動したrelayプロセスをkill
+
+ポートは socket.bind(0) で空きを取得し、RELAY_PORT env var で server.py に伝播する。
+既存の8765上の本番relayと衝突しないようにするための処置。
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from src.relay import PROTOCOL_VERSION
+from src.services import ow_service
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _pick_free_port() -> int:
+    """OSに空きポートを払い出してもらう。bind→getsockname→closeで即解放。"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _LegacyStubHandler(BaseHTTPRequestHandler):
+    """旧版relay相当のスタブ。あらゆるルートに404 + {"error":"not found"} を返す。"""
+
+    def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandlerの命名規約)
+        self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "not found"}).encode("utf-8"))
+
+    def do_POST(self):  # noqa: N802
+        self.do_GET()
+
+    def log_message(self, format, *args):  # テスト出力を汚さない
+        return
+
+
+def _start_legacy_stub_subprocess(port: int) -> subprocess.Popen:
+    """旧版相当の404スタブを別Pythonプロセスとして起動する。
+
+    別プロセスにする理由: ow_service._find_port_owners はlsofでLISTEN中のPIDを取得する。
+    同プロセス内のスレッド起動ではPID = 自プロセスになり、ensure_relay_server が
+    テストランナーを kill してしまう。
+    """
+    code = f"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({{"error": "not found"}}).encode("utf-8"))
+
+    def do_POST(self):
+        self.do_GET()
+
+    def log_message(self, format, *args):
+        return
+
+
+srv = ThreadingHTTPServer(("127.0.0.1", {port}), H)
+print("ready", flush=True)
+srv.serve_forever()
+"""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # "ready"が来るまで待つ（最大3秒）
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if proc.stdout and proc.stdout.readable():
+            line = proc.stdout.readline()
+            if line.strip() == "ready":
+                return proc
+        time.sleep(0.05)
+    proc.kill()
+    raise RuntimeError("legacy stub did not become ready in time")
+
+
+def _wait_until_port_free(port: int, timeout: float = 5.0) -> bool:
+    """ポートが解放されるまで待つ（kill直後のTIME_WAIT等を考慮）。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind(("127.0.0.1", port))
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def _kill_pids_on_port(port: int) -> None:
+    """テスト終了時のクリーンアップ: 指定ポートのLISTENプロセスを全kill。"""
+    pids = ow_service._find_port_owners(port)
+    for pid in pids:
+        ow_service._kill_relay(pid)
+
+
+@pytest.fixture
+def isolated_relay(tmp_path, monkeypatch):
+    """RELAY_URL / RELAY_PORT / RELAY_DB をテスト用に隔離する。
+
+    - 空きポート: socket.bind(0)で確保
+    - RELAY_DB: tmp_path配下に分離（本番relay.dbと無関係に）
+    - RELAY_LOCK_PATH: tmp_path配下に分離（テスト並列時の競合を防ぐ）
+    """
+    port = _pick_free_port()
+    relay_url = f"http://127.0.0.1:{port}"
+    relay_db = str(tmp_path / "relay.db")
+
+    monkeypatch.setattr(ow_service, "RELAY_URL", relay_url)
+    monkeypatch.setattr(ow_service, "_RELAY_STATE_DIR", tmp_path)
+    monkeypatch.setattr(ow_service, "_RELAY_LOCK_PATH", tmp_path / "relay.lock")
+    # _start_relay_server が起動する src.relay.server に env として伝播
+    monkeypatch.setenv("RELAY_PORT", str(port))
+    monkeypatch.setenv("RELAY_DB", relay_db)
+
+    yield port
+
+    # cleanup: テストで起動したrelayプロセスを全部kill
+    _kill_pids_on_port(port)
+    _wait_until_port_free(port, timeout=3.0)
+
+
+def _http_get(url: str, timeout: float = 2.0) -> tuple[int, dict | None]:
+    """簡易GET。(status, json_or_None) を返す。"""
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            try:
+                return resp.status, json.loads(resp.read())
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, None
+
+
+def test_ensure_relay_server_kills_legacy_stub_and_starts_new(isolated_relay):
+    """E2E: /health 404を返す旧版相当のスタブがport占有 → ensure_relay_serverが
+    そのプロセスをkill→本物のsrc.relay.serverを同portで起動→新版が version一致を返す。
+
+    Acceptance(1)(2): /health 404を返す旧版relayがportを占有しているとき、
+    新版が占有プロセスを特定してkillし起動できること、および ensure_relay_server の
+    自己修復が「旧版居座り」ケースで成立すること、をE2Eで検証する。
+    """
+    port = isolated_relay
+
+    # ① 旧版相当の404スタブを別プロセスでportにbind
+    stub = _start_legacy_stub_subprocess(port)
+    try:
+        # /healthが404を返すことを確認（前提条件）
+        status, _ = _http_get(f"http://127.0.0.1:{port}/health", timeout=1.0)
+        assert status == 404, "legacy stubが404を返していない（テストの前提崩壊）"
+
+        # ② ensure_relay_server を呼ぶ → self-healで新版が立ち上がるはず
+        ok = ow_service.ensure_relay_server()
+        assert ok is True, "ensure_relay_serverがTrueを返さなかった（self-heal失敗）"
+    finally:
+        # スタブ側はもうkillされているはずだが念のため
+        try:
+            stub.kill()
+        except Exception:
+            pass
+
+    # ③ 新版relayが応答していることを /health で確認
+    status, payload = _http_get(f"http://127.0.0.1:{port}/health", timeout=2.0)
+    assert status == 200, f"新版relayが200を返さない: status={status} payload={payload}"
+    assert isinstance(payload, dict)
+    assert payload.get("protocol_version") == PROTOCOL_VERSION, (
+        f"新版relayのprotocol_versionが一致しない: {payload}"
+    )
+
+    # ④ 元のスタブPIDは生きていないこと
+    assert stub.poll() is not None, "旧版スタブが残存している（killされていない）"
+
+
+def test_ensure_relay_server_returns_true_when_already_healthy(isolated_relay):
+    """E2E: 何も立っていないportに対して ensure_relay_server を呼ぶと
+    新版を素直に起動して True を返す（port占有なしのbaselineケース）。
+    """
+    port = isolated_relay
+
+    # スタブも本物も立てていない状態でensure_relay_serverを呼ぶ
+    ok = ow_service.ensure_relay_server()
+    assert ok is True
+
+    # 起動した新版が一致するversionを返す
+    status, payload = _http_get(f"http://127.0.0.1:{port}/health", timeout=2.0)
+    assert status == 200
+    assert payload is not None
+    assert payload.get("protocol_version") == PROTOCOL_VERSION

--- a/tests/unit/test_ow_relay_health.py
+++ b/tests/unit/test_ow_relay_health.py
@@ -281,6 +281,34 @@ class TestEnsureRelayServer:
         assert started == [True, True]
         assert cleared_count == [0, 1]
 
+    def test_retries_even_when_clear_finds_nothing(self, monkeypatch):
+        """1回目wait失敗 + 2回目のclearでも0件 → それでもretryは1回必ず実行される
+
+        clear=0でretryをスキップすると、_start_relay_server が起動途中で死んだだけのレース
+        ケースが救えなくなる。flock保持中なので無条件retryでも無限ループにはならない。
+        """
+        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)
+        # 1回目wait→None、2回目wait→揃う（retryが走らないとTrueにならない）
+        wait_calls = iter([None, {"protocol_version": PROTOCOL_VERSION, "pid": 2222}])
+        monkeypatch.setattr(
+            ow_service, "_wait_for_relay_health",
+            lambda timeout_sec=10.0, interval_sec=0.5: next(wait_calls),
+        )
+        # 全 clear で 0件 = 占有なし
+        cleared_count: list[int] = []
+        def fake_clear():
+            cleared_count.append(0)
+            return 0
+        monkeypatch.setattr(ow_service, "_clear_relay_port", fake_clear)
+        started: list[bool] = []
+        monkeypatch.setattr(ow_service, "_start_relay_server", lambda: started.append(True) or True)
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: None)
+
+        assert ow_service.ensure_relay_server() is True
+        # 2回起動・2回clear（retryがclear件数に依らず必ず実行される）
+        assert started == [True, True]
+        assert cleared_count == [0, 0]
+
     def test_returns_false_when_retry_also_fails(self, monkeypatch):
         """1回目wait失敗 → port掃除しても2回目wait失敗 → False（無限リトライ防止）"""
         monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)

--- a/tests/unit/test_ow_relay_health.py
+++ b/tests/unit/test_ow_relay_health.py
@@ -236,8 +236,7 @@ class TestEnsureRelayServer:
     def test_clears_port_owner_when_health_404(self, monkeypatch):
         """/health 404→Noneかつport占有プロセスあり → killしてから起動 → 新版がhealthyになりTrue"""
         # health=None（旧版が404を返す相当）
-        health_calls = iter([None, {"protocol_version": PROTOCOL_VERSION, "pid": 9999}])
-        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: next(health_calls))
+        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)
         monkeypatch.setattr(
             ow_service, "_wait_for_relay_health",
             lambda timeout_sec=10.0, interval_sec=0.5: {"protocol_version": PROTOCOL_VERSION, "pid": 9999},

--- a/tests/unit/test_ow_relay_health.py
+++ b/tests/unit/test_ow_relay_health.py
@@ -3,7 +3,8 @@
 カバー範囲:
 - `_get_relay_health()`: 200/dict, 404, 接続断, 不正JSON
 - `_kill_relay(pid)`: SIGTERM→exit, SIGKILL fallback, PID不在
-- `ensure_relay_server()`: 初回起動・版一致・版不一致→kill+restart・restart失敗
+- `_find_port_owners(port)` / `_clear_relay_port()`: lsofパース・不在時フォールバック
+- `ensure_relay_server()`: 初回起動・版一致・版不一致→kill+restart・restart失敗・/health 404+port占有→port掃除して再起動
 - `_open_relay_lock()`/`_close_relay_lock()`: flock取得・解放のhappy path
 
 実HTTPサーバーは立てず、urllib.request.urlopenとos.killをmockで差し替えて分岐挙動を検証する。
@@ -13,6 +14,7 @@ import io
 import json
 import os
 import signal
+import subprocess
 import urllib.error
 import urllib.request
 from unittest.mock import MagicMock
@@ -228,6 +230,68 @@ class TestEnsureRelayServer:
         monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)
         monkeypatch.setattr(ow_service, "_start_relay_server", lambda: False)
         monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: None)
+        monkeypatch.setattr(ow_service, "_clear_relay_port", lambda: 0)
+        assert ow_service.ensure_relay_server() is False
+
+    def test_clears_port_owner_when_health_404(self, monkeypatch):
+        """/health 404→Noneかつport占有プロセスあり → killしてから起動 → 新版がhealthyになりTrue"""
+        # health=None（旧版が404を返す相当）
+        health_calls = iter([None, {"protocol_version": PROTOCOL_VERSION, "pid": 9999}])
+        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: next(health_calls))
+        monkeypatch.setattr(
+            ow_service, "_wait_for_relay_health",
+            lambda timeout_sec=10.0, interval_sec=0.5: {"protocol_version": PROTOCOL_VERSION, "pid": 9999},
+        )
+        # ポート8765を占有する旧版PIDが1つ存在
+        monkeypatch.setattr(ow_service, "_find_port_owners", lambda port: [75346])
+        killed: list[int] = []
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: killed.append(pid))
+        started: list[bool] = []
+        monkeypatch.setattr(ow_service, "_start_relay_server", lambda: started.append(True) or True)
+
+        assert ow_service.ensure_relay_server() is True
+        # 起動前にport占有プロセスがkillされている（旧版居座りケースの自己修復成立）
+        assert killed == [75346]
+        assert started == [True]
+
+    def test_retries_after_clearing_port_when_health_does_not_converge(self, monkeypatch):
+        """1回目の起動後/healthが揃わずport占有も残っている → portを掃除して再起動 → 揃ってTrue"""
+        # 初回get_health=None。以後はwait_for_relay_health経由
+        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)
+        # 1回目wait→None（揃わない）、2回目wait→揃う
+        wait_calls = iter([None, {"protocol_version": PROTOCOL_VERSION, "pid": 1111}])
+        monkeypatch.setattr(
+            ow_service, "_wait_for_relay_health",
+            lambda timeout_sec=10.0, interval_sec=0.5: next(wait_calls),
+        )
+        # _clear_relay_port: 1回目=占有なし(0)、2回目=占有を見つけてkill(1)
+        clear_calls = iter([0, 1])
+        cleared_count: list[int] = []
+        def fake_clear():
+            n = next(clear_calls)
+            cleared_count.append(n)
+            return n
+        monkeypatch.setattr(ow_service, "_clear_relay_port", fake_clear)
+        started: list[bool] = []
+        monkeypatch.setattr(ow_service, "_start_relay_server", lambda: started.append(True) or True)
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: None)
+
+        assert ow_service.ensure_relay_server() is True
+        # 2回起動（初回 + リトライ）、_clear_relay_port は2回呼ばれている
+        assert started == [True, True]
+        assert cleared_count == [0, 1]
+
+    def test_returns_false_when_retry_also_fails(self, monkeypatch):
+        """1回目wait失敗 → port掃除しても2回目wait失敗 → False（無限リトライ防止）"""
+        monkeypatch.setattr(ow_service, "_get_relay_health", lambda: None)
+        monkeypatch.setattr(
+            ow_service, "_wait_for_relay_health",
+            lambda timeout_sec=10.0, interval_sec=0.5: None,
+        )
+        # 2回ともport占有あり(自己修復対象)だが新版が立ち上がらない
+        monkeypatch.setattr(ow_service, "_clear_relay_port", lambda: 1)
+        monkeypatch.setattr(ow_service, "_start_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: None)
         assert ow_service.ensure_relay_server() is False
 
     def test_returns_false_when_restart_does_not_converge(self, monkeypatch):
@@ -250,6 +314,97 @@ class TestEnsureRelayServer:
         monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: None)
         monkeypatch.setattr(ow_service, "_start_relay_server", lambda: True)
         assert ow_service.ensure_relay_server() is False
+
+
+class TestFindPortOwners:
+    """`_find_port_owners(port)` の挙動: lsof出力パース、不在・失敗時のフォールバック。"""
+
+    def test_returns_pids_when_lsof_lists_owners(self, monkeypatch):
+        """lsof stdoutに複数行のPIDがある → intリストで返す"""
+        def fake_run(cmd, capture_output, text, timeout):
+            class _R:
+                stdout = "75346\n75412\n"
+                returncode = 0
+            return _R()
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+        assert ow_service._find_port_owners(8765) == [75346, 75412]
+
+    def test_returns_empty_when_no_owner(self, monkeypatch):
+        """占有プロセスなし（lsof空出力＋returncode=1） → 空リスト"""
+        def fake_run(cmd, capture_output, text, timeout):
+            class _R:
+                stdout = ""
+                returncode = 1
+            return _R()
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+        assert ow_service._find_port_owners(8765) == []
+
+    def test_returns_empty_when_lsof_not_found(self, monkeypatch):
+        """lsof未インストール → 空リスト（フォールバック）"""
+        def fake_run(*a, **kw):
+            raise FileNotFoundError("lsof: command not found")
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+        assert ow_service._find_port_owners(8765) == []
+
+    def test_returns_empty_on_timeout(self, monkeypatch):
+        """lsofがtimeout → 空リスト"""
+        def fake_run(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd="lsof", timeout=5)
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+        assert ow_service._find_port_owners(8765) == []
+
+    def test_skips_non_numeric_lines(self, monkeypatch):
+        """lsof出力に数値以外の行が混じっていたらスキップして数値だけ集める"""
+        def fake_run(cmd, capture_output, text, timeout):
+            class _R:
+                stdout = "75346\nnot-a-pid\n75412\n"
+                returncode = 0
+            return _R()
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+        assert ow_service._find_port_owners(8765) == [75346, 75412]
+
+
+class TestClearRelayPort:
+    """`_clear_relay_port()` の挙動: port抽出 → 占有プロセス全kill → 件数返却。"""
+
+    def test_kills_all_owners(self, monkeypatch):
+        """占有プロセスが複数 → 全てkillして件数を返す"""
+        monkeypatch.setattr(ow_service, "_find_port_owners", lambda port: [11111, 22222])
+        killed: list[int] = []
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: killed.append(pid))
+        assert ow_service._clear_relay_port() == 2
+        assert killed == [11111, 22222]
+
+    def test_returns_zero_when_no_owner(self, monkeypatch):
+        """占有なし → killせず0を返す"""
+        monkeypatch.setattr(ow_service, "_find_port_owners", lambda port: [])
+        killed: list[int] = []
+        monkeypatch.setattr(ow_service, "_kill_relay", lambda pid: killed.append(pid))
+        assert ow_service._clear_relay_port() == 0
+        assert killed == []
+
+    def test_returns_zero_when_port_unparseable(self, monkeypatch):
+        """RELAY_URLからportが取れない（不正URL等） → 0でフォールバック"""
+        monkeypatch.setattr(ow_service, "_get_relay_port", lambda: None)
+        find_called = []
+        monkeypatch.setattr(ow_service, "_find_port_owners", lambda port: find_called.append(port) or [99999])
+        assert ow_service._clear_relay_port() == 0
+        # port不明時は_find_port_ownersも呼ばれないこと
+        assert find_called == []
+
+
+class TestGetRelayPort:
+    """`_get_relay_port()` の挙動: RELAY_URLからportを抽出する。"""
+
+    def test_extracts_port_from_default_url(self, monkeypatch):
+        """デフォルトの http://127.0.0.1:8765 → 8765"""
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        assert ow_service._get_relay_port() == 8765
+
+    def test_returns_none_when_no_port(self, monkeypatch):
+        """portが省略されたURL → None"""
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://relay.example.com")
+        assert ow_service._get_relay_port() is None
 
 
 class TestRelayLock:


### PR DESCRIPTION
## 概要

`/health` 404を返す旧版relayが port 8765 を占有しているケースで、新版の `ensure_relay_server` が空転して `RELAY_UNAVAILABLE` を返すバグを修正する（T32 / 元バグ: 2026-06-14 orchセッション再開時に発見）。

## バグの構造

旧 `_get_relay_health()` は /health 404 → None を返す。`ensure_relay_server` は `health is None` 枝で `_start_relay_server()` を呼ぶが、port は旧版が占有したままなので `[Errno 48] Address already in use` で bind 失敗 → `_wait_for_relay_health` が timeout → False。

`protocol_version` 不一致枝でしか `_kill_relay(stale_pid)` が走らなかったため、`/health` 404 で pid が取れないケースで詰んでいた。

## 修正内容

- `_get_relay_port()`: `RELAY_URL` から待受ポートを抽出
- `_find_port_owners(port)`: `lsof -ti:<port> -sTCP:LISTEN` で LISTEN中のPIDを取得（lsof不在・timeout時は空リストでフォールバック）
- `_clear_relay_port()`: 占有プロセスを `_kill_relay` で全てkill、kill数を返す
- `ensure_relay_server()` の `health is None` 枝で `_start_relay_server` 前に `_clear_relay_port()` を呼ぶ
- 起動後 `/health` が揃わなかった場合、もう一度 port 掃除して1回だけリトライ（無限restart防止）
- `src/relay/server.py`: `PORT` に `RELAY_PORT` env override を追加（デフォルト 8765 不変、E2Eテスト用）

## テスト

- `tests/unit/test_ow_relay_health.py` に追加:
  - `TestFindPortOwners` 5件: lsofパース、不在、未インストール、timeout、非数値スキップ
  - `TestClearRelayPort` 3件: 全kill、占有なし、port不明
  - `TestGetRelayPort` 2件: デフォルトURL抽出、portなしURL
  - `TestEnsureRelayServer` 3件追加: /health 404+port占有→killして起動、retry成立、retry失敗→False
- `tests/integration/test_relay_health.py` 新設:
  - 旧版相当の404スタブを別Pythonプロセスで空きportにbind → `ensure_relay_server` がスタブをkillして本物のrelayを起動できることをE2Eで検証
  - baseline: 何も立っていないportで `ensure_relay_server` が新版を立ち上げる

## Test plan

- [x] `uv run pytest tests/unit/test_ow_relay_health.py tests/integration/test_relay_health.py` 全通（unit 29 + E2E 2）
- [x] `uv run pytest tests/unit/test_ow_send.py tests/unit/test_ow_queue.py` 既存テスト無影響（105 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)