### PR TITLE
chore: T40+T41 recovery + worker同時稼働上限 5 へ

### DIFF
--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# workerのheartbeat eventを定期送信するバックグラウンドループ
+#
+# 使い方:
+#   PHASE_FILE=/tmp/ow_hb_phase_<alias> bash heartbeat.sh <channel_code> <handle> &
+#   echo "loading" > $PHASE_FILE   # loading=10s
+#   echo "ready"   > $PHASE_FILE   # ready/working/draining=30s
+#   rm $PHASE_FILE                 # ファイル削除でループ終了
+#
+# 環境変数:
+#   RELAY_URL   中継サーバーURL (default: http://127.0.0.1:8765)
+#   PHASE_FILE  現在フェーズを記録するファイルパス (default: /tmp/ow_hb_phase_<PID>)
+
+set -euo pipefail
+
+RELAY_URL="${RELAY_URL:-http://127.0.0.1:8765}"
+CHANNEL="${1:?channel_code is required}"
+HANDLE="${2:?handle is required}"
+PHASE_FILE="${PHASE_FILE:-/tmp/ow_hb_phase_$$}"
+
+# 初期フェーズを loading に設定（呼び出し側が事前に書いていない場合）
+[ -f "$PHASE_FILE" ] || echo "loading" > "$PHASE_FILE"
+
+while [ -f "$PHASE_FILE" ]; do
+    PHASE=$(cat "$PHASE_FILE" 2>/dev/null || echo "ready")
+
+    if [ "$PHASE" = "loading" ]; then
+        INTERVAL="${HEARTBEAT_INTERVAL_LOADING:-10}"
+    else
+        INTERVAL="${HEARTBEAT_INTERVAL_DEFAULT:-30}"
+    fi
+
+    BODY=$(printf '{"v":1,"kind":"event","from":"%s","to":"*","data":{"type":"heartbeat","phase":"%s"}}' \
+        "$HANDLE" "$PHASE")
+
+    curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${BODY}}" \
+        "${RELAY_URL}/send" > /dev/null || true
+
+    sleep "$INTERVAL"
+done

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -50,51 +50,134 @@ on Monitor発火 or 自発的タイミング:
 
 ## 通信プロトコル
 
-### orch→worker: `cmd`
+envelopeは `kind` が `command`（targeted）または `event`（broadcast）の2種。内訳は `data.type` で区別する（M#258 §4.1）。
+
+### envelope 共通形式
 
 ```json
 {
   "v": 1,
-  "kind": "cmd",
-  "from": "orch",
-  "to": "w-<alias>",
-  "task": "T<n>",
-  "verb": "assign | answer | cancel | close | ping",
-  "data": {}
+  "kind": "command" | "event",
+  "from": "<handle>",
+  "to": "<handle>" | "*",
+  "data": { "type": "<内訳種別>", ... }
 }
 ```
 
-**verb別data**:
-- `assign`: `{title, activity_id, topic_id, cwd, model（必須）, permission_mode, acceptance（必須）, context, playbook, timeout_min}` → needs_reply=true
-- `answer`: `{answer}` または `{escalate: true}`
-- `cancel`, `close`, `ping`: needs_reply=true
+- `v` は body 内 envelope のスキーマバージョン（relay 物理スキーマとは別レイヤ、M#258 §7.4）
+- `from` は messages.handle と一致しなければreducerが drop する
+- `kind=command` は `to` 必須、`kind=event` は `to` 省略または `"*"` で broadcast
 
-### worker→orch: `state`
+### orch→worker: `kind=command`
 
 ```json
-{
-  "v": 1,
-  "kind": "state",
-  "from": "w-<alias>",
-  "to": "orch",
-  "task": "T<n>",
-  "state": "<状態>",
-  "data": {}
-}
+{"v":1, "kind":"command", "from":"orch", "to":"w-<alias>", "task":"T<n>",
+ "data":{"type":"assign|close|cancel|answer|ping", ...}}
 ```
 
-| state | 意味 | data | 補足 |
+| data.type | data 内容 | 補足 |
+|---|---|---|
+| `assign` | `{title, activity_id, topic_id, cwd, model（必須）, permission_mode, acceptance（必須）, context, playbook, timeout_min}` | worker は `event:state(working)` で応答 |
+| `close` | `{reason}` | worker は退場処理（draining→terminated/cause:closed）で応答 |
+| `cancel` | `{reason}` | worker は退場処理（draining→terminated/cause:cancelled）で応答 |
+| `answer` | `{answer}` または `{escalate: true}` | blocked への応答 |
+| `ping` | `{nonce}` | worker は現在の `event:state` を返す |
+
+### worker→orch / worker→broadcast: `kind=event`
+
+workerが送る全メッセージは `kind:event`。内訳は `data.type` で:
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"orch|*", "task":"T<n>",
+ "data":{"type":"state|identity|heartbeat", ...}}
+```
+
+| data.type | to | 意味 | data 内容 |
 |---|---|---|---|
-| `ready` | 起動完了 | `{session_id, alias, cwd}` | |
-| `working` | 受諾・作業中 | `{phase, note}` | assignへの最初のworkingはin_reply_to必須 |
-| `blocked` | 判断要請 | `{question, options, context_refs}` | needs_reply=true |
-| `escalated` | エスカレーション文脈出力済み | `{report_md}` | watchdog対象外 |
-| `done` | 完了（sync済み） | `{summary, evidence, synced, materials[], decision_proposals[], cancelled?}` | needs_reply=true。cancelへの応答時はin_reply_to必須。cancelled（boolean）: cmd:cancelへの応答doneの場合にtrue、自発doneではfalseまたは省略 |
-| `closed` | クローズ受諾 | `{}` | |
-| `dead` | 起動失敗等の自己申告 | `{message}` | |
-| `fallback` | 人間対話モードへ移行宣言 | `{reason}` | |
+| `state` | `orch` | workload state 遷移宣言 | `{type:"state", state:..., ...payload}` |
+| `identity` | `*` | 身元情報 full snapshot | identity bundle（§identity 参照） |
+| `heartbeat` | `*` | liveness signal（バックグラウンドループから送信） | `{type:"heartbeat", phase, nonce?}` |
 
-**スレッド規約**: `in_reply_to` はrelay標準。存在しない親は400になるため送信前にmsg_id確定必須。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+### workload state（M#258 §5.2 と整合）
+
+```
+       spawn
+         │
+         ▼
+      loading ───────┐
+         │           │ (load 失敗)
+         ▼           ▼
+       ready      terminated (cause: dead)
+         │
+         ▼
+      working ──┬──▶ blocked ─▶ escalated ─▶ working
+         │      │
+         │      └──▶ working (continue)
+         │
+   ┌─────┴─────┐
+   ▼           ▼
+draining ──▶ terminated
+            (cause: closed/cancelled/crashed/crashed-during-drain)
+```
+
+| state | data 必須 payload | 補足 |
+|---|---|---|
+| `loading` | なし | spawn直後、context load中。長時間でもheartbeatが続けばcrash扱いしない |
+| `ready` | `{session_id, alias, cwd}` | assign待機 |
+| `working` | `{phase, note}` | assignへの最初のworkingは `in_reply_to` で assign msg_id を指す |
+| `blocked` | `{question, options, context_refs}` | orch回答待ち |
+| `escalated` | `{report_md}` | watchdog対象外 |
+| `draining` | なし | command:close/cancel 受領後の worker-sync 実行中。長時間でもheartbeatが続けばcrash扱いしない |
+| `terminated` | `{cause}` | cause ∈ {closed, cancelled, dead}。crashed/crashed-during-drain は orch reducer の推論のみで、history には書かれない |
+
+**done の扱い**: M#258 §5.2 の workload state machine に `done` は含まれない。ただし worker は acceptance 完了申告として `event:state(done)` を送る運用（worker SKILL.md §完了→done）。orchはこれを **workload state ではなく orchestration 層の完了申告イベント** として解釈し、acceptance 照合 → `command:close` 送信に進む。doneは workload遷移ではないため、heartbeat 途絶判定の対象外（worker は close 受領前まで working として heartbeat を継続）。
+
+**done の payload**: `{summary, evidence, synced, materials[], decision_proposals[], cancelled?}`。`cancelled`（boolean）は `command:cancel` への応答 doneの場合に true、自発 done では false または省略。
+
+**fallback state は v3 で正式削除**（M#258 §5.2.1）。
+
+### identity（event:identity）
+
+worker 起動時と terminated 直前に append される身元情報。orchは `ow_get_identity(channel, handle)` で最新 bundle を取得する（§identity 参照経路）。
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"*", "task":"T<n>",
+ "data":{
+   "type":"identity",
+   "role":"worker",
+   "handle":"w-<alias>",
+   "channel_code":"...",
+   "topic_id":"...",
+   "started_at":"<UTC ISO8601>",
+   "alias":"<alias>",
+   "activity_id":<id>,
+   "model":"...",
+   "cwd":"...",
+   "session_id":"...",
+   "terminated_at":"<UTC ISO8601>",   // terminated 直前の再 append でのみ set
+   "cause":"closed|cancelled|dead"     // terminated 直前の再 append でのみ set
+ }}
+```
+
+identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。M#258 §6.3.1 参照。
+
+### heartbeat（event:heartbeat）
+
+worker のバックグラウンドループ（scripts/ow/heartbeat.sh）が定期送信する liveness signal:
+
+```json
+{"v":1, "kind":"event", "from":"w-<alias>", "to":"*", "task":"T<n>",
+ "data":{"type":"heartbeat", "phase":"alive|loading|ready|working|draining"}}
+```
+
+- 周期: loading=10秒、それ以外=30秒（M#258 §5.4.1、D#2525）
+- `phase` は workload state を写像する補助情報
+
+**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない（M#258 §4.4 / D#2522）。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+
+### 旧 cmd/state envelope の後方互換放棄
+
+D#2532 により、旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は D#2479 で凍結されており、過去レコードはそのまま残置される。
 
 ## タスクキュー
 
@@ -152,35 +235,51 @@ queued → spawning → assigned → in_progress → awaiting_verify → done
 
 ## タスク完了の定義と検証
 
-**「完了」の定義**: `done` の `evidence` が `acceptance` を満たすとorchが判定 ∧ `synced: true`。無条件信頼しない。
+**「完了」の定義**: `event:state(done)` の `evidence` が `acceptance` を満たすとorchが判定 ∧ `synced: true`。無条件信頼しない。
+
+**done は workload state ではない**: M#258 §5.2 の workload state machine に done は含まれず、worker→orchの完了申告として `event:{type:state, state:done}` envelope形式で扱う（orchestration層の信号）。orchはdoneを受信したらacceptance照合し、`command:close`送信 → workerは draining → terminated(cause:closed) へ進む。
 
 **cancelと自発doneの交差**:
-- `done` の `in_reply_to` が `cancel` を指していなければ自発done
+- `event:state(done)` の `in_reply_to` が `command:cancel` を指していなければ自発done
 - orchは自発doneを優先してacceptance照合し、cancelを無効化する（完成タスクを捨てる理由がない）
 
 **done検証NG時の振る舞い**:
-- acceptance不充足 → `cmd:answer` に理由を付けてworkerに差し戻す
+- acceptance不充足 → `command:answer` に理由を付けてworkerに差し戻す
 - 差し戻しを受けてもworkerが改善できない場合 → `failed` としてキューを更新し人間に通知する
 
 **クローズハンドシェイク**:
 1. orchが「done検証OK ∧ synced:true ∧ escalated/stalled非該当」を確認
-2. `cmd:close` を送信
-3. `state:closed` 受信後に `ow_close_worker(term_ref)` でセッションをクローズ
-4. `state:closed` が来なければ閉じずに人間に通知する
+2. `command:close` を送信
+3. workerは `event:state(draining)` → worker-sync → `event:identity` 再append → `event:state(terminated, cause:closed)` を送信
+4. orchは `event:state(terminated, cause:closed)` 受信後に `ow_close_worker(term_ref)` でセッションをクローズ
+5. terminated が来なければ閉じずに人間に通知する
 
 ## watchdog
 
-**監視基準**: 「そのworkerからの最後の受信メッセージ」からの経過時間。
+**監視基準**: 「そのworkerからの最後の `event:heartbeat` 受信時刻」からの経過時間（M#258 §5.4.2、D#2525）。workload state の所要時間や `last_recv` 全般の経過では判定しない（長時間 loading や draining でも heartbeat が続けば crash 扱いしない）。
 
-**タイムアウト処理**:
-1. timeout_min超過 → `cmd:ping` を送信
-2. pingに無応答 → queueを `stalled` に更新 + 人間に通知
-3. **自動failedおよび自動クローズはしない**（長時間ツール実行中はping応答不能のため、無応答は異常の証明にならない）
-4. failedへの変更・強制クローズは人間判断
+**heartbeat 周期 × 3 の閾値**:
 
-**watchdog対象外**: `escalated` 状態のworker。escalated中はタイムアウト・クローズ対象外。
+| 現在の workload state | heartbeat 周期 | タイムアウト閾値（周期×3） |
+|---|---|---|
+| `loading` | 10秒（D#2525） | **30秒** |
+| `ready` / `working` / `blocked` / `draining` | 30秒（D#2525） | **90秒** |
+| `escalated` | 監視対象外 | — |
 
-**ready未送信タイムアウト**: spawning状態でtimeout_minを超過した場合もwatchdogと同一基準（ping→無応答でstalled+人間通知）。
+orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し、対応する閾値を選んで判定する。閾値はreducer実装のチューニング余地として残るが、orch側の初期実装は上記固定値を使う。
+
+**タイムアウト処理（heartbeat 途絶検知）**:
+1. heartbeat 途絶（loading: 30秒 / ready以降: 90秒）→ `command:ping` を送信
+2. pingに無応答（heartbeat も復活しない）→ 後述のcrash推論経路に遷移
+3. **自動failedおよび自動クローズはしない**。failedへの変更・強制クローズは人間判断
+
+**watchdog対象外**:
+- `escalated` 状態のworker（人間対話中はタイムアウト・クローズ対象外、M#258 §5.2の state machine参照）
+- `terminated` 状態のworker（既に終了済み）
+
+**ready未送信タイムアウト（loading 滞留）**: heartbeat が来ているかぎり crash 扱いしない。30秒以上 heartbeat 途絶した場合のみ crash 候補となる。長時間 loading（巨大コンテキスト読込・1Mコンテキストモデルのwarm-up等）でも heartbeat が続けばタイムアウトしない。
+
+**spawning（ready前）タイムアウト**: spawning は orch 側 queue の状態。worker が `event:identity` または `event:state(loading)` を送る前に timeout_min 経過した場合は、spawn失敗の可能性が高い（cwd不在・aliasぶつかり・relay疎通断等）。`ow_recover` で pending_spawn として検出される。
 
 ## モデル選択
 
@@ -188,14 +287,16 @@ assignの `model` は必須。一般プレイブック `skills/orch/playbook.md`
 
 ## エスカレーション
 
-1. workerが `state:blocked`（needs_reply）を送信する
+1. workerが `event:state(blocked)` を送信する
 2. orchは**特化版→一般版プレイブックと過去エスカレーションログ**（`search(tags=["escalation","domain:..."])`）を参照してから判断する
-3. 回答可能なら `cmd:answer {answer}` を送信する
-4. 判断不能なら `cmd:answer {escalate: true}` → workerはエスカレーションフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で自セッションに出力し `state:escalated` を送信する
+3. 回答可能なら `command:answer {answer}` を送信する
+4. 判断不能なら `command:answer {escalate: true}` → workerはエスカレーションフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で自セッションに出力し `event:state(escalated)` を送信する
 5. orchは人間に概要とworkerの場所（term_ref）を提示する
 6. 人間がworkerセッションで直接解決する
 7. workerがその場で記録（log必須・合意decisionも。タグ: `escalation`+`user-decision`+domain）
-8. worker → `state:working {summary, decision_ids, log_ids}` で再開通知 → orchが特化版プレイブックを更新する（§プレイブック参照）
+8. worker → `event:state(working) {summary, decision_ids, log_ids}` で再開通知 → orchが特化版プレイブックを更新する（§プレイブック参照）
+
+エスカレーション中（`event:state(escalated)`）はwatchdog対象外（§watchdog参照）。
 
 ## プレイブック参照
 
@@ -208,26 +309,53 @@ assignの `model` は必須。一般プレイブック `skills/orch/playbook.md`
 
 orchは起動時に特化版最新を取得し、assignの `playbook` フィールドで関連抜粋をworkerに渡す。
 
+## identity 取得経路
+
+orchはworkerの身元情報（alias、activity_id、model、cwd、session_id、terminated_at、cause等）を取得する際は、必ず `ow_get_identity(channel, handle)` 経由で取得する（M#258 §6 / §8.3）。`ow_history` を自前パースして identity bundle を組み立てる経路は使わない。
+
+理由:
+- reducer が event:identity の最新エントリを返す責務を持つため、orch側で二重実装しない
+- crash 推論（`cause: "crashed (inferred)"` / `"crashed-during-drain (inferred)"`）は reducer がメモリ上で付与する（DB不変、M#258 §9.2）。orch側で直接 history を見ると推論結果が得られない
+
+ID別の取得関数:
+
+| 関数 | 用途 |
+|---|---|
+| `ow_get_identity(channel, handle)` | 指定 handle の最新 identity bundle（+ crash推論結果） |
+| `ow_list_identities(channel, alive_only)` | channel上の全 handle の identity リスト（alive_only=True で terminated 除外） |
+| `ow_get_presence(channel, handle)` | SSE接続状態 + 最新 heartbeat 受信時刻から online/offline 推論 |
+| `ow_get_workload_state(channel, handle)` | 指定 handle の最新 workload state（watchdog 閾値選定に使う） |
+
+## crash 推論の cause lineup と queue 反映
+
+M#258 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで queue status を更新する。`cause` 値は `ow_get_identity` の戻り値 `cause` フィールドから判定する（履歴に明示書き込まれる closed/cancelled/dead と、reducer がメモリ上で付与する crashed/crashed-during-drain）。
+
+| cause | 発生条件 | queue status への反映 | 補足 |
+|---|---|---|---|
+| `closed` | command:close 受領 → 正常退出 | `done`（acceptance満たし & synced済み） | クローズハンドシェイク完了 |
+| `cancelled` | command:cancel 受領 → 退出 | `cancelled` | activity description先頭に[cancelled]経緯を追記 |
+| `dead` | loading 中の load 失敗 | `failed` | 人間に通知し復旧手段を判断（再spawn等） |
+| `crashed (inferred)` | ready/working/blocked/escalated 中の heartbeat 途絶 | `stalled` + 人間に通知 | 自動failedにはしない |
+| `crashed-during-drain (inferred)` | draining 中の heartbeat 途絶 | `stalled` + 人間に通知（worker-sync失敗の懸念） | done評価は人間判断（acceptance確認＋手動同期検討） |
+
+**自動 failed および自動クローズはしない**: heartbeat 途絶（crashed推論）は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明とはならない。failedへの変更・強制クローズは人間判断とする。
+
 ## crash復旧
 
