### PR TITLE
feat: tmux ターミナルアダプタ実装 (OW_TERMINAL=tmux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,50 @@ claude.ai → Settings → Integrations → Add Integration からリモート�
 
 </details>
 
+## orch/worker フレームワーク
+
+複数のClaude Codeセッションを協調動作させる実験的なマルチエージェント基盤です。`ow_spawn_worker`・`ow_close_worker`などのMCPツールで、orchセッションからworkerセッションを起動・管理できます。
+
+### ターミナルアダプタの設定
+
+workerセッションを自動起動するには、`OW_TERMINAL`環境変数でターミナルアプリを指定します。
+
+| 値 | 動作 | 前提条件 |
+|----|------|---------|
+| `iterm2` | iTerm2の新規タブでworkerを起動 | macOS + iTerm2 |
+| `tmux` | tmuxの新規windowでworkerを起動 | tmuxがインストール済み |
+| `manual`（デフォルト） | 起動コマンドを返すだけ。手動で実行が必要 | なし |
+
+`.mcp.json`の`env`フィールドに追加します:
+
+```json
+{
+  "mcpServers": {
+    "claude-code-memory": {
+      "env": {
+        "OW_TERMINAL": "tmux"
+      }
+    }
+  }
+}
+```
+
+#### tmuxアダプタの動作
+
+- `OW_TERMINAL=tmux` に設定すると、`ow_spawn_worker`呼び出し時に自動でtmuxセッション（`ow-workers`）を作成し、新規windowでworkerを起動します
+- 既存の`ow-workers`セッションがある場合は、そこに新規windowを追加します
+- `ow_close_worker`を呼ぶと、対応するpaneをkillします
+- workerの安定IDにはtmux pane ID（`%0`、`%1`のような形式）を使用します
+
+#### tmuxの推奨設定
+
+Claude Codeをtmux内で使うには、`~/.tmux.conf`に以下を追加してください:
+
+```tmux
+set -g allow-passthrough on
+set -g extended-keys on
+```
+
 ## ライセンス
 
 MIT

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -5,7 +5,7 @@
 #   tmux.sh close <term_ref>           → pane IDでpaneをkill
 #
 # worker_cmdはshlex.quote等でエスケープ済みのシェルコマンド文字列を期待する。
-# bash -c に直接渡すため、呼び出し元でのエスケープが必要。
+# base64エンコード経由でコマンドを渡すため、特殊文字のインジェクション対策済み。
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
@@ -14,7 +14,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 ACTION="$1"
-SESSION_NAME="ow-workers"
+SESSION_NAME="${OW_TMUX_SESSION:-ow-workers}"
 
 case "$ACTION" in
   spawn)
@@ -30,9 +30,13 @@ case "$ACTION" in
       tmux new-session -d -s "$SESSION_NAME" -n "ow-base"
     fi
 
+    # シェルインジェクション対策: base64エンコードしてCWDとCMDを安全に渡す
+    CWD_B64=$(printf '%s' "$CWD" | base64 | tr -d '\n')
+    CMD_B64=$(printf '%s' "$WORKER_CMD" | base64 | tr -d '\n')
+
     # 新規windowを作成してworkerを起動、pane IDを返す
