### PR TITLE
feat(orch): v3 タイムアウト判定切替 + identity統一 (T41/M#258 §10.4 step 4)

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -50,51 +50,134 @@ on Monitor発火 or 自発的タイミング:
 
 ## 通信プロトコル
 
-### orch→worker: `cmd`
+envelopeは `kind` が `command`（targeted）または `event`（broadcast）の2種。内訳は `data.type` で区別する（M#258 §4.1）。
+
+### envelope 共通形式
 
 ```json
 {
   "v": 1,
-  "kind": "cmd",
-  "from": "orch",
-  "to": "w-<alias>",
-  "task": "T<n>",
-  "verb": "assign | answer | cancel | close | ping",
-  "data": {}
+  "kind": "command" | "event",
+  "from": "<handle>",
+  "to": "<handle>" | "*",
+  "data": { "type": "<内訳種別>", ... }
 }
 ```
 
-**verb別data**:
-- `assign`: `{title, activity_id, topic_id, cwd, model（必須）, permission_mode, acceptance（必須）, context, playbook, timeout_min}` → needs_reply=true
-- `answer`: `{answer}` または `{escalate: true}`
-- `cancel`, `close`, `ping`: needs_reply=true
+- `v` は body 内 envelope のスキーマバージョン（relay 物理スキーマとは別レイヤ、M#258 §7.4）
+- `from` は messages.handle と一致しなければreducerが drop する
+- `kind=command` は `to` 必須、`kind=event` は `to` 省略または `"*"` で broadcast
 
-### worker→orch: `state`
+### orch→worker: `kind=command`
 
 ```json
-{
-  "v": 1,
-  "kind": "state",
-  "from": "w-<alias>",
-  "to": "orch",
-  "task": "T<n>",
-  "state": "<状態>",
-  "data": {}
-}
+{"v":1, "kind":"command", "from":"orch", "to":"w-<alias>", "task":"T<n>",
+ "data":{"type":"assign|close|cancel|answer|ping", ...}}
 ```
 
-| state | 意味 | data | 補足 |
+| data.type | data 内容 | 補足 |
+|---|---|---|
+| `assign` | `{title, activity_id, topic_id, cwd, model（必須）, permission_mode, acceptance（必須）, context, playbook, timeout_min}` | worker は `event:state(working)` で応答 |
+| `close` | `{reason}` | worker は退場処理（draining→terminated/cause:closed）で応答 |
+| `cancel` | `{reason}` | worker は退場処理（draining→terminated/cause:cancelled）で応答 |
+| `answer` | `{answer}` または `{escalate: true}` | blocked への応答 |
+| `ping` | `{nonce}` | worker は現在の `event:state` を返す |
+
+### worker→orch / worker→broadcast: `kind=event`
+
+workerが送る全メッセージは `kind:event`。内訳は `data.type` で:
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"orch|*", "task":"T<n>",
+ "data":{"type":"state|identity|heartbeat", ...}}
+```
+
+| data.type | to | 意味 | data 内容 |
 |---|---|---|---|
-| `ready` | 起動完了 | `{session_id, alias, cwd}` | |
-| `working` | 受諾・作業中 | `{phase, note}` | assignへの最初のworkingはin_reply_to必須 |
-| `blocked` | 判断要請 | `{question, options, context_refs}` | needs_reply=true |
-| `escalated` | エスカレーション文脈出力済み | `{report_md}` | watchdog対象外 |
-| `done` | 完了（sync済み） | `{summary, evidence, synced, materials[], decision_proposals[], cancelled?}` | needs_reply=true。cancelへの応答時はin_reply_to必須。cancelled（boolean）: cmd:cancelへの応答doneの場合にtrue、自発doneではfalseまたは省略 |
-| `closed` | クローズ受諾 | `{}` | |
-| `dead` | 起動失敗等の自己申告 | `{message}` | |
-| `fallback` | 人間対話モードへ移行宣言 | `{reason}` | |
+| `state` | `orch` | workload state 遷移宣言 | `{type:"state", state:..., ...payload}` |
+| `identity` | `*` | 身元情報 full snapshot | identity bundle（§identity 参照） |
+| `heartbeat` | `*` | liveness signal（バックグラウンドループから送信） | `{type:"heartbeat", phase, nonce?}` |
 
-**スレッド規約**: `in_reply_to` はrelay標準。存在しない親は400になるため送信前にmsg_id確定必須。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+### workload state（M#258 §5.2 と整合）
+
+```
+       spawn
+         │
+         ▼
+      loading ───────┐
+         │           │ (load 失敗)
+         ▼           ▼
+       ready      terminated (cause: dead)
+         │
+         ▼
+      working ──┬──▶ blocked ─▶ escalated ─▶ working
+         │      │
+         │      └──▶ working (continue)
+         │
+   ┌─────┴─────┐
+   ▼           ▼
+draining ──▶ terminated
+            (cause: closed/cancelled/crashed/crashed-during-drain)
+```
+
+| state | data 必須 payload | 補足 |
+|---|---|---|
+| `loading` | なし | spawn直後、context load中。長時間でもheartbeatが続けばcrash扱いしない |
+| `ready` | `{session_id, alias, cwd}` | assign待機 |
+| `working` | `{phase, note}` | assignへの最初のworkingは `in_reply_to` で assign msg_id を指す |
+| `blocked` | `{question, options, context_refs}` | orch回答待ち |
+| `escalated` | `{report_md}` | watchdog対象外 |
+| `draining` | なし | command:close/cancel 受領後の worker-sync 実行中。長時間でもheartbeatが続けばcrash扱いしない |
+| `terminated` | `{cause}` | cause ∈ {closed, cancelled, dead}。crashed/crashed-during-drain は orch reducer の推論のみで、history には書かれない |
+
+**done の扱い**: M#258 §5.2 の workload state machine に `done` は含まれない。ただし worker は acceptance 完了申告として `event:state(done)` を送る運用（worker SKILL.md §完了→done）。orchはこれを **workload state ではなく orchestration 層の完了申告イベント** として解釈し、acceptance 照合 → `command:close` 送信に進む。doneは workload遷移ではないため、heartbeat 途絶判定の対象外（worker は close 受領前まで working として heartbeat を継続）。
+
+**done の payload**: `{summary, evidence, synced, materials[], decision_proposals[], cancelled?}`。`cancelled`（boolean）は `command:cancel` への応答 doneの場合に true、自発 done では false または省略。
+
+**fallback state は v3 で正式削除**（M#258 §5.2.1）。
+
+### identity（event:identity）
+
+worker 起動時と terminated 直前に append される身元情報。orchは `ow_get_identity(channel, handle)` で最新 bundle を取得する（§identity 参照経路）。
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"*", "task":"T<n>",
+ "data":{
+   "type":"identity",
+   "role":"worker",
+   "handle":"w-<alias>",
+   "channel_code":"...",
+   "topic_id":"...",
+   "started_at":"<UTC ISO8601>",
+   "alias":"<alias>",
+   "activity_id":<id>,
+   "model":"...",
+   "cwd":"...",
+   "session_id":"...",
+   "terminated_at":"<UTC ISO8601>",   // terminated 直前の再 append でのみ set
+   "cause":"closed|cancelled|dead"     // terminated 直前の再 append でのみ set
+ }}
+```
+
+identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。M#258 §6.3.1 参照。
+
+### heartbeat（event:heartbeat）
+
+worker のバックグラウンドループ（scripts/ow/heartbeat.sh）が定期送信する liveness signal:
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"*", "task":"T<n>",
+ "data":{"type":"heartbeat", "phase":"alive|loading|ready|working|draining"}}
+```
+
+- 周期: loading=10秒、それ以外=30秒（M#258 §5.4.1、D#2525）
+- `phase` は workload state を写像する補助情報
+
+**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない（M#258 §4.4 / D#2522）。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+
+### 旧 cmd/state envelope の後方互換放棄
+
+D#2532 により、旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は D#2479 で凍結されており、過去レコードはそのまま残置される。
 
 ## タスクキュー
 
@@ -152,35 +235,51 @@ queued → spawning → assigned → in_progress → awaiting_verify → done
 
 ## タスク完了の定義と検証
 
-**「完了」の定義**: `done` の `evidence` が `acceptance` を満たすとorchが判定 ∧ `synced: true`。無条件信頼しない。
+**「完了」の定義**: `event:state(done)` の `evidence` が `acceptance` を満たすとorchが判定 ∧ `synced: true`。無条件信頼しない。
+
+**done は workload state ではない**: M#258 §5.2 の workload state machine に done は含まれず、worker→orchの完了申告として `event:{type:state, state:done}` envelope形式で扱う（orchestration層の信号）。orchはdoneを受信したらacceptance照合し、`command:close`送信 → workerは draining → terminated(cause:closed) へ進む。
 
 **cancelと自発doneの交差**:
-- `done` の `in_reply_to` が `cancel` を指していなければ自発done
+- `event:state(done)` の `in_reply_to` が `command:cancel` を指していなければ自発done
 - orchは自発doneを優先してacceptance照合し、cancelを無効化する（完成タスクを捨てる理由がない）
 
 **done検証NG時の振る舞い**:
-- acceptance不充足 → `cmd:answer` に理由を付けてworkerに差し戻す
+- acceptance不充足 → `command:answer` に理由を付けてworkerに差し戻す
 - 差し戻しを受けてもworkerが改善できない場合 → `failed` としてキューを更新し人間に通知する
 
 **クローズハンドシェイク**:
 1. orchが「done検証OK ∧ synced:true ∧ escalated/stalled非該当」を確認
-2. `cmd:close` を送信
-3. `state:closed` 受信後に `ow_close_worker(term_ref)` でセッションをクローズ
-4. `state:closed` が来なければ閉じずに人間に通知する
+2. `command:close` を送信
+3. workerは `event:state(draining)` → worker-sync → `event:identity` 再append → `event:state(terminated, cause:closed)` を送信
+4. orchは `event:state(terminated, cause:closed)` 受信後に `ow_close_worker(term_ref)` でセッションをクローズ
+5. terminated が来なければ閉じずに人間に通知する
 
 ## watchdog
 
-**監視基準**: 「そのworkerからの最後の受信メッセージ」からの経過時間。
+**監視基準**: 「そのworkerからの最後の `event:heartbeat` 受信時刻」からの経過時間（M#258 §5.4.2、D#2525）。workload state の所要時間や `last_recv` 全般の経過では判定しない（長時間 loading や draining でも heartbeat が続けば crash 扱いしない）。
 
-**タイムアウト処理**:
-1. timeout_min超過 → `cmd:ping` を送信
-2. pingに無応答 → queueを `stalled` に更新 + 人間に通知
-3. **自動failedおよび自動クローズはしない**（長時間ツール実行中はping応答不能のため、無応答は異常の証明にならない）
-4. failedへの変更・強制クローズは人間判断
+**heartbeat 周期 × 3 の閾値**:
 
-**watchdog対象外**: `escalated` 状態のworker。escalated中はタイムアウト・クローズ対象外。
+| 現在の workload state | heartbeat 周期 | タイムアウト閾値（周期×3） |
+|---|---|---|
+| `loading` | 10秒（D#2525） | **30秒** |
+| `ready` / `working` / `blocked` / `draining` | 30秒（D#2525） | **90秒** |
+| `escalated` | 監視対象外 | — |
 
-**ready未送信タイムアウト**: spawning状態でtimeout_minを超過した場合もwatchdogと同一基準（ping→無応答でstalled+人間通知）。
+orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し、対応する閾値を選んで判定する。閾値はreducer実装のチューニング余地として残るが、orch側の初期実装は上記固定値を使う。
+
+**タイムアウト処理（heartbeat 途絶検知）**:
+1. heartbeat 途絶（loading: 30秒 / ready以降: 90秒）→ `command:ping` を送信
+2. pingに無応答（heartbeat も復活しない）→ 後述のcrash推論経路に遷移
+3. **自動failedおよび自動クローズはしない**。failedへの変更・強制クローズは人間判断
+
+**watchdog対象外**:
+- `escalated` 状態のworker（人間対話中はタイムアウト・クローズ対象外、M#258 §5.2の state machine参照）
+- `terminated` 状態のworker（既に終了済み）
+
+**ready未送信タイムアウト（loading 滞留）**: heartbeat が来ているかぎり crash 扱いしない。30秒以上 heartbeat 途絶した場合のみ crash 候補となる。長時間 loading（巨大コンテキスト読込・1Mコンテキストモデルのwarm-up等）でも heartbeat が続けばタイムアウトしない。
+
+**spawning（ready前）タイムアウト**: spawning は orch 側 queue の状態。worker が `event:identity` または `event:state(loading)` を送る前に timeout_min 経過した場合は、spawn失敗の可能性が高い（cwd不在・aliasぶつかり・relay疎通断等）。`ow_recover` で pending_spawn として検出される。
 
 ## モデル選択
 
@@ -188,14 +287,16 @@ assignの `model` は必須。一般プレイブック `skills/orch/playbook.md`
 
 ## エスカレーション
 
-1. workerが `state:blocked`（needs_reply）を送信する
+1. workerが `event:state(blocked)` を送信する
 2. orchは**特化版→一般版プレイブックと過去エスカレーションログ**（`search(tags=["escalation","domain:..."])`）を参照してから判断する
-3. 回答可能なら `cmd:answer {answer}` を送信する
-4. 判断不能なら `cmd:answer {escalate: true}` → workerはエスカレーションフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で自セッションに出力し `state:escalated` を送信する
+3. 回答可能なら `command:answer {answer}` を送信する
+4. 判断不能なら `command:answer {escalate: true}` → workerはエスカレーションフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で自セッションに出力し `event:state(escalated)` を送信する
 5. orchは人間に概要とworkerの場所（term_ref）を提示する
 6. 人間がworkerセッションで直接解決する
 7. workerがその場で記録（log必須・合意decisionも。タグ: `escalation`+`user-decision`+domain）
-8. worker → `state:working {summary, decision_ids, log_ids}` で再開通知 → orchが特化版プレイブックを更新する（§プレイブック参照）
+8. worker → `event:state(working) {summary, decision_ids, log_ids}` で再開通知 → orchが特化版プレイブックを更新する（§プレイブック参照）
+
+エスカレーション中（`event:state(escalated)`）はwatchdog対象外（§watchdog参照）。
 
 ## プレイブック参照
 
@@ -208,26 +309,53 @@ assignの `model` は必須。一般プレイブック `skills/orch/playbook.md`
 
 orchは起動時に特化版最新を取得し、assignの `playbook` フィールドで関連抜粋をworkerに渡す。
 
+## identity 取得経路
+
+orchはworkerの身元情報（alias、activity_id、model、cwd、session_id、terminated_at、cause等）を取得する際は、必ず `ow_get_identity(channel, handle)` 経由で取得する（M#258 §6 / §8.3）。`ow_history` を自前パースして identity bundle を組み立てる経路は使わない。
+
+理由:
+- reducer が event:identity の最新エントリを返す責務を持つため、orch側で二重実装しない
+- crash 推論（`cause: "crashed (inferred)"` / `"crashed-during-drain (inferred)"`）は reducer がメモリ上で付与する（DB不変、M#258 §9.2）。orch側で直接 history を見ると推論結果が得られない
+
+ID別の取得関数:
+
+| 関数 | 用途 |
+|---|---|
+| `ow_get_identity(channel, handle)` | 指定 handle の最新 identity bundle（+ crash推論結果） |
+| `ow_list_identities(channel, alive_only)` | channel上の全 handle の identity リスト（alive_only=True で terminated 除外） |
+| `ow_get_presence(channel, handle)` | SSE接続状態 + 最新 heartbeat 受信時刻から online/offline 推論 |
+| `ow_get_workload_state(channel, handle)` | 指定 handle の最新 workload state（watchdog 閾値選定に使う） |
+
+## crash 推論の cause lineup と queue 反映
+
+M#258 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで queue status を更新する。`cause` 値は `ow_get_identity` の戻り値 `cause` フィールドから判定する（履歴に明示書き込まれる closed/cancelled/dead と、reducer がメモリ上で付与する crashed/crashed-during-drain）。
+
+| cause | 発生条件 | queue status への反映 | 補足 |
+|---|---|---|---|
+| `closed` | command:close 受領 → 正常退出 | `done`（acceptance満たし & synced済み） | クローズハンドシェイク完了 |
+| `cancelled` | command:cancel 受領 → 退出 | `cancelled` | activity description先頭に[cancelled]経緯を追記 |
+| `dead` | loading 中の load 失敗 | `failed` | 人間に通知し復旧手段を判断（再spawn等） |
+| `crashed (inferred)` | ready/working/blocked/escalated 中の heartbeat 途絶 | `stalled` + 人間に通知 | 自動failedにはしない |
+| `crashed-during-drain (inferred)` | draining 中の heartbeat 途絶 | `stalled` + 人間に通知（worker-sync失敗の懸念） | done評価は人間判断（acceptance確認＋手動同期検討） |
+
+**自動 failed および自動クローズはしない**: heartbeat 途絶（crashed推論）は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明とはならない。failedへの変更・強制クローズは人間判断とする。
+
 ## crash復旧
 
-1. **crash中**: workerはフォールバック規則で待機。報告はrelay SQLite履歴に残存する
+1. **crash中**: worker側はheartbeat停止のみ。報告はrelay SQLite履歴に残存する
 2. **再起動**: 人間が`orch_cwd`と同じcwdで `/orch` を起動し、queue再開候補から選択する
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` から実行（冪等性が再処理を安全にする。専用復旧ロジック不要）
-4. **整合チェック**（必須）: `ow_recover(channel, topic_id)` を呼ぶ。relay履歴since=0再走査・queue・presenceの3者突合・自動修正までを一括で行う:
-   - **ghost_active**（queue=assigned/ready/working & presence offline）→ relay最新state宣言からqueueを自動再構築（done→done、closed→closed、working/ready→stalled、failed→failed等）
-   - **pending_spawn**（queue=spawning & presence offline）→ relay履歴に当該workerのstate宣言がある場合のみ自動再構築。履歴ゼロは起動進行中の可能性が高くow_recoverは触らない（spawn racing回避）。orchは戻り値で残留spawning件数を把握し、経過時間が長い物は手動で `failed` 化判断する
-   - **stalled_done**（queue=done/closed/cancelled/failed & presence online）→ `cmd:ping` 送信で素性照会
-   - **orphans**（presence onlineだがqueue外のw-* handle）→ `cmd:ping` 送信で再リンク照会
+4. **整合チェック**（必須）: `ow_recover(channel, topic_id)` を呼ぶ。relay履歴since=0再走査・queue・identity reducerの3者突合・自動修正までを一括で行う:
+   - **ghost_active**（queue=assigned/ready/working/blocked/draining & `ow_get_identity().cause` が terminal）→ identity reducer の最新 cause から queue を自動再構築（cause:closed→done、cause:cancelled→cancelled、cause:dead→failed、cause:crashed/crashed-during-drain→stalled）
+   - **pending_spawn**（queue=spawning & identity未生成）→ relay履歴に当該workerのevent:identity または event:state が**1件もない**場合は ow_recover は触らない（spawn racing回避）。orchは戻り値で残留spawning件数を把握し、経過時間が長い物は手動で `failed` 化判断する
+   - **stalled_done**（queue=done/closed/cancelled/failed & identity が alive）→ `command:ping` 送信で素性照会
+   - **orphans**（identity に登録があるがqueue外の handle）→ `command:ping` 送信で再リンク照会
    - 検証だけしたい時は `dry_run=True` で呼ぶ
    - 戻り値の `detected`/`applied`/`warnings` を確認し、ping応答は通常受信ループで処理
    - **cc-memory activityも突合**（ow_recover対象外）: queue終端済み（done/cancelled/failed） × activity `in_progress` 残留を別途検出・修正する
