### PR TITLE
feat(ow): ow_service reducer 4関数 + 共通interface (T39/M#258 §10.4 step 2)

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -53,7 +53,9 @@ _MAX_RETRIES = 3
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
     {"loading", "ready", "working", "blocked", "escalated", "draining"}
 )
-# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+# heartbeat タイムアウト閾値（周期×3）。
+# キーは workload_state または heartbeat body の phase。両者は worker 側で同期される
+# （event:state 送信時に heartbeat phase も追従）ため、同一の値空間として共有する。
 _HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
     "loading": 30.0,  # 10s × 3
 }
@@ -1925,6 +1927,40 @@ def _infer_crash_cause(
         return None
 
 
+def _latest_events_by_type(
+    channel: str, handle: str | None, data_types: tuple[str, ...]
+) -> dict[str, dict]:
+    """指定 handle の各 data_type について最新 event を1回の ow_history で取得する。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_types: 対象とする event の data.type タプル
+
+    Returns:
+        {data_type: latest_event_dict} — 該当 event が無い type はキー欠落
+    """
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return {}
+    latest: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        t = parsed["body"].get("data", {}).get("type")
+        if t not in data_types:
+            continue
+        current = latest.get(t)
+        if current is None or parsed["msg_id"] > current["msg_id"]:
+            latest[t] = parsed
+    return latest
+
+
 def ow_get_identity(channel: str, handle: str) -> dict | None:
     """指定 handle の最新 identity bundle を返す。crash 推論を含む。
 
@@ -1935,7 +1971,8 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     Returns:
         dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
     """
-    identity_msg = _query_latest_event(channel, handle, "identity")
+    latest = _latest_events_by_type(channel, handle, ("identity", "state", "heartbeat"))
+    identity_msg = latest.get("identity")
     if identity_msg is None:
         return None
     data = identity_msg["body"].get("data", {})
@@ -1943,12 +1980,11 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     result["msg_id"] = identity_msg["msg_id"]
     result["identity_at"] = identity_msg["created_at"]
 
-    state_msg = _query_latest_event(channel, handle, "state")
-    workload_state = None
-    if state_msg is not None:
-        workload_state = state_msg["body"].get("data", {}).get("state")
-
-    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    state_msg = latest.get("state")
+    workload_state = (
+        state_msg["body"].get("data", {}).get("state") if state_msg is not None else None
+    )
+    heartbeat_msg = latest.get("heartbeat")
     last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
 
     inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
@@ -1959,35 +1995,69 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
 
 
 def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
-    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    """channel 上の全 handle の identity リスト。
+
+    alive_only=True の場合:
+    - identity bundle に terminated_at / cause(closed/cancelled/dead) を持つ entry を除外
+    - 加えて、ow_get_identity と同様の crash 推論（state が non-terminal + heartbeat 途絶）
+      で inferred_cause が付与される entry も除外する
+    handle フィールドが欠落した event は集約キーが None になるためスキップする。
+    """
     history = ow_history(channel, since=0, limit=10000)
     if "error" in history:
         return []
 
-    # handle別に最新identity msgを収集
-    latest_by_handle: dict[str, dict] = {}
+    # handle別に identity / state / heartbeat の最新msgを収集
+    identity_by_handle: dict[str, dict] = {}
+    state_by_handle: dict[str, dict] = {}
+    heartbeat_by_handle: dict[str, dict] = {}
     for msg in history.get("messages", []):
         parsed = _parse_ow_event(msg)
         if parsed is None:
             continue
+        h = parsed["handle"]
+        if h is None:
+            continue
         if parsed["body"].get("kind") != "event":
             continue
-        if parsed["body"].get("data", {}).get("type") != "identity":
-            continue
-        h = parsed["handle"]
-        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
-            latest_by_handle[h] = parsed
+        t = parsed["body"].get("data", {}).get("type")
+        if t == "identity":
+            current = identity_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                identity_by_handle[h] = parsed
+        elif t == "state":
+            current = state_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                state_by_handle[h] = parsed
+        elif t == "heartbeat":
+            current = heartbeat_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                heartbeat_by_handle[h] = parsed
 
     entries = []
-    for parsed in latest_by_handle.values():
+    for h, parsed in identity_by_handle.items():
         data = parsed["body"].get("data", {})
         entry = dict(data)
         entry["msg_id"] = parsed["msg_id"]
         entry["identity_at"] = parsed["created_at"]
 
+        state_msg = state_by_handle.get(h)
+        workload_state = (
+            state_msg["body"].get("data", {}).get("state")
+            if state_msg is not None
+            else None
+        )
+        hb_msg = heartbeat_by_handle.get(h)
+        last_heartbeat_at = hb_msg["created_at"] if hb_msg is not None else None
+        inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+        if inferred_cause is not None:
+            entry["inferred_cause"] = inferred_cause
+
         if alive_only:
             cause = entry.get("cause")
             if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+            if inferred_cause is not None:
                 continue
 
         entries.append(entry)
@@ -1995,11 +2065,14 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
     return entries
 
 
-def ow_get_presence(channel: str, handle: str) -> dict | None:
+def ow_get_presence(channel: str, handle: str) -> dict:
     """最新 heartbeat 受信時刻から online/offline を推論する。
 
     T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
     SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    heartbeat が一度も観測されない handle に対しては status="unknown" の
+    entry を返す（None は返さない）。
 
     Returns:
         dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -49,6 +49,16 @@ _RELAY_LOCK_PATH = _RELAY_STATE_DIR / "relay.lock"
 
 _MAX_RETRIES = 3
 
+# reducer: v3 workload state 分類
+_NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
+    {"loading", "ready", "working", "blocked", "escalated", "draining"}
+)
+# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+_HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
+    "loading": 30.0,  # 10s × 3
+}
+_HEARTBEAT_TIMEOUT_DEFAULT: float = 90.0  # 30s × 3（ready/working/draining共通）
+
 
 # ----------------------------
 # relay HTTPヘルパー
@@ -1775,4 +1785,260 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         "presence": presence,
         "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
         "dry_run": dry_run,
+    }
+
+
+# ----------------------------
+# reducer: v3 event sourcing
+# ----------------------------
+
+
+def _parse_ow_event(msg: dict) -> dict | None:
+    """relayメッセージからow envelopeを解釈する。
+
+    Args:
+        msg: ow_historyから返されるメッセージdict
+
+    Returns:
+        {"msg_id": int, "handle": str, "body": dict, "created_at": str} または None
+    """
+    body = msg.get("body")
+    if not isinstance(body, dict):
+        return None
+    msg_id = msg.get("msg_id")
+    v = body.get("v")
+    if v != 1:
+        logger.warning(
+            "ow_service: skip msg_id=%s (envelope v=%r, expected 1)", msg_id, v
+        )
+        return None
+    kind = body.get("kind")
+    if kind not in ("command", "event"):
+        logger.warning(
+            "ow_service: skip msg_id=%s (kind=%r, expected command/event)", msg_id, kind
+        )
+        return None
+    return {
+        "msg_id": msg_id,
+        "handle": msg.get("handle"),
+        "body": body,
+        "created_at": msg.get("created_at"),
+    }
+
+
+def _query_latest_event(
+    channel: str, handle: str | None, data_type: str, since: int = 0
+) -> dict | None:
+    """指定 channel/handle/data_type の最新 event を返す（kind=event のみ対象）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（例: "identity", "state", "heartbeat"）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        最新のparsed event dict または None
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return None
+    result = None
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        if result is None or parsed["msg_id"] > result["msg_id"]:
+            result = parsed
+    return result
+
+
+def _query_events_since(
+    channel: str,
+    handle: str | None,
+    data_type: str | None,
+    since: int = 0,
+) -> list[dict]:
+    """指定条件のeventを時系列順で全件取得（kind=event のみ）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（Noneなら全type）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        条件に合うparsed event dictのリスト（msg_id昇順）
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return []
+    results = []
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if data_type is not None and parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        results.append(parsed)
+    return results
+
+
+def _infer_crash_cause(
+    workload_state: str | None, last_heartbeat_at: str | None
+) -> str | None:
+    """crash推論ロジック（DB不変、戻り値のみに付与）。
+
+    Args:
+        workload_state: 最新のworkload state文字列
+        last_heartbeat_at: 最後のheartbeat受信時刻（ISO形式文字列）
+
+    Returns:
+        crash推論結果文字列 または None（crashでない場合）
+    """
+    if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if last_heartbeat_at is None:
+        return None
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        timeout = _HEARTBEAT_TIMEOUT_SECS.get(workload_state, _HEARTBEAT_TIMEOUT_DEFAULT)
+        if elapsed < timeout:
+            return None
+        if workload_state == "draining":
+            return "crashed-during-drain (inferred)"
+        return "crashed (inferred)"
+    except (ValueError, TypeError):
+        return None
+
+
+def ow_get_identity(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 identity bundle を返す。crash 推論を含む。
+
+    crash 推論: 最新の event:state が terminal でない（loading/ready/working/blocked/
+               escalated/draining）かつ最後の event:heartbeat 受信時刻から閾値超過 →
+               メモリ上で inferred_cause を付与（DB 不変）。
+
+    Returns:
+        dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
+    """
+    identity_msg = _query_latest_event(channel, handle, "identity")
+    if identity_msg is None:
+        return None
+    data = identity_msg["body"].get("data", {})
+    result = dict(data)
+    result["msg_id"] = identity_msg["msg_id"]
+    result["identity_at"] = identity_msg["created_at"]
+
+    state_msg = _query_latest_event(channel, handle, "state")
+    workload_state = None
+    if state_msg is not None:
+        workload_state = state_msg["body"].get("data", {}).get("state")
+
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
+
+    inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+    if inferred_cause is not None:
+        result["inferred_cause"] = inferred_cause
+
+    return result
+
+
+def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
+    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return []
+
+    # handle別に最新identity msgを収集
+    latest_by_handle: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != "identity":
+            continue
+        h = parsed["handle"]
+        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
+            latest_by_handle[h] = parsed
+
+    entries = []
+    for parsed in latest_by_handle.values():
+        data = parsed["body"].get("data", {})
+        entry = dict(data)
+        entry["msg_id"] = parsed["msg_id"]
+        entry["identity_at"] = parsed["created_at"]
+
+        if alive_only:
+            cause = entry.get("cause")
+            if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+
+        entries.append(entry)
+
+    return entries
+
+
+def ow_get_presence(channel: str, handle: str) -> dict | None:
+    """最新 heartbeat 受信時刻から online/offline を推論する。
+
+    T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
+    SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    Returns:
+        dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}
+    """
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    if heartbeat_msg is None:
+        return {"handle": handle, "status": "unknown", "last_heartbeat_at": None, "phase": None}
+
+    last_heartbeat_at = heartbeat_msg["created_at"]
+    phase = heartbeat_msg["body"].get("data", {}).get("phase")
+    timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase or "", _HEARTBEAT_TIMEOUT_DEFAULT)
+
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        status = "online" if elapsed < timeout else "offline"
+    except (ValueError, TypeError):
+        status = "unknown"
+
+    return {
+        "handle": handle,
+        "status": status,
+        "last_heartbeat_at": last_heartbeat_at,
+        "phase": phase,
+    }
+
+
+def ow_get_workload_state(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 workload state を返す。"""
+    state_msg = _query_latest_event(channel, handle, "state")
+    if state_msg is None:
+        return None
+    data = state_msg["body"].get("data", {})
+    return {
+        "handle": handle,
+        "state": data.get("state"),
+        "cause": data.get("cause"),
+        "msg_id": state_msg["msg_id"],
+        "state_at": state_msg["created_at"],
     }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1907,8 +1907,15 @@ def _infer_crash_cause(
 
     Returns:
         crash推論結果文字列 または None（crashでない場合）
+
+    Notes:
+        escalated は workload state machine 上は non-terminal だが、人間対話中の
+        worker は heartbeat 停止が「異常」を意味しないため watchdog 対象外
+        （orch SKILL.md・playbook.md でも明示）。crash 推論からも除外する。
     """
     if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if workload_state == "escalated":
         return None
     if last_heartbeat_at is None:
         return None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -227,6 +227,11 @@ class TestInferCrashCause:
         result = ow_service._infer_crash_cause("working", None)
         assert result is None
 
+    def test_escalated_state_returns_none(self):
+        """state="escalated"（人間対話中）は heartbeat が古くても crash 推論対象外。"""
+        result = ow_service._infer_crash_cause("escalated", self._old_hb(600))
+        assert result is None
+
 
 # ----------------------------
 # TestOwGetIdentity

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,4 +1,6 @@
 """ow_service reducer 4関数のユニットテスト (T39)"""
+import logging
+
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -58,7 +60,6 @@ class TestParseOwEvent:
         """v=2 → None を返し、warningログを出す。"""
         body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
         msg = _make_msg(10, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None
@@ -68,7 +69,6 @@ class TestParseOwEvent:
         """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
         body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
         msg = _make_msg(11, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,0 +1,372 @@
+"""ow_service reducer 4関数のユニットテスト (T39)"""
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from src.services import ow_service
+
+
+# ----------------------------
+# テストヘルパー
+# ----------------------------
+
+
+def _make_msg(msg_id, handle, body, created_at=None):
+    """テスト用リレーメッセージを生成する。"""
+    return {
+        "msg_id": msg_id,
+        "handle": handle,
+        "body": body,
+        "created_at": created_at or "2026-06-14T10:00:00+00:00",
+    }
+
+
+def _event_body(data_type, data_payload, handle="w-h", to="orch"):
+    """v:1 / kind:event の envelope を生成する。"""
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": to,
+        "data": {"type": data_type, **data_payload},
+    }
+
+
+def _make_history(messages):
+    return {"messages": messages}
+
+
+# ----------------------------
+# TestParseOwEvent
+# ----------------------------
+
+
+class TestParseOwEvent:
+    """_parse_ow_event のユニットテスト。"""
+
+    def test_valid_event_returns_parsed(self):
+        """v=1, kind="event" → 正常にparsed dictを返す。"""
+        body = _event_body("identity", {"alias": "w-1"})
+        msg = _make_msg(42, "w-h", body, "2026-06-14T10:00:00+00:00")
+        result = ow_service._parse_ow_event(msg)
+        assert result is not None
+        assert result["msg_id"] == 42
+        assert result["handle"] == "w-h"
+        assert result["body"] == body
+        assert result["created_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_v_mismatch_returns_none_with_warning(self, caplog):
+        """v=2 → None を返し、warningログを出す。"""
+        body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
+        msg = _make_msg(10, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("envelope v=" in r.message for r in caplog.records)
+
+    def test_unknown_kind_returns_none_with_warning(self, caplog):
+        """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
+        body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
+        msg = _make_msg(11, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("kind=" in r.message for r in caplog.records)
+
+    def test_non_dict_body_returns_none(self):
+        """body=None → None を返す。"""
+        msg = _make_msg(12, "w-h", None)
+        result = ow_service._parse_ow_event(msg)
+        assert result is None
+
+
+# ----------------------------
+# TestQueryLatestEvent
+# ----------------------------
+
+
+class TestQueryLatestEvent:
+    """_query_latest_event のユニットテスト。"""
+
+    def test_returns_latest_by_msg_id(self, monkeypatch):
+        """同じdata_typeが2件 → msg_id大きい方を返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(5, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is not None
+        assert result["msg_id"] == 5
+
+    def test_handle_filter(self, monkeypatch):
+        """複数handleがいる時、指定handleのみ返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-a", "state")
+        assert result is not None
+        assert result["handle"] == "w-a"
+
+    def test_handle_none_returns_any_handle(self, monkeypatch):
+        """handle=Noneなら全handleを対象にする。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(3, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", None, "state")
+        assert result is not None
+        assert result["msg_id"] == 3
+
+    def test_command_kind_skipped(self, monkeypatch):
+        """kind="command" のメッセージはスキップされる。"""
+        body = {"v": 1, "kind": "command", "data": {"type": "state"}}
+        msgs = [_make_msg(1, "w-h", body)]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_history_error_returns_none(self, monkeypatch):
+        """ow_historyがerrorを返す → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_since_parameter_passed_to_history(self, monkeypatch):
+        """sinceパラメータがow_historyに渡される。"""
+        received = {}
+
+        def fake_history(channel, since=0, limit=100):
+            received["since"] = since
+            return _make_history([])
+
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+        ow_service._query_latest_event("ch", "w-h", "state", since=42)
+        assert received["since"] == 42
+
+
+# ----------------------------
+# TestQueryEventsSince
+# ----------------------------
+
+
+class TestQueryEventsSince:
+    """_query_events_since のユニットテスト。"""
+
+    def test_returns_all_matching(self, monkeypatch):
+        """複数件返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", "heartbeat")
+        assert len(result) == 2
+
+    def test_data_type_none_matches_all_events(self, monkeypatch):
+        """data_type=Noneなら全eventが返る。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "working"})),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"})),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", None)
+        assert len(result) == 2
+
+    def test_history_error_returns_empty(self, monkeypatch):
+        """ow_historyがerror → 空リスト。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_events_since("ch", "w-h", "state")
+        assert result == []
+
+
+# ----------------------------
+# TestInferCrashCause
+# ----------------------------
+
+
+class TestInferCrashCause:
+    """_infer_crash_cause のユニットテスト。"""
+
+    def _old_hb(self, seconds_ago=200):
+        """現在時刻からseconds_ago秒前のISO文字列を返す。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def _recent_hb(self, seconds_ago=10):
+        """直近のheartbeat時刻。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def test_non_terminal_state_with_timeout_returns_crashed(self):
+        """state="working", 古いheartbeat → "crashed (inferred)"。"""
+        result = ow_service._infer_crash_cause("working", self._old_hb(200))
+        assert result == "crashed (inferred)"
+
+    def test_draining_with_timeout_returns_crashed_during_drain(self):
+        """state="draining", 古いheartbeat → "crashed-during-drain (inferred)"。"""
+        result = ow_service._infer_crash_cause("draining", self._old_hb(200))
+        assert result == "crashed-during-drain (inferred)"
+
+    def test_terminal_state_returns_none(self):
+        """state="terminated" → None。"""
+        result = ow_service._infer_crash_cause("terminated", self._old_hb(200))
+        assert result is None
+
+    def test_recent_heartbeat_returns_none(self):
+        """state="working", 直近heartbeat → None（まだ生きてる）。"""
+        result = ow_service._infer_crash_cause("working", self._recent_hb(10))
+        assert result is None
+
+    def test_none_heartbeat_returns_none(self):
+        """last_heartbeat_at=None → None。"""
+        result = ow_service._infer_crash_cause("working", None)
+        assert result is None
+
+
+# ----------------------------
+# TestOwGetIdentity
+# ----------------------------
+
+
+class TestOwGetIdentity:
+    """ow_get_identity のユニットテスト。"""
+
+    def _setup_history(self, monkeypatch, messages):
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(messages))
+
+    def test_returns_identity_with_msg_id_and_at(self, monkeypatch):
+        """正常系: identity eventがある → bundle + msg_id + identity_at を返す。"""
+        msgs = [
+            _make_msg(
+                1, "w-h",
+                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
+                "2026-06-14T10:00:00+00:00",
+            ),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result["alias"] == "worker-1"
+        assert result["msg_id"] == 1
+        assert result["identity_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_returns_none_when_no_identity(self, monkeypatch):
+        """identity eventなし → None。"""
+        self._setup_history(monkeypatch, [])
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is None
+
+    def test_inferred_cause_added_on_crash(self, monkeypatch):
+        """workingで古いheartbeat → inferred_cause付き。"""
+        old_hb = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("identity", {"alias": "worker-1"}), "2026-06-14T09:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T09:01:00+00:00"),
+            _make_msg(3, "w-h", _event_body("heartbeat", {"phase": "working"}), old_hb),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result.get("inferred_cause") == "crashed (inferred)"
+
+
+# ----------------------------
+# TestOwListIdentities
+# ----------------------------
+
+
+class TestOwListIdentities:
+    """ow_list_identities のユニットテスト。"""
+
+    def test_returns_all_handles(self, monkeypatch):
+        """2つのhandleそれぞれのidentityを返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch")
+        aliases = {e["alias"] for e in result}
+        assert aliases == {"worker-a", "worker-b"}
+
+    def test_alive_only_excludes_terminated(self, monkeypatch):
+        """alive_only=True → cause=closedを除外する。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b", "cause": "closed"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch", alive_only=True)
+        assert len(result) == 1
+        assert result[0]["alias"] == "worker-a"
+
+
+# ----------------------------
+# TestOwGetPresence
+# ----------------------------
+
+
+class TestOwGetPresence:
+    """ow_get_presence のユニットテスト。"""
+
+    def test_online_with_recent_heartbeat(self, monkeypatch):
+        """直近heartbeat → online。"""
+        recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), recent),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "online"
+        assert result["handle"] == "w-h"
+
+    def test_offline_with_old_heartbeat(self, monkeypatch):
+        """古いheartbeat → offline。"""
+        old = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), old),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "offline"
+
+    def test_unknown_when_no_heartbeat(self, monkeypatch):
+        """heartbeatなし → unknown。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "unknown"
+        assert result["last_heartbeat_at"] is None
+
+
+# ----------------------------
+# TestOwGetWorkloadState
+# ----------------------------
+
+
+class TestOwGetWorkloadState:
+    """ow_get_workload_state のユニットテスト。"""
+
+    def test_returns_latest_state(self, monkeypatch):
+        """最新stateを返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working", "cause": None}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is not None
+        assert result["state"] == "working"
+        assert result["handle"] == "w-h"
+        assert result["msg_id"] == 2
+        assert result["state_at"] == "2026-06-14T10:01:00+00:00"
+
+    def test_returns_none_when_no_state(self, monkeypatch):
+        """stateなし → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is None


