### PR TITLE
refactor: remove cc-memory internal ID references from code

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -31,7 +31,7 @@ _ORCH_MANAGED_TAG = "orch-managed"
 
 
 def _is_worker_session() -> bool:
-    """ow workerとして起動されたセッションかを判定する（D#2409）。
+    """ow workerとして起動されたセッションかを判定する。
 
     ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
     workerはtask fileとcheck_inで文脈を得るため、個人フロー用の

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -130,8 +130,8 @@ def _build_activities_section(conn) -> str:
     heartbeat中は別セクション表示。非heartbeatは番号付きフラットリストで出力し、
     AIスコアリング指示を末尾に追加する。
 
-    worker セッション（OW_ROLE=worker）では一覧注入自体を抑制する（D#2409）。
-    通常セッションでは orch-managed タグ付きアクティビティを除外する（D#2410）。
+    worker セッション（OW_ROLE=worker）では一覧注入自体を抑制する。
+    通常セッションでは orch-managed タグ付きアクティビティを除外する。
     """
     # worker セッションはアクティビティ一覧を注入しない
     if _is_worker_session():

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -39,7 +39,7 @@ _NUDGE_INTERVAL = 2
 
 
 def _is_orch_managed_activity(activity_id) -> bool:
-    """指定アクティビティが orch-managed タグを持つかを判定する（D#2410）。
+    """指定アクティビティが orch-managed タグを持つかを判定する。
 
     orchが管理するアクティビティにcheck-in済みのセッションは個人フローでなく
     orchフローなので、check-inブロック・nudgeの対象外とする。
@@ -133,7 +133,7 @@ def main() -> None:
             _update_checked_in_activity(state, all_events, transcript_path)
 
         # orchフロー（worker セッション or orch-managedアクティビティ）では
-        # 個人フロー用のcheck-inブロック・nudgeを抑制する（D#2409/D#2410）。
+        # 個人フロー用のcheck-inブロック・nudgeを抑制する。
         suppress_personal_flow = (
             _is_worker_session()
             or _is_orch_managed_activity(state.get_checked_in_activity())

--- a/scripts/ow/recv.sh
+++ b/scripts/ow/recv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SSE購読 + recv_filter + 自動再接続
 # 使い方: recv.sh <channel_code> <handle>
-# SSE切断時に1秒間隔で自動再接続する（M#219 §2.5）
+# SSE切断時に1秒間隔で自動再接続する
 
 RELAY_URL="${RELAY_URL:-http://127.0.0.1:8765}"
 CHANNEL="$1"

--- a/scripts/ow/recv_filter.py
+++ b/scripts/ow/recv_filter.py
@@ -7,7 +7,7 @@
 
 自分宛（to=自分のhandle）またはbroadcast（to="*"）のメッセージのみ出力する。
 不正なJSON行はスキップ（クラッシュしない）。
-python -u + 行ごとflushでMonitorへの遅延なし（D#2393）。
+python -u + 行ごとflushでMonitorへの遅延なし。
 """
 import json
 import sys

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -50,7 +50,7 @@ on Monitor発火 or 自発的タイミング:
 
 ## 通信プロトコル
 
-envelopeは `kind` が `command`（targeted）または `event`（broadcast）の2種。内訳は `data.type` で区別する（M#258 §4.1）。
+envelopeは `kind` が `command`（targeted）または `event`（broadcast）の2種。内訳は `data.type` で区別する（設計書v3 §4.1）。
 
 ### envelope 共通形式
 
@@ -64,7 +64,7 @@ envelopeは `kind` が `command`（targeted）または `event`（broadcast）�
 }
 ```
 
-- `v` は body 内 envelope のスキーマバージョン（relay 物理スキーマとは別レイヤ、M#258 §7.4）
+- `v` は body 内 envelope のスキーマバージョン（relay 物理スキーマとは別レイヤ、設計書v3 §7.4）
 - `from` は messages.handle と一致しなければreducerが drop する
 - `kind=command` は `to` 必須、`kind=event` は `to` 省略または `"*"` で broadcast
 
@@ -98,7 +98,7 @@ workerが送る全メッセージは `kind:event`。内訳は `data.type` で:
 | `identity` | `*` | 身元情報 full snapshot | identity bundle（§identity 参照） |
 | `heartbeat` | `*` | liveness signal（バックグラウンドループから送信） | `{type:"heartbeat", phase, nonce?}` |
 
-### workload state（M#258 §5.2 と整合）
+### workload state（設計書v3 §5.2 と整合）
 
 ```
        spawn
