### PR TITLE
feat: supersedes時のpin自動引き継ぎ + pinsテーブル CASCADE削除トリガー

### DIFF
--- a/migrations/0038_pins_target_index_and_cascade.sql
+++ b/migrations/0038_pins_target_index_and_cascade.sql
@@ -1,0 +1,69 @@
+-- Migration 038: pinsテーブルのtarget逆引きindex + 削除時CASCADEトリガー
+--
+-- depends: 0037_add_decisions_title
+--
+-- 背景:
+--   supersedes時のpin自動引き継ぎ（pin_service._transfer_pins_with_conn）で
+--   target_type/target_id による逆引きが必要になる。0034コメントで予告されていた
+--   idx_pins_target を追加する。
+--
+--   また、ハードDELETE経路（将来の削除サービス・tag削除等）からpinsがorphan化
+--   するのを防ぐため、relations 0033 と同形の AFTER DELETE トリガーで
+--   pinsのCASCADE削除をDB層で保証する。tag削除機能は現状未実装だが、
+--   将来の保険として6本（5 entity + tags）すべて貼る。
+--
+-- 変更内容:
+--   1. idx_pins_target（target_type, target_id）を追加
+--   2. pinsのCASCADE削除トリガー × 6（topic/activity/material/decision/log/tag）
+
+CREATE INDEX idx_pins_target ON pins(target_type, target_id);
+
+-- pinsのCASCADE削除トリガー（ポリモーフィックFKのためトリガーで実現、0033 relationsと同形）
+
+CREATE TRIGGER trg_pins_cascade_delete_topic
+AFTER DELETE ON discussion_topics
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'topic' AND source_id = OLD.id)
+                       OR (target_type = 'topic' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_activity
+AFTER DELETE ON activities
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'activity' AND source_id = OLD.id)
+                       OR (target_type = 'activity' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_material
+AFTER DELETE ON materials
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'material' AND source_id = OLD.id)
+                       OR (target_type = 'material' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_decision
+AFTER DELETE ON decisions
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'decision' AND source_id = OLD.id)
+                       OR (target_type = 'decision' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_log
+AFTER DELETE ON discussion_logs
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'log' AND source_id = OLD.id)
+                       OR (target_type = 'log' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_tag
+AFTER DELETE ON tags
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'tag' AND source_id = OLD.id)
+                       OR (target_type = 'tag' AND target_id = OLD.id);
+END;

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -228,24 +228,28 @@ def add_pin(
             "target_id": target_id,
         }
 
-        # superseded decisionへのpinはhintを付与する（自動解決はしない）
-        hints = []
-        if source_type == "decision":
-            superseder_id = _is_decision_superseded(conn, source_id)
-            if superseder_id is not None:
-                hints.append(
-                    f"decision#{source_id} は decision#{superseder_id} に superseded されています。"
-                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
-                )
-        if target_type == "decision":
-            superseder_id = _is_decision_superseded(conn, target_id)
-            if superseder_id is not None:
-                hints.append(
-                    f"decision#{target_id} は decision#{superseder_id} に superseded されています。"
-                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
-                )
-        if hints:
-            result["hint"] = "\n".join(hints)
+        # supersededへのpinはhintを付与する（自動解決はしない）。
+        # hintクエリはcommit済みpinへの補足情報。失敗してもpin挿入は維持しhintなしで返す。
+        try:
+            hints = []
+            if source_type == "decision":
+                superseder_id = _is_decision_superseded(conn, source_id)
+                if superseder_id is not None:
+                    hints.append(
+                        f"decision#{source_id} は decision#{superseder_id} に superseded されています。"
+                        f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                    )
+            if target_type == "decision":
+                superseder_id = _is_decision_superseded(conn, target_id)
+                if superseder_id is not None:
+                    hints.append(
+                        f"decision#{target_id} は decision#{superseder_id} に superseded されています。"
+                        f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                    )
+            if hints:
+                result["hint"] = "\n".join(hints)
+        except Exception:
+            pass
 
         return result
 

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -18,6 +18,79 @@ ENTITY_TABLE_MAP = {
 }
 
 
