### PR TITLE
feat: ow crash復旧自動化 + spawn前ヘルスチェック (ow_recover)

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -213,12 +213,17 @@ orchは起動時に特化版最新を取得し、assignの `playbook` フィー�
 1. **crash中**: workerはフォールバック規則で待機。報告はrelay SQLite履歴に残存する
 2. **再起動**: 人間が`orch_cwd`と同じcwdで `/orch` を起動し、queue再開候補から選択する
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` から実行（冪等性が再処理を安全にする。専用復旧ロジック不要）
-4. **整合チェック**（必須）:
-   - queue各タスクのstatus × presence（worker死活）× 履歴のready/doneを突合する
-   - `spawning` 残留: readyの有無で「assigned再リンク」または「queued戻し」を判別する
-   - queueに対応のないready（孤児worker）: `cmd:ping` で素性確認 → 再リンクまたはclose
-   - **cc-memory activityも突合**: queue終端済み（done/cancelled/failed） × activity `in_progress` 残留を検出・修正する
-5. **worker復帰**: 各workerにpingを送り、フォールバック復帰規則に従って復帰させる
+4. **整合チェック**（必須）: `ow_recover(channel, topic_id)` を呼ぶ。relay履歴since=0再走査・queue・presenceの3者突合・自動修正までを一括で行う:
+   - **ghost_active**（queue=assigned/ready/working & presence offline）→ relay最新state宣言からqueueを自動再構築（done→done、closed→closed、working/ready→stalled、failed→failed等）
+   - **pending_spawn**（queue=spawning & presence offline）→ relay履歴に当該workerのstate宣言がある場合のみ自動再構築。履歴ゼロは起動進行中の可能性が高くow_recoverは触らない（spawn racing回避）。orchは戻り値で残留spawning件数を把握し、経過時間が長い物は手動で `failed` 化判断する
+   - **stalled_done**（queue=done/closed/cancelled/failed & presence online）→ `cmd:ping` 送信で素性照会
+   - **orphans**（presence onlineだがqueue外のw-* handle）→ `cmd:ping` 送信で再リンク照会
+   - 検証だけしたい時は `dry_run=True` で呼ぶ
+   - 戻り値の `detected`/`applied`/`warnings` を確認し、ping応答は通常受信ループで処理
+   - **cc-memory activityも突合**（ow_recover対象外）: queue終端済み（done/cancelled/failed） × activity `in_progress` 残留を別途検出・修正する
+5. **worker復帰**: ow_recoverが送ったpingへの応答を受信ループで処理し、フォールバック復帰規則に従って復帰させる
+
+**spawn前バリデーション**: `ow_spawn_worker` は内部で relay疎通・channel存在・cwd存在・alias重複の4点を自動チェックする。失敗時は `{"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}` が返るので、warningsを確認して原因を解消してから再spawnする。
 
 **フォールバック復帰規則**:
 - フォールバック後に人間入力ゼロ → orchの復帰メッセージで自動復帰
@@ -239,6 +244,7 @@ orchは起動時に特化版最新を取得し、assignの `playbook` フィー�
 | `ow_spawn_worker(alias, channel, cwd, model, permission, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却） |
 | `ow_close_worker(term_ref)` | workerクローズ |
 | `ow_status(channel, topic_id)` | queue+presence統合ビュー |
+| `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×presence突合・ghost_active自動再構築・stalled/orphan ping送信） |
 | `check_in(activity_id)` | cc-memoryのアクティビティcheck-in |
 | `add_activity(...)` / `update_activity(...)` | アクティビティ管理（orch-managedタグ必須） |
 | `search(...)` | 特化プレイブック・過去エスカレーションログ検索 |

--- a/src/main.py
+++ b/src/main.py
@@ -1137,6 +1137,44 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
     return ow_service.ow_status(channel, topic_id)
 
 
+@mcp.tool()
+def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
+    """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正。
+
+    relay履歴を since=0 で全件再走査して各worker毎の最新state宣言を集計し、queueと
+    presenceに突合した上で次の3カテゴリに分類する。
+
+    - ghost_active: queue=spawning/assigned/working なのに presence offline
+      → relay 最新state宣言から queue ステータスを自動再構築（dry_run=Falseのみ）
+    - stalled_done: queue=done/closed/cancelled/failed なのに worker が presence onlineで残存
+      → cmd:ping を送信して素性照会
+    - orphans: presence online だが queue に登場しない w-* handle
+      → cmd:ping で再リンク照会
+
+    ping応答は orch の通常受信ループで処理する（本ツールは送信のみ）。queueの更新は
+    ow_service内部の単一の接点関数経由のため、queue層の物理形が将来変わっても
+    呼び出し側の影響範囲は最小。
+
+    Args:
+        channel: channelコード
+        topic_id: トピックID（queue-t<topic_id>.md 特定に使用）
+        dry_run: Trueなら検出のみ・修正/ping送信なし
+
+    Returns:
+        成功時:
+            {
+                "detected": {"ghost_active": [...], "stalled_done": [...], "orphans": [...]},
+                "applied": {"queue_updates": [...], "pings_sent": [...]},
+                "warnings": [str],
+                "presence": [str],
+                "reconstructed_max_msg_id": int,
+                "dry_run": bool,
+            }
+        relay/channel不可時: {"error": {"code": ..., "message": ...}}
+    """
+    return ow_service.ow_recover(channel, topic_id, dry_run)
+
+
 # セッションエンドポイント（HTTPモード用カスタムルート）
 @mcp.custom_route("/session/register", methods=["POST"])
 async def session_register(request: Request) -> JSONResponse:

--- a/src/main.py
+++ b/src/main.py
@@ -1142,10 +1142,12 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
     """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正。
 
     relay履歴を since=0 で全件再走査して各worker毎の最新state宣言を集計し、queueと
-    presenceに突合した上で次の3カテゴリに分類する。
+    presenceに突合した上で次の4カテゴリに分類する。
 
-    - ghost_active: queue=spawning/assigned/working なのに presence offline
+    - ghost_active: queue=assigned/working なのに presence offline
       → relay 最新state宣言から queue ステータスを自動再構築（dry_run=Falseのみ）
+    - pending_spawn: queue=spawning なのに presence offline
+      → relay履歴に当該workerのstate宣言があれば自動更新、なければ起動進行中として放置
     - stalled_done: queue=done/closed/cancelled/failed なのに worker が presence onlineで残存
       → cmd:ping を送信して素性照会
     - orphans: presence online だが queue に登場しない w-* handle
@@ -1163,7 +1165,7 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
     Returns:
         成功時:
             {
-                "detected": {"ghost_active": [...], "stalled_done": [...], "orphans": [...]},
+                "detected": {"ghost_active": [...], "pending_spawn": [...], "stalled_done": [...], "orphans": [...]},
                 "applied": {"queue_updates": [...], "pings_sent": [...]},
                 "warnings": [str],
                 "presence": [str],

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -732,7 +732,8 @@ def ow_spawn_worker(
 ) -> dict:
     """workerセッションを起動する。
 
-    処理順: queueへspawning write-ahead → task file書き出し → アダプタ呼び出し → 安定ID返却
+    処理順: spawn前ヘルスチェック → queueへspawning write-ahead → task file書き出し
+        → アダプタ呼び出し → 安定ID返却
 
     Args:
         alias: workerのhandle（例: "w-a"）
@@ -752,14 +753,18 @@ def ow_spawn_worker(
     Returns:
         {"term_ref": str, "task_file": str, "spawning": "ok"}
         manualフォールバック時: {"command": str, "manual": True, "task_file": str}
+        spawn前検証失敗時: {"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}
     """
-    # relayサーバー確認
-    if not ensure_relay_server():
-        return {"error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}}
-
-    # channel存在確認 → 未存在なら自動作成
-    if not ensure_channel(channel):
-        return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
+    # T17: spawn前ヘルスチェック (relay疎通・channel存在・cwd存在・alias重複)
+    preflight = _validate_spawn_preconditions(alias, channel, cwd, topic_id=topic_id, task_n=task_n)
+    if not preflight["ok"]:
+        return {
+            "error": {
+                "code": "SPAWN_PRECONDITION_FAILED",
+                "message": "spawn precondition check failed",
+                "warnings": preflight["warnings"],
+            },
+        }
 
     queue_dir = _get_queue_dir()
     task_dir = queue_dir / "tasks"
@@ -1071,4 +1076,561 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
             "status_counts": status_counts,
             "online_workers": [h for h in handles if h.startswith("w-")],
         },
+    }
+
+
+# ----------------------------
+# T17: crash復旧自動化・spawn前バリデーション
+# ----------------------------
+#
+# 設計方針 (T17 / A#830):
+#   - 突合ロジックの中核は relay messages history + presence のみで成立し、queue層の物理形に依存しない
+#     (T35議論で queue層が活動activity/log/material化される可能性に対する将来耐性)
+#   - queue層との接点は `_apply_queue_status_update` 1点に集約。queue層が変わったらこの関数だけ書き換えれば済む
+#   - reconstruct_state_from_relay と detect_crash_inconsistencies は純粋関数として実装し、テスト容易性を確保
+#
+# 突合分類:
+#   - ghost_active: queue=spawning/assigned/working かつ presence offline → relay最新stateから状態再構築
+#   - stalled_done: queue=done/closed/cancelled/failed かつ presence online → ping送信で素性照会
+#   - orphans:    queue外でpresence onlineのworker handle → ping送信で再リンク照会
+
+
+def _get_presence(channel: str) -> list[str]:
+    """relayのGET /presenceから接続中handle一覧を取得する。
+
+    エラー時は空リストを返し、呼び出し元が「presence情報なし」として扱える設計。
+    例外を伝播させない（fail-soft）のは ensure_channel と同じ規律（D#2458）。
+    """
+    try:
+        result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")
+    except Exception as e:
+        logger.warning("get presence failed for %s: %s", channel, e)
+        return []
+    if "error" in result:
+        return []
+    handles = result.get("handles") or []
+    return list(handles) if isinstance(handles, list) else []
+
+
+# queueにおける「workerが活動中」と分類する状態。spawningは含めない（C1対応）:
+# spawning 状態は ow_spawn_worker 進行中（terminal adapter 起動待ち、manual起動の人間操作待ち、
+# worker起動直後でreadyメッセージ未送信、等）の状態が混在しており、ow_recover がここに介入すると
+# 進行中のworker起動とレース条件を起こす。spawning は detect_crash_inconsistencies で別カテゴリ
+# pending_spawn として扱う。
+_ACTIVE_QUEUE_STATUSES: set[str] = {"assigned", "ready", "working"}
+_TERMINAL_QUEUE_STATUSES: set[str] = {"done", "closed", "cancelled", "failed"}
+
+# relay最新state宣言 → queue statusへの再構築マップ。
+# presence offline & queue active のghost_activeケースで使う。
+# 終端state (done/closed/failed/cancelled) はそのまま反映、非終端 (ready/working等) は
+# presence offline = 異常終了とみなして "stalled" に倒す（手動介入を促す）。
+# escalated/fallback は本来presence onlineのまま継続する状態だが、offlineで残る場合は
+# 人間介入のセッションごと落ちた異常とみなして stalled に倒す（workerスキルの状態モデル参照）。
+_RELAY_STATE_TO_QUEUE_STATUS: dict[str, str] = {
+    "done": "done",
+    "closed": "closed",
+    "failed": "failed",
+    "cancelled": "cancelled",
+    "ready": "stalled",
+    "working": "stalled",
+    "blocked": "stalled",
+    "escalated": "stalled",
+    "fallback": "stalled",
+    "dead": "failed",
+}
+
+
+def _validate_spawn_preconditions(
+    alias: str,
+    channel: str,
+    cwd: str,
+    topic_id: str | None = None,
+    task_n: int | None = None,
+) -> dict:
+    """ow_spawn_worker起動前の一括ヘルスチェック。
+
+    検証項目（すべて満たす必要があり、いずれか失敗すれば ok=False）:
+        - relayサーバー疎通: ensure_relay_serverで自己修復込み
+        - channel存在: ensure_channelで自動作成
+        - cwd存在: Path(cwd).expanduser()がディレクトリとして存在するか
+        - alias重複: 同aliasがpresence onlineまたはqueue上で活動中タスクのworkerとして他の
+          task_nに割当て済みでないか（同一task_nで再spawn=再リンクは許可）
+
+    Returns:
+        {
+            "ok": bool,
+            "warnings": [str],  # 失敗した検証項目のメッセージ一覧
+        }
+
+    呼び出し元はok=Falseならspawnを中止し、warningsをユーザー/orchに見せる責務を持つ。
+    """
+    warnings: list[str] = []
+
+    # 1. relay疎通
+    if not ensure_relay_server():
+        warnings.append("relay server unreachable (ensure_relay_server returned False)")
+        # 以降のチェックはrelay前提のため、ここで早期return
+        return {"ok": False, "warnings": warnings}
+
+    # 2. channel存在
+    if not ensure_channel(channel):
+        warnings.append(f"channel {channel} unavailable (ensure_channel returned False)")
+
+    # 3. cwd存在
+    try:
+        cwd_path = Path(cwd).expanduser()
+        if not cwd_path.is_dir():
+            warnings.append(f"cwd does not exist or is not a directory: {cwd}")
+    except (OSError, ValueError) as e:
+        warnings.append(f"cwd validation error for {cwd}: {e}")
+
+    # 4. alias重複 (presence)
+    presence = _get_presence(channel)
+    if alias in presence:
+        warnings.append(
+            f"alias {alias} is already present (online) in channel {channel}"
+        )
+
+    # 5. alias重複 (queue active task)
+    if topic_id is not None:
+        queue_dir = _get_queue_dir()
+        queue_file = queue_dir / f"queue-t{topic_id}.md"
+        _, tasks = _parse_queue_file(queue_file)
+        for t in tasks:
+            t_status = t.get("status", "")
+            t_worker = t.get("worker")
+            t_task = t.get("task", "")
+            if t_worker != alias or t_status not in _ACTIVE_QUEUE_STATUSES:
+                continue
+            # 同一task_n（"T<n>"）に対する再spawnは再リンクとみなして許可
+            if task_n is not None and t_task == f"T{task_n}":
+                continue
+            warnings.append(
+                f"alias {alias} already has active queue task {t_task} (status={t_status})"
+            )
+            break
+
+    return {"ok": not warnings, "warnings": warnings}
+
+
+def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
+    """relay履歴をsince=0で全件pullし、(alias, task) 単位の最新state宣言を集計する。
+
+    queue層の物理形に依存しない純粋関数。queueがcc-memory activityに移行しても、
+    queueファイルが残っても、このアルゴリズムは流用可能。
+
+    Args:
+        channel: channelコード
+        limit: 1回のpull上限（msg数）。10000は通常topic数百タスク分を十分にカバーする。
+            これを超える長期topicでは将来的にwindowed pullが必要だが、現状は単純実装でよい。
+
+    Returns:
+        成功時:
+            {
+                "by_worker_task": {
+                    "<alias>:T<n>": {
+                        "alias": str,
+                        "task": str,        # "T<n>"
+                        "latest_state": str,
+                        "latest_msg_id": int,
+                        "latest_at": str,
+                        "history_count": int,
+                    },
+                    ...
+                },
+                "max_msg_id": int,
+            }
+        失敗時:
+            {"by_worker_task": {}, "max_msg_id": 0, "error": {...}}
+    """
+    history = ow_history(channel, since=0, limit=limit)
+    if "error" in history:
+        return {"by_worker_task": {}, "max_msg_id": 0, "error": history["error"]}
+
+    by_worker_task: dict[str, dict] = {}
+    max_msg_id = 0
+
+    for msg in history.get("messages", []):
+        msg_id = msg.get("msg_id", 0)
+        if isinstance(msg_id, int) and msg_id > max_msg_id:
+            max_msg_id = msg_id
+        body = msg.get("body", {})
+        if not isinstance(body, dict):
+            continue
+        if body.get("kind") != "state":
+            continue
+        alias = body.get("from") or ""
+        task = body.get("task") or ""
+        state = body.get("state") or ""
+        if not alias or not task or not state:
+            continue
+        key = f"{alias}:{task}"
+        entry = by_worker_task.setdefault(
+            key,
+            {
+                "alias": alias,
+                "task": task,
+                "latest_state": state,
+                "latest_msg_id": msg_id,
+                "latest_at": msg.get("created_at", ""),
+                "history_count": 0,
+            },
+        )
+        entry["history_count"] += 1
+        # msg_id順序保証はrelay側に頼らず、エントリ側でmaxを取る
+        if msg_id >= entry["latest_msg_id"]:
+            entry["latest_state"] = state
+            entry["latest_msg_id"] = msg_id
+            entry["latest_at"] = msg.get("created_at", "")
+
+    return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id}
+
+
+def detect_crash_inconsistencies(
+    queue_tasks: list[dict],
+    reconstructed: dict,
+    presence: list[str],
+) -> dict:
+    """queue状態 × relay最新state × presence の3つを突合し、不整合を4カテゴリに分類する。
+
+    純粋関数（I/Oなし）。テスト容易性のためqueue/relay/presenceは全て引数で受け取る。
+
+    Args:
+        queue_tasks: `_parse_queue_file` の返り値相当
+            （[{task, title, status, worker, term_ref}, ...]）
+        reconstructed: `reconstruct_state_from_relay` の返り値
+        presence: `_get_presence` の返り値
+
+    Returns:
+        {
+            "ghost_active": [    # queue活動中(assigned/ready/working)だがpresence offline
+                {task, alias, queue_status, latest_state, latest_msg_id, latest_at, suggested_status},
+                ...
+            ],
+            "pending_spawn": [   # queue=spawning。relay履歴の有無で2通りに分かれる
+                {task, alias, queue_status, has_relay_history, latest_state, latest_msg_id, latest_at, suggested_status},
+                ...
+            ],
+            "stalled_done": [    # queue終端だがworkerがpresenceに残存
+                {task, alias, queue_status},
+                ...
+            ],
+            "orphans": [         # presence onlineだがqueue外
+                {alias, relay_tasks: [{task, latest_state, latest_msg_id}, ...]},
+                ...
+            ],
+        }
+
+    pending_spawn の解釈（C1対応）:
+        - has_relay_history=True: workerが起動してstate宣言を送ったがpresence offline → ghost_active相当の
+            扱いで `suggested_status` を入れる（ow_recoverは自動更新する）
+        - has_relay_history=False: workerはまだ何も送っていない＝起動進行中の可能性が高い。
+            ow_recoverは自動更新せず、orchに「pending_spawn 残留」を伝えるだけにする。
+    """
+    by_wt = reconstructed.get("by_worker_task", {}) or {}
+    presence_set = set(presence or [])
+
+    ghost_active: list[dict] = []
+    pending_spawn: list[dict] = []
+    stalled_done: list[dict] = []
+    queue_worker_aliases: set[str] = set()
+
+    for task in queue_tasks:
+        worker = task.get("worker")
+        status = task.get("status", "") or ""
+        task_id = task.get("task", "") or ""
+        if worker:
+            queue_worker_aliases.add(worker)
+
+        relay_entry = by_wt.get(f"{worker}:{task_id}") if worker else None
+
+        if status == "spawning" and worker and worker not in presence_set:
+            has_history = relay_entry is not None
+            latest_state = relay_entry["latest_state"] if relay_entry else None
+            suggested = (
+                _RELAY_STATE_TO_QUEUE_STATUS.get(latest_state, "stalled")
+                if has_history
+                else None  # 起動進行中の可能性 → ow_recoverは触らない
+            )
+            pending_spawn.append(
+                {
+                    "task": task_id,
+                    "alias": worker,
+                    "queue_status": status,
+                    "has_relay_history": has_history,
+                    "latest_state": latest_state,
+                    "latest_msg_id": relay_entry["latest_msg_id"] if relay_entry else 0,
+                    "latest_at": relay_entry["latest_at"] if relay_entry else "",
+                    "suggested_status": suggested,
+                }
+            )
+        elif status in _ACTIVE_QUEUE_STATUSES and worker and worker not in presence_set:
+            latest_state = relay_entry["latest_state"] if relay_entry else None
+            suggested = (
+                _RELAY_STATE_TO_QUEUE_STATUS.get(latest_state, "stalled")
+                if latest_state
+                else "stalled"
+            )
+            ghost_active.append(
+                {
+                    "task": task_id,
+                    "alias": worker,
+                    "queue_status": status,
+                    "latest_state": latest_state,
+                    "latest_msg_id": relay_entry["latest_msg_id"] if relay_entry else 0,
+                    "latest_at": relay_entry["latest_at"] if relay_entry else "",
+                    "suggested_status": suggested,
+                }
+            )
+        elif status in _TERMINAL_QUEUE_STATUSES and worker and worker in presence_set:
+            stalled_done.append(
+                {
+                    "task": task_id,
+                    "alias": worker,
+                    "queue_status": status,
+                }
+            )
+
+    orphans: list[dict] = []
+    for handle in sorted(presence_set):
+        if not handle.startswith("w-"):
+            continue
+        if handle in queue_worker_aliases:
+            continue
+        relay_tasks = [
+            {
+                "task": v["task"],
+                "latest_state": v["latest_state"],
+                "latest_msg_id": v["latest_msg_id"],
+            }
+            for v in by_wt.values()
+            if v["alias"] == handle
+        ]
+        relay_tasks.sort(key=lambda x: x["latest_msg_id"])
+        orphans.append({"alias": handle, "relay_tasks": relay_tasks})
+
+    return {
+        "ghost_active": ghost_active,
+        "pending_spawn": pending_spawn,
+        "stalled_done": stalled_done,
+        "orphans": orphans,
+    }
+
+
+def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
+    """workerにcrash復旧用cmd:pingを送信する。
+
+    needs_reply=True で送り、応答はorchの通常受信ループで処理される。
+    本関数はfire-and-forget（応答待ちはしない）。
+    """
+    body = {
+        "v": 1,
+        "kind": "cmd",
+        "from": "orch",
+        "to": alias,
+        "task": task or "T0",
+        "verb": "ping",
+        "data": {"recovery": True},
+    }
+    return ow_send(channel=channel, handle="orch", body=body, needs_reply=True)
+
+
+def _apply_queue_status_update(
+    queue_dir: Path,
+    topic_id: str,
+    task: str,
+    new_status: str,
+    note: str = "",
+) -> None:
+    """queueファイルの指定タスクのstatusヘッダーのみを更新する（他フィールドは保持）。
+
+    queue層との接点はこの関数1箇所に集約してある。T35議論結果でqueue層がcc-memory entityに
+    置換される場合も、ここを書き換えれば突合ロジック (`detect_crash_inconsistencies`) は無改修で済む。
+
+    挙動:
+        - `## T<n> | <title> | <status>` ヘッダーのstatus部分のみ置換
+        - noteが指定されていれば既存の `- note:` 行を置換、なければブロック末尾に追加
+        - flockでwrite競合を防ぐ（`_upsert_queue_task` と同じ規律）
+    """
+    queue_file = queue_dir / f"queue-t{topic_id}.md"
+    if not queue_file.exists():
+        raise FileNotFoundError(f"queue file not found: {queue_file}")
+
+    if not task.startswith("T"):
+        raise ValueError(f"unexpected task id format: {task}")
+
+    header_prefix = f"## {task} | "
+
+    fd = os.open(str(queue_file), os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        size = os.fstat(fd).st_size
+        content = os.read(fd, size).decode("utf-8") if size else ""
+        lines = content.splitlines(keepends=True)
+        start = next(
+            (i for i, line in enumerate(lines) if line.startswith(header_prefix)),
+            None,
+        )
+        if start is None:
+            raise KeyError(f"task {task} header not found in {queue_file}")
+
+        # ヘッダー行のstatus（最終 ' | ' フィールド）を置換
+        original = lines[start].rstrip("\n")
+        parts = original.split(" | ")
+        if len(parts) >= 3:
+            parts[-1] = new_status
+            new_header = " | ".join(parts) + "\n"
+        else:
+            # フォーマット崩れフォールバック: 強制再構築
+            new_header = f"## {task} | (recovered) | {new_status}\n"
+        lines[start] = new_header
+
+        # 当該タスクブロックの範囲: start+1 〜 次の '## ' まで
+        end = len(lines)
+        for j in range(start + 1, len(lines)):
+            if lines[j].startswith("## "):
+                end = j
+                break
+
+        if note:
+            note_idx = next(
+                (i for i in range(start + 1, end) if lines[i].startswith("- note:")),
+                None,
+            )
+            new_note_line = f"- note: {_sanitize_queue_field(note)}\n"
+            if note_idx is not None:
+                lines[note_idx] = new_note_line
+            else:
+                insert_at = end
+                while insert_at > start + 1 and lines[insert_at - 1].strip() == "":
+                    insert_at -= 1
+                lines.insert(insert_at, new_note_line)
+
+        data = "".join(lines).encode("utf-8")
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.ftruncate(fd, 0)
+        os.write(fd, data)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
+    """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正のエントリポイント。
+
+    手順:
+        1. ensure_relay_server / ensure_channel で前提整える
+        2. reconstruct_state_from_relay で全relay履歴から状態再構築
+        3. _get_presence で現在onlineのworker一覧取得
+        4. detect_crash_inconsistencies で3カテゴリ（ghost_active/stalled_done/orphans）に分類
+        5. dry_run=Falseなら:
+           - ghost_active: queueをrelay最新stateで自動更新
+           - stalled_done / orphans: cmd:ping送信（応答待ちはしない）
+
+    orchはこの戻り値を見て、queueの状態が更新されたことを確認し、ping送信先からの応答を
+    通常の受信ループで処理する。
+
+    Args:
+        channel: channelコード
+        topic_id: トピックID（queueファイル特定用、文字列も整数も受け付ける）
+        dry_run: Trueなら検出のみ・修正/送信なし
+
+    Returns:
+        {
+            "detected": {ghost_active: [...], stalled_done: [...], orphans: [...]},
+            "applied": {queue_updates: [...], pings_sent: [...]},
+            "warnings": [str],
+            "presence": [str],
+            "reconstructed_max_msg_id": int,
+            "dry_run": bool,
+        }
+        relay/channel不可時: {"error": {"code": ..., "message": ...}}
+    """
+    warnings: list[str] = []
+
+    if not ensure_relay_server():
+        return {
+            "error": {"code": "RELAY_UNAVAILABLE", "message": "relay server is not available"}
+        }
+    if not ensure_channel(channel):
+        return {
+            "error": {
+                "code": "CHANNEL_UNAVAILABLE",
+                "message": f"channel {channel} could not be created",
+            }
+        }
+
+    queue_dir = _get_queue_dir()
+    topic_id_str = str(topic_id)
+    queue_file = queue_dir / f"queue-t{topic_id_str}.md"
+    _, queue_tasks = _parse_queue_file(queue_file)
+
+    reconstructed = reconstruct_state_from_relay(channel)
+    if "error" in reconstructed:
+        warnings.append(f"relay history fetch error: {reconstructed['error']}")
+
+    presence = _get_presence(channel)
+    detected = detect_crash_inconsistencies(queue_tasks, reconstructed, presence)
+
+    applied: dict = {"queue_updates": [], "pings_sent": []}
+
+    if not dry_run:
+        # ghost_active + pending_spawn(has_relay_history=True) を自動更新対象とする。
+        # spawning だが relay履歴ゼロ (起動進行中の可能性) は触らない。
+        auto_update_targets = list(detected["ghost_active"]) + [
+            p for p in detected["pending_spawn"] if p["has_relay_history"]
+        ]
+        for ghost in auto_update_targets:
+            try:
+                _apply_queue_status_update(
+                    queue_dir=queue_dir,
+                    topic_id=topic_id_str,
+                    task=ghost["task"],
+                    new_status=ghost["suggested_status"],
+                    note=(
+                        f"crash-recovery: relay最新state={ghost['latest_state']} "
+                        f"(msg_id={ghost['latest_msg_id']})で再構築"
+                    ),
+                )
+                applied["queue_updates"].append(
+                    {
+                        "task": ghost["task"],
+                        "alias": ghost["alias"],
+                        "from": ghost["queue_status"],
+                        "to": ghost["suggested_status"],
+                    }
+                )
+            except (FileNotFoundError, KeyError, ValueError, OSError) as e:
+                warnings.append(
+                    f"failed to update queue for {ghost['task']} ({ghost['alias']}): {e}"
+                )
+
+        for orphan in detected["orphans"]:
+            result = _send_recovery_ping(channel, orphan["alias"])
+            applied["pings_sent"].append(
+                {
+                    "alias": orphan["alias"],
+                    "task": "T0",
+                    "reason": "orphan",
+                    "result": result,
+                }
+            )
+        for stalled in detected["stalled_done"]:
+            result = _send_recovery_ping(channel, stalled["alias"], task=stalled["task"])
+            applied["pings_sent"].append(
+                {
+                    "alias": stalled["alias"],
+                    "task": stalled["task"],
+                    "reason": "stalled_done",
+                    "result": result,
+                }
+            )
+
+    return {
+        "detected": detected,
+        "applied": applied,
+        "warnings": warnings,
+        "presence": presence,
+        "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
+        "dry_run": dry_run,
     }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1247,10 +1247,12 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
     if "error" in history:
         return {"by_worker_task": {}, "max_msg_id": 0, "error": history["error"]}
 
+    messages = history.get("messages", [])
+    truncated = len(messages) >= limit
     by_worker_task: dict[str, dict] = {}
     max_msg_id = 0
 
-    for msg in history.get("messages", []):
+    for msg in messages:
         msg_id = msg.get("msg_id", 0)
         if isinstance(msg_id, int) and msg_id > max_msg_id:
             max_msg_id = msg_id
@@ -1283,7 +1285,7 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
             entry["latest_msg_id"] = msg_id
             entry["latest_at"] = msg.get("created_at", "")
 
-    return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id}
+    return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id, "truncated": truncated}
 
 
 def detect_crash_inconsistencies(
@@ -1522,9 +1524,9 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         1. ensure_relay_server / ensure_channel で前提整える
         2. reconstruct_state_from_relay で全relay履歴から状態再構築
         3. _get_presence で現在onlineのworker一覧取得
-        4. detect_crash_inconsistencies で3カテゴリ（ghost_active/stalled_done/orphans）に分類
+        4. detect_crash_inconsistencies で4カテゴリ（ghost_active/pending_spawn/stalled_done/orphans）に分類
         5. dry_run=Falseなら:
-           - ghost_active: queueをrelay最新stateで自動更新
+           - ghost_active + pending_spawn(relay履歴あり): queueをrelay最新stateで自動更新
            - stalled_done / orphans: cmd:ping送信（応答待ちはしない）
 
     orchはこの戻り値を見て、queueの状態が更新されたことを確認し、ping送信先からの応答を
@@ -1537,7 +1539,12 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
 
     Returns:
         {
-            "detected": {ghost_active: [...], stalled_done: [...], orphans: [...]},
+            "detected": {
+                ghost_active: [...],
+                pending_spawn: [...],
+                stalled_done: [...],
+                orphans: [...],
+            },
             "applied": {queue_updates: [...], pings_sent: [...]},
             "warnings": [str],
             "presence": [str],
@@ -1545,6 +1552,7 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
             "dry_run": bool,
         }
         relay/channel不可時: {"error": {"code": ..., "message": ...}}
+        relay history取得失敗時: detected全カテゴリ空 + warnings に fetch error メッセージ
     """
     warnings: list[str] = []
 
@@ -1567,7 +1575,23 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
 
     reconstructed = reconstruct_state_from_relay(channel)
     if "error" in reconstructed:
-        warnings.append(f"relay history fetch error: {reconstructed['error']}")
+        return {
+            "detected": {
+                "ghost_active": [],
+                "pending_spawn": [],
+                "stalled_done": [],
+                "orphans": [],
+            },
+            "applied": {"queue_updates": [], "pings_sent": []},
+            "warnings": [f"relay history fetch error: {reconstructed['error']}"],
+            "presence": [],
+            "reconstructed_max_msg_id": 0,
+            "dry_run": dry_run,
+        }
+    if reconstructed.get("truncated"):
+        warnings.append(
+            "relay history truncated at limit=10000: oldest state declarations may be missing"
+        )
 
     presence = _get_presence(channel)
     detected = detect_crash_inconsistencies(queue_tasks, reconstructed, presence)

--- a/tests/integration/test_ow_crash_recovery.py
+++ b/tests/integration/test_ow_crash_recovery.py
@@ -1,0 +1,333 @@
+"""ow crash復旧自動化のintegrationテスト (T17)
+
+シナリオ:
+    1. relayサーバーを動的portで実プロセスとして起動（テスト分離のため別portを使う）
+    2. 複数workerのstate宣言（ready→working→done等）をrelayへ実送信し、履歴を蓄積
+    3. queueファイルを物理的に作成して「crash前の状態」を再現
+    4. presenceは「全worker offline」「特定workerがonline」等を制御し、3者突合の組合せを検証
+    5. ow_recoverを呼び、queue自動更新・ping送信が正しく実行されることを検証
+
+実relayサーバープロセスとファイルI/Oを使う＝「マルチプロセスでcrash→再起動→突合シナリオ」の acceptance を満たす。
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+
+def _free_port() -> int:
+    """OSに空きportを払い出してもらう（テスト間の衝突回避）。"""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
+    """与えられたbase_urlの/healthが200を返すまでpollする。"""
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"{url}/health", method="GET")
+            with urllib.request.urlopen(req, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def live_relay(tmp_path, monkeypatch):
+    """別portでrelayサーバープロセスを起動し、RELAY_URLを差し替える。
+
+    DB/lockもtmp_pathに隔離して既存稼働中のrelayと衝突しないようにする。
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "relay.db"
+
+    # 別portで起動するため、PORT属性を上書きするブートストラップコードを-cで渡す
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
+        f"from src.relay import server; server.PORT = {port}; "
+        f"server.main({repr(str(db_path))})"
+    )
+
+    env = os.environ.copy()
+    env["RELAY_DB"] = str(db_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        if not _wait_until_healthy(base_url, timeout_sec=10.0):
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"relay did not become healthy on port {port}. "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+
+        # ow_service側のURL／state dirをテスト用に差し替え
+        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
+        state_dir = tmp_path / "ow-state"
+        state_dir.mkdir()
+        monkeypatch.setattr(ow_service, "_RELAY_STATE_DIR", state_dir)
+        monkeypatch.setattr(ow_service, "_RELAY_LOCK_PATH", state_dir / "relay.lock")
+
+        yield {
+            "url": base_url,
+            "port": port,
+            "proc": proc,
+            "tmp_path": tmp_path,
+        }
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _send_state(channel: str, alias: str, task: str, state: str):
+    """workerからの state 宣言を実relayに送信する。"""
+    body = {
+        "v": 1, "kind": "state", "from": alias, "to": "orch",
+        "task": task, "state": state, "data": {},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _setup_queue(tmp_path: Path, topic_id: str, content: str) -> Path:
+    """queueファイルを物理的に作成し、OW_QUEUE_DIRを向ける。"""
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir(exist_ok=True)
+    (queue_dir / f"queue-t{topic_id}.md").write_text(content)
+    return queue_dir
+
+
+class TestCrashRecoveryScenario:
+    """worker死亡→orch再起動→ow_recoverによる自動修復のフル統合シナリオ。"""
+
+    def test_ghost_active_recovered_from_relay_history(self, live_relay, monkeypatch):
+        """シナリオ: 2workerが working/done を送って消滅 → ow_recoverでqueueが再構築される
+
+        前提:
+            - w-a が T1 で ready→working を送信、その後crash（presence offline）
+            - w-b が T2 で ready→working→done を送信、その後消滅
+            - queueファイルは crash 前の状態 (両方working) のまま
+        期待:
+            - w-a: relay最新=working & offline → queue=stalled
+            - w-b: relay最新=done & offline → queue=done
+        """
+        channel = "TestT17a"
+        tmp_path = live_relay["tmp_path"]
+
+        # relayにworker stateを蓄積
+        ow_service.ensure_channel(channel)
+        _send_state(channel, "w-a", "T1", "ready")
+        _send_state(channel, "w-a", "T1", "working")
+        _send_state(channel, "w-b", "T2", "ready")
+        _send_state(channel, "w-b", "T2", "working")
+        _send_state(channel, "w-b", "T2", "done")
+
+        # crash前のqueueファイル状態（両方workingで残留）
+        queue_dir = _setup_queue(
+            tmp_path, "999",
+            "## T1 | task-a | working\n"
+            "- worker: w-a / term_ref: ta / session: sa\n"
+            "- note: crash前\n"
+            "\n"
+            "## T2 | task-b | working\n"
+            "- worker: w-b / term_ref: tb / session: sb\n"
+            "- note: crash前\n",
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        # presence: 全worker offline (relay接続は send だけで切ったため)
+        result = ow_service.ow_recover(channel=channel, topic_id="999")
+
+        # 2件のghost_activeを検出して両方更新
+        assert result["dry_run"] is False
+        assert len(result["detected"]["ghost_active"]) == 2
+        applied_tasks = {u["task"]: u["to"] for u in result["applied"]["queue_updates"]}
+        assert applied_tasks == {"T1": "stalled", "T2": "done"}
+
+        # queueファイルが書き換わっていること
+        new_content = (queue_dir / "queue-t999.md").read_text()
+        assert "## T1 | task-a | stalled\n" in new_content
+        assert "## T2 | task-b | done\n" in new_content
+        # noteも更新されている
+        assert "crash-recovery" in new_content
+
+    def test_orphan_worker_triggers_ping(self, live_relay, monkeypatch):
+        """シナリオ: queueに登場しないworkerがpresence onlineで残存 → orphan ping
+
+        マルチプロセス: 別プロセスで SSE接続して presence登録した状態を作る。
+        """
+        channel = "TestT17b"
+        tmp_path = live_relay["tmp_path"]
+        ow_service.ensure_channel(channel)
+        _send_state(channel, "w-z", "T9", "ready")
+
+        # presence登録: 別プロセスでSSE接続を張る (短時間)
+        # SSE接続: stdout/stderrはDEVNULL（PIPEだとSSEのpayload蓄積でパイプバッファ溢れ→
+        # 子プロセスのwrite blockingでterminateが遅延する。C2対応）
+        ssec = subprocess.Popen(
+            [
+                sys.executable, "-c",
+                f"import urllib.request; "
+                f"req = urllib.request.Request('{live_relay['url']}/stream?channel={channel}&handle=w-z'); "
+                f"resp = urllib.request.urlopen(req, timeout=10); "
+                f"import time; time.sleep(15)",
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            # presence登録が反映されるまで最大10秒待つ（CI環境を考慮）
+            registered = False
+            for _ in range(100):
+                if "w-z" in ow_service._get_presence(channel):
+                    registered = True
+                    break
+                time.sleep(0.1)
+            assert registered, "presence registration timed out"
+
+            # queueはT9を含まない（orphan扱い）
+            queue_dir = _setup_queue(
+                tmp_path, "998",
+                "## T1 | task-a | working\n- worker: w-a / term_ref: ta / session: sa\n",
+            )
+            monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+            result = ow_service.ow_recover(channel=channel, topic_id="998")
+            assert any(o["alias"] == "w-z" for o in result["detected"]["orphans"])
+            # pingが送信されている
+            pings = result["applied"]["pings_sent"]
+            assert any(p["alias"] == "w-z" and p["reason"] == "orphan" for p in pings)
+
+            # 実relayの履歴にpingメッセージが残っていることを確認（end-to-end）
+            history = ow_service.ow_history(channel)
+            ping_msgs = [
+                m for m in history["messages"]
+                if isinstance(m.get("body"), dict)
+                and m["body"].get("kind") == "cmd"
+                and m["body"].get("verb") == "ping"
+                and m["body"].get("to") == "w-z"
+            ]
+            assert ping_msgs, "ping was not actually delivered to relay"
+        finally:
+            ssec.terminate()
+            try:
+                ssec.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                ssec.kill()
+                ssec.wait(timeout=2)
+
+    def test_dry_run_against_live_relay_makes_no_writes(self, live_relay, monkeypatch):
+        """dry_run=True なら実relayに対する突合検出は走るが書き込みは一切起きない"""
+        channel = "TestT17c"
+        tmp_path = live_relay["tmp_path"]
+        ow_service.ensure_channel(channel)
+        _send_state(channel, "w-a", "T1", "done")
+
+        queue_dir = _setup_queue(
+            tmp_path, "997",
+            "## T1 | task-a | working\n- worker: w-a / term_ref: ta / session: sa\n",
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        original = (queue_dir / "queue-t997.md").read_text()
+        result = ow_service.ow_recover(channel=channel, topic_id="997", dry_run=True)
+
+        # 検出はある
+        assert len(result["detected"]["ghost_active"]) == 1
+        assert result["detected"]["ghost_active"][0]["suggested_status"] == "done"
+        # 適用はゼロ
+        assert result["applied"]["queue_updates"] == []
+        assert result["applied"]["pings_sent"] == []
+        # queueファイル無変更
+        assert (queue_dir / "queue-t997.md").read_text() == original
+
+
+class TestSpawnPreflightAgainstLiveRelay:
+    """spawn前ヘルスチェックを実relayに対して動かす。"""
+
+    def test_alias_collision_detected_via_real_presence(self, live_relay, monkeypatch, tmp_path):
+        """presenceに既にonlineのhandleがいる状態 → SPAWN_PRECONDITION_FAILED"""
+        channel = "TestT17d"
+        ow_service.ensure_channel(channel)
+
+        # C2対応: stdout/stderrはDEVNULL
+        ssec = subprocess.Popen(
+            [
+                sys.executable, "-c",
+                f"import urllib.request; "
+                f"req = urllib.request.Request('{live_relay['url']}/stream?channel={channel}&handle=w-x'); "
+                f"resp = urllib.request.urlopen(req, timeout=10); "
+                f"import time; time.sleep(15)",
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            registered = False
+            for _ in range(100):
+                if "w-x" in ow_service._get_presence(channel):
+                    registered = True
+                    break
+                time.sleep(0.1)
+            assert registered, "presence registration timed out"
+
+            preflight = ow_service._validate_spawn_preconditions(
+                alias="w-x", channel=channel, cwd=str(tmp_path),
+            )
+            assert preflight["ok"] is False
+            assert any("alias w-x" in w for w in preflight["warnings"])
+        finally:
+            ssec.terminate()
+            try:
+                ssec.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                ssec.kill()
+                ssec.wait(timeout=2)
+
+    def test_cwd_missing_blocks_against_live_relay(self, live_relay, tmp_path):
+        """relay/channel生きてもcwd不在ならprecondition_failed"""
+        channel = "TestT17e"
+        ow_service.ensure_channel(channel)
+        missing = tmp_path / "no-such-dir"
+        preflight = ow_service._validate_spawn_preconditions(
+            alias="w-fresh", channel=channel, cwd=str(missing),
+        )
+        assert preflight["ok"] is False
+        assert any("cwd" in w for w in preflight["warnings"])
+
+    def test_all_clear_passes(self, live_relay, tmp_path):
+        """relay生・channel作成成功・cwd存在・alias未使用 → ok=True"""
+        channel = "TestT17f"
+        ow_service.ensure_channel(channel)
+        preflight = ow_service._validate_spawn_preconditions(
+            alias="w-fresh", channel=channel, cwd=str(tmp_path),
+        )
+        assert preflight["ok"] is True
+        assert preflight["warnings"] == []

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -159,7 +159,7 @@ class TestReconstructStateFromRelay:
             lambda channel, since=0, limit=10000: self._build_history([]),
         )
         result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
-        assert result == {"by_worker_task": {}, "max_msg_id": 0}
+        assert result == {"by_worker_task": {}, "max_msg_id": 0, "truncated": False}
 
     def test_single_worker_multiple_states(self, monkeypatch):
         """同一workerが ready→working→done と進む → latest_state=done"""
@@ -725,6 +725,27 @@ class TestOwRecover:
         }
         new_content = (queue_dir / "queue-t454.md").read_text()
         assert "## T1 | mytask | done\n" in new_content
+
+    def test_relay_history_fetch_failure_returns_empty_detected(self, monkeypatch, tmp_path):
+        """ensure_relay_serverは成功するがow_historyが失敗 → detected全空 + warningsに記録、queue未変更"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        original = "## T1 | mytask | working\n- worker: w-a / term_ref: x / session: y\n"
+        (queue_dir / "queue-t454.md").write_text(original)
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {"error": {"code": 500, "message": "timeout"}},
+        )
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert result["detected"]["ghost_active"] == []
+        assert result["detected"]["pending_spawn"] == []
+        assert result["detected"]["stalled_done"] == []
+        assert result["detected"]["orphans"] == []
+        assert any("relay history fetch error" in w for w in result["warnings"])
+        # queueファイルは無変更
+        assert (queue_dir / "queue-t454.md").read_text() == original
 
     def test_queue_update_failure_recorded_as_warning(self, monkeypatch, tmp_path):
         """queue更新中の例外はwarningsに記録され処理は継続する"""

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -1,0 +1,827 @@
+"""ow crash復旧自動化＋spawn前バリデーションのユニットテスト (T17)
+
+カバー範囲:
+- `_validate_spawn_preconditions`: relay/channel/cwd/alias 各失敗ケース + 全クリア
+- `reconstruct_state_from_relay`: 単一 worker / 複数 worker / 重複 state / 非state混在
+- `detect_crash_inconsistencies`: ghost_active / stalled_done / orphans 各分類
+- `_apply_queue_status_update`: header status 置換 / note 追加・上書き / 不在 task
+- `ow_recover`: dry_run / 自動修正適用 / relay不可
+
+突合ロジック本体は純粋関数のためHTTPはモックに差し替えず直接呼ぶ。
+relay HTTP接点（ow_history / _get_presence / ow_send 等）はmonkeypatchで差し替える。
+"""
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services import ow_service
+
+
+# ----------------------------
+# _validate_spawn_preconditions
+# ----------------------------
+
+
+class TestValidateSpawnPreconditions:
+    """spawn前ヘルスチェックの各検証項目を独立して検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _allow_relay_channel(self, monkeypatch):
+        """relay/channelは既定でOKを返す。各テストで個別に差し替える。"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+
+    def test_all_ok_returns_no_warnings(self, monkeypatch, tmp_path):
+        """全項目クリア → ok=True、warnings空"""
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is True
+        assert result["warnings"] == []
+
+    def test_relay_unreachable_short_circuits(self, monkeypatch, tmp_path):
+        """relay到達不可 → 即座にok=Falseで返り、それ以降のチェックは行わない"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: False)
+        # ensure_channelは呼ばれないことを検証
+        channel_calls = []
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: channel_calls.append(ch) or True)
+
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("relay" in w for w in result["warnings"])
+        assert channel_calls == []
+
+    def test_channel_unavailable_is_warning(self, monkeypatch, tmp_path):
+        """channel作成失敗 → ok=False、warningにchannel名"""
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: False)
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("channel ChAbCdEf" in w for w in result["warnings"])
+
+    def test_cwd_missing_is_warning(self, monkeypatch, tmp_path):
+        """存在しないcwd → ok=False、warningにcwdパス"""
+        missing = tmp_path / "does-not-exist"
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(missing)
+        )
+        assert result["ok"] is False
+        assert any("cwd" in w and str(missing) in w for w in result["warnings"])
+
+    def test_cwd_is_file_not_dir(self, monkeypatch, tmp_path):
+        """cwdがファイル → is_dir失敗で警告"""
+        f = tmp_path / "afile"
+        f.write_text("x")
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(f)
+        )
+        assert result["ok"] is False
+        assert any("cwd" in w for w in result["warnings"])
+
+    def test_alias_in_presence_is_warning(self, monkeypatch, tmp_path):
+        """presenceに既にaliasがいる → ok=False"""
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["orch", "w-x"])
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("alias w-x" in w and "online" in w for w in result["warnings"])
+
+    def test_alias_in_active_queue_task_is_warning(self, monkeypatch, tmp_path):
+        """queueで活動中のタスクに同一aliasが他task_nで割当て済み → ok=False"""
+        # queue設定: w-x が T9 で working 中
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        queue_file = queue_dir / "queue-t454.md"
+        queue_file.write_text(
+            "## T9 | dummy | working\n"
+            "- worker: w-x / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        # 異なるtask_n (T10) で再spawn試行 → 警告
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            topic_id="454",
+            task_n=10,
+        )
+        assert result["ok"] is False
+        assert any("active queue task T9" in w for w in result["warnings"])
+
+    def test_same_task_n_respawn_is_allowed(self, monkeypatch, tmp_path):
+        """同一task_nでの再spawn = 再リンクとみなして許可（warning出ない）"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        queue_file = queue_dir / "queue-t454.md"
+        queue_file.write_text(
+            "## T9 | dummy | working\n"
+            "- worker: w-x / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            topic_id="454",
+            task_n=9,
+        )
+        assert result["ok"] is True
+        assert result["warnings"] == []
+
+
+# ----------------------------
+# reconstruct_state_from_relay
+# ----------------------------
+
+
+class TestReconstructStateFromRelay:
+    """relay履歴から最新state宣言を集計する純粋ロジック。"""
+
+    def _build_history(self, messages: list[dict]) -> dict:
+        """ow_history相当の戻り値を組み立てる。"""
+        return {"messages": messages}
+
+    def test_empty_history(self, monkeypatch):
+        """履歴空 → by_worker_taskが空・max_msg_id=0"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history([]),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert result == {"by_worker_task": {}, "max_msg_id": 0}
+
+    def test_single_worker_multiple_states(self, monkeypatch):
+        """同一workerが ready→working→done と進む → latest_state=done"""
+        msgs = [
+            {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t1"},
+            {"msg_id": 2, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "working"}, "created_at": "t2"},
+            {"msg_id": 3, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t3"},
+        ]
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history(msgs),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert result["max_msg_id"] == 3
+        entry = result["by_worker_task"]["w-a:T1"]
+        assert entry["latest_state"] == "done"
+        assert entry["latest_msg_id"] == 3
+        assert entry["latest_at"] == "t3"
+        assert entry["history_count"] == 3
+
+    def test_multiple_workers_isolated(self, monkeypatch):
+        """異なる (alias, task) のstateは独立に集計される"""
+        msgs = [
+            {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t1"},
+            {"msg_id": 2, "body": {"kind": "state", "from": "w-b", "task": "T2", "state": "working"}, "created_at": "t2"},
+        ]
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history(msgs),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert set(result["by_worker_task"]) == {"w-a:T1", "w-b:T2"}
+        assert result["by_worker_task"]["w-a:T1"]["latest_state"] == "ready"
+        assert result["by_worker_task"]["w-b:T2"]["latest_state"] == "working"
+
+    def test_cmd_messages_are_ignored(self, monkeypatch):
+        """kind=cmdのメッセージは集計から除外される"""
+        msgs = [
+            {"msg_id": 1, "body": {"kind": "cmd", "from": "orch", "to": "w-a", "task": "T1", "verb": "assign"}},
+            {"msg_id": 2, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t2"},
+        ]
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history(msgs),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert "w-a:T1" in result["by_worker_task"]
+        # ready 1件のみ集計、cmdはhistory_countに含まれない
+        assert result["by_worker_task"]["w-a:T1"]["history_count"] == 1
+
+    def test_malformed_messages_skipped(self, monkeypatch):
+        """body無しやfrom/task/stateの欠落は無視される"""
+        msgs = [
+            {"msg_id": 1, "body": None},
+            {"msg_id": 2, "body": {"kind": "state", "from": "", "task": "T1", "state": "ready"}},
+            {"msg_id": 3, "body": {"kind": "state", "from": "w-a", "task": "", "state": "ready"}},
+            {"msg_id": 4, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": ""}},
+            {"msg_id": 5, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "ok"},
+        ]
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history(msgs),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert list(result["by_worker_task"]) == ["w-a:T1"]
+        assert result["by_worker_task"]["w-a:T1"]["history_count"] == 1
+        # max_msg_idは無視されたメッセージのidも含めて最大を返す
+        assert result["max_msg_id"] == 5
+
+    def test_history_error_propagates_as_empty(self, monkeypatch):
+        """ow_historyがerror dictを返したら、再構築結果はerror付きの空dict"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {"error": {"code": 500, "message": "boom"}},
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        assert result["by_worker_task"] == {}
+        assert result["max_msg_id"] == 0
+        assert "error" in result
+
+
+# ----------------------------
+# detect_crash_inconsistencies
+# ----------------------------
+
+
+class TestDetectCrashInconsistencies:
+    """queue × relay最新state × presence の突合分類。"""
+
+    def test_ghost_active_with_working_relay_state(self):
+        """queue=working & offline & relay最新=working → ghost_active, suggested=stalled"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "working", "worker": "w-a", "term_ref": "x"},
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-a:T1": {
+                    "alias": "w-a", "task": "T1",
+                    "latest_state": "working", "latest_msg_id": 100, "latest_at": "t100",
+                    "history_count": 5,
+                }
+            },
+            "max_msg_id": 100,
+        }
+        detected = ow_service.detect_crash_inconsistencies(queue_tasks, reconstructed, presence=[])
+        assert len(detected["ghost_active"]) == 1
+        g = detected["ghost_active"][0]
+        assert g["alias"] == "w-a"
+        assert g["task"] == "T1"
+        assert g["queue_status"] == "working"
+        assert g["latest_state"] == "working"
+        assert g["suggested_status"] == "stalled"
+
+    def test_ghost_active_with_done_relay_state(self):
+        """queue=working & offline & relay最新=done → suggested=done（terminal state反映）"""
+        queue_tasks = [
+            {"task": "T2", "title": "x", "status": "working", "worker": "w-b", "term_ref": "x"},
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-b:T2": {
+                    "alias": "w-b", "task": "T2",
+                    "latest_state": "done", "latest_msg_id": 200, "latest_at": "t200",
+                    "history_count": 6,
+                }
+            },
+            "max_msg_id": 200,
+        }
+        detected = ow_service.detect_crash_inconsistencies(queue_tasks, reconstructed, presence=[])
+        assert detected["ghost_active"][0]["suggested_status"] == "done"
+
+    def test_ghost_active_with_no_relay_state(self):
+        """queue=working & offline & relay履歴なし → suggested=stalled"""
+        queue_tasks = [
+            {"task": "T3", "title": "x", "status": "working", "worker": "w-c", "term_ref": "x"},
+        ]
+        reconstructed = {"by_worker_task": {}, "max_msg_id": 0}
+        detected = ow_service.detect_crash_inconsistencies(queue_tasks, reconstructed, presence=[])
+        assert len(detected["ghost_active"]) == 1
+        assert detected["ghost_active"][0]["latest_state"] is None
+        assert detected["ghost_active"][0]["suggested_status"] == "stalled"
+
+    def test_no_inconsistency_when_active_and_online(self):
+        """queue=working & online → 整合（ghost_activeに入らない）"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "working", "worker": "w-a", "term_ref": "x"},
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=["w-a", "orch"]
+        )
+        assert detected["ghost_active"] == []
+        assert detected["pending_spawn"] == []
+        assert detected["stalled_done"] == []
+        assert detected["orphans"] == []
+
+    def test_spawning_without_relay_history_is_pending_spawn(self):
+        """spawning & offline & relay履歴なし → pending_spawn (起動進行中の可能性、自動更新なし)"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "spawning", "worker": "w-a", "term_ref": "(pending)"},
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[]
+        )
+        # ghost_activeには入らない
+        assert detected["ghost_active"] == []
+        assert len(detected["pending_spawn"]) == 1
+        p = detected["pending_spawn"][0]
+        assert p["alias"] == "w-a"
+        assert p["queue_status"] == "spawning"
+        assert p["has_relay_history"] is False
+        assert p["suggested_status"] is None  # 自動更新対象外
+
+    def test_spawning_with_relay_history_is_pending_spawn_with_suggested(self):
+        """spawning & offline & relay最新=working → pending_spawn (has_relay_history=True、suggested=stalled)"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "spawning", "worker": "w-a", "term_ref": "(pending)"},
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-a:T1": {
+                    "alias": "w-a", "task": "T1",
+                    "latest_state": "working", "latest_msg_id": 50, "latest_at": "t50",
+                    "history_count": 2,
+                }
+            },
+            "max_msg_id": 50,
+        }
+        detected = ow_service.detect_crash_inconsistencies(queue_tasks, reconstructed, presence=[])
+        assert detected["ghost_active"] == []
+        assert len(detected["pending_spawn"]) == 1
+        p = detected["pending_spawn"][0]
+        assert p["has_relay_history"] is True
+        assert p["latest_state"] == "working"
+        assert p["suggested_status"] == "stalled"
+
+    def test_spawning_online_is_consistent(self):
+        """spawning & online → 整合（起動進行中の正常状態）"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "spawning", "worker": "w-a", "term_ref": "(pending)"},
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=["w-a"]
+        )
+        assert detected["ghost_active"] == []
+        assert detected["pending_spawn"] == []
+
+    def test_stalled_done_detected(self):
+        """queue=done & worker presence online → stalled_done"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "done", "worker": "w-a", "term_ref": "x"},
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=["w-a"]
+        )
+        assert detected["stalled_done"] == [{"task": "T1", "alias": "w-a", "queue_status": "done"}]
+
+    def test_orphan_detected(self):
+        """queueに登場しないw-* worker が presence にいる → orphan"""
+        queue_tasks = [
+            {"task": "T1", "title": "x", "status": "working", "worker": "w-a", "term_ref": "x"},
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-z:T9": {
+                    "alias": "w-z", "task": "T9",
+                    "latest_state": "ready", "latest_msg_id": 50, "latest_at": "t50",
+                    "history_count": 1,
+                }
+            },
+            "max_msg_id": 50,
+        }
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, reconstructed, presence=["w-a", "w-z", "orch"]
+        )
+        assert len(detected["orphans"]) == 1
+        orphan = detected["orphans"][0]
+        assert orphan["alias"] == "w-z"
+        assert orphan["relay_tasks"] == [
+            {"task": "T9", "latest_state": "ready", "latest_msg_id": 50},
+        ]
+
+    def test_orch_handle_not_orphan(self):
+        """orch handleは w-* で始まらないのでorphan判定対象外"""
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks=[], reconstructed={"by_worker_task": {}, "max_msg_id": 0},
+            presence=["orch"],
+        )
+        assert detected["orphans"] == []
+
+    def test_multiple_categories_simultaneously(self):
+        """4カテゴリが同時発生 → それぞれに正しく分類"""
+        queue_tasks = [
+            # ghost_active: working & offline
+            {"task": "T1", "title": "x", "status": "working", "worker": "w-a", "term_ref": "x"},
+            # stalled_done: done & online
+            {"task": "T2", "title": "y", "status": "done", "worker": "w-b", "term_ref": "y"},
+            # 整合
+            {"task": "T3", "title": "z", "status": "working", "worker": "w-c", "term_ref": "z"},
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-a:T1": {
+                    "alias": "w-a", "task": "T1",
+                    "latest_state": "working", "latest_msg_id": 100, "latest_at": "t100",
+                    "history_count": 4,
+                }
+            },
+            "max_msg_id": 100,
+        }
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, reconstructed,
+            presence=["w-b", "w-c", "w-z", "orch"],  # w-a offline, w-z orphan
+        )
+        assert [g["alias"] for g in detected["ghost_active"]] == ["w-a"]
+        assert [s["alias"] for s in detected["stalled_done"]] == ["w-b"]
+        assert [o["alias"] for o in detected["orphans"]] == ["w-z"]
+
+
+# ----------------------------
+# _apply_queue_status_update
+# ----------------------------
+
+
+class TestApplyQueueStatusUpdate:
+    """queueファイルの単一タスクstatus更新（queue層との接点）。"""
+
+    def _setup_queue(self, tmp_path: Path, content: str) -> Path:
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(content)
+        return queue_dir
+
+    def test_status_replaced_in_header(self, tmp_path):
+        """T1のstatus列が working → stalled に置換される"""
+        queue_dir = self._setup_queue(
+            tmp_path,
+            "## T1 | mytask | working\n"
+            "- worker: w-a / term_ref: x / session: y\n"
+            "- note: doing\n"
+            "\n"
+            "## T2 | other | queued\n"
+            "- worker: w-b\n",
+        )
+        ow_service._apply_queue_status_update(
+            queue_dir=queue_dir, topic_id="454", task="T1", new_status="stalled",
+        )
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "## T1 | mytask | stalled\n" in content
+        # T2は触らない
+        assert "## T2 | other | queued\n" in content
+
+    def test_note_replaces_existing(self, tmp_path):
+        """既存 - note: 行があれば置換される"""
+        queue_dir = self._setup_queue(
+            tmp_path,
+            "## T1 | mytask | working\n"
+            "- worker: w-a\n"
+            "- note: original note\n",
+        )
+        ow_service._apply_queue_status_update(
+            queue_dir=queue_dir, topic_id="454", task="T1",
+            new_status="done", note="recovered from relay",
+        )
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "- note: recovered from relay\n" in content
+        assert "original note" not in content
+
+    def test_note_appended_when_missing(self, tmp_path):
+        """noteがない場合はブロック末尾に追加される"""
+        queue_dir = self._setup_queue(
+            tmp_path,
+            "## T1 | mytask | working\n"
+            "- worker: w-a\n"
+            "- cwd: /tmp\n",
+        )
+        ow_service._apply_queue_status_update(
+            queue_dir=queue_dir, topic_id="454", task="T1",
+            new_status="done", note="added note",
+        )
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "- note: added note\n" in content
+        assert content.index("- cwd:") < content.index("- note:")
+
+    def test_note_with_newlines_is_sanitized(self, tmp_path):
+        """note内の改行は空白に畳まれる（1フィールド=1行不変条件）"""
+        queue_dir = self._setup_queue(
+            tmp_path,
+            "## T1 | mytask | working\n- worker: w-a\n",
+        )
+        ow_service._apply_queue_status_update(
+            queue_dir=queue_dir, topic_id="454", task="T1",
+            new_status="done", note="line1\nline2\nline3",
+        )
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "- note: line1 line2 line3\n" in content
+
+    def test_missing_task_raises_key_error(self, tmp_path):
+        """指定taskが存在しない → KeyError"""
+        queue_dir = self._setup_queue(
+            tmp_path,
+            "## T1 | mytask | working\n- worker: w-a\n",
+        )
+        with pytest.raises(KeyError):
+            ow_service._apply_queue_status_update(
+                queue_dir=queue_dir, topic_id="454", task="T999", new_status="done",
+            )
+
+    def test_missing_file_raises(self, tmp_path):
+        """queueファイル不在 → FileNotFoundError"""
+        empty_queue_dir = tmp_path / "no-queue"
+        empty_queue_dir.mkdir()
+        with pytest.raises(FileNotFoundError):
+            ow_service._apply_queue_status_update(
+                queue_dir=empty_queue_dir, topic_id="454", task="T1", new_status="done",
+            )
+
+    def test_invalid_task_format_raises(self, tmp_path):
+        """task文字列の形式不正 → ValueError"""
+        queue_dir = self._setup_queue(tmp_path, "## T1 | x | working\n")
+        with pytest.raises(ValueError):
+            ow_service._apply_queue_status_update(
+                queue_dir=queue_dir, topic_id="454", task="invalid", new_status="done",
+            )
+
+
+# ----------------------------
+# ow_recover
+# ----------------------------
+
+
+class TestOwRecover:
+    """crash復旧エントリポイント。"""
+
+    @pytest.fixture(autouse=True)
+    def _stub_relay(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        # 既定で empty history / presence
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {"messages": []},
+        )
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+
+    def test_relay_unreachable_returns_error(self, monkeypatch, tmp_path):
+        """relay到達不可 → errorを返す"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: False)
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert "error" in result
+        assert result["error"]["code"] == "RELAY_UNAVAILABLE"
+
+    def test_channel_unavailable_returns_error(self, monkeypatch, tmp_path):
+        """channel作成不可 → errorを返す"""
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: False)
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert "error" in result
+        assert result["error"]["code"] == "CHANNEL_UNAVAILABLE"
+
+    def test_dry_run_detects_but_applies_nothing(self, monkeypatch, tmp_path):
+        """dry_run=True → queue更新もping送信もしない"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | x | working\n- worker: w-a / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {
+                "messages": [
+                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "working"}, "created_at": "t1"},
+                ]
+            },
+        )
+        send_calls = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda **kw: send_calls.append(kw) or {"msg_id": 99},
+        )
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454", dry_run=True)
+        assert result["dry_run"] is True
+        assert len(result["detected"]["ghost_active"]) == 1
+        assert result["applied"]["queue_updates"] == []
+        assert result["applied"]["pings_sent"] == []
+        assert send_calls == []
+        # queueファイルは無変更
+        assert "working" in (queue_dir / "queue-t454.md").read_text()
+
+    def test_ghost_active_updates_queue(self, monkeypatch, tmp_path):
+        """dry_run=False & ghost_active 検出 → queue status を suggested で更新"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | mytask | working\n- worker: w-a / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {
+                "messages": [
+                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                ]
+            },
+        )
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert result["dry_run"] is False
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "## T1 | mytask | done\n" in content
+        assert len(result["applied"]["queue_updates"]) == 1
+        assert result["applied"]["queue_updates"][0] == {
+            "task": "T1", "alias": "w-a", "from": "working", "to": "done",
+        }
+
+    def test_orphans_trigger_ping(self, monkeypatch, tmp_path):
+        """orphan worker検出 → cmd:ping送信"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text("")
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-z"])
+
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda **kw: sent.append(kw) or {"msg_id": 99},
+        )
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert len(result["applied"]["pings_sent"]) == 1
+        assert result["applied"]["pings_sent"][0]["alias"] == "w-z"
+        assert result["applied"]["pings_sent"][0]["reason"] == "orphan"
+        assert sent and sent[0]["body"]["verb"] == "ping"
+        assert sent[0]["body"]["to"] == "w-z"
+        assert sent[0]["needs_reply"] is True
+
+    def test_stalled_done_triggers_ping(self, monkeypatch, tmp_path):
+        """stalled_done検出 → cmd:ping送信（task引数付き）"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | x | done\n- worker: w-a / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-a"])
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda **kw: sent.append(kw) or {"msg_id": 99},
+        )
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert any(p["reason"] == "stalled_done" for p in result["applied"]["pings_sent"])
+        assert sent[0]["body"]["task"] == "T1"
+
+    def test_pending_spawn_without_history_is_not_touched(self, monkeypatch, tmp_path):
+        """spawning & 履歴ゼロ → pending_spawn検出のみ、queue更新もping送信もしない (C1対応)"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | mytask | spawning\n- worker: w-a / term_ref: (pending) / session: (pending)\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        # 履歴空のまま (worker起動進行中のシナリオ)
+        send_calls = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda **kw: send_calls.append(kw) or {"msg_id": 99},
+        )
+        before = (queue_dir / "queue-t454.md").read_text()
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert len(result["detected"]["pending_spawn"]) == 1
+        assert result["detected"]["pending_spawn"][0]["has_relay_history"] is False
+        # 自動更新なし
+        assert result["applied"]["queue_updates"] == []
+        # queueファイルは無変更
+        assert (queue_dir / "queue-t454.md").read_text() == before
+
+    def test_pending_spawn_with_history_is_updated(self, monkeypatch, tmp_path):
+        """spawning & relay最新=done → pending_spawn (has_relay_history=True) → queue=done"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | mytask | spawning\n- worker: w-a / term_ref: (pending) / session: (pending)\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {
+                "messages": [
+                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                ]
+            },
+        )
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        # pending_spawnに分類されるがhas_relay_history=Trueなので自動更新対象
+        assert len(result["detected"]["pending_spawn"]) == 1
+        assert result["detected"]["pending_spawn"][0]["has_relay_history"] is True
+        assert len(result["applied"]["queue_updates"]) == 1
+        assert result["applied"]["queue_updates"][0] == {
+            "task": "T1", "alias": "w-a", "from": "spawning", "to": "done",
+        }
+        new_content = (queue_dir / "queue-t454.md").read_text()
+        assert "## T1 | mytask | done\n" in new_content
+
+    def test_queue_update_failure_recorded_as_warning(self, monkeypatch, tmp_path):
+        """queue更新中の例外はwarningsに記録され処理は継続する"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text(
+            "## T1 | mytask | working\n- worker: w-a / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {
+                "messages": [
+                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                ]
+            },
+        )
+
+        def fake_apply(**kwargs):
+            raise OSError("disk full")
+        monkeypatch.setattr(ow_service, "_apply_queue_status_update", fake_apply)
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert result["applied"]["queue_updates"] == []
+        assert any("disk full" in w for w in result["warnings"])
+
+
+# ----------------------------
+# _get_presence (HTTPラッパー fail-soft)
+# ----------------------------
+
+
+class TestGetPresence:
+    def test_success(self, monkeypatch):
+        """正常応答 → handles配列を返す"""
+        monkeypatch.setattr(
+            ow_service, "_relay_request",
+            lambda method, path: {"handles": ["orch", "w-a"]},
+        )
+        assert ow_service._get_presence("ChAbCdEf") == ["orch", "w-a"]
+
+    def test_error_dict_returns_empty(self, monkeypatch):
+        """relayがerror dictを返す → 空リスト"""
+        monkeypatch.setattr(
+            ow_service, "_relay_request",
+            lambda method, path: {"error": {"code": 500}},
+        )
+        assert ow_service._get_presence("ChAbCdEf") == []
+
+    def test_exception_returns_empty(self, monkeypatch):
+        """_relay_request例外 → 空リスト（例外を伝播しない）"""
+        def boom(method, path):
+            raise RuntimeError("net down")
+        monkeypatch.setattr(ow_service, "_relay_request", boom)
+        assert ow_service._get_presence("ChAbCdEf") == []
+
+    def test_missing_handles_key(self, monkeypatch):
+        """handlesキーがないレスポンス → 空リスト"""
+        monkeypatch.setattr(ow_service, "_relay_request", lambda method, path: {})
+        assert ow_service._get_presence("ChAbCdEf") == []
+
+
+# ----------------------------
+# ow_spawn_worker preflight integration
+# ----------------------------
+
+
+class TestOwSpawnWorkerPreflight:
+    """ow_spawn_workerがpreflight失敗時にspawn中止+warningsを返すこと。"""
+
+    def test_relay_unreachable_returns_precondition_failed(self, monkeypatch, tmp_path):
+        """relay不可 → SPAWN_PRECONDITION_FAILEDで止まる（task fileやアダプタは呼ばれない）"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: False)
+        write_called = []
+        monkeypatch.setattr(
+            ow_service, "_write_task_file",
+            lambda **kwargs: write_called.append(True) or Path("/tmp/x.md"),
+        )
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path),
+            model="claude-opus-4-7",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        assert any("relay" in w for w in result["error"]["warnings"])
+        assert write_called == []
+
+    def test_alias_collision_blocks_spawn(self, monkeypatch, tmp_path):
+        """presenceに同aliasがいる → SPAWN_PRECONDITION_FAILED"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-x"])
+        result = ow_service.ow_spawn_worker(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path),
+            model="claude-opus-4-7",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        assert any("alias w-x" in w for w in result["error"]["warnings"])

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -632,12 +632,17 @@ class TestOwStatusIntegration:
 class TestOwSpawnWorkerManualFallback:
     """ケース#14: アダプタ不在時にmanualフォールバックで起動コマンドを返す"""
 