@@ -130,11 +130,11 @@ draining ──▶ terminated
 | `draining` | なし | command:close/cancel 受領後の worker-sync 実行中。長時間でもheartbeatが続けばcrash扱いしない |
 | `terminated` | `{cause}` | cause ∈ {closed, cancelled, dead}。crashed/crashed-during-drain は orch reducer の推論のみで、history には書かれない |
 
-**done の扱い**: M#258 §5.2 の workload state machine に `done` は含まれない。ただし worker は acceptance 完了申告として `event:state(done)` を送る運用（worker SKILL.md §完了→done）。orchはこれを **workload state ではなく orchestration 層の完了申告イベント** として解釈し、acceptance 照合 → `command:close` 送信に進む。doneは workload遷移ではないため、heartbeat 途絶判定の対象外（worker は close 受領前まで working として heartbeat を継続）。
+**done の扱い**: 設計書v3 §5.2 の workload state machine に `done` は含まれない。ただし worker は acceptance 完了申告として `event:state(done)` を送る運用（worker SKILL.md §完了→done）。orchはこれを **workload state ではなく orchestration 層の完了申告イベント** として解釈し、acceptance 照合 → `command:close` 送信に進む。doneは workload遷移ではないため、heartbeat 途絶判定の対象外（worker は close 受領前まで working として heartbeat を継続）。
 
 **done の payload**: `{summary, evidence, synced, materials[], decision_proposals[], cancelled?}`。`cancelled`（boolean）は `command:cancel` への応答 doneの場合に true、自発 done では false または省略。
 
-**fallback state は v3 で正式削除**（M#258 §5.2.1）。
+**fallback state は v3 で正式削除**（設計書v3 §5.2.1）。
 
 ### identity（event:identity）
 
@@ -159,7 +159,7 @@ worker 起動時と terminated 直前に append される身元情報。orchは 
  }}
 ```
 
-identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。M#258 §6.3.1 参照。
+identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。設計書v3 §6.3.1 参照。
 
 ### heartbeat（event:heartbeat）
 
@@ -170,14 +170,14 @@ worker のバックグラウンドループ（scripts/ow/heartbeat.sh）が定�
  "data":{"type":"heartbeat", "phase":"alive|loading|ready|working|draining"}}
 ```
 
-- 周期: loading=10秒、それ以外=30秒（M#258 §5.4.1、D#2525）
+- 周期: loading=10秒、それ以外=30秒（設計書v3 §5.4.1）
 - `phase` は workload state を写像する補助情報
 
-**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない（M#258 §4.4 / D#2522）。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
+**スレッド規約**: `in_reply_to` はrelay物理カラムとして残置されているが、ow 応用層では原則使わない（設計書v3 §4.4）。例外として assign への最初の `event:state(working)` には `in_reply_to=<assign msg_id>` を付けることがある（worker SKILL.md 規約に従う）。`to` はbody内規約でサーバーはルーティングしない（宛先フィルタは受信側のローカル実装）。
 
 ### 旧 cmd/state envelope の後方互換放棄
 
-D#2532 により、旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は D#2479 で凍結されており、過去レコードはそのまま残置される。
+旧 `kind:cmd` / `kind:state` レコードは v3 reducer・orch では解釈しない。新規送受信は `kind:command` / `kind:event` のみとする。relay 物理スキーマ（messages テーブル）は凍結されており、過去レコードはそのまま残置される。
 
 ## タスクキュー
 
@@ -237,7 +237,7 @@ queued → spawning → assigned → in_progress → awaiting_verify → done
 
 **「完了」の定義**: `event:state(done)` の `evidence` が `acceptance` を満たすとorchが判定 ∧ `synced: true`。無条件信頼しない。
 
-**done は workload state ではない**: M#258 §5.2 の workload state machine に done は含まれず、worker→orchの完了申告として `event:{type:state, state:done}` envelope形式で扱う（orchestration層の信号）。orchはdoneを受信したらacceptance照合し、`command:close`送信 → workerは draining → terminated(cause:closed) へ進む。
+**done は workload state ではない**: 設計書v3 §5.2 の workload state machine に done は含まれず、worker→orchの完了申告として `event:{type:state, state:done}` envelope形式で扱う（orchestration層の信号）。orchはdoneを受信したらacceptance照合し、`command:close`送信 → workerは draining → terminated(cause:closed) へ進む。
 
 **cancelと自発doneの交差**:
 - `event:state(done)` の `in_reply_to` が `command:cancel` を指していなければ自発done
@@ -256,14 +256,14 @@ queued → spawning → assigned → in_progress → awaiting_verify → done
 
 ## watchdog
 
