### PR TITLE
refactor: PR #376 follow-up — 終了cause定数化・parametrize化・SKILL.md追記

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -38,7 +38,7 @@ on Monitor発火 or 自発的タイミング:
   人間向けダイジェスト出力（状態変化時）→ Monitor待機へ
 ```
 
-**自発的タイミングでの ow_status 呼び出し**: Monitor 発火ではなくユーザー入力・直接呼び出し等の自発的タイミングで起床した場合は、`ow_history` 処理後に `ow_status(channel, topic_id)` を呼んで worker の presence 状態を確認すること。キュー状態とworker生死の乖離を早期発見するため。
+**自発的タイミングでの ow_status 呼び出し**: Monitor 発火ではなくユーザー入力・直接呼び出し等の自発的タイミングで起床した場合は、`ow_history` 処理後に `ow_status(channel, topic_id)` を呼んで worker の presence 状態を確認すること。キュー状態とworker生死の乖離を早期発見するため。`topic_id` が手元にない場合は省略可能（`None`）。その場合 presence はチャンネル単位なのでそのまま取得でき、queue タスクは存在する全 queue ファイルを統合した結果が返る（診断用途。1 orch = 1 topic の通常運用では topic_id を明示する）。
 
 **受信処理（SSEはベル、真実源は/history）**:
 1. SSE（Monitor監視）は起床信号専用。届いたdata行の中身は処理に使わない

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1347,8 +1347,8 @@ def _get_presence(channel: str) -> list[str]:
 # worker起動直後でreadyメッセージ未送信、等）の状態が混在しており、ow_recover がここに介入すると
 # 進行中のworker起動とレース条件を起こす。spawning は detect_crash_inconsistencies で別カテゴリ
 # pending_spawn として扱う。
-_ACTIVE_QUEUE_STATUSES: set[str] = {"assigned", "ready", "working"}
-_TERMINAL_QUEUE_STATUSES: set[str] = {"done", "closed", "cancelled", "failed"}
+_ACTIVE_QUEUE_STATUSES: frozenset[str] = frozenset({"assigned", "ready", "working"})
+_TERMINAL_QUEUE_STATUSES: frozenset[str] = frozenset({"done", "closed", "cancelled", "failed"})
 
 # identity bundle の cause として「明示的に終了済み」を示す値。
 # alive判定（INV-9）や alive_only フィルタで同じ集合を参照するため一元化する。

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1350,6 +1350,10 @@ def _get_presence(channel: str) -> list[str]:
 _ACTIVE_QUEUE_STATUSES: set[str] = {"assigned", "ready", "working"}
 _TERMINAL_QUEUE_STATUSES: set[str] = {"done", "closed", "cancelled", "failed"}
 
+# identity bundle の cause として「明示的に終了済み」を示す値。
+# alive判定（INV-9）や alive_only フィルタで同じ集合を参照するため一元化する。
+_TERMINATED_IDENTITY_CAUSES: frozenset[str] = frozenset({"closed", "cancelled", "dead"})
+
 # relay最新state宣言 → queue statusへの再構築マップ。
 # presence offline & queue active のghost_activeケースで使う。
 # 終端state (done/closed/failed/cancelled) はそのまま反映、非終端 (ready/working等) は
@@ -1447,7 +1451,7 @@ def _validate_spawn_preconditions(
         inferred_cause = identity.get("inferred_cause")
         terminated_at = identity.get("terminated_at")
         is_terminated = (
-            cause in ("closed", "cancelled", "dead")
+            cause in _TERMINATED_IDENTITY_CAUSES
             or bool(terminated_at)
             or inferred_cause is not None
         )
@@ -2181,7 +2185,7 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
 
         if alive_only:
             cause = entry.get("cause")
-            if cause in ("closed", "cancelled", "dead") or entry.get("terminated_at"):
+            if cause in _TERMINATED_IDENTITY_CAUSES or entry.get("terminated_at"):
                 continue
             if inferred_cause is not None:
                 continue

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -169,24 +169,29 @@ class TestValidateSpawnPreconditions:
         assert result["ok"] is True
         assert result["warnings"] == []
 
-    def test_terminated_identity_allows_spawn(self, monkeypatch, tmp_path):
-        """terminatedなidentity（cause=closed / terminated_at設定）→ ok=True"""
-        for terminated_identity in [
+    @pytest.mark.parametrize(
+        "terminated_identity",
+        [
             {"handle": "w-x", "cause": "closed", "terminated_at": "2026-06-16T00:00:00Z"},
             {"handle": "w-x", "cause": "cancelled", "terminated_at": "2026-06-16T00:00:00Z"},
             {"handle": "w-x", "cause": "dead", "terminated_at": "2026-06-16T00:00:00Z"},
             {"handle": "w-x", "inferred_cause": "crashed (inferred)"},
-        ]:
-            monkeypatch.setattr(
-                ow_service,
-                "ow_get_identity",
-                lambda ch, h, _ident=terminated_identity: _ident,
-            )
-            result = ow_service._validate_spawn_preconditions(
-                alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
-            )
-            assert result["ok"] is True, f"terminated identity should allow spawn: {terminated_identity}"
-            assert result["warnings"] == [], f"unexpected warning for {terminated_identity}"
+            # terminated_at のみ（cause/inferred_cause なし）も alive 扱いではないため spawn 許可
+            {"handle": "w-x", "terminated_at": "2026-06-16T00:00:00Z"},
+        ],
+    )
+    def test_terminated_identity_allows_spawn(self, monkeypatch, tmp_path, terminated_identity):
+        """terminatedなidentity（cause=closed / terminated_at設定 / inferred_cause）→ ok=True"""
+        monkeypatch.setattr(
+            ow_service,
+            "ow_get_identity",
+            lambda ch, h: terminated_identity,
+        )
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is True
+        assert result["warnings"] == []
 
 
 # ----------------------------

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -308,11 +308,22 @@ class TestOwListIdentities:
         aliases = {e["alias"] for e in result}
         assert aliases == {"worker-a", "worker-b"}
 
-    def test_alive_only_excludes_terminated(self, monkeypatch):
-        """alive_only=True → cause=closedを除外する。"""
+    @pytest.mark.parametrize(
+        "terminated_payload",
+        [
+            {"cause": "closed"},
+            {"cause": "cancelled"},
+            {"cause": "dead"},
+            # terminated_at のみ（cause なし）も除外対象
+            {"terminated_at": "2026-06-16T00:00:00Z"},
+        ],
+    )
+    def test_alive_only_excludes_terminated(self, monkeypatch, terminated_payload):
+        """alive_only=True → cause=closed/cancelled/dead と terminated_at を除外する。"""
+        terminated_identity = {"alias": "worker-b", **terminated_payload}
         msgs = [
             _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
-            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b", "cause": "closed"}, handle="w-b")),
+            _make_msg(2, "w-b", _event_body("identity", terminated_identity, handle="w-b")),
         ]
         monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
         result = ow_service.ow_list_identities("ch", alive_only=True)


### PR DESCRIPTION
## Summary
PR #376 が review 取り込み push 前に main merge されたため、レビューコメントを反映する follow-up PR。

- 終了cause集合 `{\"closed\", \"cancelled\", \"dead\"}` を `_TERMINATED_IDENTITY_CAUSES`（frozenset）として定数化。`_validate_spawn_preconditions` と `ow_list_identities_alive_only` の2箇所で同じ集合を共有
- `test_terminated_identity_allows_spawn` を `@pytest.mark.parametrize` 化し、失敗ケース特定を容易にする
- `terminated_at` のみ設定（cause/inferred_cause なし）ケースのテストを追加
- `skills/orch/SKILL.md`: `ow_status` の `topic_id` 省略時の挙動を明示

## Test plan
- [x] uv run pytest tests/unit/test_ow_crash_recovery.py 全件 pass