### PR TITLE
feat: ow 旧 cmd/state envelope cutoff

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -173,11 +173,11 @@ worker のバックグラウンドループ（scripts/ow/heartbeat.sh）が定�
 - 周期: loading=10秒、それ以外=30秒（M#258 §5.4.1、D#2525）
 - `phase` は workload state を写像する補助情報
 
-**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない（M#258 §4.4 / D#2522）。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
 
 ### 旧 cmd/state envelope の後方互換放棄
 
-D#2532 により、旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は D#2479 で凍結されており、過去レコードはそのまま残置される。
+旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は凍結されており、過去レコードはそのまま残置される。
 
 ## タスクキュー
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -36,7 +36,7 @@ workerが送信するメッセージはすべて `kind:event`:
 | `identity` | 参加者の身元情報 full snapshot | `"*"` |
 | `heartbeat` | liveness signal（バックグラウンドループが自動送信） | `"*"` |
 
-orchからworkerへ届くメッセージは `kind:command`（または旧形式 `kind:cmd`）。
+orchからworkerへ届くメッセージは `kind:command`。
 
 ## 起動シーケンス
 
@@ -146,7 +146,7 @@ aliasは**連番（w-a, w-b）ではなく任意の単語**を推奨する。orc
 
 ## cmd:assign の受信 → working
 