-**監視基準**: 「そのworkerからの最後の `event:heartbeat` 受信時刻」からの経過時間（M#258 §5.4.2、D#2525）。workload state の所要時間や `last_recv` 全般の経過では判定しない（長時間 loading や draining でも heartbeat が続けば crash 扱いしない）。
+**監視基準**: 「そのworkerからの最後の `event:heartbeat` 受信時刻」からの経過時間（設計書v3 §5.4.2）。workload state の所要時間や `last_recv` 全般の経過では判定しない（長時間 loading や draining でも heartbeat が続けば crash 扱いしない）。
 
 **heartbeat 周期 × 3 の閾値**:
 
 | 現在の workload state | heartbeat 周期 | タイムアウト閾値（周期×3） |
 |---|---|---|
-| `loading` | 10秒（D#2525） | **30秒** |
-| `ready` / `working` / `blocked` / `draining` | 30秒（D#2525） | **90秒** |
+| `loading` | 10秒 | **30秒** |
+| `ready` / `working` / `blocked` / `draining` | 30秒 | **90秒** |
 | `escalated` | 監視対象外 | — |
 
 orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し、対応する閾値を選んで判定する。閾値はreducer実装のチューニング余地として残るが、orch側の初期実装は上記固定値を使う。
@@ -274,7 +274,7 @@ orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し�
 3. **自動failedおよび自動クローズはしない**。failedへの変更・強制クローズは人間判断
 
 **watchdog対象外**:
-- `escalated` 状態のworker（人間対話中はタイムアウト・クローズ対象外、M#258 §5.2の state machine参照）
+- `escalated` 状態のworker（人間対話中はタイムアウト・クローズ対象外、設計書v3 §5.2の state machine参照）
 - `terminated` 状態のworker（既に終了済み）
 
 **ready未送信タイムアウト（loading 滞留）**: heartbeat が来ているかぎり crash 扱いしない。30秒以上 heartbeat 途絶した場合のみ crash 候補となる。長時間 loading（巨大コンテキスト読込・1Mコンテキストモデルのwarm-up等）でも heartbeat が続けばタイムアウトしない。
@@ -311,11 +311,11 @@ orchは起動時に特化版最新を取得し、assignの `playbook` フィー�
 
 ## identity 取得経路
 
-orchはworkerの身元情報（alias、activity_id、model、cwd、session_id、terminated_at、cause等）を取得する際は、必ず `ow_get_identity(channel, handle)` 経由で取得する（M#258 §6 / §8.3）。`ow_history` を自前パースして identity bundle を組み立てる経路は使わない。
+orchはworkerの身元情報（alias、activity_id、model、cwd、session_id、terminated_at、cause等）を取得する際は、必ず `ow_get_identity(channel, handle)` 経由で取得する（設計書v3 §6 / §8.3）。`ow_history` を自前パースして identity bundle を組み立てる経路は使わない。
 
 理由:
 - reducer が event:identity の最新エントリを返す責務を持つため、orch側で二重実装しない
-- crash 推論（`cause: "crashed (inferred)"` / `"crashed-during-drain (inferred)"`）は reducer がメモリ上で付与する（DB不変、M#258 §9.2）。orch側で直接 history を見ると推論結果が得られない
+- crash 推論（`cause: "crashed (inferred)"` / `"crashed-during-drain (inferred)"`）は reducer がメモリ上で付与する（DB不変、設計書v3 §9.2）。orch側で直接 history を見ると推論結果が得られない
 
 ID別の取得関数:
 
@@ -328,7 +328,7 @@ ID別の取得関数:
 
 ## crash 推論の cause lineup と queue 反映
 
-M#258 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで queue status を更新する。`cause` 値は `ow_get_identity` の戻り値 `cause` フィールドから判定する（履歴に明示書き込まれる closed/cancelled/dead と、reducer がメモリ上で付与する crashed/crashed-during-drain）。
+設計書v3 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで queue status を更新する。`cause` 値は `ow_get_identity` の戻り値 `cause` フィールドから判定する（履歴に明示書き込まれる closed/cancelled/dead と、reducer がメモリ上で付与する crashed/crashed-during-drain）。
 
 | cause | 発生条件 | queue status への反映 | 補足 |
 |---|---|---|---|
