### PR TITLE
feat: tagsテーブルのnamespace CHECK制約を完全削除 (T67 Phase 1 前提)

### DIFF
--- a/migrations/0039_extend_tag_namespace.sql
+++ b/migrations/0039_extend_tag_namespace.sql
@@ -1,0 +1,62 @@
+-- Migration 039: tags テーブルの namespace CHECK 制約を完全削除
+--
+-- depends: 0038_pins_target_index_and_cascade
+--
+-- 背景:
+--   現行 tags テーブルは namespace に CHECK(namespace IN ('', 'domain', 'intent'))
+--   の enum 制約があり、新しい namespace（`ow:` / `outcome:` / 将来追加予定の他）を
+--   保存するたびに migration で enum を拡張する必要があった。
+--
+--   将来 namespace を追加するたびに migration を切るのはレールが重いため、CHECK 制約
+--   そのものをテーブルから取り去り、tags.namespace は任意の TEXT を受け付ける形に変更
+--   する。namespace の妥当性は Python 層（tag_service.validate_and_parse_tags 等）で
+--   バリデーションするポリシーに切り替える。
+--
+--   SQLite では CHECK 制約を ALTER で削除できないためテーブル再構築を行う。
+--
+-- 変更内容:
+--   - tags テーブル再構築（namespace カラムから CHECK 制約を取り除く）
+--   - 既存タグデータ・canonical_id・notes を全保持
+--   - junction tables（activity_tags / topic_tags / log_tags / decision_tags /
+--     material_tags）の REFERENCES は rename 後の tags にそのまま引き継がれる
+
+-- ============================================
+-- Step 1: 新 tags テーブル作成（CHECK なし）
+-- ============================================
+CREATE TABLE tags_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  namespace TEXT NOT NULL DEFAULT '',
+  name TEXT NOT NULL,
+  notes TEXT,
+  description TEXT DEFAULT NULL
+    CHECK(description IS NULL OR LENGTH(description) <= 100),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  canonical_id INTEGER REFERENCES tags(id),
+  UNIQUE(namespace, name)
+);
+
+-- ============================================
+-- Step 2: 既存データ移行（id 不変）
+-- ============================================
+INSERT INTO tags_new (id, namespace, name, notes, description, created_at, canonical_id)
+SELECT id, namespace, name, notes, description, created_at, canonical_id
+FROM tags;
+
+-- ============================================
+-- Step 3: 旧テーブル削除 + リネーム
+-- ============================================
+DROP TABLE tags;
+ALTER TABLE tags_new RENAME TO tags;
+
+-- ============================================
+-- Step 4: tags 用トリガーを再作成
+-- ============================================
+-- DROP TABLE tags でトリガー (0038 で作成された trg_pins_cascade_delete_tag) が
+-- 消えるため再作成する。pins の CASCADE 削除を維持する。
+CREATE TRIGGER trg_pins_cascade_delete_tag
+AFTER DELETE ON tags
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'tag' AND source_id = OLD.id)
+                       OR (target_type = 'tag' AND target_id = OLD.id);
+END;