-orchから `kind:command, data.type:assign`（または旧形式 `kind:cmd, verb:assign`）が届いたら:
+orchから `kind:command, data.type:assign` が届いたら:
 
 1. 内容を確認し、`event:state(working)` を送信する:
    ```json
@@ -175,7 +175,7 @@ orchから `kind:command, data.type:assign`（または旧形式 `kind:cmd, verb
 ```
 
 orchの応答:
-- `command:answer`（または旧形式 `cmd:answer`）が届いたら、その回答に従って作業を再開し `event:state(working)` を送信する
+- `command:answer` が届いたら、その回答に従って作業を再開し `event:state(working)` を送信する
 - orchが「エスカレーションせよ」と判断した場合は §エスカレーション へ進む
 
 ## エスカレーション（escalated）
@@ -237,12 +237,12 @@ done送信後はcloseを受けるまで**読み取り専用**で待機する:
 - `event:state(terminated)` 以外のstateを送らない（`cmd:ping`への応答を除く）
 
 orchの応答:
-- `command:close`（または旧形式 `cmd:close`）→ §退場処理 を実行する
+- `command:close` → §退場処理 を実行する
 - `command:answer` 等で差し戻し（done検証NG）→ 指示に従い `event:state(working)` に戻って作業を再開
 
 ## 退場処理（cmd:close受信時）
 
-`command:close`（または旧形式 `cmd:close`）を受信したら以下の手順を順番に実行する:
+`command:close` を受信したら以下の手順を順番に実行する:
 
 ### Step 1: event:state(draining) を送信
 
@@ -324,7 +324,7 @@ SSE（Monitor）は起床信号専用。起床したら `ow_history(channel=<cha
 
 ## cmd:ping への応答
 
-orchから `kind:command, data.type:ping`（または旧形式 `kind:cmd, verb:ping`）が届いたら、現在の state を `event:state` で返す:
+orchから `kind:command, data.type:ping` が届いたら、現在の state を `event:state` で返す:
 
 ```json
 {"v":1, "kind":"event", "from":"<alias>", "to":"orch", "task":"T<task_n>", "data":{"type":"state", "state":"<現在のstate>", "note":"pong"}}

--- a/src/main.py
+++ b/src/main.py
@@ -1001,7 +1001,7 @@ def ow_send(
 ) -> dict:
     """ow channelにメッセージを送信する。
 
-    bodyはow固有JSONを格納するdict（{"v":1, "kind":"cmd"|"state", ...}）。
+    bodyはow固有JSONを格納するdict（{"v":1, "kind":"command"|"event", ...}）。
     4xx即失敗、5xx/接続断のみ3回指数バックオフ。
 
     Args:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1553,7 +1553,7 @@ def detect_crash_inconsistencies(
 
 
 def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
-    """workerにcrash復旧用cmd:pingを送信する。
+    """workerにcrash復旧用pingを送信する（kind:command / data.type:ping）。
 
     needs_reply=True で送り、応答はorchの通常受信ループで処理される。
     本関数はfire-and-forget（応答待ちはしない）。

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -478,7 +478,7 @@ def ow_send(
     Args:
         channel: channelコード
         handle: 送信者handle（例: "orch", "w-a"）
-        body: ow固有JSON（{"v":1, "kind":"cmd"|"state", ...}）
+        body: ow固有JSON（{"v":1, "kind":"command"|"event", ...}）
         needs_reply: 返信を期待するか
         in_reply_to: 返信先のmsg_id
 
@@ -1389,11 +1389,14 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
         body = msg.get("body", {})
         if not isinstance(body, dict):
             continue
-        if body.get("kind") != "state":
+        if body.get("kind") != "event":
+            continue
+        data = body.get("data") or {}
+        if data.get("type") != "state":
             continue
         alias = body.get("from") or ""
         task = body.get("task") or ""
-        state = body.get("state") or ""
+        state = data.get("state") or ""
         if not alias or not task or not state:
             continue
         key = f"{alias}:{task}"
@@ -1557,12 +1560,11 @@ def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
     """
     body = {
         "v": 1,
-        "kind": "cmd",
+        "kind": "command",
         "from": "orch",
         "to": alias,
         "task": task or "T0",
-        "verb": "ping",
-        "data": {"recovery": True},
+        "data": {"type": "ping", "recovery": True},
     }
     return ow_send(channel=channel, handle="orch", body=body, needs_reply=True)
 

--- a/tests/integration/test_ow_crash_recovery.py
+++ b/tests/integration/test_ow_crash_recovery.py
@@ -110,8 +110,8 @@ def live_relay(tmp_path, monkeypatch):
 def _send_state(channel: str, alias: str, task: str, state: str):
     """workerからの state 宣言を実relayに送信する。"""
     body = {
-        "v": 1, "kind": "state", "from": alias, "to": "orch",
-        "task": task, "state": state, "data": {},
+        "v": 1, "kind": "event", "from": alias, "to": "orch",
+        "task": task, "data": {"type": "state", "state": state},
     }
     result = ow_service.ow_send(channel=channel, handle=alias, body=body)
     assert "msg_id" in result, f"send failed: {result}"
@@ -231,8 +231,9 @@ class TestCrashRecoveryScenario:
             ping_msgs = [
                 m for m in history["messages"]
                 if isinstance(m.get("body"), dict)
-                and m["body"].get("kind") == "cmd"
-                and m["body"].get("verb") == "ping"
+                and m["body"].get("kind") == "command"
+                and isinstance(m["body"].get("data"), dict)
+                and m["body"]["data"].get("type") == "ping"
                 and m["body"].get("to") == "w-z"
             ]
             assert ping_msgs, "ping was not actually delivered to relay"

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -164,9 +164,9 @@ class TestReconstructStateFromRelay:
     def test_single_worker_multiple_states(self, monkeypatch):
         """同一workerが ready→working→done と進む → latest_state=done"""
         msgs = [
-            {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t1"},
-            {"msg_id": 2, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "working"}, "created_at": "t2"},
-            {"msg_id": 3, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t3"},
+            {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "ready"}}, "created_at": "t1"},
+            {"msg_id": 2, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "working"}}, "created_at": "t2"},
+            {"msg_id": 3, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "done"}}, "created_at": "t3"},
         ]
         monkeypatch.setattr(
             ow_service, "ow_history",
@@ -183,8 +183,8 @@ class TestReconstructStateFromRelay:
     def test_multiple_workers_isolated(self, monkeypatch):
         """異なる (alias, task) のstateは独立に集計される"""
         msgs = [
-            {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t1"},
-            {"msg_id": 2, "body": {"kind": "state", "from": "w-b", "task": "T2", "state": "working"}, "created_at": "t2"},
+            {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "ready"}}, "created_at": "t1"},
+            {"msg_id": 2, "body": {"v": 1, "kind": "event", "from": "w-b", "task": "T2", "data": {"type": "state", "state": "working"}}, "created_at": "t2"},
         ]
         monkeypatch.setattr(
             ow_service, "ow_history",
@@ -195,11 +195,11 @@ class TestReconstructStateFromRelay:
         assert result["by_worker_task"]["w-a:T1"]["latest_state"] == "ready"
         assert result["by_worker_task"]["w-b:T2"]["latest_state"] == "working"
 
-    def test_cmd_messages_are_ignored(self, monkeypatch):
-        """kind=cmdのメッセージは集計から除外される"""
+    def test_command_messages_are_ignored(self, monkeypatch):
+        """kind=commandのメッセージはstate集計から除外される"""
         msgs = [
-            {"msg_id": 1, "body": {"kind": "cmd", "from": "orch", "to": "w-a", "task": "T1", "verb": "assign"}},
-            {"msg_id": 2, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t2"},
+            {"msg_id": 1, "body": {"v": 1, "kind": "command", "from": "orch", "to": "w-a", "task": "T1", "data": {"type": "assign"}}},
+            {"msg_id": 2, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "ready"}}, "created_at": "t2"},
         ]
         monkeypatch.setattr(
             ow_service, "ow_history",
@@ -207,17 +207,17 @@ class TestReconstructStateFromRelay:
         )
         result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
         assert "w-a:T1" in result["by_worker_task"]
-        # ready 1件のみ集計、cmdはhistory_countに含まれない
+        # ready 1件のみ集計、commandはhistory_countに含まれない
         assert result["by_worker_task"]["w-a:T1"]["history_count"] == 1
 
     def test_malformed_messages_skipped(self, monkeypatch):
         """body無しやfrom/task/stateの欠落は無視される"""
         msgs = [
             {"msg_id": 1, "body": None},
-            {"msg_id": 2, "body": {"kind": "state", "from": "", "task": "T1", "state": "ready"}},
-            {"msg_id": 3, "body": {"kind": "state", "from": "w-a", "task": "", "state": "ready"}},
-            {"msg_id": 4, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": ""}},
-            {"msg_id": 5, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "ok"},
+            {"msg_id": 2, "body": {"v": 1, "kind": "event", "from": "", "task": "T1", "data": {"type": "state", "state": "ready"}}},
+            {"msg_id": 3, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "", "data": {"type": "state", "state": "ready"}}},
+            {"msg_id": 4, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": ""}}},
+            {"msg_id": 5, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "ready"}}, "created_at": "ok"},
         ]
         monkeypatch.setattr(
             ow_service, "ow_history",
@@ -239,6 +239,26 @@ class TestReconstructStateFromRelay:
         assert result["by_worker_task"] == {}
         assert result["max_msg_id"] == 0
         assert "error" in result
+
+    def test_old_kind_cmd_state_messages_are_skipped(self, monkeypatch):
+        """旧形式 kind=cmd/state のレコードは reconstruct_state_from_relay で無視される（v3 cutoff）"""
+        msgs = [
+            # 旧形式 kind:cmd
+            {"msg_id": 1, "body": {"kind": "cmd", "from": "orch", "to": "w-a", "task": "T1", "verb": "assign"}},
+            # 旧形式 kind:state
+            {"msg_id": 2, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "ready"}, "created_at": "t2"},
+            # 新形式 kind:event data.type:state のみ集計対象
+            {"msg_id": 3, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "working"}}, "created_at": "t3"},
+        ]
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: self._build_history(msgs),
+        )
+        result = ow_service.reconstruct_state_from_relay("ChAbCdEf")
+        # 旧形式はskipされ、新形式の1件のみ集計される
+        assert "w-a:T1" in result["by_worker_task"]
+        assert result["by_worker_task"]["w-a:T1"]["history_count"] == 1
+        assert result["by_worker_task"]["w-a:T1"]["latest_state"] == "working"
 
 
 # ----------------------------
@@ -590,7 +610,7 @@ class TestOwRecover:
             ow_service, "ow_history",
             lambda channel, since=0, limit=10000: {
                 "messages": [
-                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "working"}, "created_at": "t1"},
+                    {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "working"}}, "created_at": "t1"},
                 ]
             },
         )
@@ -621,7 +641,7 @@ class TestOwRecover:
             ow_service, "ow_history",
             lambda channel, since=0, limit=10000: {
                 "messages": [
-                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                    {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "done"}}, "created_at": "t1"},
                 ]
             },
         )
@@ -652,7 +672,7 @@ class TestOwRecover:
         assert len(result["applied"]["pings_sent"]) == 1
         assert result["applied"]["pings_sent"][0]["alias"] == "w-z"
         assert result["applied"]["pings_sent"][0]["reason"] == "orphan"
-        assert sent and sent[0]["body"]["verb"] == "ping"
+        assert sent and sent[0]["body"]["data"]["type"] == "ping"
         assert sent[0]["body"]["to"] == "w-z"
         assert sent[0]["needs_reply"] is True
 
@@ -710,7 +730,7 @@ class TestOwRecover:
             ow_service, "ow_history",
             lambda channel, since=0, limit=10000: {
                 "messages": [
-                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                    {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "done"}}, "created_at": "t1"},
                 ]
             },
         )
@@ -759,7 +779,7 @@ class TestOwRecover:
             ow_service, "ow_history",
             lambda channel, since=0, limit=10000: {
                 "messages": [
-                    {"msg_id": 1, "body": {"kind": "state", "from": "w-a", "task": "T1", "state": "done"}, "created_at": "t1"},
+                    {"msg_id": 1, "body": {"v": 1, "kind": "event", "from": "w-a", "task": "T1", "data": {"type": "state", "state": "done"}}, "created_at": "t1"},
                 ]
             },
         )

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -80,6 +80,15 @@ class TestParseOwEvent:
         result = ow_service._parse_ow_event(msg)
         assert result is None
 
+    def test_old_kind_cmd_returns_none_with_warning(self, caplog):
+        """旧形式 kind=cmd → None を返し warning ログを出す（v3 cutoff）"""
+        body = {"v": 1, "kind": "cmd", "from": "orch", "to": "w-a", "verb": "assign"}
+        msg = _make_msg(20, "orch", body)
+        with caplog.at_level(logging.WARNING, logger="src.services.ow_service"):
+            result = ow_service._parse_ow_event(msg)
+        assert result is None
+        assert any("kind=" in r.message for r in caplog.records)
+
 
 # ----------------------------
 # TestQueryLatestEvent


### PR DESCRIPTION
## Summary

- 新規送信 envelope を `kind:command`/`kind:event` + `data.type` に統一（`ow_send`/`_send_recovery_ping`/docstring）
- `reconstruct_state_from_relay` を新形式（`kind:event, data.type:state`）で集計するよう修正
- skills/worker・orch の旧形式言及（「または旧形式 kind:cmd」等）を全て削除
- `_parse_ow_event` による旧 `kind:cmd`/`kind:state` の skip+warning は T39 で実装済み（今回は reducer・集計側を合わせた）

## Changed files

| ファイル | 変更内容 |
|---|---|
| `src/services/ow_service.py` | `reconstruct_state_from_relay` 新形式対応・`_send_recovery_ping` 新形式化・docstring更新 |
| `src/main.py` | ow_send ツール説明文の docstring 更新 |
| `skills/worker/SKILL.md` | 旧形式への言及 5箇所削除 |
| `skills/orch/SKILL.md` | 旧形式言及の表現整理・内部ID参照削除 |
| `tests/unit/test_ow_crash_recovery.py` | テストデータを新形式に移行・cutoff 確認テスト追加 |
| `tests/unit/test_ow_reducer.py` | cutoff 確認テスト追加 |
| `tests/integration/test_ow_crash_recovery.py` | `_send_state` ヘルパー・ping 確認ロジックを新形式に更新 |

## Test plan

- [x] `tests/unit/test_ow_crash_recovery.py` 全通過
- [x] `tests/unit/test_ow_reducer.py` 全通過（`test_old_kind_cmd_returns_none_with_warning` 追加）
- [x] `tests/unit/test_ow_send.py` / `test_ow_recv_filter.py` 全通過
- [x] `tests/unit/` + `tests/test_migrations/` 合計 1165件全通過
- [x] grep verify report: 本番コード・スキルでの旧形式参照ゼロを確認（material 保存済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)