@@ -368,7 +368,7 @@ M#258 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで
 | ツール | 用途 |
 |---|---|
 | `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ）。bodyは `kind=command`/`event` envelope |
-| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、M#258 §3.3） |
+| `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、設計書v3 §3.3） |
 | `ow_spawn_worker(alias, channel, cwd, model, permission, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却） |
 | `ow_close_worker(term_ref)` | workerクローズ |
 | `ow_status(channel, topic_id)` | queue+identity統合ビュー |

--- a/skills/orch/playbook.md
+++ b/skills/orch/playbook.md
@@ -12,9 +12,9 @@ assignの `model` は必須。タスクの性質に応じて以下の目安で�
 | 通常実装（コーディング、テスト作成、バグ修正等） | sonnet / opus |
 | 設計・複雑推論（アーキテクチャ設計、トレードオフ分析、根本原因調査等） | opus 以上 |
 
-cc-memoryプラグイン付きのworkerはコンテキスト消費が大きいため、原則 **1Mコンテキスト版**を使う（D#2449）。CLIの `--model` 引数: `sonnet[1m]`、`claude-opus-4-7` 等。
+cc-memoryプラグイン付きのworkerはコンテキスト消費が大きいため、原則 **1Mコンテキスト版**を使う。CLIの `--model` 引数: `sonnet[1m]`、`claude-opus-4-7` 等。
 
-**opus 4.8は使用禁止**（D#2476）。`opus` `opus[1m]` `opus-4-7` `opus-4-7[1m]` は無効なモデルIDまたは4.8に解決される。必ずフルID `claude-opus-4-7` を使う。
+**opus 4.8は使用禁止**。`opus` `opus[1m]` `opus-4-7` `opus-4-7[1m]` は無効なモデルIDまたは4.8に解決される。必ずフルID `claude-opus-4-7` を使う。
 
 workerのSA（サブエージェント）にも同ルールを適用する。
 
@@ -26,7 +26,7 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 - assignに明示的に指定しない場合は60分を適用する
 - タスクの性質（大規模実装・長時間調査等）に応じてorchが上書き可能
 
-### heartbeat 途絶 watchdog（M#258 §5.4.2 / D#2525）
+### heartbeat 途絶 watchdog（設計書v3 §5.4.2）
 
 orchが worker の生死を判定する基準は **heartbeat 途絶**。workload state の所要時間（`timeout_min`）とは別軸で監視する。`timeout_min` 超過は workload 上の予期外長期化、heartbeat 途絶は liveness 側のcrash候補（reducer 推論）として分けて扱う。
 

--- a/skills/setup-anchor/SKILL.md
+++ b/skills/setup-anchor/SKILL.md
@@ -19,8 +19,8 @@ description: 合意事項のanchor（検証先＝どこを見れば正しさを�
 |---|---|
 | 実装済 | 該当コードのファイル+関数（例: `src/services/checkin_service.py:check_in`）|
 | 外部仕様準拠 | doc URL |
-| 未実装 | 周辺の実装済みコード＋関連decisionの前後関係（例: 「`pin_service.py:add_pin` + D#2120/D#2148の整合を見る」）|
-| 事実調査 | material内の一次ソース（例: `M#182の調査結果`）|
+| 未実装 | 周辺の実装済みコード＋関連decisionの前後関係（例: 「`pin_service.py:add_pin` の整合を見る」）|
+| 事実調査 | material内の一次ソース（例: `materialの調査結果`）|
 
 「最新decisionを静的参照」は採用しない。未実装合意は周辺コード見渡しが基本。
 

--- a/skills/worker-sync/SKILL.md
+++ b/skills/worker-sync/SKILL.md
@@ -6,7 +6,7 @@ description: owフレームワークのworkerが退場時に実行する簡易sy
 # worker-sync
 
 owフレームワークの **worker** が退場処理（`cmd:close` 受信時）に実行する記録スキル。
-通常の `sync-memory` のworker版で、**会話相手（ユーザー）がいない**前提で設計されている（D#2397 / 設計M#219 §4.4）。
+通常の `sync-memory` のworker版で、**会話相手（ユーザー）がいない**前提で設計されている。
 
 `worker` スキルの §退場処理 から呼び出される。worker以外のセッションでは使わない（通常セッションは `sync-memory` を使う）。
 
@@ -22,7 +22,7 @@ owフレームワークの **worker** が退場処理（`cmd:close` 受信時）
 | decision記録 | 直接記録 | **原則しない**（decision_proposalsでorchに提案） |
 | 棚卸し・remember・ふりかえり | あり | **なし** |
 
