### PR TITLE
refactor: ow_spawn_worker drop permission arg auto fixed

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -77,7 +77,7 @@ envelopeは `kind` が `command`（targeted）または `event`（broadcast）�
 
 | data.type | data 内容 | 補足 |
 |---|---|---|
-| `assign` | `{title, activity_id, topic_id, cwd, model（必須）, permission_mode, acceptance（必須）, context, playbook, timeout_min}` | worker は `event:state(working)` で応答 |
+| `assign` | `{title, activity_id, topic_id, cwd, model（必須）, acceptance（必須）, context, playbook, timeout_min}` | worker は `event:state(working)` で応答 |
 | `close` | `{reason}` | worker は退場処理（draining→terminated/cause:closed）で応答 |
 | `cancel` | `{reason}` | worker は退場処理（draining→terminated/cause:cancelled）で応答 |
 | `answer` | `{answer}` または `{escalate: true}` | blocked への応答 |
@@ -159,7 +159,7 @@ worker 起動時と terminated 直前に append される身元情報。orchは 
  }}
 ```
 
-identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。M#258 §6.3.1 参照。
+identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。
 
 ### heartbeat（event:heartbeat）
 
@@ -202,7 +202,7 @@ last_seen_msg_id: 0
 ## T1 | タスク名 | status
 - worker: w-a / term_ref: iterm2:UUID / session: <uuid>
 - activity: 801
-- model: sonnet / permission: acceptEdits
+- model: sonnet
 - cwd: ~/workspace/cc-memory/.trees/feature-xxx
 - assigned: HH:MM / last_recv: HH:MM
 - acceptance: {acceptance条件}
@@ -369,7 +369,7 @@ M#258 §5.2.2 / §9 の cause lineup に基づき、orchは以下のルールで
 |---|---|
 | `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ）。bodyは `kind=command`/`event` envelope |
 | `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、M#258 §3.3） |
-| `ow_spawn_worker(alias, channel, cwd, model, permission, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却） |
+| `ow_spawn_worker(alias, channel, cwd, model, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却。permission_modeはauto固定） |
 | `ow_close_worker(term_ref)` | workerクローズ |
 | `ow_status(channel, topic_id)` | queue+identity統合ビュー |
 | `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×identity reducer突合・ghost_active自動再構築・stalled/orphan command:ping送信） |

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -101,7 +101,7 @@ ow_sendで1回だけ送信:
 }
 ```
 
-identity bundleに含めない属性: `task_n`（activity_idから逆引き可能）、`user`（relay参加者でないため）。
+identity から **除外する属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。設計詳細は設計書 v3 §6.3.1 参照。
 
 ### 5. event:state(loading) を送信
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -101,7 +101,7 @@ ow_sendで1回だけ送信:
 }
 ```
 
-identity bundleに含めない属性: `task_n`（activity_idから逆引き可能）、`permission_mode`（auto固定）、`user`（relay参加者でないため）。
+identity bundleに含めない属性: `task_n`（activity_idから逆引き可能）、`user`（relay参加者でないため）。
 
 ### 5. event:state(loading) を送信
 