-1. **crash中**: workerはフォールバック規則で待機。報告はrelay SQLite履歴に残存する
+1. **crash中**: worker側はheartbeat停止のみ。報告はrelay SQLite履歴に残存する
 2. **再起動**: 人間が`orch_cwd`と同じcwdで `/orch` を起動し、queue再開候補から選択する
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` から実行（冪等性が再処理を安全にする。専用復旧ロジック不要）
-4. **整合チェック**（必須）: `ow_recover(channel, topic_id)` を呼ぶ。relay履歴since=0再走査・queue・presenceの3者突合・自動修正までを一括で行う:
-   - **ghost_active**（queue=assigned/ready/working & presence offline）→ relay最新state宣言からqueueを自動再構築（done→done、closed→closed、working/ready→stalled、failed→failed等）
-   - **pending_spawn**（queue=spawning & presence offline）→ relay履歴に当該workerのstate宣言がある場合のみ自動再構築。履歴ゼロは起動進行中の可能性が高くow_recoverは触らない（spawn racing回避）。orchは戻り値で残留spawning件数を把握し、経過時間が長い物は手動で `failed` 化判断する
-   - **stalled_done**（queue=done/closed/cancelled/failed & presence online）→ `cmd:ping` 送信で素性照会
-   - **orphans**（presence onlineだがqueue外のw-* handle）→ `cmd:ping` 送信で再リンク照会
+4. **整合チェック**（必須）: `ow_recover(channel, topic_id)` を呼ぶ。relay履歴since=0再走査・queue・identity reducerの3者突合・自動修正までを一括で行う:
+   - **ghost_active**（queue=assigned/ready/working/blocked/draining & `ow_get_identity().cause` が terminal）→ identity reducer の最新 cause から queue を自動再構築（cause:closed→done、cause:cancelled→cancelled、cause:dead→failed、cause:crashed/crashed-during-drain→stalled）
+   - **pending_spawn**（queue=spawning & identity未生成）→ relay履歴に当該workerのevent:identity または event:state が**1件もない**場合は ow_recover は触らない（spawn racing回避）。orchは戻り値で残留spawning件数を把握し、経過時間が長い物は手動で `failed` 化判断する
+   - **stalled_done**（queue=done/closed/cancelled/failed & identity が alive）→ `command:ping` 送信で素性照会
+   - **orphans**（identity に登録があるがqueue外の handle）→ `command:ping` 送信で再リンク照会
    - 検証だけしたい時は `dry_run=True` で呼ぶ
    - 戻り値の `detected`/`applied`/`warnings` を確認し、ping応答は通常受信ループで処理
    - **cc-memory activityも突合**（ow_recover対象外）: queue終端済み（done/cancelled/failed） × activity `in_progress` 残留を別途検出・修正する
-5. **worker復帰**: ow_recoverが送ったpingへの応答を受信ループで処理し、フォールバック復帰規則に従って復帰させる
+5. **worker復帰**: ow_recoverが送った `command:ping` への応答（worker の `event:state(<現在のstate>, note:"pong")`）を受信ループで処理する。応答が来ないworkerは前述のcrash推論経路に進む
 
 **spawn前バリデーション**: `ow_spawn_worker` は内部で relay疎通・channel存在・cwd存在・alias重複の4点を自動チェックする。失敗時は `{"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}` が返るので、warningsを確認して原因を解消してから再spawnする。
-
-**フォールバック復帰規則**:
-- フォールバック後に人間入力ゼロ → orchの復帰メッセージで自動復帰
-- フォールバック後に人間入力が一度でもあり → 復帰可否をユーザーに確認
 
 ## 複数orchの運用
 
@@ -239,12 +367,16 @@ orchは起動時に特化版最新を取得し、assignの `playbook` フィー�
 
 | ツール | 用途 |
 |---|---|
-| `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ） |
-| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体） |
+| `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ）。bodyは `kind=command`/`event` envelope |
+| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、M#258 §3.3） |
 | `ow_spawn_worker(alias, channel, cwd, model, permission, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却） |
 | `ow_close_worker(term_ref)` | workerクローズ |
-| `ow_status(channel, topic_id)` | queue+presence統合ビュー |
-| `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×presence突合・ghost_active自動再構築・stalled/orphan ping送信） |
+| `ow_status(channel, topic_id)` | queue+identity統合ビュー |
+| `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×identity reducer突合・ghost_active自動再構築・stalled/orphan command:ping送信） |
+| `ow_get_identity(channel, handle)` | 指定 handle の最新 identity bundle（+ crash推論結果） |
+| `ow_list_identities(channel, alive_only)` | channel上の全 handle の identity リスト |
+| `ow_get_presence(channel, handle)` | SSE接続状態 + 最新 heartbeat 受信時刻から online/offline 推論 |
+| `ow_get_workload_state(channel, handle)` | 指定 handle の最新 workload state（watchdog 閾値選定に使う） |
 | `check_in(activity_id)` | cc-memoryのアクティビティcheck-in |
 | `add_activity(...)` / `update_activity(...)` | アクティビティ管理（orch-managedタグ必須） |
 | `search(...)` | 特化プレイブック・過去エスカレーションログ検索 |

--- a/skills/orch/playbook.md
+++ b/skills/orch/playbook.md
@@ -20,9 +20,31 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 
 ## タイムアウト既定値
 
+### worker assign の timeout_min
+
 - `timeout_min` のデフォルト値: **60分**
 - assignに明示的に指定しない場合は60分を適用する
 - タスクの性質（大規模実装・長時間調査等）に応じてorchが上書き可能
+
+### heartbeat 途絶 watchdog（M#258 §5.4.2 / D#2525）
+
+orchが worker の生死を判定する基準は **heartbeat 途絶**。workload state の所要時間（`timeout_min`）とは別軸で監視する。`timeout_min` 超過は workload 上の予期外長期化、heartbeat 途絶は liveness 側のcrash候補（reducer 推論）として分けて扱う。
+
+| 現在の workload state | heartbeat 周期 | watchdog 閾値（周期×3） |
+|---|---|---|
+| `loading` | 10秒 | **30秒** |
+| `ready` / `working` / `blocked` / `draining` | 30秒 | **90秒** |
+| `escalated` | 監視対象外 | — |
+| `terminated` | 監視対象外（既に終了済み） | — |
+
+途絶検知時のorchの行動: `command:ping` 送信 → 無応答かつ heartbeat 復活なし → reducer の `cause` を参照して queue を更新（cause lineup は orch SKILL.md §crash推論 参照）。
+
+**自動 failed / 自動クローズはしない**。failed への変更・強制クローズは人間判断（heartbeat 途絶は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明にならない）。
+
+### watchdog 対象外の state
+
+- `escalated`: 人間対話中はタイムアウト・クローズ対象外
+- `terminated`: 既に終了済み
 
 ## worker同時稼働数上限
 
@@ -39,7 +61,7 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 
 ## エスカレーション基準
 
-workerがエスカレーション（`state:blocked` → `cmd:answer {escalate: true}`）を要請する典型的な場面:
+workerがエスカレーション（`event:state(blocked)` → `command:answer {escalate: true}`）を要請する典型的な場面:
 
 | 類型 | 例 |
 |---|---|
@@ -52,7 +74,7 @@ workerがエスカレーション（`state:blocked` → `cmd:answer {escalate: t
 
 エスカレーションの際はフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で出力する。
 
-orchが自力で判断できる場合は `cmd:answer {answer}` で直接回答し、エスカレーションに進めない。escalate指示は慎重に使う。
+orchが自力で判断できる場合は `command:answer {answer}` で直接回答し、エスカレーションに進めない。escalate指示は慎重に使う。
 
 ## 報告頻度
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -7,77 +7,180 @@ description: owフレームワークのworkerとして動作する。orchから�
 
 owフレームワークのworkerとして動作する。orchからの指示を受けてタスクを実行し、結果を報告する。
 
-このスキルは**ステートマシン**として記述されている。workerの全メッセージは「現在状態の宣言」（`state`）であり、各状態の遷移条件と送信メッセージを以下に定義する。
+このスキルは**ステートマシン**として記述されている。workerのすべての送信メッセージは `kind:event` であり、`data.type` で内訳を区別する。
 
 ## 状態一覧
 
-| state | 意味 | 主なdata |
-|-------|------|---------|
-| `ready` | 起動完了・assign待ち | `session_id`, `alias`, `cwd` |
-| `working` | assign受諾・作業中 | `phase`, `note`（assignへの初回は`in_reply_to`必須） |
-| `blocked` | 判断要請（orchに回答 or エスカレーション判断を仰ぐ） | `question`, `options`, `context_refs`（`needs_reply`） |
-| `escalated` | 人間へのエスカレーション中 | `report_md`（解決時は`summary`/`decision_ids`/`log_ids`を添えて`working`へ戻る） |
-| `done` | 作業完了・検証待ち | `summary`, `evidence`, `synced`, `materials[]`, `decision_proposals[]`（`needs_reply`） |
-| `closed` | 退場処理完了・終了 | （なし） |
-| `dead` | 起動失敗（task file不在等） | `message` |
-| `fallback` | orch通信不能・人間対話モードへ移行 | `reason` |
+| state | 意味 |
+|-------|------|
+| `loading` | 起動中・コンテキスト読み込み中 |
+| `ready` | 起動完了・assign待ち |
+| `working` | assign受諾・作業中 |
+| `blocked` | 判断要請中（orch回答待ち） |
+| `escalated` | 人間へのエスカレーション中 |
+| `done` | 作業完了・orch検証待ち |
+| `draining` | close受領・worker-sync実行中 |
+| `terminated` | 終了（cause: closed / cancelled / dead） |
 
-メッセージ共通形式:
+### メッセージ共通形式（workerが送信するevent）
+
+workerが送信するメッセージはすべて `kind:event`:
+
 ```json
-{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"<state>", "data":{...}}
+{"v":1, "kind":"event", "from":"<alias>", "to":"<宛先>", "task":"T<task_n>", "data":{"type":"<内訳>", ...}}
 ```
 
-## 起動
+| data.type | 意味 | toフィールド |
+|-----------|------|------------|
+| `state` | workload state 遷移宣言 | `"orch"` |
+| `identity` | 参加者の身元情報 full snapshot | `"*"` |
+| `heartbeat` | liveness signal（バックグラウンドループが自動送信） | `"*"` |
 
-1. task fileを読み込む: orchのbootstrapプロンプトで渡されたパス（`.md`）を読む。task fileはYAML frontmatter（機械可読の起動パラメータ）＋本文（タスク内容）のマークダウン形式
-   - **task fileが存在しない/読めない場合は `state:dead`（data: `{"message":"task file not found: <path>"}`）を送信して終了する**
-2. task fileから起動パラメータと内容を取得する
-   - frontmatterから: `channel`(channel_code), `alias`, `task`(task_n), `cwd`, `model`, `permission_mode`, `timeout_min`, `activity_id`, `topic_id`
-   - 本文から: タイトル（H1）, `## Acceptance`, `## Context`, `## Playbook`（各セクションは存在する場合のみ）
-3. Monitorを起動する: `Monitor recv.sh <channel_code> <alias> (persistent)`
-   - `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
-4. `check_in(activity_id)` でアクティビティの関連情報を取得する
-5. `ow_send` で `state:ready` を送信する:
-   ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"ready", "data":{"session_id":"<session_id>", "alias":"<alias>", "cwd":"<cwd>"}}
-   ```
-6. **ready送信直後に `ow_history(channel=<channel_code>, since=<ready_msg_id>)` を実行する**。orchがready受信後にすぐ送ったcmd:assignをSSE接続完了前に取りこぼす場合があるため、自分でpullして補完する。
+orchからworkerへ届くメッセージは `kind:command`（または旧形式 `kind:cmd`）。
+
+## 起動シーケンス
+
+### 1. task fileを読み込む
+
+orchのbootstrapプロンプトで渡されたパス（`.md`）を読む。task fileはYAML frontmatter（起動パラメータ）＋本文（タスク内容）のマークダウン形式。
+
+frontmatterから取得するパラメータ:
+- `channel` (channel_code), `alias`, `task` (task_n), `cwd`, `model`, `timeout_min`, `activity_id`, `topic_id`
+
+本文から取得する情報:
+- タイトル（H1）, `## Acceptance`, `## Context`, `## Playbook`
+
+**task fileが存在しない / 読めない場合の処理（起動失敗）:**
+```
+可能ならば: event:identity（最小bundle + terminated_at + cause:"dead"）を送信
+           → event:state(terminated, cause:"dead") を送信
+不可能な場合: event:state(terminated, cause:"dead") のみ送信
+→ 終了
+```
+
+### 2. heartbeatループ起動
+
+`scripts/ow/heartbeat.sh` をバックグラウンドで起動し、`PHASE_FILE`（`/tmp/ow_hb_phase_<alias>`）を `loading` に設定する:
+
+```bash
+PHASE_FILE="/tmp/ow_hb_phase_<alias>"
+echo "loading" > "$PHASE_FILE"
+PHASE_FILE="$PHASE_FILE" bash ~/workspace/cc-memory/scripts/ow/heartbeat.sh <channel_code> <alias> &
+```
+
+heartbeatループは `PHASE_FILE` の内容を読んで送信間隔を決定する:
+- `loading` → 10秒間隔
+- それ以外 → 30秒間隔
+
+### 3. event:heartbeat(alive) を即時送信
+
+ow_sendで1回だけ送信:
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>", "data":{"type":"heartbeat", "phase":"alive"}}
+```
+
+### 4. event:identity を送信
+
+```json
+{
+  "v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>",
+  "data":{
+    "type":"identity",
+    "role":"worker",
+    "handle":"<alias>",
+    "channel_code":"<channel_code>",
+    "topic_id":"<topic_id>",
+    "started_at":"<UTC ISO8601>",
+    "alias":"<alias>",
+    "activity_id":<activity_id>,
+    "model":"<model>",
+    "cwd":"<cwd>",
+    "session_id":"<session_id>"
+  }
+}
+```
+
+identity bundleに含めない属性: `task_n`（activity_idから逆引き可能）、`permission_mode`（auto固定）、`user`（relay参加者でないため）。
+
+### 5. event:state(loading) を送信
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"loading"}}
+```
+
+### 6. context load（Monitorとcheck_in）
+
+- Monitorを起動: `Monitor recv.sh <channel_code> <alias> (persistent)`
+  - `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
+- `check_in(activity_id)` でアクティビティの関連情報を取得する
+
+### 7. event:state(ready) を送信
+
+context load完了後、PHASE_FILEを `ready` に更新してからstateを宣言:
+
+```bash
+echo "ready" > /tmp/ow_hb_phase_<alias>
+```
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"ready", "session_id":"<session_id>", "alias":"<alias>", "cwd":"<cwd>"}}
+```
+
+### 8. ow_historyでpull補完
+
+```
+ow_history(channel=<channel_code>, since=<ready_msg_id>)
+```
+
+orchがready受信後にすぐ送ったcmd:assignをSSE接続前に取りこぼす場合があるため、自分でpullして補完する。
+
+## alias 命名ガイドライン
+
+aliasは**連番（w-a, w-b）ではなく任意の単語**を推奨する。orcがspawn時に決定する。
+
+- 例（汎用）: `crystal`, `forge`, `quill`, `anvil`, `lens`, `scribe`
+- 例（role寄り）: `designer-1`, `implementer-2`, `reviewer-3`
+
+理由: 連番は並行worker数が増えると識別性が低い。固有名のほうがorchの認知負荷が下がる。
 
 ## cmd:assign の受信 → working
 
-orchから `cmd:assign` が届いたら:
-1. 内容を確認し、`state:working` を送信する（**in_reply_toにassignのmsg_idを指定 — 必須**）:
+orchから `kind:command, data.type:assign`（または旧形式 `kind:cmd, verb:assign`）が届いたら:
+
+1. 内容を確認し、`event:state(working)` を送信する:
    ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working", "data":{"phase":"starting", "note":"assign received, beginning work"}}
+   {"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"working", "phase":"starting", "note":"assign received, beginning work"}}
    ```
-2. タスクの作業を開始する
+2. PHASE_FILEが `ready` になっていることを確認（なっていなければ更新）
+3. タスクの作業を開始する
 
 ## 作業中（working）
 
 - 通常の実装作業を行う（コーディング、テスト作成、PR作成等）
-- 節目ごとに `state:working` を送信してorchに進捗を知らせる:
+- 節目ごとに `event:state(working)` を送信してorchに進捗を知らせる:
   ```json
-  {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working", "data":{"phase":"<phase>", "note":"<進捗メモ>"}}
+  {"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"working", "phase":"<phase>", "note":"<進捗メモ>"}}
   ```
 - cc-memoryへの記録方針はworker専用の規律に従う（§記録規律）
-- SAを使う場合のモデル選択: 機械的作業→haiku/sonnet、通常実装→sonnet/claude-opus-4-7、設計・複雑推論→claude-opus-4-7以上。**opus 4.8は使用禁止**（D#2476）。`opus` 等の省略形は4.8に解決されるか無効。必ずフルID `claude-opus-4-7` を使う
+- SAを使う場合のモデル選択: 機械的作業→haiku/sonnet、通常実装→sonnet/claude-opus-4-7、設計・複雑推論→claude-opus-4-7以上。**opus 4.8は使用禁止**。フルID `claude-opus-4-7` を使う
 
 ## 判断に迷ったら → blocked
 
-タスクスコープ内で判断がつかない（仕様の解釈が割れる、前提が矛盾している、設計判断が必要等）場合は、独断で進めず `state:blocked` を送信してorchに判断を仰ぐ:
+タスクスコープ内で判断がつかない（仕様の解釈が割れる、前提が矛盾している、設計判断が必要等）場合は、独断で進めず `event:state(blocked)` を送信してorchに判断を仰ぐ:
+
 ```json
-{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"blocked",
- "data":{"question":"<判断を仰ぎたい点>", "options":["<選択肢A>","<選択肢B>"], "context_refs":["T<task_n>","A#<activity_id>","msg_id:<n>"]}}
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>",
+ "data":{"type":"state", "state":"blocked", "question":"<判断を仰ぎたい点>", "options":["<選択肢A>","<選択肢B>"], "context_refs":["T<task_n>","A#<activity_id>","msg_id:<n>"]}}
 ```
-（`needs_reply=true` で送信する）
 
 orchの応答:
-- `cmd:answer` が届いたら、その回答に従って作業を再開し `state:working` を送信する
+- `command:answer`（または旧形式 `cmd:answer`）が届いたら、その回答に従って作業を再開し `event:state(working)` を送信する
 - orchが「エスカレーションせよ」と判断した場合は §エスカレーション へ進む
 
 ## エスカレーション（escalated）
 
-orchが人間へのエスカレーションを指示したら、以下の**エスカレーションフォーマット**をmarkdownで組み立て、`state:escalated`（data: `{"report_md":"<下記フォーマット>"}`）を送信する:
+orchが人間へのエスカレーションを指示したら、以下の**エスカレーションフォーマット**をmarkdownで組み立て、`event:state(escalated)`（data: `{"type":"state", "state":"escalated", "report_md":"<下記フォーマット>"}`）を送信する:
 
 ```markdown
 ## エスカレーション: <1行サマリ>
@@ -98,7 +201,6 @@ orchが人間へのエスカレーションを指示したら、以下の**エ�
 ### 関連ID
 - task: T<task_n> / activity: A#<activity_id> / topic: #<topic_id>
 - 関連msg_id: <blocked等のmsg_id>
-- 関連decision/material: D#... / M#...
 ```
 
 その後の流れ:
@@ -106,36 +208,25 @@ orchが人間へのエスカレーションを指示したら、以下の**エ�
 2. 人間と合意した内容を記録する（**エスカレーション時の例外: workerがその場でdecisionを記録してよい**）:
    - **log必須**（経緯）。タグに `escalation`・`user-decision`・`domain:<topic_domain>` を付ける
    - 合意した決定事項は `add_decisions` で記録してよい（同タグ）
-3. 記録した `decision_ids` / `log_ids` を添えて `state:working` に戻り、orchへ必ず通知する（監査保全・D#2397）:
+3. 記録した `decision_ids` / `log_ids` を添えて `event:state(working)` に戻り、orchへ必ず通知する:
    ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"working",
-    "data":{"phase":"escalation_resolved", "note":"<解決内容>", "decision_ids":[...], "log_ids":[...]}}
+   {"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>",
+    "data":{"type":"state", "state":"working", "phase":"escalation_resolved", "note":"<解決内容>", "decision_ids":[...], "log_ids":[...]}}
    ```
 
 エスカレーション中（escalated）はorchのタイムアウト・クローズ対象外になる。
-
-## フォールバック（fallback）
-
-orchとの通信が途絶した場合の縮退動作（D#2384 / D#2399）:
-
-1. `needs_reply=true` で送ったメッセージに **10分** 応答がなければ同じメッセージを再送する
-2. 再送後さらに **10分** 応答がなければ `state:fallback`（data: `{"reason":"orch unreachable: <状況>"}`）を宣言し、**人間対話モード**へ移行する（以降はこのセッションのユーザーと直接対話して作業を進める）
-
-復帰規則:
-- フォールバック後、**人間の入力が一度もなければ**、orchからの復帰メッセージ（`cmd`）受信で自動的にworkerモードへ復帰する
-- **人間の入力が一度でもあれば**、自動復帰せず、人間に復帰可否を確認してから復帰する（人間の作業を中断・上書きしないため）
 
 ## 完了 → done
 
 作業が完了したら:
 1. acceptanceを満たしていることを確認し、証拠（evidence: テスト結果・PR URL等）を揃える
 2. worker専用の記録規律（§記録規律）に従い、material保存・decision_proposalsの準備を済ませる
-3. `state:done` を送信する（`needs_reply=true`）:
+3. `event:state(done)` を送信する:
    ```json
-   {"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"done",
-    "data":{"summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[<material_id...>], "decision_proposals":[{"decision":"...","reason":"..."}]}}
+   {"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>",
+    "data":{"type":"state", "state":"done", "summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[<material_id...>], "decision_proposals":[{"decision":"...","reason":"..."}]}}
    ```
-   - `synced:true` は「material保存済み・decision_proposals本メッセージに添付済みでorchが検証可能な状態」を意味する。最終的な作業経緯ログの確定はcmd:close時のworker-syncで行う（§退場処理・D#2446）
+   - `synced:true` は「material保存済み・decision_proposals添付済みでorchが検証可能な状態」を意味する。最終作業経緯ログの確定はcmd:close時の退場処理で行う
 4. orchからの応答を待つ（§完了後の待機）
 
 ## 完了後の待機
@@ -143,24 +234,71 @@ orchとの通信が途絶した場合の縮退動作（D#2384 / D#2399）:
 done送信後はcloseを受けるまで**読み取り専用**で待機する:
 - 新しい作業を始めない
 - cc-memoryへの追記もしない（退場処理を除く）
-- `state:closed` 以外のstateを送らない（`cmd:ping`への応答を除く）
+- `event:state(terminated)` 以外のstateを送らない（`cmd:ping`への応答を除く）
 
 orchの応答:
-- `cmd:close` → §退場処理 を実行してから `state:closed` を送信して終了
-- `cmd:answer` 等で差し戻し（done検証NG）→ 指示に従い `state:working` に戻って作業を再開
+- `command:close`（または旧形式 `cmd:close`）→ §退場処理 を実行する
+- `command:answer` 等で差し戻し（done検証NG）→ 指示に従い `event:state(working)` に戻って作業を再開
 
 ## 退場処理（cmd:close受信時）
 
-`cmd:close` を受信したら、`state:closed` を送信する**前に** `worker-sync` スキルを実行する（D#2446: done時点ではなくclose確定後にsyncする。orchが差し戻す可能性があるため）。
+`command:close`（または旧形式 `cmd:close`）を受信したら以下の手順を順番に実行する:
+
+### Step 1: event:state(draining) を送信
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"draining"}}
+```
+
+PHASE_FILEを `draining` に更新する:
+```bash
+echo "draining" > /tmp/ow_hb_phase_<alias>
+```
+heartbeatループは draining フェーズで 30秒間隔を維持する（worker-sync中もliveness信号を継続）。
+
+### Step 2: worker-sync スキルを実行
 
 `worker-sync` スキルは以下を行う（詳細はworker-syncスキル参照）:
 - **log記録**: セッション中の作業経緯（実装アプローチ・障害・orchとのやり取り）を1件のログとして記録
-- **material記録**: state:doneで報告済み以外の中間成果物があれば保存（related=担当activity）
-- **decisionは原則記録しない**: workerはdecisionを直接書かず、done時の `decision_proposals` でorchに提案する（D書き込み権限のorch集約・D#2397）。エスカレーションで人間と直接合意した分は例外として記録済み
+- **material記録**: state:doneで報告済み以外の中間成果物があれば保存
+- **decisionは原則記録しない**: decision_proposalsでorchに提案する（D#2397）
 
-worker-syncスキル完了後に `state:closed` を送信して終了する:
+### Step 3: event:identity 再 append（terminated情報付き）
+
+terminated_atと cause を付与してidentityを再送する:
+
 ```json
-{"v":1, "kind":"state", "from":"<alias>", "to":"orch", "task":"T<task_n>", "state":"closed", "data":{}}
+{
+  "v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>",
+  "data":{
+    "type":"identity",
+    "role":"worker",
+    "handle":"<alias>",
+    "channel_code":"<channel_code>",
+    "topic_id":"<topic_id>",
+    "started_at":"<started_at（起動時と同じ値）>",
+    "alias":"<alias>",
+    "activity_id":<activity_id>,
+    "model":"<model>",
+    "cwd":"<cwd>",
+    "session_id":"<session_id>",
+    "terminated_at":"<現在時刻 UTC ISO8601>",
+    "cause":"closed"
+  }
+}
+```
+
+### Step 4: event:state(terminated, cause:closed) を送信
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"terminated", "cause":"closed"}}
+```
+
+### Step 5: heartbeatループ停止
+
+PHASE_FILEを削除してheartbeatループを終了させる:
+```bash
+rm /tmp/ow_hb_phase_<alias>
 ```
 
 ## 記録規律（worker専用）
@@ -168,8 +306,8 @@ worker-syncスキル完了後に `state:closed` を送信して終了する:
 workerは会話相手（ユーザー）がいないため、通常のsync-memoryではなく `worker-sync` スキルの規律に従う:
 - **log**: 実装経緯・障害・orchとのやり取りを記録（worker自身が直接記録してよい）
 - **material**: 生データをそのまま保存。`related` で担当activityに紐づける（worker自身が直接保存してよい）
-- **decision**: 原則 `decision_proposals` でorchに提案し、orchが採否・記録する（D集約）。**workerは直接 `add_decisions` しない**
-  - 例外: エスカレーションで人間がこのworkerセッション内で直接合意した内容はworkerが記録してよい。記録したD#/L#は `state` 遷移で必ずorchに通知する
+- **decision**: 原則 `decision_proposals` でorchに提案し、orchが採否・記録する。**workerは直接 `add_decisions` しない**
+  - 例外: エスカレーションで人間がこのworkerセッション内で直接合意した内容はworkerが記録してよい
 - **topic/activityの新規作成はしない**
 
 ## 状態不明時の再導出（compaction後等）
@@ -177,7 +315,7 @@ workerは会話相手（ユーザー）がいないため、通常のsync-memory
 コンテキストが失われて現在状態が分からなくなった場合:
 1. `ow_history(channel=<channel_code>, since=0)` で全履歴を取得する
 2. 自分のhandle（alias）が `from` または `to` のメッセージだけにフィルタする
-3. 自分が最後に送った `state` 宣言を見つけ、そこから現在状態を再導出する
+3. 自分が最後に送った `data.type:state` のeventを見つけ、そこから現在状態を再導出する
 4. orchから未処理のcmdがあれば対応する
 
 ## 受信処理
@@ -186,12 +324,16 @@ SSE（Monitor）は起床信号専用。起床したら `ow_history(channel=<cha
 
 ## cmd:ping への応答
 
-orchから `cmd:ping` が届いたら、現在の状態を表す `state`（通常は `working`、完了後待機中なら直近のstate）で返す。
+orchから `kind:command, data.type:ping`（または旧形式 `kind:cmd, verb:ping`）が届いたら、現在の state を `event:state` で返す:
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"<現在のstate>", "note":"pong"}}
+```
 
 ## 禁止事項
 
 - orchの指示なしにタスクスコープを拡張しない
 - topic/activityを新規作成しない
 - decisionを直接記録しない（エスカレーション例外を除く。原則decision_proposalsでorchに提案）
-- `state:closed` 送信後にツールを呼ばない
+- `event:state(terminated)` 送信後にツールを呼ばない
 - done送信後、closeを受けるまで新しい作業を始めない・cc-memoryへ追記しない（退場処理を除く）

--- a/src/relay/server.py
+++ b/src/relay/server.py
@@ -91,6 +91,10 @@ def init_db(db_path: str = DB_PATH) -> None:
                 in_reply_to  INTEGER,
                 created_at   TEXT NOT NULL
             );
+            CREATE INDEX IF NOT EXISTS idx_messages_channel_msg_id
+                ON messages(channel_code, msg_id);
+            CREATE INDEX IF NOT EXISTS idx_messages_channel_handle_msg
+                ON messages(channel_code, handle, msg_id DESC);
         """)
         conn.commit()
     finally:
@@ -328,8 +332,20 @@ def get_presence(channel_code: str) -> list[str]:
 
 
 def _broadcast(channel_code: str, sender_handle: str, msg: dict) -> None:
-    """同一 channel の購読者（送信者と同一 handle を除く）にメッセージを配信する（D#2286）。"""
-    payload = json.dumps(msg, ensure_ascii=False)
+    """同一 channel の購読者（送信者と同一 handle を除く）にメッセージを配信する（D#2286）。
+
+    SSE ペイロードは msg_id / body / handle / created_at の4フィールドに絞る。
+    受信側が body フィールド有無を許容する後方互換設計を前提とする。
+    """
+    payload = json.dumps(
+        {
+            "msg_id": msg["msg_id"],
+            "body": msg["body"],
+            "handle": msg["handle"],
+            "created_at": msg["created_at"],
+        },
+        ensure_ascii=False,
+    )
     with _sub_lock:
         entries = list(_subscribers.get(channel_code, []))
     for handle, q in entries:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -53,7 +53,9 @@ _MAX_RETRIES = 3
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
     {"loading", "ready", "working", "blocked", "escalated", "draining"}
 )
-# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+# heartbeat タイムアウト閾値（周期×3）。
+# キーは workload_state または heartbeat body の phase。両者は worker 側で同期される
+# （event:state 送信時に heartbeat phase も追従）ため、同一の値空間として共有する。
 _HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
     "loading": 30.0,  # 10s × 3
 }
@@ -1925,6 +1927,40 @@ def _infer_crash_cause(
         return None
 
 
+def _latest_events_by_type(
+    channel: str, handle: str | None, data_types: tuple[str, ...]
+) -> dict[str, dict]:
+    """指定 handle の各 data_type について最新 event を1回の ow_history で取得する。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_types: 対象とする event の data.type タプル
+
+    Returns:
+        {data_type: latest_event_dict} — 該当 event が無い type はキー欠落
+    """
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return {}
+    latest: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        t = parsed["body"].get("data", {}).get("type")
+        if t not in data_types:
+            continue
+        current = latest.get(t)
+        if current is None or parsed["msg_id"] > current["msg_id"]:
+            latest[t] = parsed
+    return latest
+
+
 def ow_get_identity(channel: str, handle: str) -> dict | None:
     """指定 handle の最新 identity bundle を返す。crash 推論を含む。
 
@@ -1935,7 +1971,8 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     Returns:
         dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
     """
-    identity_msg = _query_latest_event(channel, handle, "identity")
+    latest = _latest_events_by_type(channel, handle, ("identity", "state", "heartbeat"))
+    identity_msg = latest.get("identity")
     if identity_msg is None:
         return None
     data = identity_msg["body"].get("data", {})
@@ -1943,12 +1980,11 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
     result["msg_id"] = identity_msg["msg_id"]
     result["identity_at"] = identity_msg["created_at"]
 
-    state_msg = _query_latest_event(channel, handle, "state")
-    workload_state = None
-    if state_msg is not None:
-        workload_state = state_msg["body"].get("data", {}).get("state")
-
-    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    state_msg = latest.get("state")
+    workload_state = (
+        state_msg["body"].get("data", {}).get("state") if state_msg is not None else None
+    )
+    heartbeat_msg = latest.get("heartbeat")
     last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
 
     inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
@@ -1959,35 +1995,69 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
 
 
 def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
-    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    """channel 上の全 handle の identity リスト。
+
+    alive_only=True の場合:
+    - identity bundle に terminated_at / cause(closed/cancelled/dead) を持つ entry を除外
+    - 加えて、ow_get_identity と同様の crash 推論（state が non-terminal + heartbeat 途絶）
+      で inferred_cause が付与される entry も除外する
+    handle フィールドが欠落した event は集約キーが None になるためスキップする。
+    """
     history = ow_history(channel, since=0, limit=10000)
     if "error" in history:
         return []
 
-    # handle別に最新identity msgを収集
-    latest_by_handle: dict[str, dict] = {}
+    # handle別に identity / state / heartbeat の最新msgを収集
+    identity_by_handle: dict[str, dict] = {}
+    state_by_handle: dict[str, dict] = {}
+    heartbeat_by_handle: dict[str, dict] = {}
     for msg in history.get("messages", []):
         parsed = _parse_ow_event(msg)
         if parsed is None:
             continue
+        h = parsed["handle"]
+        if h is None:
+            continue
         if parsed["body"].get("kind") != "event":
             continue
-        if parsed["body"].get("data", {}).get("type") != "identity":
-            continue
-        h = parsed["handle"]
-        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
-            latest_by_handle[h] = parsed
+        t = parsed["body"].get("data", {}).get("type")
+        if t == "identity":
+            current = identity_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                identity_by_handle[h] = parsed
+        elif t == "state":
+            current = state_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                state_by_handle[h] = parsed
+        elif t == "heartbeat":
+            current = heartbeat_by_handle.get(h)
+            if current is None or parsed["msg_id"] > current["msg_id"]:
+                heartbeat_by_handle[h] = parsed
 
     entries = []
-    for parsed in latest_by_handle.values():
+    for h, parsed in identity_by_handle.items():
         data = parsed["body"].get("data", {})
         entry = dict(data)
         entry["msg_id"] = parsed["msg_id"]
         entry["identity_at"] = parsed["created_at"]
 
+        state_msg = state_by_handle.get(h)
+        workload_state = (
+            state_msg["body"].get("data", {}).get("state")
+            if state_msg is not None
+            else None
+        )
+        hb_msg = heartbeat_by_handle.get(h)
+        last_heartbeat_at = hb_msg["created_at"] if hb_msg is not None else None
+        inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+        if inferred_cause is not None:
+            entry["inferred_cause"] = inferred_cause
+
         if alive_only:
             cause = entry.get("cause")
             if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+            if inferred_cause is not None:
                 continue
 
         entries.append(entry)
@@ -1995,11 +2065,14 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
     return entries
 
 
-def ow_get_presence(channel: str, handle: str) -> dict | None:
+def ow_get_presence(channel: str, handle: str) -> dict:
     """最新 heartbeat 受信時刻から online/offline を推論する。
 
     T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
     SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    heartbeat が一度も観測されない handle に対しては status="unknown" の
+    entry を返す（None は返さない）。
 
     Returns:
         dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -49,6 +49,16 @@ _RELAY_LOCK_PATH = _RELAY_STATE_DIR / "relay.lock"
 
 _MAX_RETRIES = 3
 
+# reducer: v3 workload state 分類
+_NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
+    {"loading", "ready", "working", "blocked", "escalated", "draining"}
+)
+# heartbeat タイムアウト閾値（M#258 §5.4.2: 周期×3）
+_HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
+    "loading": 30.0,  # 10s × 3
+}
+_HEARTBEAT_TIMEOUT_DEFAULT: float = 90.0  # 30s × 3（ready/working/draining共通）
+
 
 # ----------------------------
 # relay HTTPヘルパー
@@ -1775,4 +1785,260 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         "presence": presence,
         "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
         "dry_run": dry_run,
+    }
+
+
+# ----------------------------
+# reducer: v3 event sourcing
+# ----------------------------
+
+
+def _parse_ow_event(msg: dict) -> dict | None:
+    """relayメッセージからow envelopeを解釈する。
+
+    Args:
+        msg: ow_historyから返されるメッセージdict
+
+    Returns:
+        {"msg_id": int, "handle": str, "body": dict, "created_at": str} または None
+    """
+    body = msg.get("body")
+    if not isinstance(body, dict):
+        return None
+    msg_id = msg.get("msg_id")
+    v = body.get("v")
+    if v != 1:
+        logger.warning(
+            "ow_service: skip msg_id=%s (envelope v=%r, expected 1)", msg_id, v
+        )
+        return None
+    kind = body.get("kind")
+    if kind not in ("command", "event"):
+        logger.warning(
+            "ow_service: skip msg_id=%s (kind=%r, expected command/event)", msg_id, kind
+        )
+        return None
+    return {
+        "msg_id": msg_id,
+        "handle": msg.get("handle"),
+        "body": body,
+        "created_at": msg.get("created_at"),
+    }
+
+
+def _query_latest_event(
+    channel: str, handle: str | None, data_type: str, since: int = 0
+) -> dict | None:
+    """指定 channel/handle/data_type の最新 event を返す（kind=event のみ対象）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（例: "identity", "state", "heartbeat"）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        最新のparsed event dict または None
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return None
+    result = None
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        if result is None or parsed["msg_id"] > result["msg_id"]:
+            result = parsed
+    return result
+
+
+def _query_events_since(
+    channel: str,
+    handle: str | None,
+    data_type: str | None,
+    since: int = 0,
+) -> list[dict]:
+    """指定条件のeventを時系列順で全件取得（kind=event のみ）。
+
+    Args:
+        channel: channelコード
+        handle: workerハンドル（Noneなら全handle対象）
+        data_type: eventのdata.type（Noneなら全type）
+        since: このmsg_idより大きいものを返す（0=全件）
+
+    Returns:
+        条件に合うparsed event dictのリスト（msg_id昇順）
+    """
+    history = ow_history(channel, since=since, limit=10000)
+    if "error" in history:
+        return []
+    results = []
+    for msg in history.get("messages", []):
+        if handle is not None and msg.get("handle") != handle:
+            continue
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if data_type is not None and parsed["body"].get("data", {}).get("type") != data_type:
+            continue
+        results.append(parsed)
+    return results
+
+
+def _infer_crash_cause(
+    workload_state: str | None, last_heartbeat_at: str | None
+) -> str | None:
+    """crash推論ロジック（DB不変、戻り値のみに付与）。
+
+    Args:
+        workload_state: 最新のworkload state文字列
+        last_heartbeat_at: 最後のheartbeat受信時刻（ISO形式文字列）
+
+    Returns:
+        crash推論結果文字列 または None（crashでない場合）
+    """
+    if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if last_heartbeat_at is None:
+        return None
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        timeout = _HEARTBEAT_TIMEOUT_SECS.get(workload_state, _HEARTBEAT_TIMEOUT_DEFAULT)
+        if elapsed < timeout:
+            return None
+        if workload_state == "draining":
+            return "crashed-during-drain (inferred)"
+        return "crashed (inferred)"
+    except (ValueError, TypeError):
+        return None
+
+
+def ow_get_identity(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 identity bundle を返す。crash 推論を含む。
+
+    crash 推論: 最新の event:state が terminal でない（loading/ready/working/blocked/
+               escalated/draining）かつ最後の event:heartbeat 受信時刻から閾値超過 →
+               メモリ上で inferred_cause を付与（DB 不変）。
+
+    Returns:
+        dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
+    """
+    identity_msg = _query_latest_event(channel, handle, "identity")
+    if identity_msg is None:
+        return None
+    data = identity_msg["body"].get("data", {})
+    result = dict(data)
+    result["msg_id"] = identity_msg["msg_id"]
+    result["identity_at"] = identity_msg["created_at"]
+
+    state_msg = _query_latest_event(channel, handle, "state")
+    workload_state = None
+    if state_msg is not None:
+        workload_state = state_msg["body"].get("data", {}).get("state")
+
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    last_heartbeat_at = heartbeat_msg["created_at"] if heartbeat_msg is not None else None
+
+    inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
+    if inferred_cause is not None:
+        result["inferred_cause"] = inferred_cause
+
+    return result
+
+
+def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
+    """channel 上の全 handle の identity リスト。alive_only=True で terminated を除外。"""
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return []
+
+    # handle別に最新identity msgを収集
+    latest_by_handle: dict[str, dict] = {}
+    for msg in history.get("messages", []):
+        parsed = _parse_ow_event(msg)
+        if parsed is None:
+            continue
+        if parsed["body"].get("kind") != "event":
+            continue
+        if parsed["body"].get("data", {}).get("type") != "identity":
+            continue
+        h = parsed["handle"]
+        if h not in latest_by_handle or parsed["msg_id"] > latest_by_handle[h]["msg_id"]:
+            latest_by_handle[h] = parsed
+
+    entries = []
+    for parsed in latest_by_handle.values():
+        data = parsed["body"].get("data", {})
+        entry = dict(data)
+        entry["msg_id"] = parsed["msg_id"]
+        entry["identity_at"] = parsed["created_at"]
+
+        if alive_only:
+            cause = entry.get("cause")
+            if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+                continue
+
+        entries.append(entry)
+
+    return entries
+
+
+def ow_get_presence(channel: str, handle: str) -> dict | None:
+    """最新 heartbeat 受信時刻から online/offline を推論する。
+
+    T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
+    SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
+
+    Returns:
+        dict: {handle, status("online"|"offline"|"unknown"), last_heartbeat_at, phase}
+    """
+    heartbeat_msg = _query_latest_event(channel, handle, "heartbeat")
+    if heartbeat_msg is None:
+        return {"handle": handle, "status": "unknown", "last_heartbeat_at": None, "phase": None}
+
+    last_heartbeat_at = heartbeat_msg["created_at"]
+    phase = heartbeat_msg["body"].get("data", {}).get("phase")
+    timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase or "", _HEARTBEAT_TIMEOUT_DEFAULT)
+
+    try:
+        hb_time = datetime.fromisoformat(last_heartbeat_at)
+        if hb_time.tzinfo is None:
+            hb_time = hb_time.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - hb_time).total_seconds()
+        status = "online" if elapsed < timeout else "offline"
+    except (ValueError, TypeError):
+        status = "unknown"
+
+    return {
+        "handle": handle,
+        "status": status,
+        "last_heartbeat_at": last_heartbeat_at,
+        "phase": phase,
+    }
+
+
+def ow_get_workload_state(channel: str, handle: str) -> dict | None:
+    """指定 handle の最新 workload state を返す。"""
+    state_msg = _query_latest_event(channel, handle, "state")
+    if state_msg is None:
+        return None
+    data = state_msg["body"].get("data", {})
+    return {
+        "handle": handle,
+        "state": data.get("state"),
+        "cause": data.get("cause"),
+        "msg_id": state_msg["msg_id"],
+        "state_at": state_msg["created_at"],
     }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1907,8 +1907,15 @@ def _infer_crash_cause(
 
     Returns:
         crash推論結果文字列 または None（crashでない場合）
+
+    Notes:
+        escalated は workload state machine 上は non-terminal だが、人間対話中の
+        worker は heartbeat 停止が「異常」を意味しないため watchdog 対象外
+        （orch SKILL.md・playbook.md でも明示）。crash 推論からも除外する。
     """
     if workload_state not in _NON_TERMINAL_WORKLOAD_STATES:
+        return None
+    if workload_state == "escalated":
         return None
     if last_heartbeat_at is None:
         return None

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -1,0 +1,288 @@
+"""heartbeat.sh のユニットテスト
+
+scripts/ow/heartbeat.sh が relay /send エンドポイントへ正しい
+v3 envelope を送信し、PHASE_FILE の値でインターバルを切り替え、
+ファイル削除でループが停止することを検証する。
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent / "scripts" / "ow" / "heartbeat.sh"
+)
+
+# ========================================
+# Mock relay server
+# ========================================
+
+
+class _RelayHandler(BaseHTTPRequestHandler):
+    """POST /send リクエストを受け取って記録するスタブ"""
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            data = {}
+        self.server.received.append(data)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"msg_id": 1}')
+
+    def log_message(self, *args):
+        pass  # suppress output
+
+
+def _start_mock_relay():
+    """空きポートでスタブサーバーを起動し (server, url) を返す"""
+    server = HTTPServer(("127.0.0.1", 0), _RelayHandler)
+    server.received = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    return server, f"http://127.0.0.1:{port}"
+
+
+# ========================================
+# Fixtures
+# ========================================
+
+
+@pytest.fixture
+def mock_relay():
+    server, url = _start_mock_relay()
+    yield server, url
+    server.shutdown()
+
+
+@pytest.fixture
+def tmp_phase_file(tmp_path):
+    f = tmp_path / "ow_hb_phase_test"
+    f.write_text("loading")
+    yield f
+    if f.exists():
+        f.unlink()
+
+
+# ========================================
+# Tests
+# ========================================
+
+
+class TestHeartbeatShSyntax:
+    def test_script_exists(self):
+        assert SCRIPT_PATH.exists(), f"heartbeat.sh が存在しない: {SCRIPT_PATH}"
+
+    def test_script_is_executable_or_interpretable(self):
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"bash -n が失敗: {result.stderr}"
+
+
+class TestHeartbeatShEnvelope:
+    def test_sends_v3_envelope_with_loading_phase(self, mock_relay, tmp_phase_file):
+        """loading フェーズで v3 envelope が /send に届く"""
+        server, relay_url = mock_relay
+        tmp_phase_file.write_text("loading")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_TEST", "w-test"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # 最低1件届くまで待つ（最大2秒）
+        deadline = time.time() + 2.0
+        while not server.received and time.time() < deadline:
+            time.sleep(0.05)
+
+        # ループ停止
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+
+        assert len(server.received) >= 1
+        req = server.received[0]
+        body = req.get("body", {})
+        assert body.get("v") == 1
+        assert body.get("kind") == "event"
+        assert body.get("from") == "w-test"
+        data = body.get("data", {})
+        assert data.get("type") == "heartbeat"
+        assert data.get("phase") == "loading"
+
+    def test_sends_v3_envelope_with_ready_phase(self, mock_relay, tmp_phase_file):
+        """ready フェーズで v3 envelope の phase フィールドが ready になる"""
+        server, relay_url = mock_relay
+        tmp_phase_file.write_text("ready")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_TEST", "w-test"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.time() + 2.0
+        while not server.received and time.time() < deadline:
+            time.sleep(0.05)
+
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+
+        assert len(server.received) >= 1
+        body = server.received[0].get("body", {})
+        assert body.get("data", {}).get("phase") == "ready"
+
+    def test_channel_and_handle_in_request(self, mock_relay, tmp_phase_file):
+        """channel と handle が relay /send リクエストに含まれる"""
+        server, relay_url = mock_relay
+        tmp_phase_file.write_text("loading")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "MY_CHANNEL", "my-handle"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.time() + 2.0
+        while not server.received and time.time() < deadline:
+            time.sleep(0.05)
+
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+
+        assert len(server.received) >= 1
+        req = server.received[0]
+        assert req.get("channel") == "MY_CHANNEL"
+        assert req.get("handle") == "my-handle"
+
+
+class TestHeartbeatShLoopControl:
+    def test_loop_stops_when_phase_file_deleted(self, mock_relay, tmp_phase_file):
+        """PHASE_FILE 削除でループが終了する"""
+        server, relay_url = mock_relay
+        tmp_phase_file.write_text("loading")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_STOP", "w-stop"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # 1件届くまで待つ
+        deadline = time.time() + 2.0
+        while not server.received and time.time() < deadline:
+            time.sleep(0.05)
+
+        # PHASE_FILEを削除してループ停止を誘発
+        tmp_phase_file.unlink()
+
+        # スクリプトが正常終了するまで待つ（最大3秒）
+        try:
+            proc.wait(timeout=3)
+            exited = True
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+            exited = False
+
+        assert exited, "PHASE_FILE 削除後にスクリプトが終了しなかった"
+
+    def test_interval_switches_with_phase(self, mock_relay, tmp_phase_file):
+        """PHASE_FILE を loading → ready に変更すると interval が変わる"""
+        server, relay_url = mock_relay
+        tmp_phase_file.write_text("loading")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_SWITCH", "w-switch"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # loading フェーズで数件届くのを確認
+        deadline = time.time() + 1.5
+        while len(server.received) < 2 and time.time() < deadline:
+            time.sleep(0.05)
+
+        loading_count = len(server.received)
+
+        # ready フェーズに切り替え
+        tmp_phase_file.write_text("ready")
+
+        deadline = time.time() + 1.0
+        while len(server.received) < loading_count + 1 and time.time() < deadline:
+            time.sleep(0.05)
+
+        # ready フェーズのメッセージが届いているはず
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+
+        ready_msgs = [
+            m for m in server.received
+            if m.get("body", {}).get("data", {}).get("phase") == "ready"
+        ]
+        assert len(ready_msgs) >= 1

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -227,6 +227,11 @@ class TestInferCrashCause:
         result = ow_service._infer_crash_cause("working", None)
         assert result is None
 
+    def test_escalated_state_returns_none(self):
+        """state="escalated"（人間対話中）は heartbeat が古くても crash 推論対象外。"""
+        result = ow_service._infer_crash_cause("escalated", self._old_hb(600))
+        assert result is None
+
 
 # ----------------------------
 # TestOwGetIdentity

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,4 +1,6 @@
 """ow_service reducer 4関数のユニットテスト (T39)"""
+import logging
+
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -58,7 +60,6 @@ class TestParseOwEvent:
         """v=2 → None を返し、warningログを出す。"""
         body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
         msg = _make_msg(10, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None
@@ -68,7 +69,6 @@ class TestParseOwEvent:
         """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
         body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
         msg = _make_msg(11, "w-h", body)
-        import logging
         with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
             result = ow_service._parse_ow_event(msg)
         assert result is None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,4 +1,4 @@
-"""ow_service reducer 4関数のユニットテスト (T39)"""
+"""ow_service reducer 4関数のユニットテスト。"""
 import logging
 
 import pytest

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,0 +1,372 @@
+"""ow_service reducer 4関数のユニットテスト (T39)"""
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from src.services import ow_service
+
+
+# ----------------------------
+# テストヘルパー
+# ----------------------------
+
+
+def _make_msg(msg_id, handle, body, created_at=None):
+    """テスト用リレーメッセージを生成する。"""
+    return {
+        "msg_id": msg_id,
+        "handle": handle,
+        "body": body,
+        "created_at": created_at or "2026-06-14T10:00:00+00:00",
+    }
+
+
+def _event_body(data_type, data_payload, handle="w-h", to="orch"):
+    """v:1 / kind:event の envelope を生成する。"""
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": to,
+        "data": {"type": data_type, **data_payload},
+    }
+
+
+def _make_history(messages):
+    return {"messages": messages}
+
+
+# ----------------------------
+# TestParseOwEvent
+# ----------------------------
+
+
+class TestParseOwEvent:
+    """_parse_ow_event のユニットテスト。"""
+
+    def test_valid_event_returns_parsed(self):
+        """v=1, kind="event" → 正常にparsed dictを返す。"""
+        body = _event_body("identity", {"alias": "w-1"})
+        msg = _make_msg(42, "w-h", body, "2026-06-14T10:00:00+00:00")
+        result = ow_service._parse_ow_event(msg)
+        assert result is not None
+        assert result["msg_id"] == 42
+        assert result["handle"] == "w-h"
+        assert result["body"] == body
+        assert result["created_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_v_mismatch_returns_none_with_warning(self, caplog):
+        """v=2 → None を返し、warningログを出す。"""
+        body = {"v": 2, "kind": "event", "data": {"type": "identity"}}
+        msg = _make_msg(10, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("envelope v=" in r.message for r in caplog.records)
+
+    def test_unknown_kind_returns_none_with_warning(self, caplog):
+        """kind="state"（commandでもeventでもない） → None を返し、warningログを出す。"""
+        body = {"v": 1, "kind": "state", "data": {"type": "identity"}}
+        msg = _make_msg(11, "w-h", body)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("kind=" in r.message for r in caplog.records)
+
+    def test_non_dict_body_returns_none(self):
+        """body=None → None を返す。"""
+        msg = _make_msg(12, "w-h", None)
+        result = ow_service._parse_ow_event(msg)
+        assert result is None
+
+
+# ----------------------------
+# TestQueryLatestEvent
+# ----------------------------
+
+
+class TestQueryLatestEvent:
+    """_query_latest_event のユニットテスト。"""
+
+    def test_returns_latest_by_msg_id(self, monkeypatch):
+        """同じdata_typeが2件 → msg_id大きい方を返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(5, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is not None
+        assert result["msg_id"] == 5
+
+    def test_handle_filter(self, monkeypatch):
+        """複数handleがいる時、指定handleのみ返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-a", "state")
+        assert result is not None
+        assert result["handle"] == "w-a"
+
+    def test_handle_none_returns_any_handle(self, monkeypatch):
+        """handle=Noneなら全handleを対象にする。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
+            _make_msg(3, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", None, "state")
+        assert result is not None
+        assert result["msg_id"] == 3
+
+    def test_command_kind_skipped(self, monkeypatch):
+        """kind="command" のメッセージはスキップされる。"""
+        body = {"v": 1, "kind": "command", "data": {"type": "state"}}
+        msgs = [_make_msg(1, "w-h", body)]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_history_error_returns_none(self, monkeypatch):
+        """ow_historyがerrorを返す → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_latest_event("ch", "w-h", "state")
+        assert result is None
+
+    def test_since_parameter_passed_to_history(self, monkeypatch):
+        """sinceパラメータがow_historyに渡される。"""
+        received = {}
+
+        def fake_history(channel, since=0, limit=100):
+            received["since"] = since
+            return _make_history([])
+
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+        ow_service._query_latest_event("ch", "w-h", "state", since=42)
+        assert received["since"] == 42
+
+
+# ----------------------------
+# TestQueryEventsSince
+# ----------------------------
+
+
+class TestQueryEventsSince:
+    """_query_events_since のユニットテスト。"""
+
+    def test_returns_all_matching(self, monkeypatch):
+        """複数件返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", "heartbeat")
+        assert len(result) == 2
+
+    def test_data_type_none_matches_all_events(self, monkeypatch):
+        """data_type=Noneなら全eventが返る。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "working"})),
+            _make_msg(2, "w-h", _event_body("heartbeat", {"phase": "working"})),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service._query_events_since("ch", "w-h", None)
+        assert len(result) == 2
+
+    def test_history_error_returns_empty(self, monkeypatch):
+        """ow_historyがerror → 空リスト。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+        result = ow_service._query_events_since("ch", "w-h", "state")
+        assert result == []
+
+
+# ----------------------------
+# TestInferCrashCause
+# ----------------------------
+
+
+class TestInferCrashCause:
+    """_infer_crash_cause のユニットテスト。"""
+
+    def _old_hb(self, seconds_ago=200):
+        """現在時刻からseconds_ago秒前のISO文字列を返す。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def _recent_hb(self, seconds_ago=10):
+        """直近のheartbeat時刻。"""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return dt.isoformat()
+
+    def test_non_terminal_state_with_timeout_returns_crashed(self):
+        """state="working", 古いheartbeat → "crashed (inferred)"。"""
+        result = ow_service._infer_crash_cause("working", self._old_hb(200))
+        assert result == "crashed (inferred)"
+
+    def test_draining_with_timeout_returns_crashed_during_drain(self):
+        """state="draining", 古いheartbeat → "crashed-during-drain (inferred)"。"""
+        result = ow_service._infer_crash_cause("draining", self._old_hb(200))
+        assert result == "crashed-during-drain (inferred)"
+
+    def test_terminal_state_returns_none(self):
+        """state="terminated" → None。"""
+        result = ow_service._infer_crash_cause("terminated", self._old_hb(200))
+        assert result is None
+
+    def test_recent_heartbeat_returns_none(self):
+        """state="working", 直近heartbeat → None（まだ生きてる）。"""
+        result = ow_service._infer_crash_cause("working", self._recent_hb(10))
+        assert result is None
+
+    def test_none_heartbeat_returns_none(self):
+        """last_heartbeat_at=None → None。"""
+        result = ow_service._infer_crash_cause("working", None)
+        assert result is None
+
+
+# ----------------------------
+# TestOwGetIdentity
+# ----------------------------
+
+
+class TestOwGetIdentity:
+    """ow_get_identity のユニットテスト。"""
+
+    def _setup_history(self, monkeypatch, messages):
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(messages))
+
+    def test_returns_identity_with_msg_id_and_at(self, monkeypatch):
+        """正常系: identity eventがある → bundle + msg_id + identity_at を返す。"""
+        msgs = [
+            _make_msg(
+                1, "w-h",
+                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
+                "2026-06-14T10:00:00+00:00",
+            ),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result["alias"] == "worker-1"
+        assert result["msg_id"] == 1
+        assert result["identity_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_returns_none_when_no_identity(self, monkeypatch):
+        """identity eventなし → None。"""
+        self._setup_history(monkeypatch, [])
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is None
+
+    def test_inferred_cause_added_on_crash(self, monkeypatch):
+        """workingで古いheartbeat → inferred_cause付き。"""
+        old_hb = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("identity", {"alias": "worker-1"}), "2026-06-14T09:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T09:01:00+00:00"),
+            _make_msg(3, "w-h", _event_body("heartbeat", {"phase": "working"}), old_hb),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result.get("inferred_cause") == "crashed (inferred)"
+
+
+# ----------------------------
+# TestOwListIdentities
+# ----------------------------
+
+
+class TestOwListIdentities:
+    """ow_list_identities のユニットテスト。"""
+
+    def test_returns_all_handles(self, monkeypatch):
+        """2つのhandleそれぞれのidentityを返す。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch")
+        aliases = {e["alias"] for e in result}
+        assert aliases == {"worker-a", "worker-b"}
+
+    def test_alive_only_excludes_terminated(self, monkeypatch):
+        """alive_only=True → cause=closedを除外する。"""
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b", "cause": "closed"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch", alive_only=True)
+        assert len(result) == 1
+        assert result[0]["alias"] == "worker-a"
+
+
+# ----------------------------
+# TestOwGetPresence
+# ----------------------------
+
+
+class TestOwGetPresence:
+    """ow_get_presence のユニットテスト。"""
+
+    def test_online_with_recent_heartbeat(self, monkeypatch):
+        """直近heartbeat → online。"""
+        recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), recent),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "online"
+        assert result["handle"] == "w-h"
+
+    def test_offline_with_old_heartbeat(self, monkeypatch):
+        """古いheartbeat → offline。"""
+        old = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
+        msgs = [
+            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), old),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "offline"
+
+    def test_unknown_when_no_heartbeat(self, monkeypatch):
+        """heartbeatなし → unknown。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "unknown"
+        assert result["last_heartbeat_at"] is None
+
+
+# ----------------------------
+# TestOwGetWorkloadState
+# ----------------------------
+
+
+class TestOwGetWorkloadState:
+    """ow_get_workload_state のユニットテスト。"""
+
+    def test_returns_latest_state(self, monkeypatch):
+        """最新stateを返す。"""
+        msgs = [
+            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
+            _make_msg(2, "w-h", _event_body("state", {"state": "working", "cause": None}), "2026-06-14T10:01:00+00:00"),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is not None
+        assert result["state"] == "working"
+        assert result["handle"] == "w-h"
+        assert result["msg_id"] == 2
+        assert result["state_at"] == "2026-06-14T10:01:00+00:00"
+
+    def test_returns_none_when_no_state(self, monkeypatch):
+        """stateなし → None。"""
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is None

--- a/tests/unit/test_relay_server.py
+++ b/tests/unit/test_relay_server.py
@@ -1,0 +1,175 @@
+"""relay/server.py のユニットテスト。
+
+カバー範囲:
+- _broadcast: 送信者と同一handleの購読者はブロードキャスト対象外（test_case17相当）
+- _broadcast: SSE notifyペイロードに msg_id / body / handle / created_at の4フィールドが添付される
+- init_db: idx_messages_channel_msg_id / idx_messages_channel_handle_msg インデックスが作成される
+"""
+import json
+import queue
+import sqlite3
+
+import pytest
+
+import src.relay.server as srv
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    db_path = str(tmp_path / "relay.db")
+    srv.init_db(db_path)
+    return db_path
+
+
+@pytest.fixture
+def channel(tmp_db):
+    code = srv.create_channel(tmp_db)
+    yield code
+    with srv._sub_lock:
+        srv._subscribers.pop(code, None)
+
+
+def _make_msg(channel_code, handle="alice", body='{"v":1}', msg_id=1):
+    return {
+        "msg_id": msg_id,
+        "channel_code": channel_code,
+        "handle": handle,
+        "body": body,
+        "needs_reply": False,
+        "in_reply_to": None,
+        "created_at": "2026-06-14T10:00:00+00:00",
+    }
+
+
+class TestBroadcastSenderExcluded:
+    """送信者と同一handleの購読者はブロードキャスト対象外（test_case17相当）。"""
+
+    def test_sender_handle_excluded_from_broadcast(self, channel):
+        """送信者alice自身のqueueにはメッセージが届かず、別ユーザーbobのqueueには届く。"""
+        sender_q: queue.Queue = queue.Queue()
+        other_q: queue.Queue = queue.Queue()
+
+        with srv._sub_lock:
+            srv._subscribers[channel] = [
+                ("alice", sender_q),
+                ("bob", other_q),
+            ]
+
+        srv._broadcast(channel, "alice", _make_msg(channel))
+
+        assert not other_q.empty(), "bob にメッセージが届いていない"
+        assert sender_q.empty(), "送信者 alice 自身にエコーされた"
+
+    def test_multiple_same_handle_all_excluded(self, channel):
+        """送信者と同じhandleを持つ複数purchaserが全員除外される。"""
+        alice_q1: queue.Queue = queue.Queue()
+        alice_q2: queue.Queue = queue.Queue()
+        bob_q: queue.Queue = queue.Queue()
+
+        with srv._sub_lock:
+            srv._subscribers[channel] = [
+                ("alice", alice_q1),
+                ("alice", alice_q2),
+                ("bob", bob_q),
+            ]
+
+        srv._broadcast(channel, "alice", _make_msg(channel))
+
+        assert alice_q1.empty(), "alice の1つ目のqueueにエコーされた"
+        assert alice_q2.empty(), "alice の2つ目のqueueにエコーされた"
+        assert not bob_q.empty(), "bob にメッセージが届いていない"
+
+
+class TestBroadcastPayloadBody:
+    """SSE notifyペイロードにbody本体4フィールドが添付される。"""
+
+    def test_payload_contains_msg_id(self, channel):
+        """ペイロードにmsg_idが含まれる。"""
+        q: queue.Queue = queue.Queue()
+        with srv._sub_lock:
+            srv._subscribers[channel] = [("bob", q)]
+
+        srv._broadcast(channel, "alice", _make_msg(channel, msg_id=42))
+        payload = json.loads(q.get(timeout=1))
+
+        assert payload["msg_id"] == 42
+
+    def test_payload_contains_body(self, channel):
+        """ペイロードにbody（JSON文字列）が含まれる。"""
+        body_content = '{"v":1,"kind":"event","data":{"type":"state"}}'
+        q: queue.Queue = queue.Queue()
+        with srv._sub_lock:
+            srv._subscribers[channel] = [("bob", q)]
+
+        srv._broadcast(channel, "alice", _make_msg(channel, body=body_content))
+        payload = json.loads(q.get(timeout=1))
+
+        assert payload["body"] == body_content
+
+    def test_payload_contains_handle(self, channel):
+        """ペイロードにhandleが含まれる。"""
+        q: queue.Queue = queue.Queue()
+        with srv._sub_lock:
+            srv._subscribers[channel] = [("bob", q)]
+
+        srv._broadcast(channel, "alice", _make_msg(channel, handle="alice"))
+        payload = json.loads(q.get(timeout=1))
+
+        assert payload["handle"] == "alice"
+
+    def test_payload_contains_created_at(self, channel):
+        """ペイロードにcreated_atが含まれる。"""
+        q: queue.Queue = queue.Queue()
+        with srv._sub_lock:
+            srv._subscribers[channel] = [("bob", q)]
+
+        msg = _make_msg(channel)
+        srv._broadcast(channel, "alice", msg)
+        payload = json.loads(q.get(timeout=1))
+
+        assert payload["created_at"] == "2026-06-14T10:00:00+00:00"
+
+    def test_payload_excludes_extra_fields(self, channel):
+        """ペイロードにchannel_code/needs_reply/in_reply_toは含まれない。"""
+        q: queue.Queue = queue.Queue()
+        with srv._sub_lock:
+            srv._subscribers[channel] = [("bob", q)]
+
+        srv._broadcast(channel, "alice", _make_msg(channel))
+        payload = json.loads(q.get(timeout=1))
+
+        assert "channel_code" not in payload
+        assert "needs_reply" not in payload
+        assert "in_reply_to" not in payload
+
+
+class TestInitDbIndexes:
+    """init_db でインデックスが作成される（非破壊改修）。"""
+
+    def test_creates_channel_msg_id_index(self, tmp_path):
+        """idx_messages_channel_msg_id インデックスが作成される。"""
+        db_path = str(tmp_path / "relay.db")
+        srv.init_db(db_path)
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_channel_msg_id'"
+        ).fetchone()
+        conn.close()
+        assert row is not None, "idx_messages_channel_msg_id が作成されていない"
+
+    def test_creates_channel_handle_msg_index(self, tmp_path):
+        """idx_messages_channel_handle_msg インデックスが作成される。"""
+        db_path = str(tmp_path / "relay.db")
+        srv.init_db(db_path)
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_channel_handle_msg'"
+        ).fetchone()
+        conn.close()
+        assert row is not None, "idx_messages_channel_handle_msg が作成されていない"
+
+    def test_init_db_idempotent(self, tmp_path):
+        """init_db を2回呼んでも CREATE INDEX IF NOT EXISTS でエラーが起きない。"""
+        db_path = str(tmp_path / "relay.db")
+        srv.init_db(db_path)
+        srv.init_db(db_path)


### PR DESCRIPTION
## Summary
- PR #360/#361 が Stacked PR base 指定により main に着地しなかった件のリカバリ
- `feature/t41-orch-v3`（T38+T39+T40+T41 全部入り、w-l review対応含む）を main にマージ
- ついでに worker 同時稼働数上限を **3 → 5** に変更

## 含まれる変更
- `scripts/ow/heartbeat.sh` 新規（T40: heartbeat送信ループ）
- `skills/orch/SKILL.md` v3対応（T41: command/event envelope、heartbeat watchdog、identity reducer経由）
- `skills/orch/playbook.md` v3対応（T41）＋同時稼働上限 5 反映
- `skills/worker/SKILL.md` v3対応（T40: loading/draining lifecycle）
- `tests/unit/test_heartbeat_sh.py` 新規

## conflict 解決方針
`src/relay/server.py` / `tests/unit/test_ow_reducer.py` / `tests/unit/test_relay_server.py` は feature/t41-orch-v3 側（w-l レビュー対応の最終形）を採用。

## Test plan
- [ ] CI（unit + integration-e2e）緑
- [ ] マージ後 `git log main` で T40+T41 関連 commits 含む確認
- [ ] 反映後の orch 動作（reducer 経由 identity 取得等）確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)