-5. **worker復帰**: ow_recoverが送ったpingへの応答を受信ループで処理し、フォールバック復帰規則に従って復帰させる
+5. **worker復帰**: ow_recoverが送った `command:ping` への応答（worker の `event:state(<現在のstate>, note:"pong")`）を受信ループで処理する。応答が来ないworkerは前述のcrash推論経路に進む
 
 **spawn前バリデーション**: `ow_spawn_worker` は内部で relay疎通・channel存在・cwd存在・alias重複の4点を自動チェックする。失敗時は `{"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}` が返るので、warningsを確認して原因を解消してから再spawnする。
-
-**フォールバック復帰規則**:
-- フォールバック後に人間入力ゼロ → orchの復帰メッセージで自動復帰
-- フォールバック後に人間入力が一度でもあり → 復帰可否をユーザーに確認
 
 ## 複数orchの運用
 
@@ -239,12 +367,16 @@ orchは起動時に特化版最新を取得し、assignの `playbook` フィー�
 
 | ツール | 用途 |
 |---|---|
-| `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ） |
-| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体） |
+| `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ）。bodyは `kind=command`/`event` envelope |
+| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、M#258 §3.3） |
 | `ow_spawn_worker(alias, channel, cwd, model, permission, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却） |
 | `ow_close_worker(term_ref)` | workerクローズ |
-| `ow_status(channel, topic_id)` | queue+presence統合ビュー |
-| `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×presence突合・ghost_active自動再構築・stalled/orphan ping送信） |
+| `ow_status(channel, topic_id)` | queue+identity統合ビュー |
+| `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×identity reducer突合・ghost_active自動再構築・stalled/orphan command:ping送信） |
+| `ow_get_identity(channel, handle)` | 指定 handle の最新 identity bundle（+ crash推論結果） |
+| `ow_list_identities(channel, alive_only)` | channel上の全 handle の identity リスト |
+| `ow_get_presence(channel, handle)` | SSE接続状態 + 最新 heartbeat 受信時刻から online/offline 推論 |
+| `ow_get_workload_state(channel, handle)` | 指定 handle の最新 workload state（watchdog 閾値選定に使う） |
 | `check_in(activity_id)` | cc-memoryのアクティビティcheck-in |
 | `add_activity(...)` / `update_activity(...)` | アクティビティ管理（orch-managedタグ必須） |
 | `search(...)` | 特化プレイブック・過去エスカレーションログ検索 |

--- a/skills/orch/playbook.md
+++ b/skills/orch/playbook.md
@@ -20,9 +20,31 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 
 ## タイムアウト既定値
 
+### worker assign の timeout_min
+
 - `timeout_min` のデフォルト値: **60分**
 - assignに明示的に指定しない場合は60分を適用する
 - タスクの性質（大規模実装・長時間調査等）に応じてorchが上書き可能
+
+### heartbeat 途絶 watchdog（M#258 §5.4.2 / D#2525）
+
+orchが worker の生死を判定する基準は **heartbeat 途絶**。workload state の所要時間（`timeout_min`）とは別軸で監視する。`timeout_min` 超過は workload 上の予期外長期化、heartbeat 途絶は liveness 側のcrash候補（reducer 推論）として分けて扱う。
+
+| 現在の workload state | heartbeat 周期 | watchdog 閾値（周期×3） |
+|---|---|---|
+| `loading` | 10秒 | **30秒** |
+| `ready` / `working` / `blocked` / `draining` | 30秒 | **90秒** |
+| `escalated` | 監視対象外 | — |
+| `terminated` | 監視対象外（既に終了済み） | — |
+
+途絶検知時のorchの行動: `command:ping` 送信 → 無応答かつ heartbeat 復活なし → reducer の `cause` を参照して queue を更新（cause lineup は orch SKILL.md §crash推論 参照）。
+
+**自動 failed / 自動クローズはしない**。failed への変更・強制クローズは人間判断（heartbeat 途絶は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明にならない）。
+
+### watchdog 対象外の state
+
+- `escalated`: 人間対話中はタイムアウト・クローズ対象外
+- `terminated`: 既に終了済み
 
 ## worker同時稼働数上限
 
@@ -39,7 +61,7 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 
 ## エスカレーション基準
 
-workerがエスカレーション（`state:blocked` → `cmd:answer {escalate: true}`）を要請する典型的な場面:
+workerがエスカレーション（`event:state(blocked)` → `command:answer {escalate: true}`）を要請する典型的な場面:
 
 | 類型 | 例 |
 |---|---|
@@ -52,7 +74,7 @@ workerがエスカレーション（`state:blocked` → `cmd:answer {escalate: t
 
 エスカレーションの際はフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で出力する。
 
-orchが自力で判断できる場合は `cmd:answer {answer}` で直接回答し、エスカレーションに進めない。escalate指示は慎重に使う。
+orchが自力で判断できる場合は `command:answer {answer}` で直接回答し、エスカレーションに進めない。escalate指示は慎重に使う。
 
 ## 報告頻度
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -53,7 +53,9 @@ _MAX_RETRIES = 3
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
     {"loading", "ready", "working", "blocked", "escalated", "draining"}
 )
-# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+# heartbeat タイムアウト閾値（周期×3）。
+# キーは workload_state または heartbeat body の phase。両者は worker 側で同期される
+# （event:state 送信時に heartbeat phase も追従）ため、同一の値空間として共有する。
 _HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
     "loading": 30.0,  # 10s × 3
 }
@@ -1925,6 +1927,40 @@ def _infer_crash_cause(
         return None
 
 
+def _latest_events_by_type(
+    channel: str, handle: str | None, data_types: tuple[str, ...]
+) -> dict[str, dict]:
+    """指定 handle の各 data_type について最新 event を1回の ow_history で取得する。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_types: 対象とする event の data.type タプル
+
+    Returns:
+        {data_type: latest_event_dict} — 該当 event が無い type はキー欠落
+    """
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return {}
+    latest: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        t = parsed["body"].get("data", {}).get("type")
+        if t not in data_types:
+            continue
+        current = latest.get(t)
+        if current is None or parsed["msg_id"] > current["msg_id"]:
+            latest[t] = parsed
+    return latest
+
+
 def ow_get_identity(channel: str, handle: str) -> dict | None:
     """指定 handle の最新 identity bundle を返す。crash 推論を含む。
 
@@ -1935,7 +1971,8 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     Returns:
         dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
     """
-    identity_msg = _query_latest_event(channel, handle, "identity")
+    latest = _latest_events_by_type(channel, handle, ("identity", "state", "heartbeat"))
+    identity_msg = latest.get("identity")
     if identity_msg is None:
         return None
     data = identity_msg["body"].get("data", {})
@@ -1943,12 +1980,11 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     result["msg_id"] = identity_msg["msg_id"]
     result["identity_at"] = identity_msg["created_at"]
 
-    state_msg = _query_latest_event(channel, handle, "state")
-    workload_state = None
-    if state_msg is not None:
-        workload_state = state_msg["body"].get("data", {}).get("state")
-
-    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    state_msg = latest.get("state")
+    workload_state = (
+        state_msg["body"].get("data", {}).get("state") if state_msg is not None else None
+    )
+    heartbeat_msg = latest.get("heartbeat")
     last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
 
     inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
@@ -1959,35 +1995,69 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
 
 
 def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
-    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    """channel 上の全 handle の identity リスト。
+
+    alive_only=True の場合:
+    - identity bundle に terminated_at / cause(closed/cancelled/dead) を持つ entry を除外
+    - 加えて、ow_get_identity と同様の crash 推論（state が non-terminal + heartbeat 途絶）
+      で inferred_cause が付与される entry も除外する
+    handle フィールドが欠落した event は集約キーが None になるためスキップする。
+    """
     history = ow_history(channel, since=0, limit=10000)
     if "error" in history:
         return []
 
-    # handle別に最新identity msgを収集
-    latest_by_handle: dict[str, dict] = {}
+    # handle別に identity / state / heartbeat の最新msgを収集
+    identity_by_handle: dict[str, dict] = {}
+    state_by_handle: dict[str, dict] = {}
+    heartbeat_by_handle: dict[str, dict] = {}
     for msg in history.get("messages", []):
         parsed = _parse_ow_event(msg)
         if parsed is None:
             continue
+        h = parsed["handle"]
+        if h is None:
+            continue
         if parsed["body"].get("kind") != "event":
             continue
-        if parsed["body"].get("data", {}).get("type") != "identity":
-            continue
-        h = parsed["handle"]
-        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
-            latest_by_handle[h] = parsed
+        t = parsed["body"].get("data", {}).get("type")
+        if t == "identity":
+            current = identity_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                identity_by_handle[h] = parsed
+        elif t == "state":
+            current = state_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                state_by_handle[h] = parsed
+        elif t == "heartbeat":
+            current = heartbeat_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                heartbeat_by_handle[h] = parsed
 
     entries = []
-    for parsed in latest_by_handle.values():
+    for h, parsed in identity_by_handle.items():
         data = parsed["body"].get("data", {})
         entry = dict(data)
         entry["msg_id"] = parsed["msg_id"]
         entry["identity_at"] = parsed["created_at"]
 
+        state_msg = state_by_handle.get(h)
+        workload_state = (
+            state_msg["body"].get("data", {}).get("state")
+            if state_msg is not None
+            else None
+        )
+        hb_msg = heartbeat_by_handle.get(h)
+        last_heartbeat_at = hb_msg["created_at"] if hb_msg is not None else None
+        inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+        if inferred_cause is not None:
+            entry["inferred_cause"] = inferred_cause
+
         if alive_only:
             cause = entry.get("cause")
             if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+            if inferred_cause is not None:
                 continue
 
         entries.append(entry)
@@ -1995,11 +2065,14 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
     return entries
 
 
-def ow_get_presence(channel: str, handle: str) -> dict | None:
+def ow_get_presence(channel: str, handle: str) -> dict:
     """最新 heartbeat 受信時刻から online/offline を推論する。
 
     T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
     SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    heartbeat が一度も観測されない handle に対しては status="unknown" の
+    entry を返す（None は返さない）。
 
     Returns:
         dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -49,6 +49,16 @@ _RELAY_LOCK_PATH = _RELAY_STATE_DIR / "relay.lock"
 
 _MAX_RETRIES = 3
 
+# reducer: v3 workload state 分類
+_NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
+    {"loading", "ready", "working", "blocked", "escalated", "draining"}
+)
+# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+_HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
+    "loading": 30.0,  # 10s × 3
+}
+_HEARTBEAT_TIMEOUT_DEFAULT: float = 90.0  # 30s × 3（ready/working/draining共通）
+
 
 # ----------------------------
 # relay HTTPヘルパー
@@ -1775,4 +1785,260 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         "presence": presence,
         "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
         "dry_run": dry_run,
+    }
+
+
+# ----------------------------
+# reducer: v3 event sourcing
+# ----------------------------
+
+
+def _parse_ow_event(msg: dict) -> dict | None:
+    """relayメッセージからow envelopeを解釈する。
+
+    Args:
+        msg: ow_historyから返されるメッセージdict
+
+    Returns:
+        {"msg_id": int, "handle": str, "body": dict, "created_at": str} または None
+    """
+    body = msg.get("body")
+    if not isinstance(body, dict):
+        return None
+    msg_id = msg.get("msg_id")
+    v = body.get("v")
+    if v != 1:
+        logger.warning(
+            "ow_service: skip msg_id=%s (envelope v=%r, expected 1)", msg_id, v
+        )
+        return None
+    kind = body.get("kind")
+    if kind not in ("command", "event"):
+        logger.warning(
+            "ow_service: skip msg_id=%s (kind=%r, expected command/event)", msg_id, kind
+        )
+        return None
+    return {
+        "msg_id": msg_id,
+        "handle": msg.get("handle"),
+        "body": body,
+        "created_at": msg.get("created_at"),
+    }
+
+
+def _query_latest_event(
+    channel: str, handle: str | None, data_type: str, since: int = 0
+) -> dict | None:
+    """指定 channel/handle/data_type の最新 event を返す（kind=event のみ対象）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（例: "identity", "state", "heartbeat"）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        最新のparsed event dict または None
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return None
+    result = None
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        if result is None or parsed["msg_id"] > result["msg_id"]:
+            result = parsed
+    return result
+
+
+def _query_events_since(
+    channel: str,
+    handle: str | None,
+    data_type: str | None,
+    since: int = 0,
+) -> list[dict]:
+    """指定条件のeventを時系列順で全件取得（kind=event のみ）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（Noneなら全type）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        条件に合うparsed event dictのリスト（msg_id昇順）
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return []
+    results = []
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if data_type is not None and parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        results.append(parsed)
+    return results
+
+
+def _infer_crash_cause(
+    workload_state: str | None, last_heartbeat_at: str | None
+) -> str | None:
+    """crash推論ロジック（DB不変、戻り値のみに付与）。
+
+    Args:
+        workload_state: 最新のworkload state文字列
+        last_heartbeat_at: 最後のheartbeat受信時刻（ISO形式文字列）
+
+    Returns:
+        crash推論結果文字列 または None（crashでない場合）
+    """
+    if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if last_heartbeat_at is None:
+        return None
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        timeout = _HEARTBEAT_TIMEOUT_SECS.get(workload_state, _HEARTBEAT_TIMEOUT_DEFAULT)
+        if elapsed < timeout:
+            return None
+        if workload_state == "draining":
+            return "crashed-during-drain (inferred)"
+        return "crashed (inferred)"
+    except (ValueError, TypeError):
+        return None
+
+
+def ow_get_identity(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 identity bundle を返す。crash 推論を含む。
+
+    crash 推論: 最新の event:state が terminal でない（loading/ready/working/blocked/
+               escalated/draining）かつ最後の event:heartbeat 受信時刻から閾値超過 →
+               メモリ上で inferred_cause を付与（DB 不変）。
+
+    Returns:
+        dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
+    """
+    identity_msg = _query_latest_event(channel, handle, "identity")
+    if identity_msg is None:
+        return None
+    data = identity_msg["body"].get("data", {})
+    result = dict(data)
+    result["msg_id"] = identity_msg["msg_id"]
+    result["identity_at"] = identity_msg["created_at"]
+
+    state_msg = _query_latest_event(channel, handle, "state")
+    workload_state = None
+    if state_msg is not None:
+        workload_state = state_msg["body"].get("data", {}).get("state")
+
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
+
+    inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+    if inferred_cause is not None:
+        result["inferred_cause"] = inferred_cause
+
+    return result
+
+
+def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
+    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return []
+
+    # handle別に最新identity msgを収集
+    latest_by_handle: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != "identity":
+            continue
+        h = parsed["handle"]
+        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
+            latest_by_handle[h] = parsed
+
+    entries = []
+    for parsed in latest_by_handle.values():
+        data = parsed["body"].get("data", {})
+        entry = dict(data)
+        entry["msg_id"] = parsed["msg_id"]
+        entry["identity_at"] = parsed["created_at"]
+
+        if alive_only:
+            cause = entry.get("cause")
+            if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+
+        entries.append(entry)
+
+    return entries
+
+
+def ow_get_presence(channel: str, handle: str) -> dict | None:
+    """最新 heartbeat 受信時刻から online/offline を推論する。
+
+    T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
+    SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    Returns:
+        dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}
+    """
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    if heartbeat_msg is None:
+        return {"handle": handle, "status": "unknown", "last_heartbeat_at": None, "phase": None}
+
+    last_heartbeat_at = heartbeat_msg["created_at"]
+    phase = heartbeat_msg["body"].get("data", {}).get("phase")
+    timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase or "", _HEARTBEAT_TIMEOUT_DEFAULT)
+
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        status = "online" if elapsed < timeout else "offline"
+    except (ValueError, TypeError):
+        status = "unknown"
+
+    return {
+        "handle": handle,
+        "status": status,
+        "last_heartbeat_at": last_heartbeat_at,
+        "phase": phase,
+    }
+
+
+def ow_get_workload_state(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 workload state を返す。"""
+    state_msg = _query_latest_event(channel, handle, "state")
+    if state_msg is None:
+        return None
+    data = state_msg["body"].get("data", {})
+    return {
+        "handle": handle,
+        "state": data.get("state"),
+        "cause": data.get("cause"),
+        "msg_id": state_msg["msg_id"],
+        "state_at": state_msg["created_at"],
     }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1907,8 +1907,15 @@ def _infer_crash_cause(
 
     Returns:
         crash推論結果文字列 または None（crashでない場合）
+
+    Notes:
+        escalated は workload state machine 上は non-terminal だが、人間対話中の
+        worker は heartbeat 停止が「異常」を意味しないため watchdog 対象外
+        （orch SKILL.md・playbook.md でも明示）。crash 推論からも除外する。
     """
     if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if workload_state == "escalated":
         return None
     if last_heartbeat_at is None:
         return None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -227,6 +227,11 @@ class TestInferCrashCause:
         result = ow_service._infer_crash_cause("working", None)
         assert result is None
 
+    def test_escalated_state_returns_none(self):
+        """state="escalated"（人間対話中）は heartbeat が古くても crash 推論対象外。"""
+        result = ow_service._infer_crash_cause("escalated", self._old_hb(600))
+        assert result is None
+
 
 # ----------------------------
 # TestOwGetIdentity

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,4 +1,6 @@
 """ow_service reducer 4関数のユニットテスト (T39)"""
+import logging
+
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -58,7 +60,6 @@ class TestParseOwEvent:
         """v=2 → None を返し、warningログを出す。"""
         body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
         msg = _make_msg(10, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None
@@ -68,7 +69,6 @@ class TestParseOwEvent:
         """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
         body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
         msg = _make_msg(11, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,4 +1,4 @@
-"""ow_service reducer 4関数のユニットテスト (T39)"""
+"""ow_service reducer 4関数のユニットテスト。"""
 import logging
 
 import pytest

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,0 +1,372 @@
+"""ow_service reducer 4関数のユニットテスト (T39)"""
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from src.services import ow_service
+
+
+# ----------------------------
+# テストヘルパー
+# ----------------------------
+
+
+def _make_msg(msg_id, handle, body, created_at=None):
+    """テスト用リレーメッセージを生成する。"""
+    return {
+        "msg_id": msg_id,
+        "handle": handle,
+        "body": body,
+        "created_at": created_at or "2026-06-14T10:00:00+00:00",
+    }
+
+
+def _event_body(data_type, data_payload, handle="w-h", to="orch"):
+    """v:1 / kind:event の envelope を生成する。"""
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": to,
+        "data": {"type": data_type, **data_payload},
+    }
+
+
+def _make_history(messages):
+    return {"messages": messages}
+
+
+# ----------------------------
+# TestParseOwEvent
+# ----------------------------
+
+
+class TestParseOwEvent:
+    """_parse_ow_event のユニットテスト。"""
+
+    def test_valid_event_returns_parsed(self):
+        """v=1, kind="event" → 正常にparsed dictを返す。"""
+        body = _event_body("identity", {"alias": "w-1"})
+        msg = _make_msg(42, "w-h", body, "2026-06-14T10:00:00+00:00")
+        result = ow_service._parse_ow_event(msg)
+        assert result is not None
+        assert result["msg_id"] == 42
+        assert result["handle"] == "w-h"
+        assert result["body"] == body
+        assert result["created_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_v_mismatch_returns_none_with_warning(self, caplog):
+        """v=2 → None を返し、warningログを出す。"""
+        body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
+        msg = _make_msg(10, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("envelope v=" in r.message for r in caplog.records)
+
+    def test_unknown_kind_returns_none_with_warning(self, caplog):
+        """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
+        body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
+        msg = _make_msg(11, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("kind=" in r.message for r in caplog.records)
+
+    def test_non_dict_body_returns_none(self):
+        """body=None → None を返す。"""
+        msg = _make_msg(12, "w-h", None)
+        result = ow_service._parse_ow_event(msg)
+        assert result is None
+
+
+# ----------------------------
+# TestQueryLatestEvent
+# ----------------------------
+
+
+class TestQueryLatestEvent:
+    """_query_latest_event のユニットテスト。"""
+
+    def test_returns_latest_by_msg_id(self, monkeypatch):
+        """同じdata_typeが2件 → msg_id大きい方を返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(5, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is not None
+        assert result["msg_id"] == 5
+
+    def test_handle_filter(self, monkeypatch):
+        """複数handleがいる時、指定handleのみ返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-a", "state")
+        assert result is not None
+        assert result["handle"] == "w-a"
+
+    def test_handle_none_returns_any_handle(self, monkeypatch):
+        """handle=Noneなら全handleを対象にする。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(3, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", None, "state")
+        assert result is not None
+        assert result["msg_id"] == 3
+
+    def test_command_kind_skipped(self, monkeypatch):
+        """kind="command" のメッセージはスキップされる。"""
+        body = {"v": 1, "kind": "command", "data": {"type": "state"}}
+        msgs = [_make_msg(1, "w-h", body)]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_history_error_returns_none(self, monkeypatch):
+        """ow_historyがerrorを返す → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_since_parameter_passed_to_history(self, monkeypatch):
+        """sinceパラメータがow_historyに渡される。"""
+        received = {}
+
+        def fake_history(channel, since=0, limit=100):
+            received["since"] = since
+            return _make_history([])
+
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+        ow_service._query_latest_event("ch", "w-h", "state", since=42)
+        assert received["since"] == 42
+
+
+# ----------------------------
+# TestQueryEventsSince
+# ----------------------------
+
+
+class TestQueryEventsSince:
+    """_query_events_since のユニットテスト。"""
+
+    def test_returns_all_matching(self, monkeypatch):
+        """複数件返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", "heartbeat")
+        assert len(result) == 2
+
+    def test_data_type_none_matches_all_events(self, monkeypatch):
+        """data_type=Noneなら全eventが返る。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "working"})),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"})),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", None)
+        assert len(result) == 2
+
+    def test_history_error_returns_empty(self, monkeypatch):
+        """ow_historyがerror → 空リスト。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_events_since("ch", "w-h", "state")
+        assert result == []
+
+
+# ----------------------------
+# TestInferCrashCause
+# ----------------------------
+
+
+class TestInferCrashCause:
+    """_infer_crash_cause のユニットテスト。"""
+
+    def _old_hb(self, seconds_ago=200):
+        """現在時刻からseconds_ago秒前のISO文字列を返す。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def _recent_hb(self, seconds_ago=10):
+        """直近のheartbeat時刻。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def test_non_terminal_state_with_timeout_returns_crashed(self):
+        """state="working", 古いheartbeat → "crashed (inferred)"。"""
+        result = ow_service._infer_crash_cause("working", self._old_hb(200))
+        assert result == "crashed (inferred)"
+
+    def test_draining_with_timeout_returns_crashed_during_drain(self):
+        """state="draining", 古いheartbeat → "crashed-during-drain (inferred)"。"""
+        result = ow_service._infer_crash_cause("draining", self._old_hb(200))
+        assert result == "crashed-during-drain (inferred)"
+
+    def test_terminal_state_returns_none(self):
+        """state="terminated" → None。"""
+        result = ow_service._infer_crash_cause("terminated", self._old_hb(200))
+        assert result is None
+
+    def test_recent_heartbeat_returns_none(self):
+        """state="working", 直近heartbeat → None（まだ生きてる）。"""
+        result = ow_service._infer_crash_cause("working", self._recent_hb(10))
+        assert result is None
+
+    def test_none_heartbeat_returns_none(self):
+        """last_heartbeat_at=None → None。"""
+        result = ow_service._infer_crash_cause("working", None)
+        assert result is None
+
+
+# ----------------------------
+# TestOwGetIdentity
+# ----------------------------
+
+
+class TestOwGetIdentity:
+    """ow_get_identity のユニットテスト。"""
+
+    def _setup_history(self, monkeypatch, messages):
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(messages))
+
+    def test_returns_identity_with_msg_id_and_at(self, monkeypatch):
+        """正常系: identity eventがある → bundle + msg_id + identity_at を返す。"""
+        msgs = [
+            _make_msg(
+                1, "w-h",
+                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
+                "2026-06-14T10:00:00+00:00",
+            ),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result["alias"] == "worker-1"
+        assert result["msg_id"] == 1
+        assert result["identity_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_returns_none_when_no_identity(self, monkeypatch):
+        """identity eventなし → None。"""
+        self._setup_history(monkeypatch, [])
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is None
+
+    def test_inferred_cause_added_on_crash(self, monkeypatch):
+        """workingで古いheartbeat → inferred_cause付き。"""
+        old_hb = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("identity", {"alias": "worker-1"}), "2026-06-14T09:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T09:01:00+00:00"),
+            _make_msg(3, "w-h", _event_body("heartbeat", {"phase": "working"}), old_hb),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result.get("inferred_cause") == "crashed (inferred)"
+
+
+# ----------------------------
+# TestOwListIdentities
+# ----------------------------
+
+
+class TestOwListIdentities:
+    """ow_list_identities のユニットテスト。"""
+
+    def test_returns_all_handles(self, monkeypatch):
+        """2つのhandleそれぞれのidentityを返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch")
+        aliases = {e["alias"] for e in result}
+        assert aliases == {"worker-a", "worker-b"}
+
+    def test_alive_only_excludes_terminated(self, monkeypatch):
+        """alive_only=True → cause=closedを除外する。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b", "cause": "closed"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch", alive_only=True)
+        assert len(result) == 1
+        assert result[0]["alias"] == "worker-a"
+
+
+# ----------------------------
+# TestOwGetPresence
+# ----------------------------
+
+
+class TestOwGetPresence:
+    """ow_get_presence のユニットテスト。"""
+
+    def test_online_with_recent_heartbeat(self, monkeypatch):
+        """直近heartbeat → online。"""
+        recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), recent),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "online"
+        assert result["handle"] == "w-h"
+
+    def test_offline_with_old_heartbeat(self, monkeypatch):
+        """古いheartbeat → offline。"""
+        old = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), old),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "offline"
+
+    def test_unknown_when_no_heartbeat(self, monkeypatch):
+        """heartbeatなし → unknown。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "unknown"
+        assert result["last_heartbeat_at"] is None
+
+
+# ----------------------------
+# TestOwGetWorkloadState
+# ----------------------------
+
+
+class TestOwGetWorkloadState:
+    """ow_get_workload_state のユニットテスト。"""
+
+    def test_returns_latest_state(self, monkeypatch):
+        """最新stateを返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working", "cause": None}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is not None
+        assert result["state"] == "working"
+        assert result["handle"] == "w-h"
+        assert result["msg_id"] == 2
+        assert result["state_at"] == "2026-06-14T10:01:00+00:00"
+
+    def test_returns_none_when_no_state(self, monkeypatch):
+        """stateなし → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is None


