### PR TITLE
fix: worker起動コマンドに--add-dirでtask fileディレクトリを追加

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -950,6 +950,7 @@ def ow_spawn_worker(
         f'env OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
         f'OW_TASK_FILE={shlex.quote(str(task_file))} '
         f'claude --model {shlex.quote(model)} --permission-mode {shlex.quote(permission)} '
+        f'--add-dir {shlex.quote(str(task_file.parent))} '
         f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
     )
 

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -677,8 +677,7 @@ class TestOwSpawnWorkerManualFallback:
         assert result.get("manual") is True
         cmd = result["command"]
         expected_task_dir = str(tmp_path / "tasks")
-        assert "--add-dir" in cmd
-        assert expected_task_dir in cmd
+        assert f"--add-dir {expected_task_dir}" in cmd
 
 
 class TestOwSpawnWorkerAdapter:

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -665,6 +665,21 @@ class TestOwSpawnWorkerManualFallback:
         assert result.get("manual") is True
         assert "command" in result
 
+    def test_worker_cmd_includes_add_dir_for_task_file_dir(self, tmp_path: Path, monkeypatch):
+        """worker起動コマンドにtask_fileディレクトリへの--add-dirが含まれる（CWD外task fileの許可プロンプト抑制）"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", topic_id="99", task_n=1,
+        )
+        assert result.get("manual") is True
+        cmd = result["command"]
+        expected_task_dir = str(tmp_path / "tasks")
+        assert "--add-dir" in cmd
+        assert expected_task_dir in cmd
+
 
 class TestOwSpawnWorkerAdapter:
     """アダプタ経由でworkerを起動し、stdoutからterm_refを取得する"""


### PR DESCRIPTION
## Summary

- `permission-mode auto` はCWD外ファイルへのアクセスに許可プロンプトを出す動作をする
- worker が読む task file は `~/.cc-memory/ow/orch/tasks/` にあり、worker の cwd（リポジトリのworktree）とは別ディレクトリ
- worker 起動コマンドに `--add-dir <task_file_dir>` を追加し、task file ディレクトリへのアクセスを事前許可することで解消

## Changes

- `src/services/ow_service.py`: `ow_spawn_worker` の `worker_cmd` 構築に `--add-dir {task_file.parent}` を追加
- `tests/unit/test_ow_queue.py`: `--add-dir` がコマンドに含まれることを検証するテストを追加

## Test plan

- [x] `tests/unit/test_ow_queue.py` — 新規テスト `test_worker_cmd_includes_add_dir_for_task_file_dir` 追加・通過
- [x] 全テスト 1533件通過

🤖 Generated with [Claude Code](https://claude.ai/claude-code)