-    PANE_ID=$(tmux new-window -t "$SESSION_NAME" -P -F "#{pane_id}" -c "$CWD" -- \
-      bash -c "$WORKER_CMD")
+    PANE_ID=$(tmux new-window -t "$SESSION_NAME" -n "ow-worker" -P -F "#{pane_id}" -- \
+      bash -c "cd \$(echo $CWD_B64 | base64 -d) && \$(echo $CMD_B64 | base64 -d)")
 
     echo "$PANE_ID"
     ;;

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# tmux ターミナルアダプタ
+# 使い方:
+#   tmux.sh spawn <cwd> <worker_cmd>   → 新window起動、tmux pane IDをstdoutに返す
+#   tmux.sh close <term_ref>           → pane IDでpaneをkill
+#
+# worker_cmdはshlex.quote等でエスケープ済みのシェルコマンド文字列を期待する。
+# bash -c に直接渡すため、呼び出し元でのエスケープが必要。
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: tmux.sh spawn <cwd> <worker_cmd> | close <term_ref>" >&2
+  exit 1
+fi
+
+ACTION="$1"
+SESSION_NAME="ow-workers"
+
+case "$ACTION" in
+  spawn)
+    if [[ $# -lt 3 ]]; then
+      echo "Usage: tmux.sh spawn <cwd> <worker_cmd>" >&2
+      exit 1
+    fi
+    CWD="$2"
+    WORKER_CMD="$3"
+
+    # 既存セッションがなければ新規作成 (detached)。window 0 は基準窓として残す
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+      tmux new-session -d -s "$SESSION_NAME" -n "ow-base"
+    fi
+
+    # 新規windowを作成してworkerを起動、pane IDを返す
+    PANE_ID=$(tmux new-window -t "$SESSION_NAME" -P -F "#{pane_id}" -c "$CWD" -- \
+      bash -c "$WORKER_CMD")
+
+    echo "$PANE_ID"
+    ;;
+
+  close)
+    if [[ $# -lt 2 ]]; then
+      echo "Usage: tmux.sh close <term_ref>" >&2
+      exit 1
+    fi
+    TERM_REF="$2"
+    # pane IDでpaneをkill (存在しない場合はエラーを無視)
+    tmux kill-pane -t "$TERM_REF" 2>/dev/null || true
+    ;;
+
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+esac

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -1,0 +1,151 @@
+"""tmux.sh ターミナルアダプタのユニットテスト
+
+tmuxコマンドをモックして、spawn/closeの正常系・異常系・特殊文字処理を確認する。
+"""
+import os
+import subprocess
+from pathlib import Path
+
+ADAPTER = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "adapters" / "tmux.sh"
+MOCK_PANE_ID = "%42"
+
+
+def _make_mock_tmux(tmp_path: Path, *, has_session: bool = True, capture_file: Path | None = None) -> Path:
+    """tmuxをモックするシェルスクリプトを作成する。
+
+    spawn時はMOCK_PANE_IDを返す。close時は何も出力しない。
+    capture_fileが指定された場合、受け取った引数を追記する。
+    """
+    mock_dir = tmp_path / "mock_bin"
+    mock_dir.mkdir(exist_ok=True)
+    mock = mock_dir / "tmux"
+
+    has_session_exit = "0" if has_session else "1"
+    capture_cmd = f'printf "%s\\n" "$*" >> "{capture_file}"' if capture_file else ""
+
+    mock.write_text(
+        f'#!/usr/bin/env bash\n'
+        f'{capture_cmd}\n'
+        f'if [ "$1" = "has-session" ]; then exit {has_session_exit}; fi\n'
+        f'if [ "$1" = "new-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
+        f'exit 0\n'
+    )
+    mock.chmod(0o755)
+    return mock_dir
+
+
+def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple[subprocess.CompletedProcess, str]:
+    """tmux.shをモックtmux環境で実行し、(result, captured_args)を返す。"""
+    capture_file = tmp_path / "tmux_args.txt"
+    capture_file.write_text("")
+    mock_dir = _make_mock_tmux(tmp_path, capture_file=capture_file, **mock_kwargs)
+
+    env = os.environ.copy()
+    env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+
+    result = subprocess.run(
+        [str(ADAPTER)] + args,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, capture_file.read_text()
+
+
+class TestTmuxAdapterSpawn:
+    def test_spawn_returns_pane_id(self, tmp_path):
+        """通常のCWD/WORKER_CMDでspawnが正常終了し、tmux pane IDを返す。"""
+        result, _ = _run_adapter(["spawn", "/tmp/normal", "claude"], tmp_path)
+        assert result.returncode == 0
+        assert MOCK_PANE_ID in result.stdout
+
+    def test_spawn_creates_session_when_missing(self, tmp_path):
+        """tmuxセッションが存在しない場合、new-sessionが呼ばれる。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude"], tmp_path, has_session=False
+        )
+        assert result.returncode == 0
+        assert "new-session" in captured
+
+    def test_spawn_skips_session_creation_when_exists(self, tmp_path):
+        """tmuxセッションが既に存在する場合、new-sessionが呼ばれない。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude"], tmp_path, has_session=True
+        )
+        assert result.returncode == 0
+        assert "new-session" not in captured
+
+    def test_spawn_cwd_with_spaces(self, tmp_path):
+        """CWDにスペースが含まれても正常終了する。"""
+        result, _ = _run_adapter(["spawn", "/Users/John Doe/my project", "claude"], tmp_path)
+        assert result.returncode == 0
+
+    def test_spawn_worker_cmd_with_single_quotes(self, tmp_path):
+        """WORKER_CMDにシングルクォートが含まれても正常終了する。"""
+        cmd = "claude --arg 'value with spaces'"
+        result, _ = _run_adapter(["spawn", "/tmp/work", cmd], tmp_path)
+        assert result.returncode == 0
+
+    def test_spawn_worker_cmd_with_backslash(self, tmp_path):
+        """WORKER_CMDにバックスラッシュが含まれても正常終了する。"""
+        cmd = r'claude --path /some/path\ with\ spaces'
+        result, _ = _run_adapter(["spawn", "/tmp/work", cmd], tmp_path)
+        assert result.returncode == 0
+
+    def test_spawn_worker_cmd_with_japanese(self, tmp_path):
+        """WORKER_CMDに日本語が含まれても正常終了する。"""
+        cmd = 'claude "workerスキルに従って作業を開始して。"'
+        result, _ = _run_adapter(["spawn", "/tmp/work", cmd], tmp_path)
+        assert result.returncode == 0
+
+    def test_spawn_new_window_called(self, tmp_path):
+        """spawnでtmux new-windowが呼ばれる。"""
+        result, captured = _run_adapter(["spawn", "/tmp/work", "claude"], tmp_path)
+        assert result.returncode == 0
+        assert "new-window" in captured
+
+
+class TestTmuxAdapterClose:
+    def test_close_normal_pane_id(self, tmp_path):
+        """%42形式のpane IDでcloseが正常終了する。"""
+        result, captured = _run_adapter(["close", "%42"], tmp_path)
+        assert result.returncode == 0
+        assert "kill-pane" in captured
+
+    def test_close_pane_id_passed_to_kill(self, tmp_path):
+        """closeでtmux kill-paneにpane IDが渡される。"""
+        result, captured = _run_adapter(["close", "%99"], tmp_path)
+        assert result.returncode == 0
+        assert "%99" in captured
+
+    def test_close_nonexistent_pane_exits_zero(self, tmp_path):
+        """存在しないpane IDでもcloseはゼロで終了する（エラーを無視）。"""
+        # kill-paneが失敗しても || true で無視するため、exit 0 を期待
+        result, _ = _run_adapter(["close", "%999"], tmp_path)
+        assert result.returncode == 0
+
+
+class TestTmuxAdapterErrors:
+    def test_unknown_action_exits_nonzero(self, tmp_path):
+        """未知のactionはゼロ以外のexit codeとエラーメッセージを返す。"""
+        result, _ = _run_adapter(["unknown_action"], tmp_path)
+        assert result.returncode != 0
+        assert "Unknown action" in result.stderr
+
+    def test_no_args_exits_nonzero(self, tmp_path):
+        """引数なし呼び出しはゼロ以外のexit codeとUsageメッセージを返す。"""
+        result, _ = _run_adapter([], tmp_path)
+        assert result.returncode != 0
+        assert "Usage" in result.stderr
+
+    def test_spawn_missing_args_exits_nonzero(self, tmp_path):
+        """spawnで引数が足りない場合はゼロ以外のexit codeとUsageメッセージを返す。"""
+        result, _ = _run_adapter(["spawn", "/tmp/work"], tmp_path)
+        assert result.returncode != 0
+        assert "Usage" in result.stderr
+
+    def test_close_missing_args_exits_nonzero(self, tmp_path):
+        """closeで引数が足りない場合はゼロ以外のexit codeとUsageメッセージを返す。"""
+        result, _ = _run_adapter(["close"], tmp_path)
+        assert result.returncode != 0
+        assert "Usage" in result.stderr

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -10,11 +10,18 @@ ADAPTER = Path(__file__).resolve().parent.parent.parent / "scripts" / "ow" / "ad
 MOCK_PANE_ID = "%42"
 
 
-def _make_mock_tmux(tmp_path: Path, *, has_session: bool = True, capture_file: Path | None = None) -> Path:
+def _make_mock_tmux(
+    tmp_path: Path,
+    *,
+    has_session: bool = True,
+    capture_file: Path | None = None,
+    kill_pane_exit: int = 0,
+) -> Path:
     """tmuxをモックするシェルスクリプトを作成する。
 
     spawn時はMOCK_PANE_IDを返す。close時は何も出力しない。
     capture_fileが指定された場合、受け取った引数を追記する。
+    kill_pane_exitが1の場合、kill-paneが失敗するモックになる。
     """
     mock_dir = tmp_path / "mock_bin"
     mock_dir.mkdir(exist_ok=True)
@@ -28,14 +35,18 @@ def _make_mock_tmux(tmp_path: Path, *, has_session: bool = True, capture_file: P
         f'{capture_cmd}\n'
         f'if [ "$1" = "has-session" ]; then exit {has_session_exit}; fi\n'
         f'if [ "$1" = "new-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
+        f'if [ "$1" = "kill-pane" ]; then exit {kill_pane_exit}; fi\n'
         f'exit 0\n'
     )
     mock.chmod(0o755)
     return mock_dir
 
 
-def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple[subprocess.CompletedProcess, str]:
-    """tmux.shをモックtmux環境で実行し、(result, captured_args)を返す。"""
+def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple["subprocess.CompletedProcess[str]", str]:
+    """tmux.shをモックtmux環境で実行し、(result, captured_args)を返す。
+
+    mock_kwargsはそのまま_make_mock_tmuxに渡す（has_session, kill_pane_exitなど）。
+    """
     capture_file = tmp_path / "tmux_args.txt"
     capture_file.write_text("")
     mock_dir = _make_mock_tmux(tmp_path, capture_file=capture_file, **mock_kwargs)
@@ -122,6 +133,12 @@ class TestTmuxAdapterClose:
         """存在しないpane IDでもcloseはゼロで終了する（エラーを無視）。"""
         # kill-paneが失敗しても || true で無視するため、exit 0 を期待
         result, _ = _run_adapter(["close", "%999"], tmp_path)
+        assert result.returncode == 0
+
+    def test_close_pane_kill_failure_still_exits_zero(self, tmp_path):
+        """kill-paneがexit 1を返しても、|| true によりcloseはゼロで終了する。"""
+        # kill_pane_exit=1でkill-paneが常に失敗するモックを使用
+        result, _ = _run_adapter(["close", "%999"], tmp_path, kill_pane_exit=1)
         assert result.returncode == 0
 
 


### PR DESCRIPTION
## Summary

- `scripts/ow/adapters/tmux.sh` を新規作成。`OW_TERMINAL=tmux` 設定時に `ow_spawn_worker` から呼ばれ、tmux セッション (`ow-workers`) の新規 window で Claude Code worker を起動する
- iterm2.sh と同等のインターフェース: `spawn <cwd> <worker_cmd>` → pane ID 返却 / `close <term_ref>` → pane kill
- 既存 tmux セッションがなければ自動作成、あれば新規 window を追加
- 安定 ID は tmux pane ID (`%0`、`%42` のような形式)
- `tests/unit/test_tmux_adapter.py` を追加（15 件）
- README に orch/worker フレームワーク説明とターミナルアダプタ設定方法を追記

## Test plan

- [ ] `uv run pytest tests/unit/test_tmux_adapter.py` — 15 件全通過を確認
- [ ] `uv run pytest tests/unit/` — 既存テスト全通過を確認
- [ ] (手動) `OW_TERMINAL=tmux` 設定で `ow_spawn_worker` を呼び、tmux の `ow-workers` セッションに新規 window が開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)