### PR DESCRIPTION
## Summary

- `src/services/ow_service.py` に v3 reducer 実装を追加（M#258 §8 設計書に準拠）
- kind=command/event の2種のみ解釈（旧 cmd/state は skip+warning）
- envelope v:1 不一致時も skip+warning
- MCPツール登録は本PRには含まない（次フェーズで判断）

### 追加関数

| 関数 | 種別 | 役割 |
|---|---|---|
| `_parse_ow_event` | 内部 | v:1/kind バリデーション、旧 cmd/state は warning |
| `_query_latest_event` | 内部共通 | 指定 channel/handle/data_type の最新 event 取得 |
| `_query_events_since` | 内部共通 | 条件一致 event を時系列順で全件取得 |
| `_infer_crash_cause` | 内部 | 非 terminal state + heartbeat 途絶 → crash 推論 (DB 不変) |
| `ow_get_identity` | 公開 | 最新 identity bundle + crash 推論 |
| `ow_list_identities` | 公開 | channel 全 handle の identity リスト |
| `ow_get_presence` | 公開 | heartbeat 時刻ベースの online/offline 推論 |
| `ow_get_workload_state` | 公開 | 最新 workload state 取得 |

### crash 推論

- `_infer_crash_cause` を共通化し T17 ow_recover と統一
- draining 中 heartbeat 途絶 → `"crashed-during-drain (inferred)"`
- それ以外の非 terminal → `"crashed (inferred)"`
- DB 不変（reducer 戻り値のみに付与）

## Test plan

- [ ] `uv run pytest tests/unit/test_ow_reducer.py -v` — 28 テスト全通過
- [ ] `uv run pytest --tb=short` — 全スイート通過 (1514 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)