+    @pytest.fixture(autouse=True)
+    def _stub_preflight(self, monkeypatch):
+        """spawn前ヘルスチェック(T17) の relay/channel/presence を本物に当てずに通す。"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+
     def test_manual_fallback_when_ow_terminal_unset(self, tmp_path: Path, monkeypatch):
         """OW_TERMINAL未設定 → manual=True + commandキーを返す"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
-        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
-        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
@@ -652,8 +657,6 @@ class TestOwSpawnWorkerManualFallback:
         """OW_TERMINAL=manual → manual=True"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "manual")
-        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
-        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         result = ow_service.ow_spawn_worker(
             alias="w-b", channel="ch2", cwd="/tmp", model="haiku",
@@ -666,12 +669,16 @@ class TestOwSpawnWorkerManualFallback:
 class TestOwSpawnWorkerAdapter:
     """アダプタ経由でworkerを起動し、stdoutからterm_refを取得する"""
 
+    @pytest.fixture(autouse=True)
+    def _stub_preflight(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+
     def test_adapter_returns_term_ref_from_stdout(self, tmp_path: Path, monkeypatch):
         """アダプタのstdoutをterm_refとして使用する"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
-        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
-        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\necho 'session-uuid-from-iterm2'\n")
@@ -689,8 +696,6 @@ class TestOwSpawnWorkerAdapter:
         """アダプタがstdoutに何も返さない場合はUUIDフォールバック"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
-        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
-        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\n")
@@ -708,8 +713,6 @@ class TestOwSpawnWorkerAdapter:
         """アダプタが失敗した場合はmanualフォールバック"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setenv("OW_TERMINAL", "iterm2")