+def _is_decision_superseded(conn: sqlite3.Connection, decision_id: int) -> Optional[int]:
+    """decisionがsupersedeされていれば、supersederのdecision_id（1件）を返す。
+
+    複数のsupersederがある場合は最新の created_at の1件を返す。
+    superseded されていなければ None。
+    """
+    row = conn.execute(
+        "SELECT source_id FROM decision_supersedes WHERE target_id = ? "
+        "ORDER BY created_at DESC LIMIT 1",
+        (decision_id,),
+    ).fetchone()
+    return row["source_id"] if row else None
+
+
+def _transfer_pins_with_conn(
+    conn: sqlite3.Connection,
+    entity_type: str,
+    old_id: int,
+    new_id: int,
+) -> int:
+    """旧entityへのpinを新entityへ付け替える（target側 + source側の両方向）。
+
+    INSERT OR IGNORE + DELETE の2文方式（両方向で計4文）。
+    - UNIQUE衝突（new側に既存pinあり）はOR IGNOREでマージ → 旧行DELETEで消滅
+    - 自己参照化するpin（旧⇔新間のpin）はWHERE除外＋DELETEで消滅させる
+    - 新pinの created_at は旧pinの値を引き継ぐ
+
+    Args:
+        conn: DB接続（呼び出し元のトランザクションに参加）
+        entity_type: 付け替え対象entityの種別（supersedes用途では現状 "decision"）
+        old_id: 付け替え元entityのID
+        new_id: 付け替え先entityのID
+
+    Returns:
+        実際にINSERTされたpin件数。
+        衝突マージ（OR IGNOREで除かれた行）と自己参照化で消滅した行はカウントしない。
+    """
+    # target側付け替え: pin(X, old) → pin(X, new)
+    # 自己参照化(pin(new, old) → pin(new, new))は WHERE で除外して移動を止め、
+    # 旧行は後段の DELETE で消滅させる
+    target_cursor = conn.execute(
+        "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id, created_at) "
+        "SELECT source_type, source_id, ?, ?, created_at "
+        "FROM pins "
+        "WHERE target_type = ? AND target_id = ? "
+        "AND NOT (source_type = ? AND source_id = ?)",
+        (entity_type, new_id, entity_type, old_id, entity_type, new_id),
+    )
+    target_inserted = target_cursor.rowcount
+    conn.execute(
+        "DELETE FROM pins WHERE target_type = ? AND target_id = ?",
+        (entity_type, old_id),
+    )
+
+    # source側付け替え: pin(old, Y) → pin(new, Y)
+    # 自己参照化(pin(old, new) → pin(new, new))は WHERE で除外
+    source_cursor = conn.execute(
+        "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id, created_at) "
+        "SELECT ?, ?, target_type, target_id, created_at "
+        "FROM pins "
+        "WHERE source_type = ? AND source_id = ? "
+        "AND NOT (target_type = ? AND target_id = ?)",
+        (entity_type, new_id, entity_type, old_id, entity_type, new_id),
+    )
+    source_inserted = source_cursor.rowcount
+    conn.execute(
+        "DELETE FROM pins WHERE source_type = ? AND source_id = ?",
+        (entity_type, old_id),
+    )
+
+    return target_inserted + source_inserted
+
+
 def _resolve_ref(
     conn: sqlite3.Connection, entity_type: str, ref: Union[int, str]
 ) -> tuple[Optional[int], Optional[dict]]:
@@ -148,12 +221,33 @@ def add_pin(
         )
         conn.commit()
 
