### PR TITLE
fix: recompose-context発火しきい値を5→30に引き上げ

### DIFF
--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -20,7 +20,7 @@ DECISIONS_FULL_LIMIT = 15
 # recomposeナッジhintのしきい値。
 # 実運用での発火頻度を見ながら調整する前提の暫定値。
 # メンテナッジ: recomposed material最終更新以降に増えたdecisionがこの件数以上で発火。
-_RECOMPOSE_HINT_DELTA_THRESHOLD = 5
+_RECOMPOSE_HINT_DELTA_THRESHOLD = 30
 # ブートストラップナッジ: material未整備のtagでdecision総数がこの件数以上で発火。
 _RECOMPOSE_HINT_BOOTSTRAP_THRESHOLD = 15
 


### PR DESCRIPTION
## Summary

- `_RECOMPOSE_HINT_DELTA_THRESHOLD` を 5 → 30 に変更
- 通常運用での過敏発火を抑え、本当にrecomposeすべきスパイク日のみ検出する水準に調整

## 背景

現状の5件しきい値は、tag「ow」で「recompose当日にdecision 5件追加→即発火」する過敏挙動を引き起こしていた。

実運用観測（tag「ow」直近1週間、recompose v2は2026-06-16作成）:

| 日付 | 件数 |
|---|---|
| 2026-06-14 | 48 (本質再考T35＋v3統合設計改訂が同日に集中したスパイク) |
| 2026-06-15 | 5 (ノイズレベル) |
| 2026-06-16 | 12 (H-1〜H-3確定+A#862関連+議論中ストック中心、本質責務記述には影響しない周辺decision) |

30件にすることで、6/14のような明確なスパイク日のみrecompose-context推奨が発火し、通常の小さな積み上げでは沈黙する。

## Test plan

- [x] `tests/integration/test_checkin_service.py` の `TestRecomposeHints` 10件全パス
- [ ] マージ後、通常運用での発火頻度を観測（過剰に沈黙していないかの確認、ただし元が過敏側なのでまずはこの水準でよい想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)