### PR TITLE
feat: ow_service.py 新形式envelope対応 — nonce必須化 + nonce echo判定 (FT-2/FT-3)

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1644,16 +1644,24 @@ def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
 
     needs_reply=True で送り、応答はorchの通常受信ループで処理される。
     本関数はfire-and-forget（応答待ちはしない）。
+
+    Returns:
+        ow_send の戻り値に nonce フィールドを追加したdict。
+        nonce は ow_recover の pending_pings 引数に渡すことで、
+        次回呼び出し時に nonce echo の有無を確認できる。
     """
+    nonce = uuid.uuid4().hex
     body = {
         "v": 1,
         "kind": "command",
         "from": "orch",
         "to": alias,
         "task": task or "T0",
-        "data": {"type": "ping", "recovery": True},
+        "data": {"type": "ping", "nonce": nonce, "recovery": True},
     }
-    return ow_send(channel=channel, handle="orch", body=body, needs_reply=True)
+    result = ow_send(channel=channel, handle="orch", body=body, needs_reply=True)
+    result["nonce"] = nonce
+    return result
 
 
 def _apply_queue_status_update(
@@ -1854,6 +1862,7 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
                 {
                     "alias": orphan["alias"],
                     "task": "T0",
+                    "nonce": result.get("nonce"),
                     "reason": "orphan",
                     "result": result,
                 }
@@ -1864,6 +1873,7 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
                 {
                     "alias": stalled["alias"],
                     "task": stalled["task"],
+                    "nonce": result.get("nonce"),
                     "reason": "stalled_done",
                     "result": result,
                 }

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1660,7 +1660,11 @@ def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
         "data": {"type": "ping", "nonce": nonce, "recovery": True},
     }
     result = ow_send(channel=channel, handle="orch", body=body, needs_reply=True)
-    result["nonce"] = nonce
+    # ow_send 失敗時は nonce を付与しない。送信が成立していないものを
+    # pending_pings に積むと、後続の nonce echo チェックで "応答なし" と
+    # "送信途中" が区別できなくなる。
+    if "error" not in result:
+        result["nonce"] = nonce
     return result
 
 
@@ -1859,6 +1863,7 @@ def ow_recover(
             "presence": [],
             "reconstructed_max_msg_id": 0,
             "dry_run": dry_run,
+            "nonce_echo_results": [],
         }
     if reconstructed.get("truncated"):
         warnings.append(

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1664,6 +1664,35 @@ def _send_recovery_ping(channel: str, alias: str, task: str = "T0") -> dict:
     return result
 
 
+def _check_nonce_echo(channel: str, nonce: str, after_msg_id: int = 0) -> bool:
+    """ping送信後のrelayでin_reply_nonceが一致するeventを探す。
+
+    Args:
+        channel: channelコード
+        nonce: _send_recovery_pingが生成したnonce文字列
+        after_msg_id: pingを送った直後のmsg_id（これより大きいメッセージのみ対象）
+
+    Returns:
+        True: 対応nonceを持つevent:heartbeatまたはevent:stateが見つかった
+        False: 見つからなかった、またはrelay取得失敗
+    """
+    history = ow_history(channel, since=after_msg_id, limit=1000)
+    if "error" in history:
+        return False
+    for msg in history.get("messages", []):
+        body = msg.get("body", {})
+        if not isinstance(body, dict):
+            continue
+        if body.get("kind") != "event":
+            continue
+        data = body.get("data") or {}
+        if data.get("type") not in ("heartbeat", "state"):
+            continue
+        if data.get("in_reply_nonce") == nonce:
+            return True
+    return False
+
+
 def _apply_queue_status_update(
     queue_dir: Path,
     topic_id: str,
@@ -1744,7 +1773,12 @@ def _apply_queue_status_update(
         os.close(fd)
 
 
-def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
+def ow_recover(
+    channel: str,
+    topic_id: str,
+    dry_run: bool = False,
+    pending_pings: list[dict] | None = None,
+) -> dict:
     """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正のエントリポイント。
 
     手順:
@@ -1752,17 +1786,24 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         2. reconstruct_state_from_relay で全relay履歴から状態再構築
         3. _get_presence で現在onlineのworker一覧取得
         4. detect_crash_inconsistencies で4カテゴリ（ghost_active/pending_spawn/stalled_done/orphans）に分類
-        5. dry_run=Falseなら:
+        5. pending_pings が渡された場合: nonce echo 確認（前回ping送信後の応答有無）
+        6. dry_run=Falseなら:
            - ghost_active + pending_spawn(relay履歴あり): queueをrelay最新stateで自動更新
            - stalled_done / orphans: cmd:ping送信（応答待ちはしない）
 
     orchはこの戻り値を見て、queueの状態が更新されたことを確認し、ping送信先からの応答を
-    通常の受信ループで処理する。
+    通常の受信ループで処理する。nonce echo確認のユースケース:
+        1回目: ow_recover() → pings_sentにnonceが記録される
+        2回目（待機後）: ow_recover(..., pending_pings=[{alias, task, nonce, sent_after_msg_id}])
+            → nonce_echo_resultsでworkerの生存確認結果を取得
 
     Args:
         channel: channelコード
         topic_id: トピックID（queueファイル特定用、文字列も整数も受け付ける）
         dry_run: Trueなら検出のみ・修正/送信なし
+        pending_pings: 前回のping送信情報。各要素は:
+            {alias: str, task: str, nonce: str, sent_after_msg_id: int}
+            sent_after_msg_idより大きいmsg_idのrelayメッセージでnonce echoを探す。
 
     Returns:
         {
@@ -1777,6 +1818,10 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
             "presence": [str],
             "reconstructed_max_msg_id": int,
             "dry_run": bool,
+            "nonce_echo_results": [
+                {alias: str, task: str, nonce: str, echo_found: bool},
+                ...
+            ],
         }
         relay/channel不可時: {"error": {"code": ..., "message": ...}}
         relay history取得失敗時: detected全カテゴリ空 + warnings に fetch error メッセージ
@@ -1879,6 +1924,23 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
                 }
             )
 
+    # pending_pings が渡された場合、nonce echo の有無を確認する
+    nonce_echo_results: list[dict] = []
+    for pp in pending_pings or []:
+        echo_found = _check_nonce_echo(
+            channel=channel,
+            nonce=pp["nonce"],
+            after_msg_id=pp.get("sent_after_msg_id", 0),
+        )
+        nonce_echo_results.append(
+            {
+                "alias": pp["alias"],
+                "task": pp["task"],
+                "nonce": pp["nonce"],
+                "echo_found": echo_found,
+            }
+        )
+
     return {
         "detected": detected,
         "applied": applied,
@@ -1886,6 +1948,7 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         "presence": presence,
         "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
         "dry_run": dry_run,
+        "nonce_echo_results": nonce_echo_results,
     }
 
 

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -6,6 +6,9 @@
 - `detect_crash_inconsistencies`: ghost_active / stalled_done / orphans 各分類
 - `_apply_queue_status_update`: header status 置換 / note 追加・上書き / 不在 task
 - `ow_recover`: dry_run / 自動修正適用 / relay不可
+- `_send_recovery_ping`: nonce生成と envelope 形式 (FT-2)
+- `_check_nonce_echo`: nonce echo 判定ロジック (FT-3)
+- `ow_recover` pending_pings: nonce echo 結果の統合 (FT-3)
 
 突合ロジック本体は純粋関数のためHTTPはモックに差し替えず直接呼ぶ。
 relay HTTP接点（ow_history / _get_presence / ow_send 等）はmonkeypatchで差し替える。
@@ -934,3 +937,224 @@ class TestSendRecoveryPingNonce:
         assert body["data"]["recovery"] is True
         assert body["to"] == "w-a"
         assert body["task"] == "T3"