-        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
-        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
 
         adapter_script = tmp_path / "iterm2.sh"
         adapter_script.write_text("#!/bin/bash\nexit 1\n")
@@ -725,13 +728,14 @@ class TestOwSpawnWorkerAdapter:
 
 
 class TestOwSpawnWorkerEnsureChannel:
-    """ow_spawn_worker: ensure_channel呼び出しの動作確認"""
+    """ow_spawn_worker: spawn前ヘルスチェック (T17) と ensure_channel 連携の動作確認"""
 
     def test_ensure_channel_called_before_spawn(self, tmp_path: Path, monkeypatch):
         """ensure_channelが成功すれば通常通りspawnが進む"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
 
         called_channels = []
 
@@ -748,18 +752,25 @@ class TestOwSpawnWorkerEnsureChannel:
         assert called_channels == ["TestCh01"]
         assert result.get("manual") is True  # OW_TERMINAL未設定なのでmanual
 
-    def test_ensure_channel_failure_returns_error(self, tmp_path: Path, monkeypatch):
-        """ensure_channelが失敗するとCHANNEL_UNAVAILABLEエラーを返す"""
+    def test_ensure_channel_failure_returns_precondition_failed(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """ensure_channelが失敗すると spawn前ヘルスチェックで SPAWN_PRECONDITION_FAILED を返し、
+        warningsに具体的なchannel名を含む。
+        """
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: False)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
 
         result = ow_service.ow_spawn_worker(
             alias="w-a", channel="BadCh01", cwd="/tmp", model="sonnet",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
-        assert result["error"]["code"] == "CHANNEL_UNAVAILABLE"
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        warnings = result["error"]["warnings"]
+        assert any("BadCh01" in w for w in warnings)
 
 
 class TestOwCloseWorkerTermRef:


### PR DESCRIPTION
## Summary

orch crash後の手動回復を撤廃し、relay履歴 × queue × presence の3者突合・自動修正を `ow_recover` MCPツールに集約する。再起動時の運用知識を unifying tool 1つに圧縮（運用知識ゼロ原則）。

突合アルゴリズム本体は queue層に依存せず、relay history + presence のみで動作。queue層との接点を `_apply_queue_status_update` 1点に集約してあるので、別議論で進む queue層の再設計（cc-memory entity化等）が決着しても、突合ロジック側の変更は不要。

ow_spawn_worker 起動前にも relay疎通・channel存在・cwd存在・alias重複の一括検証（preflight）を組み込み、失敗時は `SPAWN_PRECONDITION_FAILED` + 具体的 warnings 配列で返す。

### 主な追加・変更

- `reconstruct_state_from_relay`: relay履歴 since=0 全件 → (alias, task) 単位の最新state集計（純粋関数）
- `detect_crash_inconsistencies`: 4カテゴリ分類（ghost_active / pending_spawn / stalled_done / orphans）
- `_apply_queue_status_update`: queue層との単一接点。header status 置換と note の上書き／追加に対応
- `ow_recover(channel, topic_id, dry_run)`: MCPツール公開。ghost_active と pending_spawn(履歴あり) は queue を自動再構築、stalled_done と orphans には cmd:ping を fire-and-forget で送信
- `_validate_spawn_preconditions` + `ow_spawn_worker` に組み込み。同一task_n再spawnは再リンクとして許可
- `skills/orch/SKILL.md` の crash復旧節を ow_recover ベースに書き換え

### 設計上のポイント

- **spawning状態はレース回避のため別扱い**: ow_recover が spawn 進行中の worker を `stalled` に倒すレース条件を避けるため、queue=spawning は `pending_spawn` として独立カテゴリに分離。relay履歴に当該worker の state宣言があれば自動更新対象、無ければ起動進行中の可能性が高いので触らない
- **dry_run対応**: 検証だけしたい時は `dry_run=True` で呼べる
- **致命/非致命の選別**: relay/channel不可は致命（早期return）、queue更新中の例外は warnings集約のみで処理継続

## Test plan

- [x] unit 47件: `_validate_spawn_preconditions` 各失敗ケース / `reconstruct_state_from_relay` の各種履歴パターン / `detect_crash_inconsistencies` の4カテゴリ × edge cases / `_apply_queue_status_update` のheader置換とnote挿入 / `ow_recover` のdry_run・自動修正・例外集約
- [x] integration 6件: 動的portで実relayプロセス起動し、複数workerのstate宣言を実送信→ ow_recover でqueue再構築・ping送信を end-to-end 検証。SSE接続による presence登録もマルチプロセスで再現
- [x] code-review-enforcer SA (opus 4.7) でレビュー実施。Blocker 0 / Critical 2 / Major 4 / Minor/Nit 2。Critical 2件 (spawning state race condition / SSE subprocess pipe deadlock) と spawning状態の扱いは本PRで反映済み
- [x] 全テスト 1469 passed regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)