-workerは記録ストア上をorchフローとして走るため、知識層への書き込み権限はorchに集約する。workerが勝手にtopic/activity/decisionを量産すると、orchの認知漏れとrelay履歴からの監査欠落を招く（D#2397）。
+workerは記録ストア上をorchフローとして走るため、知識層への書き込み権限はorchに集約する。workerが勝手にtopic/activity/decisionを量産すると、orchの認知漏れとrelay履歴からの監査欠落を招く。
 
 ## 実行手順
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -261,7 +261,7 @@ heartbeatループは draining フェーズで 30秒間隔を維持する（work
 `worker-sync` スキルは以下を行う（詳細はworker-syncスキル参照）:
 - **log記録**: セッション中の作業経緯（実装アプローチ・障害・orchとのやり取り）を1件のログとして記録
 - **material記録**: state:doneで報告済み以外の中間成果物があれば保存
-- **decisionは原則記録しない**: decision_proposalsでorchに提案する（D#2397）
+- **decisionは原則記録しない**: decision_proposalsでorchに提案する
 
 ### Step 3: event:identity 再 append（terminated情報付き）
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # リトライ設定
 MAX_RETRIES = 3
 
-# ow ON/OFFトグル（M#219 §2.6）
+# ow ON/OFFトグル
 # CCM_OW=1またはOW_ROLE=workerのセッションのみow_*ツールを可視にする
 _OW_ENABLED = os.environ.get("CCM_OW") == "1" or os.environ.get("OW_ROLE") == "worker"
 
@@ -274,7 +274,7 @@ async def _bridge() -> None:
             read_streamが終了したとき、stdin_eofがFalseならサーバー側切断と判断し
             ServerDisconnectedをraiseしてtask group全体をキャンセルする。
 
-            OW無効時はtools/listレスポンスからow_*ツールを除外する（M#219 §2.6）。
+            OW無効時はtools/listレスポンスからow_*ツールを除外する。
             """
             try:
                 async for session_msg_or_exc in read_stream:

--- a/src/main.py
+++ b/src/main.py
@@ -1023,7 +1023,7 @@ def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
     """ow channelの履歴を取得する。受信処理の本体。
 
     since自身を含まない（msg_id > since）。
-    SSEは起床信号専用。起床後はこのツールで未処理メッセージを全件pull（D#2392）。
+    SSEは起床信号専用。起床後はこのツールで未処理メッセージを全件pull。
 
     Args:
         channel: channelコード

--- a/src/relay/server.py
+++ b/src/relay/server.py
@@ -13,7 +13,7 @@
 到達順は厳密に保証しない（受信側は GetHistory + msg_id で冪等突合する設計）。
 SQLite 同時書き込みは WAL モード + busy_timeout で吸収する（`_db_connect`）。
 
-標準ライブラリのみ。依存ゼロ（D#2282）。
+標準ライブラリのみ。依存ゼロ。
 """
 import json
 import os
@@ -62,7 +62,7 @@ def _db_connect(db_path: str = DB_PATH) -> sqlite3.Connection:
     ThreadingHTTPServer 配下で複数スレッドが同時に書き込むため、WAL モードと
     busy_timeout を設定して ``sqlite3.OperationalError: database is locked`` を
     回避する。複数 Claude が同一 channel に同時 send するのがこのシステムの常態で
-    あり、並行書き込みは想定内のため（D#2285 でハンドルは非検証＝アクセスは
+    あり、並行書き込みは想定内のため（ハンドルは非検証であり、アクセスは
     bridge-connect 経由に限られるが、同時アクセス自体は起こりうる）。
     """
     conn = sqlite3.connect(db_path, check_same_thread=False, timeout=5.0)
@@ -111,7 +111,7 @@ def _now_iso() -> str:
 # ---------------------------------------------------------------------------
 
 def create_channel(db_path: str = DB_PATH) -> str:
-    """channel を作成し channel_code を返す。衝突時はリトライ（D#2287）。"""
+    """channel を作成し channel_code を返す。衝突時はリトライ。"""
     conn = _db_connect(db_path)
     try:
         for _ in range(10):
@@ -332,7 +332,7 @@ def get_presence(channel_code: str) -> list[str]:
 
 
 def _broadcast(channel_code: str, sender_handle: str, msg: dict) -> None:
-    """同一 channel の購読者（送信者と同一 handle を除く）にメッセージを配信する（D#2286）。
+    """同一 channel の購読者（送信者と同一 handle を除く）にメッセージを配信する。
 
     SSE ペイロードは msg_id / body / handle / created_at の4フィールドに絞る。
     受信側が body フィールド有無を許容する後方互換設計を前提とする。
@@ -350,7 +350,7 @@ def _broadcast(channel_code: str, sender_handle: str, msg: dict) -> None:
         entries = list(_subscribers.get(channel_code, []))
     for handle, q in entries:
         if handle == sender_handle:
-            # 送信者自身へはエコーしない（D#2286）
+            # 送信者自身へはエコーしない
             continue
         q.put(payload)
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -5,7 +5,7 @@ relay HTTPサーバーとのやり取り、worker spawn/close、ステータス�
 
 relayサーバーはcc-memoryリポ内のsrc/relay/にvendoringされており、ow_serviceと
 PROTOCOL_VERSIONを構造的に共有する。ensure_relay_serverは/healthのversion不一致時に
-古いrelayをkillして再起動する自己修復gate（D#2481）。
+古いrelayをkillして再起動する自己修復gate。
 """
 import errno
 import fcntl
@@ -136,7 +136,7 @@ def _get_relay_health() -> dict | None:
     旧 `_is_relay_running` は404でもTrueを返す設計だったため、改名前の古いrelayが
     動いていても「running」と誤判定して新規spawnを諦めていた。本関数はversion不一致時に
     呼び出し元（ensure_relay_server）がkill+restartで自己修復できるよう
-    /healthレスポンスをそのまま返す（D#2481）。
+    /healthレスポンスをそのまま返す。
     """
     try:
         req = urllib.request.Request(f"{RELAY_URL}/health", method="GET")
@@ -435,7 +435,7 @@ def ensure_channel(channel_code: str) -> bool:
     """channelが存在しなければrelayに作成する（idempotent）。
 
     POST /createにchannel_codeを指定して送信する。relayサーバー側で
-    既存なら何もせず、未存在なら作成する（D#2453）。
+    既存なら何もせず、未存在なら作成する。
 
     Args:
         channel_code: 存在を保証したいchannel_code
@@ -458,7 +458,7 @@ def ensure_channel(channel_code: str) -> bool:
 
 
 # ----------------------------
-# T1: ow_send
+# ow_send
 # ----------------------------
 
 
@@ -507,7 +507,7 @@ def ow_send(
 
 
 # ----------------------------
-# T2: ow_history
+# ow_history
 # ----------------------------
 
 
@@ -544,7 +544,7 @@ def ow_history(channel: str, since: int = 0, limit: int = 100) -> dict:
 
 
 # ----------------------------
-# T3: ow_spawn_worker / ow_close_worker
+# ow_spawn_worker / ow_close_worker
 # ----------------------------
 
 
@@ -885,7 +885,7 @@ def ow_spawn_worker(
         manualフォールバック時: {"command": str, "manual": True, "task_file": str}
         spawn前検証失敗時: {"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}
     """
