### PR TITLE
feat: tmuxアダプタに分割表示UXを追加 (tmux_target_pane引数)

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -51,17 +51,20 @@ case "$ACTION" in
         | tail -1)
 
       if [[ -z "$EXISTING_WORKER" ]]; then
-        # 最初: target_paneの右に30%水平分割
-        PANE_ID=$(tmux split-window -h -t "$TARGET_PANE" -l "30%" -P -F "#{pane_id}" -- \
+        # 最初: target_paneの右に30%水平分割（-d でフォーカスを呼び出し元paneに残す）
+        PANE_ID=$(tmux split-window -h -d -t "$TARGET_PANE" -l "30%" -P -F "#{pane_id}" -- \
           bash -c "$SHELL_CMD")
       else
-        # 2個目以降: 最新worker paneを垂直分割（下に新workerが入る）
-        PANE_ID=$(tmux split-window -v -t "$EXISTING_WORKER" -P -F "#{pane_id}" -- \
+        # 2個目以降: 最新worker paneを垂直分割（下に新workerが入る、-d でフォーカス維持）
+        PANE_ID=$(tmux split-window -v -d -t "$EXISTING_WORKER" -P -F "#{pane_id}" -- \
           bash -c "$SHELL_CMD")
       fi
 
       # pane-titleで識別用マーカーを設定（pane-border-status未有効でも内部値は保持される）
-      tmux select-pane -t "$PANE_ID" -T "$WORKER_TITLE" 2>/dev/null || true
+      # -T はtmux 2.0+のみ対応。未対応環境では pane-title が空になり次回spawnで「最初」扱いに
+      # なり続けるため、stderr に警告を出して診断可能にする（subprocess.runのcapture_outputで拾える）。
+      tmux select-pane -t "$PANE_ID" -T "$WORKER_TITLE" 2>/dev/null \
+        || echo "warn: tmux select-pane -T unsupported (requires tmux 2.0+), pane-title not set" >&2
     else
       # フォールバック: 従来の ow-workers 別session方式
       if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # tmux ターミナルアダプタ
 # 使い方:
-#   tmux.sh spawn <cwd> <worker_cmd>   → 新window起動、tmux pane IDをstdoutに返す
+#   tmux.sh spawn <cwd> <worker_cmd> [target_pane]
+#     target_pane 未指定: 従来通り ow-workers セッションに新windowで起動
+#     target_pane 指定:   target_paneと同じwindow内で split-window
+#                         - window内に pane-title=ow-worker のpaneが0個 → 右に30%水平分割
+#                         - 1個以上 → 最新worker paneを垂直分割
 #   tmux.sh close <term_ref>           → pane IDでpaneをkill
 #
 # worker_cmdはshlex.quote等でエスケープ済みのシェルコマンド文字列を期待する。
@@ -9,34 +13,64 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: tmux.sh spawn <cwd> <worker_cmd> | close <term_ref>" >&2
+  echo "Usage: tmux.sh spawn <cwd> <worker_cmd> [target_pane] | close <term_ref>" >&2
   exit 1
 fi
 
 ACTION="$1"
 SESSION_NAME="${OW_TMUX_SESSION:-ow-workers}"
+WORKER_TITLE="ow-worker"
 
 case "$ACTION" in
   spawn)
     if [[ $# -lt 3 ]]; then
-      echo "Usage: tmux.sh spawn <cwd> <worker_cmd>" >&2
+      echo "Usage: tmux.sh spawn <cwd> <worker_cmd> [target_pane]" >&2
       exit 1
     fi
     CWD="$2"
     WORKER_CMD="$3"
-
-    # 既存セッションがなければ新規作成 (detached)。window 0 は基準窓として残す
-    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-      tmux new-session -d -s "$SESSION_NAME" -n "ow-base"
-    fi
+    TARGET_PANE="${4:-}"
 
     # シェルインジェクション対策: base64エンコードしてCWDとCMDを安全に渡す
     CWD_B64=$(printf '%s' "$CWD" | base64 | tr -d '\n')
     CMD_B64=$(printf '%s' "$WORKER_CMD" | base64 | tr -d '\n')
+    SHELL_CMD="cd \$(echo $CWD_B64 | base64 -d) && \$(echo $CMD_B64 | base64 -d)"
 
-    # 新規windowを作成してworkerを起動、pane IDを返す
-    PANE_ID=$(tmux new-window -t "$SESSION_NAME" -n "ow-worker" -P -F "#{pane_id}" -- \
-      bash -c "cd \$(echo $CWD_B64 | base64 -d) && \$(echo $CMD_B64 | base64 -d)")
+    if [[ -n "$TARGET_PANE" ]]; then
+      # split-window方式: target_paneと同じwindowに分割して入れる
+      WINDOW_ID=$(tmux display -t "$TARGET_PANE" -p "#{window_id}" 2>/dev/null || true)
+      if [[ -z "$WINDOW_ID" ]]; then
+        echo "target_pane not found: $TARGET_PANE" >&2
+        exit 1
+      fi
+
+      # window内の既存worker pane (pane-title=ow-worker) を pane_id 昇順で取得し、末尾を「最新」とする
+      EXISTING_WORKER=$(tmux list-panes -t "$WINDOW_ID" -F "#{pane_id}|#{pane_title}" 2>/dev/null \
+        | awk -F'|' -v t="$WORKER_TITLE" '$2 == t { print $1 }' \
+        | sort -t'%' -k2 -n \
+        | tail -1)
+
+      if [[ -z "$EXISTING_WORKER" ]]; then
+        # 最初: target_paneの右に30%水平分割
+        PANE_ID=$(tmux split-window -h -t "$TARGET_PANE" -l "30%" -P -F "#{pane_id}" -- \
+          bash -c "$SHELL_CMD")
+      else
+        # 2個目以降: 最新worker paneを垂直分割（下に新workerが入る）
+        PANE_ID=$(tmux split-window -v -t "$EXISTING_WORKER" -P -F "#{pane_id}" -- \
+          bash -c "$SHELL_CMD")
+      fi
+
+      # pane-titleで識別用マーカーを設定（pane-border-status未有効でも内部値は保持される）
+      tmux select-pane -t "$PANE_ID" -T "$WORKER_TITLE" 2>/dev/null || true
+    else
+      # フォールバック: 従来の ow-workers 別session方式
+      if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        tmux new-session -d -s "$SESSION_NAME" -n "ow-base"
+      fi
+
+      PANE_ID=$(tmux new-window -t "$SESSION_NAME" -n "ow-worker" -P -F "#{pane_id}" -- \
+        bash -c "$SHELL_CMD")
+    fi
 
     echo "$PANE_ID"
     ;;

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -357,6 +357,8 @@ ID別の取得関数:
 
 **spawn前バリデーション**: `ow_spawn_worker` は内部で relay疎通・channel存在・cwd存在・alias重複の4点を自動チェックする。失敗時は `{"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}` が返るので、warningsを確認して原因を解消してから再spawnする。
 
+**tmux分割表示**: `OW_TERMINAL=tmux` の環境では、orchが自身の `os.environ['TMUX_PANE']` を読んで `ow_spawn_worker(..., tmux_target_pane=<TMUX_PANE>)` に渡すと、orchペインと同じwindow内にworker paneが分割表示される（最初は右に30%水平、以降は右ペインを垂直分割で積む）。未指定時は従来の `ow-workers` 別sessionに新windowで起動する。MCPサーバープロセスのenvは起動時にフリーズするためサーバー側で参照できない、必ずクライアント側で読んで渡すこと。
+
 ## 複数orchの運用
 
 - インスタンスキー = `topic_id`。channel・queueファイル・worker aliasすべて分離する
@@ -369,7 +371,7 @@ ID別の取得関数:
 |---|---|
 | `ow_send(channel, handle, body, needs_reply, in_reply_to)` | メッセージ送信（4xx即失敗、5xx/接続断のみ3回指数バックオフ）。bodyは `kind=command`/`event` envelope |
 | `ow_history(channel, since, limit)` | 履歴pull（受信処理の本体・保険経路。SSE push本体添付が主軸、設計書v3 §3.3） |
-| `ow_spawn_worker(alias, channel, cwd, model, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却。permission_modeはauto固定） |
+| `ow_spawn_worker(alias, channel, cwd, model, task_title, acceptance, context, playbook, timeout_min, activity_id, topic_id, task_n, tmux_target_pane)` | worker起動（spawning write-ahead→task file書き出し→アダプタ起動→安定ID返却。permission_modeはauto固定）。OW_TERMINAL=tmux時は orch自身の TMUX_PANE を `tmux_target_pane` に渡すと同window内に分割表示される |
 | `ow_close_worker(term_ref)` | workerクローズ |
 | `ow_status(channel, topic_id)` | queue+identity統合ビュー |
 | `ow_recover(channel, topic_id, dry_run)` | crash復旧（queue×relay履歴×identity reducer突合・ghost_active自動再構築・stalled/orphan command:ping送信） |

--- a/src/main.py
+++ b/src/main.py
@@ -1050,6 +1050,7 @@ def ow_spawn_worker(
     activity_id: int | None = None,
     topic_id: str | None = None,
     task_n: int = 1,
+    tmux_target_pane: str | None = None,
 ) -> dict:
     """workerセッションを起動する。
 
@@ -1057,6 +1058,9 @@ def ow_spawn_worker(
     relay疎通確認・起動（ensure-server処理）も内包。permission_modeはautoに固定。
 
     OW_TERMINAL環境変数でアダプタを選択（iterm2/tmux/manual。manualは起動コマンド表示のフォールバック）。
+    OW_TERMINAL=tmuxのとき、tmux_target_pane（呼び出し元のTMUX_PANE）を渡すと、その
+    paneと同じwindow内にworker paneを分割表示できる（最初は右に30%水平、以降は最新
+    worker paneを垂直分割）。未指定時は従来の `ow-workers` 別sessionに新windowで起動する。
 
     Args:
         alias: workerのhandle（例: "w-a"）
@@ -1071,6 +1075,9 @@ def ow_spawn_worker(
         activity_id: 対応するアクティビティID（optional）
         topic_id: 対応するトピックID（optional）
         task_n: タスク番号（T<n>）
+        tmux_target_pane: tmux分割表示用の基準pane ID（例: "%0"）。クライアント側で
+            os.environ['TMUX_PANE']を読んで渡す。MCPサーバープロセスのenvは起動時に
+            フリーズするためサーバー側で参照できない。
 
     Returns:
         成功時: {"term_ref": str, "task_file": str, "spawning": "ok", "alias": str}
@@ -1090,6 +1097,7 @@ def ow_spawn_worker(
         activity_id=activity_id,
         topic_id=topic_id,
         task_n=task_n,
+        tmux_target_pane=tmux_target_pane,
     )
 
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -923,6 +923,7 @@ def ow_spawn_worker(
     activity_id: int | None = None,
     topic_id: str | None = None,
     task_n: int = 1,
+    tmux_target_pane: str | None = None,
 ) -> dict:
     """workerセッションを起動する。
 
@@ -944,6 +945,12 @@ def ow_spawn_worker(
         activity_id: 対応するアクティビティID
         topic_id: 対応するトピックID
         task_n: タスク番号（Tn）
+        tmux_target_pane: OW_TERMINAL=tmuxのとき、worker paneを分割する基準pane ID。
+            指定時はそのpaneと同じwindow内に split-window で入れる（最初は右に30%水平、
+            以降は最新worker paneを垂直分割）。未指定時は従来の `ow-workers` 別sessionに
+            新windowで起動する。クライアント（spawn呼び出し元）が自身の os.environ['TMUX_PANE']
+            を読んで渡す想定。MCPサーバープロセスのenvは起動時にフリーズするためサーバー側で
+            参照できない。
 
     Returns:
         {"term_ref": str, "task_file": str, "spawning": "ok"}
@@ -1037,9 +1044,12 @@ def ow_spawn_worker(
         }
 
     # アダプタ呼び出し — stdoutから安定IDを取得する
+    adapter_args = ["bash", str(adapter_path), "spawn", cwd, worker_cmd]
+    if terminal == "tmux" and tmux_target_pane:
+        adapter_args.append(tmux_target_pane)
     try:
         result = subprocess.run(
-            ["bash", str(adapter_path), "spawn", cwd, worker_cmd],
+            adapter_args,
             check=True,
             capture_output=True,
             text=True,

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -739,6 +739,97 @@ class TestOwSpawnWorkerAdapter:
         assert result.get("manual") is True
         assert "adapter_error" in result
 
+    def test_tmux_target_pane_appended_when_terminal_is_tmux(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """OW_TERMINAL=tmux かつ tmux_target_pane 指定時、adapter args の末尾に target_pane が追加される"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        adapter_script = tmp_path / "tmux.sh"
+        adapter_script.write_text("#!/bin/bash\necho '%9'\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        captured_args: list[list[str]] = []
+        real_run = ow_service.subprocess.run
+
+        def capturing_run(args, **kwargs):
+            captured_args.append(list(args))
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=1,
+            tmux_target_pane="%0",
+        )
+        assert result.get("spawning") == "ok"
+        # adapter_args は ["bash", "<script>", "spawn", cwd, worker_cmd, target_pane] の6要素
+        assert len(captured_args[0]) == 6
+        assert captured_args[0][-1] == "%0"
+
+    def test_tmux_target_pane_omitted_when_none(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """OW_TERMINAL=tmux かつ tmux_target_pane=None のとき adapter args に target_pane が追加されない"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        adapter_script = tmp_path / "tmux.sh"
+        adapter_script.write_text("#!/bin/bash\necho '%5'\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        captured_args: list[list[str]] = []
+        real_run = ow_service.subprocess.run
+
+        def capturing_run(args, **kwargs):
+            captured_args.append(list(args))
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-b", channel="ch2", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=2,
+        )
+        assert result.get("spawning") == "ok"
+        # tmux_target_pane未指定なので adapter_args は5要素のみ
+        assert len(captured_args[0]) == 5
+
+    def test_tmux_target_pane_ignored_when_terminal_is_not_tmux(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """OW_TERMINAL=iterm2 のとき tmux_target_pane 指定は無視され adapter args に追加されない"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "iterm2")
+
+        adapter_script = tmp_path / "iterm2.sh"
+        adapter_script.write_text("#!/bin/bash\necho 'iterm2-uuid'\n")
+        adapter_script.chmod(0o755)
+        monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
+
+        captured_args: list[list[str]] = []
+        real_run = ow_service.subprocess.run
+
+        def capturing_run(args, **kwargs):
+            captured_args.append(list(args))
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-c", channel="ch3", cwd="/tmp", model="sonnet",
+            task_title="test", acceptance="done", task_n=3,
+            tmux_target_pane="%0",
+        )
+        assert result.get("spawning") == "ok"
+        # iterm2のため tmux_target_pane は無視され adapter_args は5要素、"%0"も含まれない
+        assert len(captured_args[0]) == 5
+        assert "%0" not in captured_args[0]
+
 
 class TestOwSpawnWorkerEnsureChannel:
     """ow_spawn_worker: spawn前ヘルスチェック (T17) と ensure_channel 連携の動作確認"""

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -16,12 +16,18 @@ def _make_mock_tmux(
     has_session: bool = True,
     capture_file: Path | None = None,
     kill_pane_exit: int = 0,
+    target_pane_exists: bool = True,
+    existing_worker_panes: str = "",
 ) -> Path:
     """tmuxをモックするシェルスクリプトを作成する。
 
     spawn時はMOCK_PANE_IDを返す。close時は何も出力しない。
     capture_fileが指定された場合、受け取った引数を追記する。
     kill_pane_exitが1の場合、kill-paneが失敗するモックになる。
+
+    target_pane_exists=Falseのとき `tmux display` がexit 1を返す（target_pane不在シミュレーション）。
+    existing_worker_panesは `tmux list-panes -F "#{pane_id}|#{pane_title}"` の擬似出力。
+    例: "%5|ow-worker\\n%7|other-title" を渡すと既存worker paneが1個ある状態を模擬する。
     """
     mock_dir = tmp_path / "mock_bin"
     mock_dir.mkdir(exist_ok=True)
@@ -29,13 +35,18 @@ def _make_mock_tmux(
 
     has_session_exit = "0" if has_session else "1"
     capture_cmd = f'printf "%s\\n" "$*" >> "{capture_file}"' if capture_file else ""
+    display_exit = "0" if target_pane_exists else "1"
+    display_out = '"@1"' if target_pane_exists else '""'
 
     mock.write_text(
         f'#!/usr/bin/env bash\n'
         f'{capture_cmd}\n'
         f'if [ "$1" = "has-session" ]; then exit {has_session_exit}; fi\n'
         f'if [ "$1" = "new-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
+        f'if [ "$1" = "split-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
         f'if [ "$1" = "kill-pane" ]; then exit {kill_pane_exit}; fi\n'
+        f'if [ "$1" = "display" ]; then echo {display_out}; exit {display_exit}; fi\n'
+        f'if [ "$1" = "list-panes" ]; then printf "%b\\n" "{existing_worker_panes}"; fi\n'
         f'exit 0\n'
     )
     mock.chmod(0o755)
@@ -140,6 +151,77 @@ class TestTmuxAdapterClose:
         # kill_pane_exit=1でkill-paneが常に失敗するモックを使用
         result, _ = _run_adapter(["close", "%999"], tmp_path, kill_pane_exit=1)
         assert result.returncode == 0
+
+
+class TestTmuxAdapterSplit:
+    """target_pane指定時のsplit-window方式のテスト。"""
+
+    def test_spawn_with_target_pane_calls_split_window(self, tmp_path):
+        """target_pane指定時はsplit-windowが呼ばれ、new-windowは呼ばれない。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"], tmp_path
+        )
+        assert result.returncode == 0
+        assert "split-window" in captured
+        assert "new-window" not in captured
+
+    def test_no_target_pane_falls_back_to_new_window(self, tmp_path):
+        """target_pane未指定時は従来通りnew-windowで起動し、split-windowは呼ばれない。"""
+        result, captured = _run_adapter(["spawn", "/tmp/work", "claude"], tmp_path)
+        assert result.returncode == 0
+        assert "new-window" in captured
+        assert "split-window" not in captured
+
+    def test_first_worker_uses_horizontal_30pct(self, tmp_path):
+        """既存worker pane 0個のとき、最初のworkerは -h -l 30% で水平分割される。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="",
+        )
+        assert result.returncode == 0
+        assert "split-window -h" in captured
+        assert "30%" in captured
+
+    def test_subsequent_worker_uses_vertical_split(self, tmp_path):
+        """既存worker pane (pane-title=ow-worker) があるとき、-v で垂直分割される。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|ow-worker",
+        )
+        assert result.returncode == 0
+        assert "split-window -v" in captured
+
+    def test_split_sets_pane_title_ow_worker(self, tmp_path):
+        """split-window後にselect-paneでpane-title=ow-workerが設定される。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"], tmp_path
+        )
+        assert result.returncode == 0
+        assert "select-pane" in captured
+        assert "ow-worker" in captured
+
+    def test_non_worker_titled_panes_ignored(self, tmp_path):
+        """pane-titleがow-worker以外のpaneは既存workerとして扱わず、水平30%分割になる。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|other-title\\n%7|zsh",
+        )
+        assert result.returncode == 0
+        assert "split-window -h" in captured
+        assert "30%" in captured
+
+    def test_target_pane_not_found_exits_nonzero(self, tmp_path):
+        """target_paneが存在しないとき、exit 1とstderrエラーメッセージを返す。"""
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%999"],
+            tmp_path,
+            target_pane_exists=False,
+        )
+        assert result.returncode != 0
+        assert "target_pane not found" in result.stderr
 
 
 class TestTmuxAdapterErrors:


### PR DESCRIPTION
## Summary

- `ow_spawn_worker` に `tmux_target_pane: str | None = None` 引数を追加。クライアント側が自身の `TMUX_PANE` を渡すと、その pane と同じ window 内に worker pane を分割表示する
- 配置ルール: 最初は右に 30% 水平分割、以降は最新 worker pane (`pane-title=ow-worker` で識別) を垂直分割。close で pane が消えれば自動的に「最初」扱いに戻る
- `tmux_target_pane` 未指定時は従来の `ow-workers` 別 session 方式にフォールバック（破壊的変更なし）
- `skills/orch/SKILL.md` に orch が `os.environ['TMUX_PANE']` を渡すルールを追記

## 背景

A#858（[調査] tmuxアダプタ動作確認）で次のことが判明:

- `os.environ.get('OW_TERMINAL')` を参照する `ow_service.ow_spawn_worker` は、MCP HTTP サーバープロセス（永続デーモン）の **起動時 env がフリーズする** ためクライアントの現環境を反映できない
- リモート MCP（claude.ai 経由）ではサーバー側 env 参照は根本的に成立しない
- 既存の tmux アダプタは単体テスト緑のまま merge されたが、実機ではアダプタ選択ロジックが iTerm2 にフォールバックして tmux が使われていなかった

このため、ターミナル選択や分割ターゲットは **クライアント側で読み取って引数で渡す** 方式に変更する必要があった。

確定 decision: D#2554-2557

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/services/ow_service.py` | `tmux_target_pane: str \| None = None` 引数追加。adapter 呼び出し時、`terminal == 'tmux'` かつ非 None なら subprocess 引数として append |
| `src/main.py` | 同 MCP ツール定義に引数追加・docstring 更新 |
| `scripts/ow/adapters/tmux.sh` | 第 4 引数 `target_pane` を受け取り、ある場合は split-window 方式に分岐。`pane-title=ow-worker` で既存 worker を識別、0 個 → `-h -l 30%`、1 個以上 → 最新 worker pane を `-v` で垂直分割 |
| `skills/orch/SKILL.md` | spawn 前バリデーション直後に「tmux 分割表示」セクション追加。MCP ツール一覧のシグネチャも更新 |
| `tests/unit/test_tmux_adapter.py` | `TestTmuxAdapterSplit` クラス追加（7 ケース） |

## Edge case

- target_pane が消えている → `tmux display` exit 1 → adapter exit 1 → caller がmanualフォールバック相当のエラーを受ける
- pane-title が `ow-worker` 以外の pane → 既存 worker としてカウントしない（最初扱い）
- iTerm2 環境 → `tmux.sh` は呼ばれないので新引数は無視される
- リモート MCP → クライアント側 `TMUX_PANE` 未設定なので未指定扱い、従来フォールバック

## 実機検証

`tmux` 内 Claude Code から `tmux.sh` を直接呼び出し、worker_cmd=`sleep 9999`:

| ステップ | 期待 | 実測 |
|---|---|---|
| spawn 1 | 右 30% 水平 | 親 148x54 / worker `%6` 63x54 |
| spawn 2 | 右ペイン上下分割 | `%6` 63x27 / `%7` 63x26 |
| spawn 3 | 右下を再上下分割 | `%7` 63x13 / `%8` 63x12 |
| 各 pane | title=ow-worker | 全て付与済 |
| close x3 | レイアウト解消 | 親 → 212x54 (元幅) |
| 全消し後 spawn | 「最初」扱い | `%9` 再び 63x54 |

ユーザー目視確認済（右 3 分割の worker pane が見えた）。

## 単体テスト

```
1171 passed, 2 warnings in 231.22s
```

`test_tmux_adapter.py` は 23 ケース全パス（新規 7 ケース含む）。

## tag note の追記

`terminal-adapter` タグの notes に「PR 前の実機動作確認が必須」を追記。`ow_spawn_worker` のような「環境を選ぶ」コードは mock 前提の単体テストで env 伝搬の落とし穴を捕捉できないため、PR 前に対象環境で実機確認する運用ルールを定着させる。

## Test plan

- [x] `pytest tests/unit/` 全件パス
- [x] tmux 内 Claude Code から `tmux.sh` 直接呼び出しで分割挙動を実機確認
- [x] close → 再 spawn で「最初」扱いに戻ることを確認
- [x] target_pane 未指定時の従来挙動（`ow-workers` 別 session）が維持されていることを確認（既存テスト緑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)