-        return {
+        result = {
             "source_type": source_type,
             "source_id": source_id,
             "target_type": target_type,
             "target_id": target_id,
         }
+
+        # superseded decisionへのpinはhintを付与する（自動解決はしない）
+        hints = []
+        if source_type == "decision":
+            superseder_id = _is_decision_superseded(conn, source_id)
+            if superseder_id is not None:
+                hints.append(
+                    f"decision#{source_id} は decision#{superseder_id} に superseded されています。"
+                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                )
+        if target_type == "decision":
+            superseder_id = _is_decision_superseded(conn, target_id)
+            if superseder_id is not None:
+                hints.append(
+                    f"decision#{target_id} は decision#{superseder_id} に superseded されています。"
+                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                )
+        if hints:
+            result["hint"] = "\n".join(hints)
+
+        return result
 
     except Exception as e:
         conn.rollback()

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -267,23 +267,29 @@ def _has_supersedes_path(conn: sqlite3.Connection, from_id: int, to_id: int) -> 
     return False
 
 
-def _add_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> int:
+def _add_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> tuple[int, int]:
     """supersedesリレーションをdecision_supersedesテーブルに追加する。
 
     循環を検出した場合はValueErrorを送出する。
+    INSERT成功時のみ pins の付け替えを同一トランザクション内で実行する
+    （重複add（changes()=0）では発火しない）。
 
     Args:
         conn: DB接続
-        source_id: 上書き元のdecision ID
-        target_ids: 上書き先のdecision IDリスト
+        source_id: 上書き元（新）のdecision ID
+        target_ids: 上書き先（旧）のdecision IDリスト
 
     Returns:
-        追加件数
+        (追加件数, pin付け替え件数)
 
     Raises:
         ValueError: 循環が検出された場合
     """
+    # pin_service との循環import回避のためローカルimport
+    from src.services.pin_service import _transfer_pins_with_conn
+
     added = 0
+    pins_transferred = 0
     for target_id in target_ids:
         # 自己参照はCHECK制約で弾かれるが、明示的にスキップ
         if source_id == target_id:
@@ -302,7 +308,9 @@ def _add_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_i
         )
         if conn.execute("SELECT changes()").fetchone()[0] > 0:
             added += 1
-    return added
+            # INSERT成功時のみpin付け替えを実行（superseded側=target_id, superseder側=source_id）
+            pins_transferred += _transfer_pins_with_conn(conn, "decision", target_id, source_id)
+    return added, pins_transferred
 
 
 def _remove_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, target_ids: list[int]) -> int:
@@ -375,10 +383,24 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
             added = 0
             for target in targets:
                 added += _add_depends_on_with_conn(conn, source_id, target["ids"])
+            conn.commit()
+            return {"added": added}
         elif relation_type == "supersedes":
             added = 0
+            pins_transferred = 0
             for target in targets:
-                added += _add_supersedes_with_conn(conn, source_id, target["ids"])
+                a, p = _add_supersedes_with_conn(conn, source_id, target["ids"])
+                added += a
+                pins_transferred += p
+            conn.commit()
+            result: dict = {"added": added}
+            if pins_transferred > 0:
+                result["pins_transferred"] = pins_transferred
+                logger.info(
+                    f"supersedes added: source_id={source_id}, "
+                    f"added={added}, pins_transferred={pins_transferred}"
+                )
+            return result
         else:
             added = _add_relation_with_conn(conn, source_type, source_id, targets)
         conn.commit()

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -5,6 +5,7 @@ import tempfile
 import pytest
 
 from src.db import get_connection, init_database
+from src.services.pin_service import add_pin
 from src.services.relation_service import add_relation, get_map, remove_relation
 from src.services.tag_service import _injected_tags
 from tests.helpers import add_decision, retract_decision
@@ -1123,6 +1124,287 @@ class TestGetMapDecisionLogFilter:
         # decision自体は出力に含まれない
         types_in_result = {ent["type"] for ent in result["entities"]}
         assert "decision" not in types_in_result