--- a/tests/test_migrations/test_0039_extend_tag_namespace.py
+++ b/tests/test_migrations/test_0039_extend_tag_namespace.py
@@ -1,0 +1,275 @@
+"""migration 0039_extend_tag_namespace のテスト
+
+tags テーブルの namespace CHECK 制約を完全削除し、任意の namespace 文字列を
+受け付けるよう変更する migration。
+
+検証項目:
+- 0039適用後、任意の namespace ('ow' / 'outcome' / 'bogus' / 既存 'domain' 等)
+  がそのまま INSERT 可能になる
+- 既存タグデータ（id, namespace, name, notes, canonical_id）が完全保持される
+- 既存 junction 行（activity_tags 等）が消えずに新 tags への参照が維持される
+- 0038適用時点（CHECK 制約あり）では新規 namespace は拒否される（前提確認）
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration適用後（0039含む）"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0039():
+    """0038までのmigrationを適用したDB（0039の分離検証用）"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0039 = MigrationList([m for m in all_migs if m.id < "0039"])
+        with backend.lock():
+            backend.apply_migrations(pre_0039)
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0039(db_path: str) -> None:
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0039 = MigrationList(
+        [m for m in all_migs if m.id.startswith("0039_extend_tag_namespace")]
+    )
+    with backend.lock():
+        backend.apply_migrations(only_0039)
+
+
+class TestNamespaceUnrestricted:
+    def test_ow_namespace_accepted_after_0039(self, migrated_db):
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES ('ow', 'managed')"
+            )
+            row = conn.execute(
+                "SELECT namespace, name FROM tags WHERE namespace = 'ow'"
+            ).fetchone()
+            assert row["namespace"] == "ow"
+            assert row["name"] == "managed"
+        finally:
+            conn.close()
+
+    def test_outcome_namespace_accepted_after_0039(self, migrated_db):
+        conn = get_connection()
+        try:
+            conn.executemany(
+                "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                [("outcome", "cancelled"), ("outcome", "failed")],
+            )
+            rows = conn.execute(
+                "SELECT name FROM tags WHERE namespace = 'outcome' ORDER BY name"
+            ).fetchall()
+            assert [r["name"] for r in rows] == ["cancelled", "failed"]
+        finally:
+            conn.close()
+
+    def test_legacy_namespaces_still_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            conn.executemany(
+                "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                [
+                    ("", "plain-tag"),
+                    ("domain", "cc-memory-ext"),
+                    ("intent", "discuss-ext"),
+                ],
+            )
+            for ns, name in [("", "plain-tag"), ("domain", "cc-memory-ext"),
+                              ("intent", "discuss-ext")]:
+                row = conn.execute(
+                    "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                    (ns, name),
+                ).fetchone()
+                assert row is not None
+        finally:
+            conn.close()
+
+    def test_arbitrary_namespace_accepted(self, migrated_db):
+        """任意の namespace 文字列が CHECK 違反なく INSERT できる。
+
+        namespace の妥当性は Python 層でバリデーションするポリシーに移行したため、
+        DB スキーマレベルでは any TEXT を受け付ける。
+        """
+        conn = get_connection()
+        try:
+            for ns in ["bogus", "future-ns", "x", "0", "a-b-c"]:
+                conn.execute(
+                    "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                    (ns, "test-name"),
+                )
+            count = conn.execute(
+                "SELECT COUNT(*) AS c FROM tags WHERE name = 'test-name'"
+            ).fetchone()["c"]
+            assert count == 5
+        finally:
+            conn.close()
+
+    def test_ow_namespace_rejected_before_0039(self, db_before_0039):
+        """0038時点では 'ow' namespace は CHECK 違反で拒否される（前提確認）"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO tags (namespace, name) VALUES ('ow', 'managed')"
+                )
+        finally:
+            conn.close()
+
+
+class TestExistingDataPreserved:
+    def test_pre_existing_tag_data_kept_intact(self, db_before_0039):
+        """0038時点で投入した tag データが 0039 適用後も同じ id で残っている"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO tags (namespace, name, notes) VALUES (?, ?, ?)",
+                ("domain", "test-domain", "メモ"),
+            )
+            tid = cur.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0039(db_before_0039)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id, namespace, name, notes FROM tags WHERE id = ?", (tid,)
+            ).fetchone()
+            assert row is not None
+            assert row["namespace"] == "domain"
+            assert row["name"] == "test-domain"
+            assert row["notes"] == "メモ"
+        finally:
+            conn.close()
+
+    def test_canonical_id_relation_preserved(self, db_before_0039):
+        """canonical_id によるエイリアス関係が 0039 適用後も保持される"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                ("domain", "canonical-tag"),
+            )
+            canonical_id = cur.lastrowid
+            cur = conn.execute(
+                "INSERT INTO tags (namespace, name, canonical_id) VALUES (?, ?, ?)",
+                ("domain", "alias-tag", canonical_id),
+            )
+            alias_id = cur.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0039(db_before_0039)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT canonical_id FROM tags WHERE id = ?", (alias_id,)
+            ).fetchone()
+            assert row["canonical_id"] == canonical_id
+        finally:
+            conn.close()
+
+    def test_junction_tables_preserved_after_rebuild(self, db_before_0039):
+        """既存 activity_tags 行が 0039 (tags 再構築) 後も維持される"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES (?, ?)",
+                ("domain", "preserved-junction-tag"),
+            )
+            tag_id = cur.lastrowid
+            cur = conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                ("act", "", "pending"),
+            )
+            aid = cur.lastrowid
+            conn.execute(
+                "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+                (aid, tag_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0039(db_before_0039)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                """
+                SELECT a.id, t.name FROM activity_tags at
+                JOIN activities a ON a.id = at.activity_id
+                JOIN tags t ON t.id = at.tag_id
+                WHERE a.id = ?
+                """,
+                (aid,),
+            ).fetchone()
+            assert row is not None, (
+                "tags 再構築後に activity_tags 経由のJOINで行が見つからない"
+                "（junction の REFERENCES が切れている可能性）"
+            )
+            assert row["name"] == "preserved-junction-tag"
+        finally:
+            conn.close()
+
+
+class TestSchemaShapeRetained:
+    def test_tags_columns_retained(self, migrated_db):
+        conn = get_connection()
+        try:
+            rows = conn.execute("PRAGMA table_info(tags)").fetchall()
+            cols = {r["name"] for r in rows}
+            for col in ["id", "namespace", "name", "notes", "description",
+                         "created_at", "canonical_id"]:
+                assert col in cols, f"tags.{col} が 0039 適用後に欠落"
+        finally:
+            conn.close()
+
+    def test_unique_namespace_name_constraint_retained(self, migrated_db):
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO tags (namespace, name) VALUES ('ow', 'dup-test')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO tags (namespace, name) VALUES ('ow', 'dup-test')"
+                )
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
- `tags.namespace` の CHECK 制約を **完全削除** し、任意 TEXT を受け付けるようテーブル再構築
- queue→activity管理化（T67 Phase 1）の前提となる migration を独立切り出し
- 後続PR（T67 Phase 1 本体）が `ow:managed` / `outcome:cancelled` / `outcome:failed` タグを使用できるようにする
- namespace の妥当性は Python 層（`tag_service.validate_and_parse_tags` 等）で担う方針へ切り替え

## 背景
T67 Phase 1 の実装で、
- `ow:managed` タグで ow 管理対象 activity を識別
- `outcome:cancelled` / `outcome:failed` タグで worker 末状態を表現

する必要がある。現行 tags テーブルの CHECK 制約 `namespace IN ('', 'domain', 'intent')` では新規 namespace が拒否される。

当初は enum 拡張（`('', 'domain', 'intent', 'ow', 'outcome')`）を検討したが、将来 namespace を追加するたびに migration を切るのはレールが重いため、CHECK 制約自体をテーブルから取り去る方針に変更した（ユーザー指示）。namespace バリデーションは Python 層側に集約する。

SQLite では CHECK 制約を ALTER で変更できないため tags テーブル再構築が必要。スキーマ変更の影響範囲がリリースの中心領域に及ぶため、T67 Phase 1 本体 PR から独立切り出しでレビュー範囲を絞る。

## 実装
- migration 039: `tags_new` テーブル作成（CHECK なし）→ データ移行 → DROP TABLE tags → RENAME
- 既存データ（id / namespace / name / notes / canonical_id）は全保持
- junction tables（activity_tags / topic_tags / log_tags / decision_tags / material_tags）からの REFERENCES は rename 後の tags を参照し続ける

## Test plan
- [x] `tests/test_migrations/test_0039_extend_tag_namespace.py` 10件全合格
  - 'ow' / 'outcome' / 任意 namespace ('bogus' / 'future-ns' 等) の INSERT 成功
  - 既存 namespace ('', 'domain', 'intent') 引き続き受理
  - 既存タグデータ（id / notes / canonical_id 含む）保持
  - junction tables の参照行が tags 再構築後も生存
  - UNIQUE(namespace, name) 制約は維持
- [ ] CI緑確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)