+
+
+# ----------------------------
+# _check_nonce_echo (FT-3)
+# ----------------------------
+
+
+class TestCheckNonceEcho:
+    """nonce echo 判定ロジックのテスト（FT-3）。"""
+
+    def _make_history(self, messages):
+        return {"messages": messages}
+
+    def _heartbeat_msg(self, msg_id, alias, nonce):
+        return {
+            "msg_id": msg_id,
+            "body": {
+                "v": 1, "kind": "event", "from": alias, "to": "*",
+                "data": {"type": "heartbeat", "phase": "working", "in_reply_nonce": nonce},
+            },
+        }
+
+    def _state_msg(self, msg_id, alias, state, nonce):
+        return {
+            "msg_id": msg_id,
+            "body": {
+                "v": 1, "kind": "event", "from": alias, "to": "orch",
+                "data": {"type": "state", "state": state, "in_reply_nonce": nonce},
+            },
+        }
+
+    def test_heartbeat_with_matching_nonce_returns_true(self, monkeypatch):
+        """event:heartbeat で in_reply_nonce が一致 → True"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: self._make_history([
+                self._heartbeat_msg(101, "w-a", "abc123"),
+            ]),
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=100) is True
+
+    def test_state_with_matching_nonce_returns_true(self, monkeypatch):
+        """event:state で in_reply_nonce が一致 → True"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: self._make_history([
+                self._state_msg(101, "w-a", "working", "xyz789"),
+            ]),
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "xyz789", after_msg_id=100) is True
+
+    def test_no_matching_nonce_returns_false(self, monkeypatch):
+        """一致する nonce がない → False"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: self._make_history([
+                self._heartbeat_msg(101, "w-a", "different_nonce"),
+            ]),
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=100) is False
+
+    def test_empty_history_returns_false(self, monkeypatch):
+        """応答なし（空履歴）→ False"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: self._make_history([]),
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=100) is False
+
+    def test_relay_error_returns_false(self, monkeypatch):
+        """relay取得失敗 → False（例外伝播しない）"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: {"error": {"code": 500}},
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=0) is False
+
+    def test_non_event_kind_ignored(self, monkeypatch):
+        """kind=command や kind=state（旧形式）は in_reply_nonce があっても無視"""
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=1000: self._make_history([
+                {
+                    "msg_id": 101,
+                    "body": {
+                        "kind": "command", "from": "orch",
+                        "data": {"type": "pong", "in_reply_nonce": "abc123"},
+                    },
+                },
+            ]),
+        )
+        assert ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=100) is False
+
+    def test_after_msg_id_filters_old_messages(self, monkeypatch):
+        """after_msg_id より前のメッセージは無視（ow_historyのsince引数に渡る）"""
+        called_with = []
+        def fake_history(channel, since=0, limit=1000):
+            called_with.append(since)
+            return self._make_history([])
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+        ow_service._check_nonce_echo("ChAbCdEf", "abc123", after_msg_id=500)
+        assert called_with == [500]
+
+
+# ----------------------------
+# ow_recover pending_pings (FT-3)
+# ----------------------------
+
+
+class TestOwRecoverPendingPings:
+    """ow_recover の pending_pings 引数と nonce_echo_results の統合テスト（FT-3）。"""
+
+    @pytest.fixture(autouse=True)
+    def _stub_relay(self, monkeypatch, tmp_path):
+        """relay/channel/presence/history を既定でスタブ化する。"""
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+        monkeypatch.setattr(
+            ow_service, "ow_history",
+            lambda channel, since=0, limit=10000: {"messages": []},
+        )
+        # queueディレクトリ（空のqueueファイル）
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        (queue_dir / "queue-t454.md").write_text("")
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+    def test_no_pending_pings_returns_empty_results(self, monkeypatch):
+        """pending_pings なし（デフォルト）→ nonce_echo_results が空リスト"""
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert result["nonce_echo_results"] == []
+
+    def test_nonce_echo_found(self, monkeypatch):
+        """pending_pings に nonce を渡し、relay に対応 nonce echo がある → echo_found=True"""
+        def fake_history(channel, since=0, limit=10000):
+            if since == 100:
+                # _check_nonce_echo が呼ぶ側（limit=1000）
+                return {
+                    "messages": [
+                        {
+                            "msg_id": 101,
+                            "body": {
+                                "v": 1, "kind": "event", "from": "w-a", "to": "*",
+                                "data": {"type": "heartbeat", "phase": "working", "in_reply_nonce": "abc123"},
+                            },
+                        },
+                    ]
+                }
+            return {"messages": []}
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+
+        pending = [{"alias": "w-a", "task": "T1", "nonce": "abc123", "sent_after_msg_id": 100}]
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454", pending_pings=pending)
+        assert len(result["nonce_echo_results"]) == 1
+        er = result["nonce_echo_results"][0]
+        assert er["alias"] == "w-a"
+        assert er["nonce"] == "abc123"
+        assert er["echo_found"] is True
+
+    def test_nonce_echo_not_found(self, monkeypatch):
+        """pending_pings に nonce を渡し、relay に対応 nonce echo がない → echo_found=False"""
+        result = ow_service.ow_recover(
+            channel="ChAbCdEf",
+            topic_id="454",
+            pending_pings=[{"alias": "w-a", "task": "T1", "nonce": "xyz999", "sent_after_msg_id": 50}],
+        )
+        assert len(result["nonce_echo_results"]) == 1
+        assert result["nonce_echo_results"][0]["echo_found"] is False
+
+    def test_multiple_pending_pings(self, monkeypatch):
+        """複数の pending_pings それぞれの echo_found が独立して判定される"""
+        def fake_history(channel, since=0, limit=10000):
+            if since == 10:
+                return {
+                    "messages": [
+                        {
+                            "msg_id": 11,
+                            "body": {
+                                "v": 1, "kind": "event", "from": "w-a", "to": "*",
+                                "data": {"type": "heartbeat", "in_reply_nonce": "nonce-a"},
+                            },
+                        },
+                    ]
+                }
+            return {"messages": []}
+        monkeypatch.setattr(ow_service, "ow_history", fake_history)
+
+        pending = [
+            {"alias": "w-a", "task": "T1", "nonce": "nonce-a", "sent_after_msg_id": 10},
+            {"alias": "w-b", "task": "T2", "nonce": "nonce-b", "sent_after_msg_id": 20},
+        ]
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454", pending_pings=pending)
+        echo_by_alias = {r["alias"]: r["echo_found"] for r in result["nonce_echo_results"]}
+        assert echo_by_alias["w-a"] is True
+        assert echo_by_alias["w-b"] is False
+
+    def test_pings_sent_includes_nonce(self, monkeypatch):
+        """ow_recoverがstalled_done workerにpingを送ったとき、pings_sentにnonceが含まれる"""
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-a"])
+        # queue に done タスク（w-a は presence にいる = stalled_done）
+        import tempfile
+        tmp = tempfile.mkdtemp()
+        qd = Path(tmp) / "queue"
+        qd.mkdir()
+        (qd / "queue-t454.md").write_text(
+            "## T1 | x | done\n- worker: w-a / term_ref: x / session: y\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(qd))
+
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: sent.append(body) or {"msg_id": 99},
+        )
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert len(result["applied"]["pings_sent"]) == 1
+        ps = result["applied"]["pings_sent"][0]
+        assert "nonce" in ps
+        assert ps["nonce"] is not None
+        assert ps["nonce"] != ""

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -1134,18 +1134,14 @@ class TestOwRecoverPendingPings:
         assert echo_by_alias["w-a"] is True
         assert echo_by_alias["w-b"] is False
 
-    def test_pings_sent_includes_nonce(self, monkeypatch):
+    def test_pings_sent_includes_nonce(self, monkeypatch, tmp_path):
         """ow_recoverがstalled_done workerにpingを送ったとき、pings_sentにnonceが含まれる"""
         monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-a"])
-        # queue に done タスク（w-a は presence にいる = stalled_done）
-        import tempfile
-        tmp = tempfile.mkdtemp()
-        qd = Path(tmp) / "queue"
-        qd.mkdir()
-        (qd / "queue-t454.md").write_text(
+        # autouseフィクスチャが作成済みのqueueファイルを done タスクで上書き
+        # （w-a が presence にいる + queue が done = stalled_done）
+        (tmp_path / "queue" / "queue-t454.md").write_text(
             "## T1 | x | done\n- worker: w-a / term_ref: x / session: y\n"
         )
-        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(qd))
 
         sent = []
         monkeypatch.setattr(

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -866,3 +866,71 @@ class TestOwSpawnWorkerPreflight:
         assert "error" in result
         assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
         assert any("alias w-x" in w for w in result["error"]["warnings"])
+
+
+# ----------------------------
+# _send_recovery_ping: nonce (FT-2)
+# ----------------------------
+
+
+class TestSendRecoveryPingNonce:
+    """_send_recovery_ping が nonce を生成して envelope に含めることを確認する（FT-2）。"""
+
+    def test_nonce_included_in_data(self, monkeypatch):
+        """送信 envelope の data.nonce が存在し、空でないこと"""
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: sent.append(body) or {"msg_id": 1},
+        )
+        ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T1")
+        assert len(sent) == 1
+        data = sent[0]["data"]
+        assert "nonce" in data
+        assert data["nonce"] != ""
+
+    def test_nonce_unique_per_call(self, monkeypatch):
+        """呼び出しごとに異なる nonce が生成されること"""
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: sent.append(body) or {"msg_id": 1},
+        )
+        ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T1")
+        ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T1")
+        assert sent[0]["data"]["nonce"] != sent[1]["data"]["nonce"]
+
+    def test_return_value_contains_nonce(self, monkeypatch):
+        """戻り値に nonce フィールドが含まれること（pending_pings 管理用）"""
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: {"msg_id": 99},
+        )
+        result = ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T1")
+        assert "nonce" in result
+        assert result["nonce"] != ""
+
+    def test_nonce_in_return_matches_envelope(self, monkeypatch):
+        """戻り値の nonce と envelope の data.nonce が一致すること"""
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: sent.append(body) or {"msg_id": 1},
+        )
+        result = ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T1")
+        assert result["nonce"] == sent[0]["data"]["nonce"]
+
+    def test_envelope_format(self, monkeypatch):
+        """送信 envelope が v3 形式（kind=command, data.type=ping, recovery=True）であること"""
+        sent = []
+        monkeypatch.setattr(
+            ow_service, "ow_send",
+            lambda channel, handle, body, needs_reply=False: sent.append(body) or {"msg_id": 1},
+        )
+        ow_service._send_recovery_ping("ChAbCdEf", "w-a", task="T3")
+        body = sent[0]
+        assert body["kind"] == "command"
+        assert body["data"]["type"] == "ping"
+        assert body["data"]["recovery"] is True
+        assert body["to"] == "w-a"
+        assert body["task"] == "T3"


### PR DESCRIPTION
## Summary

- **FT-1** (`reconstruct_state_from_relay`): コミット `4e0f96b` で既に新形式対応済みを確認。本PRに追加変更なし
- **FT-2** (`_send_recovery_ping`): ping envelope の `data.nonce` にランダム UUID を付与。`pings_sent` エントリにも nonce を記録し、orchが次回 ow_recover に `pending_pings` として渡せるようにした
- **FT-3** (`_check_nonce_echo` + `ow_recover`): `_check_nonce_echo` 関数を新規追加。`ow_recover` に `pending_pings` 引数を追加し、対応 nonce を持つ event:heartbeat/state のみを応答とみなす nonce echo 判定ロジックを実装。戻り値に `nonce_echo_results` を追加

設計根拠: 設計書 §6.1.2-4（nonce echo プロトコル）、§6.1.3（ping envelope 形式）

## Test plan

- [ ] `python -m pytest tests/unit/test_ow_crash_recovery.py -q` → 66 passed
- [ ] CI グリーン確認
- [ ] `TestSendRecoveryPingNonce`: nonce生成・一意性・戻り値整合・envelope形式（5件）
- [ ] `TestCheckNonceEcho`: heartbeat/state応答・無応答・relay障害・旧形式無視・after_msg_idフィルタ（7件）
- [ ] `TestOwRecoverPendingPings`: pending_pings統合・複数nonce並行・pings_sent nonce記録（5件）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)