--- a/src/main.py
+++ b/src/main.py
@@ -1043,7 +1043,6 @@ def ow_spawn_worker(
     channel: str,
     cwd: str,
     model: str,
-    permission: str = "auto",
     task_title: str = "",
     acceptance: str = "",
     context: str = "",
@@ -1056,7 +1055,7 @@ def ow_spawn_worker(
     """workerセッションを起動する。
 
     処理順: queueへspawning write-ahead → task file書き出し → アダプタ起動 → 安定ID返却。
-    relay疎通確認・起動（ensure-server処理）も内包。
+    relay疎通確認・起動（ensure-server処理）も内包。permission_modeはautoに固定。
 
     OW_TERMINAL環境変数でアダプタを選択（iterm2/tmux/manual。manualは起動コマンド表示のフォールバック）。
 
@@ -1065,7 +1064,6 @@ def ow_spawn_worker(
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "auto"）。autoは全操作を自動承認するため、orchが管理する信頼されたタスクでの使用を前提とする
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト
@@ -1085,7 +1083,6 @@ def ow_spawn_worker(
         channel=channel,
         cwd=cwd,
         model=model,
-        permission=permission,
         task_title=task_title,
         acceptance=acceptance,
         context=context,

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -698,7 +698,6 @@ def _write_queue_spawning(
     cwd: str,
     task_title: str = "",
     model: str = "",
-    permission: str = "",
     acceptance: str = "",
     orch_activity_id: int | None = None,
     channel_code: str = "",
@@ -721,8 +720,8 @@ def _write_queue_spawning(
     ]
     if orch_activity_id is not None:
         fields.append(("activity", str(orch_activity_id)))
-    if model or permission:
-        fields.append(("model", f"{model} / permission: {permission}"))
+    if model:
+        fields.append(("model", model))
     fields.append(("cwd", cwd))
     fields.append(("spawning", now))
     if acceptance:
@@ -782,7 +781,6 @@ def _write_task_file(
     channel: str,
     cwd: str,
     model: str,
-    permission: str,
     task_title: str,
     acceptance: str,
     context: str,
@@ -814,7 +812,7 @@ def _write_task_file(
         "channel": channel,
         "cwd": cwd,
         "model": model,
-        "permission_mode": permission,
+        "permission_mode": "auto",
         "timeout_min": timeout_min,
         "activity_id": activity_id,
         "topic_id": topic_id,
@@ -850,7 +848,6 @@ def ow_spawn_worker(
     channel: str,
     cwd: str,
     model: str,
-    permission: str = "auto",
     task_title: str = "",
     acceptance: str = "",
     context: str = "",
@@ -865,12 +862,13 @@ def ow_spawn_worker(
     処理順: spawn前ヘルスチェック → queueへspawning write-ahead → task file書き出し
         → アダプタ呼び出し → 安定ID返却
 
+    permission_modeは常にautoに固定される。
+
     Args:
         alias: workerのhandle（例: "w-a"）
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（例: "sonnet", "opus"）
-        permission: permission_mode（デフォルト: "auto"）。autoは全操作を自動承認するため、orchが管理する信頼されたタスクでの使用を前提とする
         task_title: タスクタイトル
         acceptance: 完了条件
         context: タスクコンテキスト
@@ -917,7 +915,6 @@ def ow_spawn_worker(
             cwd,
             task_title=task_title,
             model=model,
-            permission=permission,
             acceptance=acceptance,
             orch_activity_id=activity_id,
             channel_code=channel,
@@ -932,7 +929,6 @@ def ow_spawn_worker(
         channel=channel,
         cwd=cwd,
         model=model,
-        permission=permission,
         task_title=task_title,
         acceptance=acceptance,
         context=context,
@@ -949,7 +945,7 @@ def ow_spawn_worker(
     worker_cmd = (
         f'env OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
         f'OW_TASK_FILE={shlex.quote(str(task_file))} '
-        f'claude --model {shlex.quote(model)} --permission-mode {shlex.quote(permission)} '
+        f'claude --model {shlex.quote(model)} --permission-mode auto '
         f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
     )
 

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -228,7 +228,6 @@ class TestWriteQueueSpawning:
             tmp_path, "454", "w-a", 1, "/workspace/repo",
             task_title="queue統合タスク",
             model="opus",
-            permission="acceptEdits",
             acceptance="テスト全通過",
             orch_activity_id=798,
             channel_code="AbCdEfGh",
@@ -248,7 +247,7 @@ class TestWriteQueueSpawning:
         assert "## T1 | queue統合タスク | spawning" in content
         assert "- worker: w-a / term_ref: (pending) / session: (pending)" in content
         assert "- activity: 798" in content
-        assert "- model: opus / permission: acceptEdits" in content
+        assert "- model: opus" in content
         assert "- cwd: /workspace/repo" in content
         assert "- acceptance: テスト全通過" in content
         assert "- note: spawning write-ahead" in content
@@ -859,7 +858,7 @@ class TestWriteTaskFile:
         """task fileがmarkdown（frontmatter＋本文）として作成される"""
         task_file = ow_service._write_task_file(
             task_dir=tmp_path, task_n=1, alias="w-a", channel="AbCdEfGh",
-            cwd="/tmp", model="sonnet", permission="auto",
+            cwd="/tmp", model="sonnet",
             task_title="テストタスク", acceptance="全テスト通過", context="背景説明",
             playbook="", timeout_min=60, activity_id=1, topic_id="10"
         )
@@ -885,7 +884,7 @@ class TestWriteTaskFile:
         """topic_id未指定・slug空時はT{n}.md形式にフォールバックする"""
         task_file = ow_service._write_task_file(
             task_dir=tmp_path, task_n=5, alias="w-e", channel="ch1",
-            cwd="/tmp", model="haiku", permission="default",
+            cwd="/tmp", model="haiku",
             task_title="", acceptance="", context="", playbook="",
             timeout_min=30, activity_id=None, topic_id=None
         )
@@ -895,7 +894,7 @@ class TestWriteTaskFile:
         """topic_id・タイトル指定時はt{topic_id}-T{n}-{slug}.md形式になる"""
         task_file = ow_service._write_task_file(
             task_dir=tmp_path, task_n=16, alias="w-a", channel="ch1",
-            cwd="/tmp", model="opus", permission="acceptEdits",
+            cwd="/tmp", model="opus",
             task_title="queue読み書き一元化 — ow_serviceがorch queueフォーマットを扱う",
             acceptance="", context="", playbook="",
             timeout_min=60, activity_id=821, topic_id="454"
@@ -906,13 +905,13 @@ class TestWriteTaskFile:
         """同じtask_nでもtopicが異なれば別ファイルになる（衝突しない）"""
         f1 = ow_service._write_task_file(
             task_dir=tmp_path, task_n=1, alias="w-a", channel="ch1",
-            cwd="/tmp", model="opus", permission="acceptEdits",
+            cwd="/tmp", model="opus",
             task_title="topic454タスク", acceptance="", context="", playbook="",
             timeout_min=60, activity_id=1, topic_id="454"
         )
         f2 = ow_service._write_task_file(
             task_dir=tmp_path, task_n=1, alias="w-b", channel="ch2",
-            cwd="/tmp", model="opus", permission="acceptEdits",
+            cwd="/tmp", model="opus",
             task_title="topic100タスク", acceptance="", context="", playbook="",
             timeout_min=60, activity_id=2, topic_id="100"
         )
@@ -927,7 +926,7 @@ class TestWriteTaskFile:
         nested_dir = tmp_path / "deep" / "nested" / "tasks"
         task_file = ow_service._write_task_file(
             task_dir=nested_dir, task_n=1, alias="w-a", channel="ch",
-            cwd="/tmp", model="sonnet", permission="auto",
+            cwd="/tmp", model="sonnet",
             task_title="", acceptance="", context="", playbook="",
             timeout_min=60, activity_id=None, topic_id=None
         )

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -871,6 +871,7 @@ class TestWriteTaskFile:
         assert fm["channel"] == "AbCdEfGh"
         assert fm["v"] == 1
         assert fm["activity_id"] == 1
+        assert fm["permission_mode"] == "auto"
         # 本文にタイトル・acceptance・contextが入る
         assert "# T1: テストタスク" in body
         assert "## Acceptance" in body

--- a/tests/unit/test_ow_task_file_sanitize.py
+++ b/tests/unit/test_ow_task_file_sanitize.py
@@ -86,7 +86,7 @@ class TestWriteTaskFileSanitize:
             channel="testchan",
             cwd="/tmp",
             model="claude-sonnet-4-6",
-            permission="auto",
+
             task_title="サニタイズテスト",
             acceptance="テスト全通過</parameter>",
             context="",
@@ -109,7 +109,7 @@ class TestWriteTaskFileSanitize:
             channel="testchan",
             cwd="/tmp",
             model="claude-sonnet-4-6",
-            permission="auto",
+
             task_title="サニタイズテスト",
             acceptance="",
             context='<invoke name="foo">背景情報</invoke>',
@@ -133,7 +133,7 @@ class TestWriteTaskFileSanitize:
             channel="testchan",
             cwd="/tmp",
             model="claude-sonnet-4-6",
-            permission="auto",
+
             task_title="サニタイズテスト",
             acceptance="</parameter>",
             context="",
@@ -154,7 +154,7 @@ class TestWriteTaskFileSanitize:
             channel="chan",
             cwd="/tmp",
             model="claude-sonnet-4-6",
-            permission="auto",
+
             task_title="クリーンテスト",
             acceptance="PRを作成してCIが通ること",
             context="背景情報",


### PR DESCRIPTION
## Summary

- `ow_spawn_worker` の `permission` 引数を削除し、`permission_mode` を `auto` に固定
- `_write_queue_spawning` / `_write_task_file` からも `permission` パラメータを削除
- `worker_cmd` の `--permission-mode` フラグを `auto` ハードコードに変更
- `skills/orch/SKILL.md` / `skills/worker/SKILL.md` から `permission_mode` / `permission` 引数参照を削除
- テスト（`test_ow_queue.py`）内の `permission=` 引数呼び出しを全て削除し、アサーションも更新

## Test plan

- [x] `tests/unit/test_ow_queue.py` 57件全通過
- [x] 全テストスイート 1532件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)