### PR DESCRIPTION
## Summary

M#258 §10.4 step 4 として orch SKILL.md と一般 playbook を v3 へ更新する。

- envelope を `kind=command/event` の 2 種に統一（旧 `cmd/state` 形式の用例を排除）
- workload state 列を loading/ready/working/blocked/escalated/draining/terminated に同期（fallback 削除）
- watchdog 判定を heartbeat 途絶基準に変更（loading=30秒、ready以降=90秒、escalated は対象外）
- identity 取得経路を `ow_get_identity` / `ow_list_identities` / `ow_get_presence` / `ow_get_workload_state` 経由に統一
- crash 推論 cause lineup（closed/cancelled/dead/crashed/crashed-during-drain）に基づく queue status 反映ロジックを SKILL.md に追加
- クローズハンドシェイクを `command:close` → `event:state(draining)` → `event:identity` 再append → `event:state(terminated, cause:closed)` に更新
- `done` は workload state ではなく orchestration 層の完了申告イベントとして位置づけ（T40 w-i decision_proposal への応答）
- playbook.md にも heartbeat 周期 × 3 の watchdog 既定値を追記

## Base

`feature/t40-worker-v3`（T40 マージで自動的に main に切り替わる、bottom-up）

## 参照

- M#258 §5.2 / §5.4.2 / §6 / §8.3 / §9
- D#2521 / D#2522 / D#2523 / D#2525 / D#2530 / D#2532

## Test plan

- [ ] SKILL.md / playbook.md のレンダリング確認
- [ ] envelope 用例が command/event に揃っているか目視チェック
- [ ] cause lineup と queue status マッピングの整合性レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)