### PR TITLE
fix: tmuxアダプタのworker pane識別をpane user optionに変更

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -51,7 +51,7 @@ case "$ACTION" in
       # pane-title はclaudeセッションが ANSI escape sequence (\e]2;...\a) で動的に上書きするため
       # マーカーとして使えない。pane user option (@プレフィックス) は tmux server 内部の属性で
       # クライアントから escape 経由で書き換え不可なので、安定したマーカーとして利用できる。
-      EXISTING_WORKER=$(tmux list-panes -t "$WINDOW_ID" -F "#{pane_id}|#{${WORKER_MARKER_OPT}}" 2>/dev/null \
+      EXISTING_WORKER=$(tmux list-panes -t "$WINDOW_ID" -F "#{pane_id}|#{@ow-worker}" 2>/dev/null \
         | awk -F'|' '$2 == "1" { print $1 }' \
         | sort -t'%' -k2 -n \
         | tail -1)
@@ -68,9 +68,10 @@ case "$ACTION" in
 
       # pane user option で識別用マーカーを設定（claudeの escape sequence では上書き不可）。
       # set-option -p は pane-local オプション、@<name> カスタムオプションは tmux 1.8+ 対応。
-      # 未対応環境では次回spawnで「最初」扱いになり続けるため、stderr に警告を出して診断可能にする。
-      tmux set-option -p -t "$PANE_ID" "$WORKER_MARKER_OPT" 1 2>/dev/null \
-        || echo "warn: tmux set-option -p @ow-worker unsupported (requires tmux 1.8+), worker marker not set" >&2
+      # マーカー未設定では次回spawnで「最初」扱いになり続けるため、失敗時は警告を出して診断可能にする
+      # （非対応バージョン以外にも pane消失・tmux server断などが要因になりうるため、原因は断定しない）。
+      tmux set-option -p -t "$PANE_ID" "$WORKER_MARKER_OPT" 1 \
+        || echo "warn: tmux set-option -p @ow-worker failed (possibly tmux <1.8 or pane gone), worker marker not set" >&2
     else
       # フォールバック: 従来の ow-workers 別session方式
       if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -4,7 +4,7 @@
 #   tmux.sh spawn <cwd> <worker_cmd> [target_pane]
 #     target_pane 未指定: 従来通り ow-workers セッションに新windowで起動
 #     target_pane 指定:   target_paneと同じwindow内で split-window
-#                         - window内に pane-title=ow-worker のpaneが0個 → 右に30%水平分割
+#                         - window内に pane user option @ow-worker=1 のpaneが0個 → 右に30%水平分割
 #                         - 1個以上 → 最新worker paneを垂直分割
 #   tmux.sh close <term_ref>           → pane IDでpaneをkill
 #
@@ -19,7 +19,7 @@ fi
 
 ACTION="$1"
 SESSION_NAME="${OW_TMUX_SESSION:-ow-workers}"
-WORKER_TITLE="ow-worker"
+WORKER_MARKER_OPT="@ow-worker"
 
 case "$ACTION" in
   spawn)
@@ -47,9 +47,12 @@ case "$ACTION" in
         exit 1
       fi
 
-      # window内の既存worker pane (pane-title=ow-worker) を pane_id 昇順で取得し、末尾を「最新」とする
-      EXISTING_WORKER=$(tmux list-panes -t "$WINDOW_ID" -F "#{pane_id}|#{pane_title}" 2>/dev/null \
-        | awk -F'|' -v t="$WORKER_TITLE" '$2 == t { print $1 }' \
+      # window内の既存worker pane (pane user option @ow-worker=1) を pane_id 昇順で取得し、末尾を「最新」とする。
+      # pane-title はclaudeセッションが ANSI escape sequence (\e]2;...\a) で動的に上書きするため
+      # マーカーとして使えない。pane user option (@プレフィックス) は tmux server 内部の属性で
+      # クライアントから escape 経由で書き換え不可なので、安定したマーカーとして利用できる。
+      EXISTING_WORKER=$(tmux list-panes -t "$WINDOW_ID" -F "#{pane_id}|#{${WORKER_MARKER_OPT}}" 2>/dev/null \
+        | awk -F'|' '$2 == "1" { print $1 }' \
         | sort -t'%' -k2 -n \
         | tail -1)
 
@@ -63,11 +66,11 @@ case "$ACTION" in
           bash -c "$SHELL_CMD")
       fi
 
