### PR TITLE
fix: ow_spawn_workerでkick promptがworker claudeに届かないバグを修正 (A#862)

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -32,9 +32,12 @@ case "$ACTION" in
     TARGET_PANE="${4:-}"
 
     # シェルインジェクション対策: base64エンコードしてCWDとCMDを安全に渡す
+    # cd側はダブルクォートでword splittingを抑止、worker_cmd側はevalでシェル構文として
+    # 再パースさせる（shlex.quoteのリテラル引用符を正しく解釈させるため）。
+    # evalに渡すソースはow_serviceが組み立てた信頼コマンド文字列のみ（base64で運搬）。
     CWD_B64=$(printf '%s' "$CWD" | base64 | tr -d '\n')
     CMD_B64=$(printf '%s' "$WORKER_CMD" | base64 | tr -d '\n')
-    SHELL_CMD="cd \$(echo $CWD_B64 | base64 -d) && \$(echo $CMD_B64 | base64 -d)"
+    SHELL_CMD="cd \"\$(echo $CWD_B64 | base64 -d)\" && eval \"\$(echo $CMD_B64 | base64 -d)\""
 
     if [[ -n "$TARGET_PANE" ]]; then
       # split-window方式: target_paneと同じwindowに分割して入れる

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1026,11 +1026,14 @@ def ow_spawn_worker(
     terminal = os.environ.get("OW_TERMINAL", "manual")
     adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
 
+    # --add-dir は variadic option (`<directories...>`) のため、続く positional prompt まで
+    # ディレクトリ引数として食ってしまう。`--` で variadic を打ち切って prompt を positional
+    # として確実に届ける。
     worker_cmd = (
         f'env OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
         f'OW_TASK_FILE={shlex.quote(str(task_file))} '
         f'claude --model {shlex.quote(model)} --permission-mode auto '
-        f'--add-dir {shlex.quote(str(task_file.parent))} '
+        f'--add-dir {shlex.quote(str(task_file.parent))} -- '
         f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
     )
 


### PR DESCRIPTION
## Summary

`ow_spawn_worker` でtmux分割paneにworkerをspawnしても、kick promptがclaude CLIに届かず workerスキルが起動しなかったバグを修正する。

独立した2バグの組み合わせが原因だったので、両方を最小修正：

### バグ① tmux.sh の word splitting
`bash -c "cd \$(...) && \$(...)"` の `\$(...)` がノークォートのため、デコードされた `worker_cmd` が word splitting にかかる。shlex.quote のリテラル引用符が単なる文字として残り、スペース含みの prompt 引数が複数 token に分裂していた。

**修正**: `eval "\$(...)"` でデコード結果をシェル構文として再パースさせる。

### バグ② --add-dir の variadic 食い込み
`claude --add-dir <directories...>` は variadic option (`...` 表記) で、空白区切りで複数 dir を受け取る。そのため続く positional prompt 引数まで dir として食ってしまい、prompt が claude に positional として認識されず auto-submit されなかった。

**修正**: `--add-dir <dir> -- <prompt>` の `--` で variadic を打ち切る。

### なぜ両方必要か
- `--` のみ: auto-submit は走るが word splitting で prompt が分裂し、claude が「タスク内容が途中で切れてる」と返答する
- eval のみ: word splitting は防げるが variadic 食い込みで auto-submit されない

## 実機検証

tmux 内 Claude Code セッションから `ow_spawn_worker(tmux_target_pane=\$TMUX_PANE)` を実行：

\`\`\`
❯ workerスキルに従って作業を開始して。task:
  /Users/.../t454-T4-A-862-eval-+-dash-dash-両方修正-最終実機検証.md

⏺ Skill(worker)
  ⎿  Successfully loaded skill

  Reading 1 file…
\`\`\`

- ✅ kick prompt が完全形で auto-submit
- ✅ workerスキル loaded
- ✅ task file 読み込み開始
- ✅ ps の argv で prompt がクォートなしの単一引数として claude に届くことを確認

## Test plan

- [x] 実機: tmux内Claude Codeからow_spawn_worker → worker pane でworkerスキル起動シーケンス完遂
- [x] argv観察: ps で claude に positional prompt が単一引数（クォートなし）で届くことを確認
- [ ] 既存のtmuxアダプタ単体テスト (tests/unit/test_tmux_adapter.py) がgreenのまま

## 関連

- A#862 (cc-memory activity)
- 過去PR #373 (tmux分割UX対応、本バグの直接の発覚元)