-    # T17: spawn前ヘルスチェック (relay疎通・channel存在・cwd存在・alias重複)
+    # spawn前ヘルスチェック (relay疎通・channel存在・cwd存在・alias重複)
     preflight = _validate_spawn_preconditions(alias, channel, cwd, topic_id=topic_id, task_n=task_n)
     if not preflight["ok"]:
         return {
@@ -899,13 +899,13 @@ def ow_spawn_worker(
     queue_dir = _get_queue_dir()
     task_dir = queue_dir / "tasks"
 
-    # queueへspawning write-ahead（孤児worker対策 D#2395）
+    # queueへspawning write-ahead（孤児worker対策）
     orch_cwd = os.environ.get("OW_ORCH_CWD", "")
     if not orch_cwd:
         orch_cwd = os.getcwd()
         logger.warning(
             "OW_ORCH_CWD not set, using cwd=%s as orch_cwd. "
-            "Crash recovery requires the same cwd (D#2394).",
+            "Crash recovery requires the same cwd.",
             orch_cwd,
         )
     if topic_id is not None:
@@ -962,7 +962,7 @@ def ow_spawn_worker(
             "alias": alias,
         }
 
-    # アダプタ呼び出し — stdoutから安定IDを取得する（D#2400）
+    # アダプタ呼び出し — stdoutから安定IDを取得する
     try:
         result = subprocess.run(
             ["bash", str(adapter_path), "spawn", cwd, worker_cmd],
@@ -1044,7 +1044,7 @@ def ow_close_worker(term_ref: str) -> dict:
 
 
 # ----------------------------
-# T4: ow_status
+# ow_status
 # ----------------------------
 
 
@@ -1181,7 +1181,7 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
                 fm, file_tasks = _parse_queue_file(queue_file)
                 tasks.extend(file_tasks)
                 if fm and not frontmatter:
-                    # 1 orch = 1 topic（D#2383）のためtopic_id指定が原則。
+                    # 1 orch = 1 topic のため topic_id 指定が原則。
                     # topic_id未指定の全件走査は診断用途のみ想定し、最初のfrontmatterを代表とする。
                     frontmatter = fm
 
@@ -1210,12 +1210,12 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
 
 
 # ----------------------------
-# T17: crash復旧自動化・spawn前バリデーション
+# crash復旧自動化・spawn前バリデーション
 # ----------------------------
 #
-# 設計方針 (T17 / A#830):
+# 設計方針:
 #   - 突合ロジックの中核は relay messages history + presence のみで成立し、queue層の物理形に依存しない
-#     (T35議論で queue層が活動activity/log/material化される可能性に対する将来耐性)
+#     (queue層が活動activity/log/material化される可能性に対する将来耐性)
 #   - queue層との接点は `_apply_queue_status_update` 1点に集約。queue層が変わったらこの関数だけ書き換えれば済む
 #   - reconstruct_state_from_relay と detect_crash_inconsistencies は純粋関数として実装し、テスト容易性を確保
 #
@@ -1229,7 +1229,7 @@ def _get_presence(channel: str) -> list[str]:
     """relayのGET /presenceから接続中handle一覧を取得する。
 
     エラー時は空リストを返し、呼び出し元が「presence情報なし」として扱える設計。
-    例外を伝播させない（fail-soft）のは ensure_channel と同じ規律（D#2458）。
+    例外を伝播させない（fail-soft）のは ensure_channel と同じ規律。
     """
     try:
         result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")
@@ -1576,7 +1576,7 @@ def _apply_queue_status_update(
 ) -> None:
     """queueファイルの指定タスクのstatusヘッダーのみを更新する（他フィールドは保持）。
 
-    queue層との接点はこの関数1箇所に集約してある。T35議論結果でqueue層がcc-memory entityに
+    queue層との接点はこの関数1箇所に集約してある。queue層がcc-memory entityに
     置換される場合も、ここを書き換えれば突合ロジック (`detect_crash_inconsistencies`) は無改修で済む。
 
     挙動:
@@ -2075,7 +2075,7 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
 def ow_get_presence(channel: str, handle: str) -> dict:
     """最新 heartbeat 受信時刻から online/offline を推論する。
 
-    T17 ow_recover の _get_presence() と推論ロジックを統一した実装。
+    ow_recover の _get_presence() と推論ロジックを統一した実装。
     SSE 接続状態ではなく heartbeat 時刻ベースの推論を行う。
 
     heartbeat が一度も観測されない handle に対しては status="unknown" の

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -107,7 +107,7 @@ def add_pin(
                 }
             }
 
-        # 自己参照拒否（D#2147）
+        # 自己参照拒否
         if source_type == target_type and source_id == target_id:
             return {
                 "error": {
@@ -116,7 +116,7 @@ def add_pin(
                 }
             }
 
-        # 存在性チェック（D#2152）
+        # 存在性チェック
         source_table = ENTITY_TABLE_MAP[source_type]
         row = conn.execute(
             f"SELECT id FROM {source_table} WHERE id = ?", (source_id,)
@@ -141,7 +141,7 @@ def add_pin(
                 }
             }
 
-        # INSERT OR IGNORE（D#2154 冪等）
+        # INSERT OR IGNORE（冪等）
         conn.execute(
             "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
             (source_type, source_id, target_type, target_id),
@@ -203,7 +203,7 @@ def remove_pin(
 
     conn = get_connection()
     try:
-        # ref解決。tag str 未存在は冪等な {"removed": 0} で短絡（D#2347）
+        # ref解決。tag str 未存在は冪等な {"removed": 0} で短絡
         source_id, err = _resolve_ref(conn, source_type, source_ref)
         if err:
             return err

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1401,7 +1401,7 @@ def search(
     if date_before is not None and len(date_before) == 10:
         date_before = date_before + " 23:59:59"
 
-    # domain → tagsマージ（D#1695: 重複除去）
+    # domain → tagsマージ（重複除去）
     if domain:
         domain_tag = f"domain:{domain}"
         if tags is None:

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -144,7 +144,7 @@ def get_timeline(
         if "decision" in types:
             # supersedes関係はスカラー（1:1前提）で返す。
             # decision_supersedesは多対多のスキーマだが、APIレスポンスのreplaces/replaced_byは
-            # D#1874で{type, id}のスカラーと定義されているため、最新の1件のみ返す。
+            # {type, id}のスカラーと定義されているため、最新の1件のみ返す。
             union_parts.append(
                 f"SELECT d.id, 'decision' AS type, COALESCE(d.title, d.decision) AS title, d.created_at,"
                 f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaces_id,"

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -318,7 +318,7 @@ class TestSessionStartHookHabits:
 
 
 class TestSessionStartHookWorkerSuppression:
-    """OW_ROLE=worker セッションでのアクティビティ一覧抑制テスト（D#2409）"""
+    """OW_ROLE=worker セッションでのアクティビティ一覧抑制テスト"""
 
     def test_worker_session_suppresses_activity_list(self, temp_db):
         """OW_ROLE=worker時はアクティビティがあってもアクティビティ一覧セクションが出ない"""
@@ -353,7 +353,7 @@ class TestSessionStartHookWorkerSuppression:
 
 
 class TestSessionStartHookOrchManagedExclusion:
-    """orch-managedタグ付きアクティビティの除外テスト（D#2410）"""
+    """orch-managedタグ付きアクティビティの除外テスト"""
 
     def test_orch_managed_activity_excluded(self, temp_db):
         """orch-managedタグ付きアクティビティはアクティビティ一覧に出ない"""

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -757,7 +757,7 @@ def _seed_orch_managed_db(db_path: str, activity_id: int, monkeypatch) -> None:
 
 
 class TestOrchFlowSuppression:
-    """orchフロー（worker セッション・orch-managedアクティビティ）でのcheck-inブロック/nudge抑制（D#2409/D#2410）"""
+    """orchフロー（worker セッション・orch-managedアクティビティ）でのcheck-inブロック/nudge抑制"""
 
     def test_worker_session_no_checkin_block(self, env_setup):
         """OW_ROLE=worker時はcheck-in未呼出でもturn>=2でblockしない"""

--- a/tests/unit/test_ow_launcher_filter.py
+++ b/tests/unit/test_ow_launcher_filter.py
@@ -1,4 +1,4 @@
-"""launcherのtools/listフィルタのユニットテスト（M#219 §2.6）
+"""launcherのtools/listフィルタのユニットテスト
 
 エッジケース:
 - CCM_OW未設定&OW_ROLE未設定 → tools/list応答からow_*を除外

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -1,4 +1,4 @@
-"""queueファイルのパース/シリアライズのユニットテスト（M#219 §3.2）"""
+"""queueファイルのパース/シリアライズのユニットテスト"""
 import json
 from pathlib import Path
 

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -220,7 +220,7 @@ class TestOwSendSuccess:
         assert result["messages"][0]["msg_id"] == 5
 
     def test_body_serialized_as_json_string(self, monkeypatch):
-        """bodyはJSON文字列としてrelayに送信される（D#2405）"""
+        """bodyはJSON文字列としてrelayに送信される"""
         sent_data = {}
 
         class FakeResponse:

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -342,7 +342,7 @@ class TestRemovePin:
         assert result["error"]["code"] == "VALIDATION_ERROR"
 
     def test_remove_pin_nonexistent_tag_string_is_idempotent(self, activity, temp_db):
-        """存在しないtag名文字列で remove しても {"removed": 0} を返し冪等になる（D#2347）"""
+        """存在しないtag名文字列で remove しても {"removed": 0} を返し冪等になる"""
         activity_id = activity["activity_id"]
 
         result = remove_pin("tag", "domain:nonexistent", "activity", activity_id)

--- a/tests/unit/test_retract_service.py
+++ b/tests/unit/test_retract_service.py
@@ -257,7 +257,7 @@ class TestRetractWithPin:
             ).fetchone()
             assert row["retracted_at"] is not None
 
-            # pinsテーブルのエントリはそのまま残る（D#2149: retract時pins残置）
+            # pinsテーブルのエントリはそのまま残る（retract時pins残置）
             pin_row = conn.execute(
                 "SELECT * FROM pins WHERE source_type='activity' AND source_id=? AND target_type='decision' AND target_id=?",
                 (aid, decision_id),


### PR DESCRIPTION
## Summary

cc-memory内部ID（`D#nnnn` / `M#nnnn` / `A#nnnn` / `L#nnnn` / `T#nnn`）が、コード・コメント・docstring・テストに漏れ出していたものを一括で除去する。

- `hooks/`, `scripts/`, `src/`, `skills/`, `tests/` 全域が対象
- 単純参照（括弧注釈）は括弧ごと削除
- `M#258`（ow統合設計書v3）参照はセクション番号を保持し「設計書v3 §X.X」に書き換え
- 機能・ロジックの変更なし（コメント・docstring・文字列リテラルのみ）

## Test plan

- [x] `uv run pytest tests/unit/` — 1125 passed
- [ ] e2e テストは手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)