-      # pane-titleで識別用マーカーを設定（pane-border-status未有効でも内部値は保持される）
-      # -T はtmux 2.0+のみ対応。未対応環境では pane-title が空になり次回spawnで「最初」扱いに
-      # なり続けるため、stderr に警告を出して診断可能にする（subprocess.runのcapture_outputで拾える）。
-      tmux select-pane -t "$PANE_ID" -T "$WORKER_TITLE" 2>/dev/null \
-        || echo "warn: tmux select-pane -T unsupported (requires tmux 2.0+), pane-title not set" >&2
+      # pane user option で識別用マーカーを設定（claudeの escape sequence では上書き不可）。
+      # set-option -p は pane-local オプション、@<name> カスタムオプションは tmux 1.8+ 対応。
+      # 未対応環境では次回spawnで「最初」扱いになり続けるため、stderr に警告を出して診断可能にする。
+      tmux set-option -p -t "$PANE_ID" "$WORKER_MARKER_OPT" 1 2>/dev/null \
+        || echo "warn: tmux set-option -p @ow-worker unsupported (requires tmux 1.8+), worker marker not set" >&2
     else
       # フォールバック: 従来の ow-workers 別session方式
       if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -221,7 +221,7 @@ class TestTmuxAdapterSplit:
         result, captured = _run_adapter(
             ["spawn", "/tmp/work", "claude", "%0"],
             tmp_path,
-            # claudeに上書きされた pane-title 等が混入しても、@ow-worker の値は空のままなので非worker扱い
+            # list-panes 出力で @ow-worker 列が空（未設定）の2 pane を模擬
             existing_worker_panes="%5|\\n%7|",
         )
         assert result.returncode == 0

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -26,8 +26,8 @@ def _make_mock_tmux(
     kill_pane_exitが1の場合、kill-paneが失敗するモックになる。
 
     target_pane_exists=Falseのとき `tmux display` がexit 1を返す（target_pane不在シミュレーション）。
-    existing_worker_panesは `tmux list-panes -F "#{pane_id}|#{pane_title}"` の擬似出力。
-    例: "%5|ow-worker\\n%7|other-title" を渡すと既存worker paneが1個ある状態を模擬する。
+    existing_worker_panesは `tmux list-panes -F "#{pane_id}|#{@ow-worker}"` の擬似出力。
+    例: "%5|1\\n%7|" を渡すと既存worker paneが1個ある状態を模擬する（"1"がworkerマーカー、空欄が非worker）。
     """
     mock_dir = tmp_path / "mock_bin"
     mock_dir.mkdir(exist_ok=True)
@@ -184,34 +184,61 @@ class TestTmuxAdapterSplit:
         assert "30%" in captured
 
     def test_subsequent_worker_uses_vertical_split(self, tmp_path):
-        """既存worker pane (pane-title=ow-worker) があるとき、-v で垂直分割される。"""
+        """既存worker pane (pane user option @ow-worker=1) があるとき、-v で垂直分割される。"""
         result, captured = _run_adapter(
             ["spawn", "/tmp/work", "claude", "%0"],
             tmp_path,
-            existing_worker_panes="%5|ow-worker",
+            existing_worker_panes="%5|1",
         )
         assert result.returncode == 0
         assert "split-window -v" in captured
 
-    def test_split_sets_pane_title_ow_worker(self, tmp_path):
-        """split-window後にselect-paneでpane-title=ow-workerが設定される。"""
+    def test_split_sets_pane_user_option_marker(self, tmp_path):
+        """split-window後にset-option -p で @ow-worker=1 が設定される。"""
         result, captured = _run_adapter(
             ["spawn", "/tmp/work", "claude", "%0"], tmp_path
         )
         assert result.returncode == 0
-        assert "select-pane" in captured
-        assert "ow-worker" in captured
+        assert "set-option -p" in captured
+        assert "@ow-worker" in captured
+        # 値 "1" が引数列に含まれること (例: "set-option -p -t %42 @ow-worker 1")
+        assert "@ow-worker 1" in captured
 
-    def test_non_worker_titled_panes_ignored(self, tmp_path):
-        """pane-titleがow-worker以外のpaneは既存workerとして扱わず、水平30%分割になる。"""
+    def test_split_does_not_use_pane_title_marker(self, tmp_path):
+        """旧マーカー方式（select-pane -T "ow-worker"）が呼ばれていないことを保証する。
+
+        claude セッションが pane-title を ANSI escape で動的上書きするため、
+        pane-title をマーカーとしては使えない。
+        """
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"], tmp_path
+        )
+        assert result.returncode == 0
+        assert "select-pane" not in captured
+
+    def test_non_worker_panes_ignored(self, tmp_path):
+        """@ow-worker が未設定（空欄）のpaneは既存workerとして扱わず、水平30%分割になる。"""
         result, captured = _run_adapter(
             ["spawn", "/tmp/work", "claude", "%0"],
             tmp_path,
-            existing_worker_panes="%5|other-title\\n%7|zsh",
+            # claudeに上書きされた pane-title 等が混入しても、@ow-worker の値は空のままなので非worker扱い
+            existing_worker_panes="%5|\\n%7|",
         )
         assert result.returncode == 0
         assert "split-window -h" in captured
         assert "30%" in captured
+
+    def test_list_panes_filter_uses_pane_user_option(self, tmp_path):
+        """list-panes のフォーマット指定が #{@ow-worker} を参照していることを確認する。
+
+        pane-title ベース判定への退行を防ぐ回帰テスト。
+        """
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"], tmp_path
+        )
+        assert result.returncode == 0
+        assert "#{@ow-worker}" in captured
+        assert "#{pane_title}" not in captured
 
     def test_target_pane_not_found_exits_nonzero(self, tmp_path):
         """target_paneが存在しないとき、exit 1とstderrエラーメッセージを返す。"""


### PR DESCRIPTION
## Summary

- `OW_TERMINAL=tmux` で連続spawn時、2人目以降のworker paneが期待通り垂直分割されず、target_paneの右に水平分割が繰り返されるバグを修正
- 原因: 識別マーカーに `pane-title="ow-worker"` を使っていたが、claudeセッションが ANSI escape sequence でpane-titleを動的上書きするため、次回spawn時にlist-panesで0件マッチ → 「最初」扱いが永続化
- 修正: pane user option (`@ow-worker=1`) に切替。tmux server内部属性でescape経由の書き換え不可、安定マーカーとして利用できる
- `select-pane -T "ow-worker"` は撤去
- ユニットテスト追加: マーカー設定・list-panesフィルタ参照・旧方式未使用の回帰テスト

## Changes

- `scripts/ow/adapters/tmux.sh`
  - `tmux set-option -p -t \"$PANE_ID\" @ow-worker 1` でマーカー設定
  - `list-panes -F \"#{pane_id}|#{@ow-worker}\" | awk '\$2 == \"1\"'` で識別
  - 旧 `select-pane -T \"$WORKER_TITLE\"` と未使用になった `WORKER_TITLE` 変数を撤去
- `tests/unit/test_tmux_adapter.py`
  - 既存テストを新マーカー仕様に追随（`%5|1` / 空欄表記）
  - 新規: `test_split_sets_pane_user_option_marker`、`test_split_does_not_use_pane_title_marker`、`test_list_panes_filter_uses_pane_user_option`

## tmuxバージョン要件

- `set-option -p` (pane-local option): tmux 2.0+
- `@<name>` カスタムオプション: tmux 1.8+
- `list-panes -F \"#{@<name>}\"` 参照: 同上
- 未対応環境では stderr に warn を出して診断可能

## Test plan

- [x] `uv run pytest tests/unit/test_tmux_adapter.py -v` → 25 passed
- [ ] CI緑確認
- [ ] 実機 (tmux 3.6a) で連続spawn時に2人目以降が垂直分割される確認