### PR TITLE
feat: orch自発ow_status呼び出し規則追記 + alias identity aliveチェック実装 (T59)

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -38,6 +38,8 @@ on Monitor発火 or 自発的タイミング:
   人間向けダイジェスト出力（状態変化時）→ Monitor待機へ
 ```
 
+**自発的タイミングでの ow_status 呼び出し**: Monitor 発火ではなくユーザー入力・直接呼び出し等の自発的タイミングで起床した場合は、`ow_history` 処理後に `ow_status(channel, topic_id)` を呼んで worker の presence 状態を確認すること。キュー状態とworker生死の乖離を早期発見するため。
+
 **受信処理（SSEはベル、真実源は/history）**:
 1. SSE（Monitor監視）は起床信号専用。届いたdata行の中身は処理に使わない
 2. 起床したら `ow_history(since=last_seen_msg_id)` で未処理メッセージを全件pull

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1427,6 +1427,23 @@ def _validate_spawn_preconditions(
             )
             break
 
+    # 6. identity alive check (INV-9: 同一 handle で alive 期間が時間的に重複しない)
+    identity = ow_get_identity(channel, alias)
+    if identity is not None:
+        cause = identity.get("cause")
+        inferred_cause = identity.get("inferred_cause")
+        terminated_at = identity.get("terminated_at")
+        is_terminated = (
+            cause in ("closed", "cancelled", "dead")
+            or bool(terminated_at)
+            or inferred_cause is not None
+        )
+        if not is_terminated:
+            warnings.append(
+                f"alias {alias} has an alive identity on channel {channel} "
+                "(not yet terminated); cannot spawn duplicate worker (INV-9)"
+            )
+
     return {"ok": not warnings, "warnings": warnings}
 
 

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -908,6 +908,7 @@ class TestOwSpawnWorkerPreflight:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-x"])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
         result = ow_service.ow_spawn_worker(
             alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path),
             model="claude-opus-4-7",

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -35,6 +35,8 @@ class TestValidateSpawnPreconditions:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+        # デフォルトはidentity未存在（alive identityなし）
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
 
     def test_all_ok_returns_no_warnings(self, monkeypatch, tmp_path):
         """全項目クリア → ok=True、warnings空"""
@@ -138,6 +140,53 @@ class TestValidateSpawnPreconditions:
         )
         assert result["ok"] is True
         assert result["warnings"] == []
+
+    def test_alias_alive_identity_blocks_spawn(self, monkeypatch, tmp_path):
+        """alive identity（terminated_at/cause未設定）があればok=False・INV-9警告"""
+        monkeypatch.setattr(
+            ow_service,
+            "ow_get_identity",
+            lambda ch, h: {
+                "type": "identity",
+                "role": "worker",
+                "handle": h,
+                "alias": h,
+                # terminated_at / cause がない = alive
+            },
+        )
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("INV-9" in w for w in result["warnings"])
+
+    def test_no_identity_allows_spawn(self, monkeypatch, tmp_path):
+        """identityが存在しない（ow_get_identity=None）→ ok=True"""
+        # autouseフィクスチャがNoneを返すデフォルト設定
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is True
+        assert result["warnings"] == []
+
+    def test_terminated_identity_allows_spawn(self, monkeypatch, tmp_path):
+        """terminatedなidentity（cause=closed / terminated_at設定）→ ok=True"""
+        for terminated_identity in [
+            {"handle": "w-x", "cause": "closed", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-x", "cause": "cancelled", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-x", "cause": "dead", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-x", "inferred_cause": "crashed (inferred)"},
+        ]:
+            monkeypatch.setattr(
+                ow_service,
+                "ow_get_identity",
+                lambda ch, h, _ident=terminated_identity: _ident,
+            )
+            result = ow_service._validate_spawn_preconditions(
+                alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            )
+            assert result["ok"] is True, f"terminated identity should allow spawn: {terminated_identity}"
+            assert result["warnings"] == [], f"unexpected warning for {terminated_identity}"
 
 
 # ----------------------------

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -637,6 +637,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
 
     def test_manual_fallback_when_ow_terminal_unset(self, tmp_path: Path, monkeypatch):
         """OW_TERMINAL未設定 → manual=True + commandキーを返す"""
@@ -687,6 +688,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
 
     def test_adapter_returns_term_ref_from_stdout(self, tmp_path: Path, monkeypatch):
         """アダプタのstdoutをterm_refとして使用する"""
@@ -840,6 +842,7 @@ class TestOwSpawnWorkerEnsureChannel:
         monkeypatch.delenv("OW_TERMINAL", raising=False)
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
 
         called_channels = []
 
@@ -866,6 +869,7 @@ class TestOwSpawnWorkerEnsureChannel:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: False)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
 
         result = ow_service.ow_spawn_worker(
             alias="w-a", channel="BadCh01", cwd="/tmp", model="sonnet",
@@ -1125,6 +1129,7 @@ class TestOwSpawnWorkerModelValidation:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
     def test_haiku_returns_invalid_model_error(self, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- **問題14対応**: `skills/orch/SKILL.md` の運転ループ節に「自発的タイミング（Monitor発火以外の起床）では `ow_status(channel, topic_id)` を呼んでworker presence状態を確認する」運用ルールを一文追記
- **問題6対応 (INV-9)**: `ow_spawn_worker` の事前バリデーション (`_validate_spawn_preconditions`) に identity alive チェックを追加。同一 channel で当該 alias の identity が alive（terminated_at/cause未設定かつ inferred_cause なし）ならば `SPAWN_PRECONDITION_FAILED` に統合してwarningsで原因明示
- **ユニットテスト3パターン追加**: alive identity / no identity / terminated identity（closed/cancelled/dead/crashed-inferred）の計4ケースをパラメータ化

## Test plan

- [x] `tests/unit/test_ow_crash_recovery.py::TestValidateSpawnPreconditions` 11/11 passed
- [x] 全ユニットテスト 1177 passed（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)