+
+
+class TestSupersedesPinTransfer:
+    """supersedesリレーション追加時のpin自動引き継ぎテスト"""
+
+    def test_target_side_pin_transferred(self, entities_with_decision_log):
+        """pin(activity, old_decision) は supersedes(new, old) で pin(activity, new_decision) に付け替わる"""
+        e = entities_with_decision_log
+        # 旧decisionへpin
+        add_pin("activity", e["a1"], "decision", e["d1"])
+
+        # d2 supersedes d1
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" not in result
+        assert result["added"] == 1
+        assert result.get("pins_transferred") == 1
+
+        # 付け替え確認
+        conn = get_connection()
+        try:
+            old_row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d1"],),
+            ).fetchone()
+            new_row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d2"],),
+            ).fetchone()
+            assert old_row is None
+            assert new_row is not None
+            assert new_row["source_type"] == "activity"
+            assert new_row["source_id"] == e["a1"]
+        finally:
+            conn.close()
+
+    def test_source_side_pin_transferred(self, entities_with_decision_log):
+        """pin(old_decision, material) は supersedes(new, old) で pin(new_decision, material) に付け替わる"""
+        e = entities_with_decision_log
+        add_pin("decision", e["d1"], "material", e["m1"])
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result.get("pins_transferred") == 1
+
+        conn = get_connection()
+        try:
+            new_row = conn.execute(
+                "SELECT * FROM pins WHERE source_type='decision' AND source_id=?",
+                (e["d2"],),
+            ).fetchone()
+            assert new_row is not None
+            assert new_row["target_type"] == "material"
+            assert new_row["target_id"] == e["m1"]
+        finally:
+            conn.close()
+
+    def test_both_sides_transferred_simultaneously(self, entities_with_decision_log):
+        """target側とsource側のpinが同一add_relationで両方付け替わる"""
+        e = entities_with_decision_log
+        add_pin("activity", e["a1"], "decision", e["d1"])  # target側
+        add_pin("decision", e["d1"], "material", e["m1"])  # source側
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result.get("pins_transferred") == 2
+
+        conn = get_connection()
+        try:
+            d1_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='decision' AND source_id=?) OR (target_type='decision' AND target_id=?)",
+                (e["d1"], e["d1"]),
+            ).fetchone()["c"]
+            assert d1_count == 0
+        finally:
+            conn.close()
+
+    def test_created_at_preserved(self, entities_with_decision_log):
+        """付け替え後の新pinのcreated_atは旧pinの値から引き継ぐ"""
+        e = entities_with_decision_log
+        add_pin("activity", e["a1"], "decision", e["d1"])
+
+        conn = get_connection()
+        try:
+            # 古いcreated_atに書き換える
+            conn.execute(
+                "UPDATE pins SET created_at='2020-01-01 00:00:00' "
+                "WHERE target_type='decision' AND target_id=?",
+                (e["d1"],),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+
+        conn = get_connection()
+        try:
+            new_row = conn.execute(
+                "SELECT created_at FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d2"],),
+            ).fetchone()
+            assert new_row["created_at"] == "2020-01-01 00:00:00"
+        finally:
+            conn.close()
+
+    def test_conflict_merges_via_or_ignore(self, entities_with_decision_log):
+        """new側に既存pinがあると衝突マージ（OR IGNORE）され、旧行は削除、pins_transferredは実INSERT数のみ"""
+        e = entities_with_decision_log
+        add_pin("activity", e["a1"], "decision", e["d1"])  # 旧側
+        add_pin("activity", e["a1"], "decision", e["d2"])  # 新側に既存（衝突相手）
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        # 衝突マージなので実INSERT数は0、pins_transferredキーは付かない
+        assert "pins_transferred" not in result
+
+        conn = get_connection()
+        try:
+            old_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d1"],),
+            ).fetchone()["c"]
+            new_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d2"],),
+            ).fetchone()["c"]
+            assert old_count == 0
+            assert new_count == 1
+        finally:
+            conn.close()
+
+    def test_self_referencing_pin_vanishes(self, entities_with_decision_log):
+        """付け替えで自己参照化するpin（pin(new, old) / pin(old, new)）は消滅する"""
+        e = entities_with_decision_log
+        # pin(d2, d1): supersedes(d2, d1) で pin(d2, d2) になりかけるが除外
+        add_pin("decision", e["d2"], "decision", e["d1"])
+        # pin(d1, d2): pin(d2, d2) になりかけるが除外
+        add_pin("decision", e["d1"], "decision", e["d2"])
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        # どちらも自己参照化で消えるためpins_transferredキーは付かない
+        assert "pins_transferred" not in result
+
+        conn = get_connection()
+        try:
+            self_ref = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "source_type='decision' AND source_id=? AND target_type='decision' AND target_id=?",
+                (e["d2"], e["d2"]),
+            ).fetchone()["c"]
+            assert self_ref == 0
+            # d1への参照も残らない
+            d1_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='decision' AND source_id=?) OR (target_type='decision' AND target_id=?)",
+                (e["d1"], e["d1"]),
+            ).fetchone()["c"]
+            assert d1_count == 0
+        finally:
+            conn.close()
+
+    def test_no_pins_no_op(self, entities_with_decision_log):
+        """旧decisionにpinが無い場合 pins_transferred キーが付かない"""
+        e = entities_with_decision_log
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result["added"] == 1
+        assert "pins_transferred" not in result
+
+    def test_duplicate_add_does_not_re_fire_hook(self, entities_with_decision_log):
+        """重複add（INSERT OR IGNOREで弾かれる）時はpin引き継ぎhookが発火しない"""
+        e = entities_with_decision_log
+        # 初回supersedesでpin移動を完了させる
+        add_pin("activity", e["a1"], "decision", e["d1"])
+        result1 = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result1.get("pins_transferred") == 1
+
+        # この時点で pin(activity, d2) に移動済み。ここで pin(activity, d2) を pin(activity, d1) に戻して、
+        # もう一度同じsupersedesを張ってhookが不発火（pins_transferredキー無し）なことを確認する
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE pins SET target_id=? WHERE target_type='decision' AND target_id=?",
+                (e["d1"], e["d2"]),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result2 = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result2["added"] == 0
+        assert "pins_transferred" not in result2
+        # pin(activity, d1) のまま移動していない
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d1"],),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_cycle_rollback_does_not_move_pins(self, entities_with_decision_log):
+        """循環検出時のrollbackでpinの移動も巻き戻される"""
+        e = entities_with_decision_log
+        # 既存: d1 → d2 (d1 supersedes d2)
+        add_relation(
+            "decision", e["d1"], [{"type": "decision", "ids": [e["d2"]]}],
+            relation_type="supersedes",
+        )
+        add_pin("activity", e["a1"], "decision", e["d2"])
+
+        # d2 supersedes [d3, d1] を同一バッチで張ると、d2→d3 INSERT後にd2→d1で循環検出 → rollback
+        result = add_relation(
+            "decision", e["d2"],
+            [{"type": "decision", "ids": [e["d3"], e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "CIRCULAR_SUPERSEDES"
+
+        # pin(activity, d2) が残っている（移動していない）
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE target_type='decision' AND target_id=?",
+                (e["d2"],),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_mixed_entity_type_pin_target_side(self, entities_with_decision_log):
+        """pin相手側がdecision以外（topic/material/activity）でも正常に付け替わる"""
+        e = entities_with_decision_log
+        add_pin("topic", e["t1"], "decision", e["d1"])
+        add_pin("material", e["m1"], "decision", e["d1"])
+        add_pin("activity", e["a1"], "decision", e["d1"])
+
+        result = add_relation(
+            "decision", e["d2"], [{"type": "decision", "ids": [e["d1"]]}],
+            relation_type="supersedes",
+        )
+        assert result.get("pins_transferred") == 3
+
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT source_type FROM pins WHERE target_type='decision' AND target_id=? "
+                "ORDER BY source_type",
+                (e["d2"],),
+            ).fetchall()
+            types = sorted(r["source_type"] for r in rows)
+            assert types == ["activity", "material", "topic"]
+        finally:
+            conn.close()
 
 
 class TestFKLossImpact:

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -432,6 +432,21 @@ class TestAddPinSupersededHint:
         assert "error" not in result
         assert "hint" not in result
 
+    def test_pin_both_sides_superseded_returns_two_hints(self, topic):
+        """source/target両方がsuperseded decisionの場合hintが2件結合される"""
+        topic_id = topic["topic_id"]
+        d_src_old, d_src_new = self._setup_superseded(topic_id)
+        d_tgt_old, d_tgt_new = self._setup_superseded(topic_id)
+
+        result = add_pin("decision", d_src_old, "decision", d_tgt_old)
+
+        assert "error" not in result
+        assert "hint" in result
+        hint_lines = result["hint"].split("\n")
+        assert len(hint_lines) == 2
+        assert any(f"decision#{d_src_old}" in line and f"decision#{d_src_new}" in line for line in hint_lines)
+        assert any(f"decision#{d_tgt_old}" in line and f"decision#{d_tgt_new}" in line for line in hint_lines)
+
 
 class TestTransferPinsWithConn:
     """_transfer_pins_with_conn 単体テスト"""

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -348,3 +348,284 @@ class TestRemovePin:
         result = remove_pin("tag", "domain:nonexistent", "activity", activity_id)
 
         assert result == {"removed": 0}
+
+
+class TestAddPinSupersededHint:
+    """add_pin: supersededなdecisionへのpinはhintを返す"""
+
+    def _setup_superseded(self, topic_id: int) -> tuple[int, int]:
+        """topic_id 配下に d_old, d_new を作り、d_new supersedes d_old の関係を張る"""
+        from src.services.relation_service import add_relation
+
+        d_old_res = add_decisions([
+            {"topic_id": topic_id, "decision": "古い決定", "reason": "旧"},
+        ])
+        d_new_res = add_decisions([
+            {"topic_id": topic_id, "decision": "新しい決定", "reason": "新"},
+        ])
+        d_old = d_old_res["created"][0]["decision_id"]
+        d_new = d_new_res["created"][0]["decision_id"]
+        add_relation(
+            "decision", d_new, [{"type": "decision", "ids": [d_old]}],
+            relation_type="supersedes",
+        )
+        return d_old, d_new
+
+    def test_pin_to_superseded_target_returns_hint(self, topic, activity):
+        """add_pinのtargetがsuperseded decisionの場合hintキーが付き、pin自体は張られる"""
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        d_old, d_new = self._setup_superseded(topic_id)
+
+        result = add_pin("activity", activity_id, "decision", d_old)
+
+        assert "error" not in result
+        assert result["source_type"] == "activity"
+        assert result["target_id"] == d_old
+        assert "hint" in result
+        assert f"decision#{d_old}" in result["hint"]
+        assert f"decision#{d_new}" in result["hint"]
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM pins WHERE source_type='activity' AND source_id=? "
+                "AND target_type='decision' AND target_id=?",
+                (activity_id, d_old),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_pin_to_superseded_source_returns_hint(self, topic, material):
+        """add_pinのsourceがsuperseded decisionの場合hintキーが付く"""
+        topic_id = topic["topic_id"]
+        material_id = material["material_id"]
+        d_old, _d_new = self._setup_superseded(topic_id)
+
+        result = add_pin("decision", d_old, "material", material_id)
+
+        assert "error" not in result
+        assert "hint" in result
+
+    def test_pin_to_non_superseded_decision_no_hint(self, topic, activity):
+        """通常のdecisionへのpinはhintキーが付かない"""
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        d_res = add_decisions([
+            {"topic_id": topic_id, "decision": "通常", "reason": "r"},
+        ])
+        decision_id = d_res["created"][0]["decision_id"]
+
+        result = add_pin("activity", activity_id, "decision", decision_id)
+
+        assert "error" not in result
+        assert "hint" not in result
+
+    def test_pin_to_non_decision_target_no_hint(self, topic, activity, material):
+        """target_typeがdecision以外の場合hintキーは付かない"""
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        result = add_pin("activity", activity_id, "material", material_id)
+
+        assert "error" not in result
+        assert "hint" not in result
+
+
+class TestTransferPinsWithConn:
+    """_transfer_pins_with_conn 単体テスト"""
+
+    def _create_decisions(self, topic_id: int) -> tuple[int, int]:
+        d1 = add_decisions([{"topic_id": topic_id, "decision": "d1", "reason": "r"}])
+        d2 = add_decisions([{"topic_id": topic_id, "decision": "d2", "reason": "r"}])
+        return d1["created"][0]["decision_id"], d2["created"][0]["decision_id"]
+
+    def test_no_pins_returns_zero(self, topic):
+        """旧entityにpinが無い場合は0を返す"""
+        from src.services.pin_service import _transfer_pins_with_conn
+
+        topic_id = topic["topic_id"]
+        d_old, d_new = self._create_decisions(topic_id)
+
+        conn = get_connection()
+        try:
+            n = _transfer_pins_with_conn(conn, "decision", d_old, d_new)
+            conn.commit()
+        finally:
+            conn.close()
+        assert n == 0
+
+    def test_target_side_only(self, topic, activity):
+        """target側のpinだけを移動"""
+        from src.services.pin_service import _transfer_pins_with_conn
+
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        d_old, d_new = self._create_decisions(topic_id)
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) "
+                "VALUES ('activity', ?, 'decision', ?)",
+                (activity_id, d_old),
+            )
+            conn.commit()
+            n = _transfer_pins_with_conn(conn, "decision", d_old, d_new)
+            conn.commit()
+        finally:
+            conn.close()
+        assert n == 1
+
+    def test_conflict_returns_zero_inserts(self, topic, activity):
+        """new側に既存pinがある場合、OR IGNOREで実INSERTは0、旧行は消滅"""
+        from src.services.pin_service import _transfer_pins_with_conn
+
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        d_old, d_new = self._create_decisions(topic_id)
+
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) "
+                "VALUES ('activity', ?, 'decision', ?)",
+                (activity_id, d_old),
+            )
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) "
+                "VALUES ('activity', ?, 'decision', ?)",
+                (activity_id, d_new),
+            )
+            conn.commit()
+            n = _transfer_pins_with_conn(conn, "decision", d_old, d_new)
+            conn.commit()
+
+            old_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE target_type='decision' AND target_id=?",
+                (d_old,),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert n == 0
+        assert old_count == 0
+
+
+class TestPinsCascadeDelete:
+    """migration 0038: 各entityのDELETE時にpinsがCASCADE削除されること"""
+
+    def _add_decision_to(self, topic_id: int) -> int:
+        res = add_decisions([{"topic_id": topic_id, "decision": "d", "reason": "r"}])
+        return res["created"][0]["decision_id"]
+
+    def test_topic_delete_cascades_pins(self, topic, activity):
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        add_pin("topic", topic_id, "activity", activity_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM discussion_topics WHERE id=?", (topic_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='topic' AND source_id=?) OR (target_type='topic' AND target_id=?)",
+                (topic_id, topic_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0
+
+    def test_activity_delete_cascades_pins(self, topic, activity, material):
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+        add_pin("activity", activity_id, "material", material_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM activities WHERE id=?", (activity_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='activity' AND source_id=?) OR (target_type='activity' AND target_id=?)",
+                (activity_id, activity_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0
+
+    def test_material_delete_cascades_pins(self, topic, activity, material):
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+        add_pin("activity", activity_id, "material", material_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM materials WHERE id=?", (material_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='material' AND source_id=?) OR (target_type='material' AND target_id=?)",
+                (material_id, material_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0
+
+    def test_decision_delete_cascades_pins(self, topic, activity):
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        decision_id = self._add_decision_to(topic_id)
+        add_pin("activity", activity_id, "decision", decision_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM decisions WHERE id=?", (decision_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='decision' AND source_id=?) OR (target_type='decision' AND target_id=?)",
+                (decision_id, decision_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0
+
+    def test_log_delete_cascades_pins(self, topic, activity):
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+        log_res = add_logs([{"topic_id": topic_id, "content": "log", "title": "log title"}])
+        log_id = log_res["created"][0]["log_id"]
+        add_pin("activity", activity_id, "log", log_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM discussion_logs WHERE id=?", (log_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='log' AND source_id=?) OR (target_type='log' AND target_id=?)",
+                (log_id, log_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0
+
+    def test_tag_delete_cascades_pins(self, topic, activity, temp_db):
+        activity_id = activity["activity_id"]
+        conn = get_connection()
+        try:
+            tag_ids = ensure_tag_ids(conn, [("domain", "cc-memory")])
+            conn.commit()
+            tag_id = tag_ids[0]
+        finally:
+            conn.close()
+        add_pin("tag", tag_id, "activity", activity_id)
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM tags WHERE id=?", (tag_id,))
+            conn.commit()
+            cnt = conn.execute(
+                "SELECT COUNT(*) AS c FROM pins WHERE "
+                "(source_type='tag' AND source_id=?) OR (target_type='tag' AND target_id=?)",
+                (tag_id, tag_id),
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+        assert cnt == 0


### PR DESCRIPTION
## 概要

A#733 の実装。`add_relation` で `supersedes` 関係を張った時に、superseded 側エンティティに紐づく pin を superseder 側へ自動付け替えする。pin の単純削除では情報が失われ、ユーザーが手動で付け替える運用も漏れやすいため、relation の意味論（supersedes = 新旧入替）に整合する形でDB層に責務を寄せる。

設計提案: M#207、ユーザー承認済み判断ポイント D#2572 / D#2573 / D#2574 / D#2575（D#2575 supersedes D#2177）。

## 変更内容

### 1. `_transfer_pins_with_conn(conn, entity_type, old_id, new_id)`（pin_service）
- entity_type 非依存の汎用シグネチャ（D#2572）
- 旧行の `created_at` を新行へ引き継ぐ（D#2573、`INSERT ... SELECT` で `created_at` 列もコピー）
- conn 共有版ヘルパーパターン

### 2. add_relation フック（relation_service）
- `supersedes` ブランチで `_transfer_pins_with_conn` を呼ぶ
- 早期 return で他 relation kind と衝突しない

### 3. add_pin の hint 付与（D#2574）
- 対象が superseded decision の場合、pin は張る（自動解決しない）
- レスポンスに hint を返してエージェント側で気付けるようにする

### 4. migration 0038 — pin の DB-level CASCADE 削除（D#2575）
- D#2177（アプリ層削除）から方針転換
- `idx_pins_target` インデックス追加
- 6 種の AFTER DELETE トリガー（topics / activities / materials / decisions / discussion_logs / tags）

> migration 番号は当初指示が 0037 だったが、PR #353（`decisions.title` 関連）で 0037 が先に取られていたため 0038 へ繰り上げた。

## テスト

- フルスイート: **1604 passed (2 warnings)**
- 新規テスト:
  - pin transfer 正常系 / created_at 保持 / entity_type 混合ケース: 10件
  - 後付けpin の hint 返却: 4件
  - `_transfer_pins_with_conn` unit: 3件
  - CASCADE 削除トリガー動作: 6件

## レビュー

T3 worker による事前レビューで Blocker/Critical なし。詳細は L#2674。
- 設計準拠（D#2572-2575）✓
- D#2535（cc-memory 内部ID 出力禁止）✓ — hint メッセージの `decision#{id}` 形式は M#207 で動的識別子として明示されており対象外
- retracted_at フィルタ要件: `decision_supersedes` テーブルは migration 0031 時点で当該カラムなし、フィルタ不要
- `_with_conn` パターン遵守 ✓
- 自己参照化除外条件 SQL 検証 ✓

## 関連

- 設計: M#207
- 判断: D#2572 / D#2573 / D#2574 / D#2575（D#2175 supersedes D#2177）
- 前段PR: #334 (pins有向化 PR-a), #336 (pins有向化 PR-b), #339 (migration 0036), #353 (migration 0037)
- topic 452 / activity A#733

🤖 Generated with [Claude Code](https://claude.com/claude-code)