### PR TITLE
fix: ow_spawn_worker task_file sanitization

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -848,14 +848,15 @@ def _write_task_file(
 
     acceptance_clean = _sanitize_task_body_field(acceptance, "acceptance")
     context_clean = _sanitize_task_body_field(context, "context")
+    playbook_clean = _sanitize_task_body_field(playbook, "playbook")
 
     body_lines = [f"# {fm_data['task']}: {task_title}".rstrip()]
     if acceptance_clean:
         body_lines += ["", "## Acceptance", "", acceptance_clean]
     if context_clean:
         body_lines += ["", "## Context", "", context_clean]
-    if playbook:
-        body_lines += ["", "## Playbook", "", playbook]
+    if playbook_clean:
+        body_lines += ["", "## Playbook", "", playbook_clean]
     body = "\n".join(body_lines) + "\n"
 
     content = f"---\n{fm_yaml}---\n\n{body}"

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -592,6 +592,31 @@ def _sanitize_queue_field(value: str) -> str:
     return " ".join(str(value).splitlines()).strip()
 
 
+# MCP/Claudeプロトコルで使われる予約XMLタグのパターン（antml:プレフィックス含む）
+_MCP_RESERVED_TAG_RE = re.compile(
+    r"</?(?:antml:)?(?:function_calls|invoke|parameter|tool_result)(?:\s[^>]*)?>",
+    re.IGNORECASE,
+)
+
+
+def _sanitize_task_body_field(value: str, field_name: str = "") -> str:
+    """task_file本文フィールド（acceptance/context等）からMCP予約XMLタグを除去する。
+
+    orchがtool callの引数としてフィールド値を渡すとき、XML構文ミスでタグ残骸
+    （例: </parameter>, <invoke name="..."> 等）が混入することがある。
+    workerがtask_fileとして読むとき、これらがMCPプロトコルの一部として
+    誤解釈される恐れがあるため、既知の予約タグは除去する。
+    """
+    cleaned, count = _MCP_RESERVED_TAG_RE.subn("", value)
+    if count:
+        logger.warning(
+            "_write_task_file: %sフィールドにMCP予約XMLタグが%d件混入していました（除去済み）",
+            field_name or "unknown",
+            count,
+        )
+    return cleaned
+
+
 def _format_queue_task_entry(
     task_n: int,
     title: str,
@@ -821,11 +846,14 @@ def _write_task_file(
     }
     fm_yaml = yaml.safe_dump(fm_data, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
+    acceptance_clean = _sanitize_task_body_field(acceptance, "acceptance")
+    context_clean = _sanitize_task_body_field(context, "context")
+
     body_lines = [f"# {fm_data['task']}: {task_title}".rstrip()]
-    if acceptance:
-        body_lines += ["", "## Acceptance", "", acceptance]
-    if context:
-        body_lines += ["", "## Context", "", context]
+    if acceptance_clean:
+        body_lines += ["", "## Acceptance", "", acceptance_clean]
+    if context_clean:
+        body_lines += ["", "## Context", "", context_clean]
     if playbook:
         body_lines += ["", "## Playbook", "", playbook]
     body = "\n".join(body_lines) + "\n"

--- a/tests/unit/test_ow_task_file_sanitize.py
+++ b/tests/unit/test_ow_task_file_sanitize.py
@@ -1,0 +1,168 @@
+"""_write_task_file / _sanitize_task_body_field のサニタイズ動作テスト"""
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+
+class TestSanitizeTaskBodyField:
+    def test_clean_input_unchanged(self):
+        """タグを含まない入力はそのまま返す"""
+        value = "完了条件: テスト全通過 + PR作成"
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result == value
+
+    def test_removes_closing_parameter_tag(self):
+        """末尾に混入した </parameter> タグを除去する"""
+        value = "テストが全通過すること</parameter>"
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result == "テストが全通過すること"
+        assert "</parameter>" not in result
+
+    def test_removes_opening_parameter_tag(self):
+        """開始タグ <parameter name="..."> を除去する"""
+        value = '<parameter name="acceptance">完了条件'
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result == "完了条件"
+
+    def test_removes_invoke_tags(self):
+        """<invoke> / </invoke> タグを除去する"""
+        value = '<invoke name="ow_spawn_worker">残骸</invoke>'
+        result = ow_service._sanitize_task_body_field(value, "context")
+        assert result == "残骸"
+        assert "<invoke" not in result
+        assert "</invoke>" not in result
+
+    def test_removes_function_calls_tags(self):
+        """<function_calls> / </function_calls> タグを除去する"""
+        value = "<function_calls>本文</function_calls>"
+        result = ow_service._sanitize_task_body_field(value)
+        assert result == "本文"
+
+    def test_removes_antml_prefix_tags(self):
+        """antml:プレフィックス付きタグも除去する"""
+        value = "<invoke>残骸</invoke>"
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result == "残骸"
+
+    def test_removes_tool_result_tags(self):
+        """<tool_result> タグを除去する"""
+        value = "<tool_result>出力</tool_result>"
+        result = ow_service._sanitize_task_body_field(value, "context")
+        assert result == "出力"
+
+    def test_removes_multiple_tags(self):
+        """複数のMCP予約タグが混在している場合も全て除去する"""
+        value = '</parameter></invoke><function_calls>本文</function_calls>'
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result == "本文"
+        assert "<" not in result
+
+    def test_case_insensitive(self):
+        """大文字小文字を区別しない"""
+        value = "</PARAMETER></INVOKE>"
+        result = ow_service._sanitize_task_body_field(value, "acceptance")
+        assert result.strip() == ""
+
+    def test_non_mcp_xml_preserved(self):
+        """MCP予約タグ以外のXMLタグはそのまま残す"""
+        value = "出力形式: <json>{'key': 'value'}</json>"
+        result = ow_service._sanitize_task_body_field(value, "context")
+        assert "<json>" in result
+
+    def test_empty_string(self):
+        """空文字列は空文字列を返す"""
+        assert ow_service._sanitize_task_body_field("", "acceptance") == ""
+
+
+class TestWriteTaskFileSanitize:
+    def test_acceptance_with_mcp_tags_written_clean(self, tmp_path: Path):
+        """acceptanceにMCPタグが混入してもtask_fileのAcceptanceセクションにタグが残らない"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path,
+            task_n=99,
+            alias="w-test",
+            channel="testchan",
+            cwd="/tmp",
+            model="claude-sonnet-4-6",
+            permission="auto",
+            task_title="サニタイズテスト",
+            acceptance="テスト全通過</parameter>",
+            context="",
+            playbook="",
+            timeout_min=30,
+            activity_id=None,
+            topic_id=None,
+        )
+        content = task_file.read_text(encoding="utf-8")
+        assert "</parameter>" not in content
+        assert "テスト全通過" in content
+        assert "## Acceptance" in content
+
+    def test_context_with_invoke_tags_written_clean(self, tmp_path: Path):
+        """contextに<invoke>タグが混入してもtask_fileのContextセクションにタグが残らない"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path,
+            task_n=99,
+            alias="w-test",
+            channel="testchan",
+            cwd="/tmp",
+            model="claude-sonnet-4-6",
+            permission="auto",
+            task_title="サニタイズテスト",
+            acceptance="",
+            context='<invoke name="foo">背景情報</invoke>',
+            playbook="",
+            timeout_min=30,
+            activity_id=None,
+            topic_id=None,
+        )
+        content = task_file.read_text(encoding="utf-8")
+        assert "<invoke" not in content
+        assert "</invoke>" not in content
+        assert "背景情報" in content
+        assert "## Context" in content
+
+    def test_acceptance_empty_after_sanitize_omits_section(self, tmp_path: Path):
+        """サニタイズ後にacceptanceが空になった場合はAcceptanceセクション自体を出力しない"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path,
+            task_n=99,
+            alias="w-test",
+            channel="testchan",
+            cwd="/tmp",
+            model="claude-sonnet-4-6",
+            permission="auto",
+            task_title="サニタイズテスト",
+            acceptance="</parameter>",
+            context="",
+            playbook="",
+            timeout_min=30,
+            activity_id=None,
+            topic_id=None,
+        )
+        content = task_file.read_text(encoding="utf-8")
+        assert "## Acceptance" not in content
+
+    def test_clean_input_acceptance_preserved(self, tmp_path: Path):
+        """タグを含まないacceptanceはそのまま書き出される"""
+        task_file = ow_service._write_task_file(
+            task_dir=tmp_path,
+            task_n=1,
+            alias="w-a",
+            channel="chan",
+            cwd="/tmp",
+            model="claude-sonnet-4-6",
+            permission="auto",
+            task_title="クリーンテスト",
+            acceptance="PRを作成してCIが通ること",
+            context="背景情報",
+            playbook="",
+            timeout_min=60,
+            activity_id=None,
+            topic_id=None,
+        )
+        content = task_file.read_text(encoding="utf-8")
+        assert "PRを作成してCIが通ること" in content
+        assert "背景情報" in content


### PR DESCRIPTION
## Summary

- `_sanitize_task_body_field()` を追加: MCP予約XMLタグ（`function_calls` / `invoke` / `parameter` / `tool_result`、`antml:` プレフィックス対応）を正規表現で除去し、混入件数を warning ログに出力
- `_write_task_file()` の `acceptance` / `context` にサニタイズを適用してから書き出すよう変更
- ユニットテスト 15 件追加（タグ除去・複合ケース・サニタイズ後空になった場合のセクション省略・クリーン入力の保持）

## 背景

orchがtool callの引数としてacceptance/contextを渡すとき、XML構文ミスでタグ残骸（例: `</parameter>`）が混入し、workerがtask_fileを読み込んだときにMCPプロトコル上で誤解釈される問題が実例として確認された。サニタイズ強化のみがスコープ（queue insert位置バグは別議論）。

## Test plan

- [ ] `uv run pytest tests/unit/test_ow_task_file_sanitize.py -v` — 新規テスト15件全通過
- [ ] `uv run pytest tests/unit/` — 既存含む1140件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)