### PR TITLE
feat: queue→activity管理化 Phase 1 基盤 (T67)

### DIFF
--- a/migrations/0040_add_ow_tables.sql
+++ b/migrations/0040_add_ow_tables.sql
@@ -1,0 +1,99 @@
+-- Migration 040: ow_channels / ow_workers / ow_applied_msg_ids テーブル追加
+--
+-- depends: 0039_extend_tag_namespace
+--
+-- 背景:
+--   旧queue-t<topic_id>.md（ファイルベースのworker queue管理）を廃止し、
+--   cc-memory本体DBにowランタイム状態を集約する設計（T53）の Phase 1 基盤。
+--   relay履歴を権威ソースとした event-sourcing reducer が書き込む派生ビュー(MV)で、
+--   1) ow_channels: relayチャネルとtopic/orchの紐づけ
+--   2) ow_workers: worker run instance（再spawn可能、履歴付き）
+--   3) ow_applied_msg_ids: reducer idempotency 用
+--
+--   ユーザー判断:
+--   - session_id は NULL 許容（identity未受信のready前workerもreducerで表現可能にするため）
+--   - workload_state / cause / outcome は CHECK 制約 enum 化
+--   - 1 worker = 1 activity の物理強制は部分 UNIQUE INDEX で実現
+--
+-- 変更内容:
+--   - ow_channels テーブル新規追加
+--   - ow_workers テーブル新規追加 + 部分UNIQUE INDEX 3つ + 通常INDEX 3つ
+--   - ow_applied_msg_ids テーブル新規追加
+
+-- ============================================
+-- ow_channels: relayチャネルとtopic/orchの紐づけ
+-- ============================================
+CREATE TABLE ow_channels (
+    channel_code         TEXT PRIMARY KEY,
+    topic_id             INTEGER NOT NULL,
+    orch_handle          TEXT NOT NULL,
+    orch_activity_id     INTEGER,
+    orch_cwd             TEXT,
+    orch_session_id      TEXT,
+    last_seen_msg_id     INTEGER NOT NULL DEFAULT 0,
+    deleted_at           TEXT,
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL,
+    FOREIGN KEY (topic_id) REFERENCES discussion_topics(id),
+    FOREIGN KEY (orch_activity_id) REFERENCES activities(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_ow_channels_topic ON ow_channels(topic_id);
+
+-- ============================================
+-- ow_workers: workerランタイム状態 MV
+-- ============================================
+CREATE TABLE ow_workers (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel_code         TEXT NOT NULL,
+    handle               TEXT NOT NULL,
+    alias                TEXT NOT NULL,
+    activity_id          INTEGER,
+    topic_id             INTEGER NOT NULL,
+    task_n               INTEGER NOT NULL,
+    model                TEXT,
+    cwd                  TEXT,
+    permission_mode      TEXT,
+    timeout_min          INTEGER,
+    task_material_id     INTEGER,
+    session_id           TEXT,
+    workload_state       TEXT NOT NULL DEFAULT 'spawning' CHECK(workload_state IN
+                          ('spawning','loading','ready','working','blocked','escalated','draining','terminated')),
+    cause                TEXT CHECK(cause IS NULL OR cause IN
+                          ('closed','cancelled','dead','crashed','crashed-during-drain')),
+    last_state_msg_id    INTEGER,
+    last_heartbeat_at    TEXT,
+    spawned_at           TEXT NOT NULL,
+    ready_at             TEXT,
+    terminated_at        TEXT,
+    FOREIGN KEY (channel_code) REFERENCES ow_channels(channel_code),
+    FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE SET NULL,
+    FOREIGN KEY (topic_id) REFERENCES discussion_topics(id),
+    FOREIGN KEY (task_material_id) REFERENCES materials(id) ON DELETE SET NULL
+);
+
+-- alive worker の handle 単位一意（再spawnで terminated は履歴として残せる）
+CREATE UNIQUE INDEX uq_ow_workers_alive_handle
+    ON ow_workers(channel_code, handle) WHERE workload_state != 'terminated';
+
+-- 1 worker = 1 activity の物理強制（活動中のみ）
+CREATE UNIQUE INDEX uq_ow_workers_one_alive_per_activity
+    ON ow_workers(activity_id) WHERE workload_state != 'terminated' AND activity_id IS NOT NULL;
+
+-- channel単位の task_n 連番一意
+CREATE UNIQUE INDEX uq_ow_workers_task_n ON ow_workers(channel_code, task_n);
+
+CREATE INDEX idx_ow_workers_activity ON ow_workers(activity_id);
+CREATE INDEX idx_ow_workers_state ON ow_workers(channel_code, workload_state);
+CREATE INDEX idx_ow_workers_alive ON ow_workers(channel_code) WHERE workload_state != 'terminated';
+
+-- ============================================
+-- ow_applied_msg_ids: reducer idempotency
+-- ============================================
+CREATE TABLE ow_applied_msg_ids (
+    channel_code         TEXT NOT NULL,
+    msg_id               INTEGER NOT NULL,
+    applied_at           TEXT NOT NULL,
+    outcome              TEXT NOT NULL CHECK(outcome IN ('applied','skipped')),
+    PRIMARY KEY (channel_code, msg_id)
+);

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -470,6 +470,39 @@ def _extract_intent_tag(tags: list[str]) -> str:
     return "(未設定)"
 
 
+def _build_ow_summary_line(
+    conn,
+    activity_id: int,
+    topic_ids: list[int],
+) -> str | None:
+    """ow:managed activity に対し、ダッシュボード render の該当行を抜粋して返す。
+
+    activity が ow:managed タグを持たない、または topic_id が紐づいていない、
+    あるいは render 結果に該当行が無い場合は None を返す（既存挙動を維持）。
+    """
+    from src.services.ow.dashboard import (
+        extract_activity_line,
+        is_ow_managed_activity_with_conn,
+        render_with_conn,
+    )
+
+    if not is_ow_managed_activity_with_conn(conn, activity_id):
+        return None
+    if not topic_ids:
+        return None
+    # 複数 topic 紐付けは現状想定外なので先頭のみ採用
+    topic_id = topic_ids[0]
+    try:
+        dashboard_text = render_with_conn(conn, topic_id=topic_id, role="general")
+    except Exception as e:
+        logger.warning("ow dashboard render failed for activity %d: %s", activity_id, e)
+        return None
+    line = extract_activity_line(dashboard_text, activity_id)
+    if not line:
+        return None
+    return f"  ow: {line}"
+
+
 def _build_summary(
     activity: dict,
     tags: list[str],
@@ -617,6 +650,13 @@ def check_in(activity_id: int, session_id: str | None = None) -> dict:
 
         # 10. summary生成
         summary = _build_summary(activity, tags)
+        # 10a. ow:managed activity の場合、ダッシュボード抜粋を summary に追加する
+        #      （M#288 §3.8: 単一レンダラから生成した行を check_in summary にも共有）
+        ow_summary_line = _build_ow_summary_line(
+            conn, activity_id, direct.get("topic", [])
+        )
+        if ow_summary_line:
+            summary = f"{summary}\n{ow_summary_line}"
 
         # 戻り値組み立て（coverageをトップレベルの最初のキーに）
         result = {

--- a/src/services/ow/__init__.py
+++ b/src/services/ow/__init__.py
@@ -1,0 +1,13 @@
+"""ow worker / channel ランタイム状態の派生ビュー (MV) を扱うサブパッケージ。
+
+旧 queue-t<topic_id>.md ファイルベースのworker管理を廃止し、cc-memory本体DB上に
+event-sourcing reducer + projector の2層モデルで集約する設計（T53 Phase 1）。
+
+モジュール構成:
+- channels.py        : ow_channels CRUD
+- workers.py         : ow_workers CRUD
+- applied_msgs.py    : ow_applied_msg_ids CRUD (reducer idempotency)
+- reducer.py         : ow_apply_state（純粋reducer、relay history → ow_*テーブル書き込みのみ）
+- projector.py       : ow_project_activities（ow_workers → activities 同期、副作用許可）
+- dashboard.py       : ow_dashboard render + extract_activity_line ヘルパー
+"""

--- a/src/services/ow/applied_msgs.py
+++ b/src/services/ow/applied_msgs.py
@@ -1,0 +1,60 @@
+"""ow_applied_msg_ids テーブルの CRUD ヘルパー。
+
+reducer の idempotency を保証する用途。msg_id 単位で「適用済み (applied)」または
+「解釈不能で skip (skipped)」を記録する。
+"""
+import sqlite3
+
+
+def mark_msg_applied_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    msg_id: int,
+    applied_at: str,
+    outcome: str = "applied",
+) -> None:
+    """msg_id を applied/skipped として記録する。既に記録済みなら何もしない (PK重複は無視)。"""
+    if outcome not in ("applied", "skipped"):
+        raise ValueError(f"invalid outcome: {outcome}")
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO ow_applied_msg_ids
+          (channel_code, msg_id, applied_at, outcome)
+        VALUES (?, ?, ?, ?)
+        """,
+        (channel_code, msg_id, applied_at, outcome),
+    )
+
+
+def is_msg_applied_with_conn(
+    conn: sqlite3.Connection, *, channel_code: str, msg_id: int
+) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM ow_applied_msg_ids WHERE channel_code = ? AND msg_id = ?",
+        (channel_code, msg_id),
+    ).fetchone()
+    return row is not None
+
+
+def get_applied_msg_id_set_with_conn(
+    conn: sqlite3.Connection, *, channel_code: str
+) -> set[int]:
+    """指定channelで適用済みの msg_id 全集合。reducer の冪等性チェックに使う。"""
+    rows = conn.execute(
+        "SELECT msg_id FROM ow_applied_msg_ids WHERE channel_code = ?",
+        (channel_code,),
+    ).fetchall()
+    return {r["msg_id"] for r in rows}
+
+
+def get_max_applied_msg_id_with_conn(
+    conn: sqlite3.Connection, *, channel_code: str
+) -> int:
+    """指定channelで適用済みの最大 msg_id。未適用なら 0。"""
+    row = conn.execute(
+        "SELECT COALESCE(MAX(msg_id), 0) AS m "
+        "FROM ow_applied_msg_ids WHERE channel_code = ?",
+        (channel_code,),
+    ).fetchone()
+    return row["m"] or 0

--- a/src/services/ow/channels.py
+++ b/src/services/ow/channels.py
@@ -1,0 +1,151 @@
+"""ow_channels テーブルの CRUD ヘルパー。
+
+ow_channels はrelay側channelとtopic/orchの紐づけを保持する。relay.db との cross-DB FK
+は張れないため channel_code は TEXT として保持し、reducer が必要に応じて整合を遅延検出する。
+"""
+import sqlite3
+
+from src.db import get_connection, row_to_dict
+
+
+def upsert_channel_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    topic_id: int,
+    orch_handle: str,
+    orch_activity_id: int | None = None,
+    orch_cwd: str | None = None,
+    orch_session_id: str | None = None,
+    now: str,
+) -> None:
+    """ow_channels に対し INSERT or UPDATE する。
+
+    既存行があれば orch_* / updated_at のみ更新し、last_seen_msg_id / deleted_at / topic_id
+    / orch_handle / created_at は保持する。
+    """
+    existing = conn.execute(
+        "SELECT 1 FROM ow_channels WHERE channel_code = ?", (channel_code,)
+    ).fetchone()
+    if existing is None:
+        conn.execute(
+            """
+            INSERT INTO ow_channels
+              (channel_code, topic_id, orch_handle, orch_activity_id,
+               orch_cwd, orch_session_id, last_seen_msg_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+            """,
+            (channel_code, topic_id, orch_handle, orch_activity_id,
+             orch_cwd, orch_session_id, now, now),
+        )
+        return
+    conn.execute(
+        """
+        UPDATE ow_channels
+        SET orch_activity_id = COALESCE(?, orch_activity_id),
+            orch_cwd = COALESCE(?, orch_cwd),
+            orch_session_id = COALESCE(?, orch_session_id),
+            updated_at = ?
+        WHERE channel_code = ?
+        """,
+        (orch_activity_id, orch_cwd, orch_session_id, now, channel_code),
+    )
+
+
+def get_channel_with_conn(
+    conn: sqlite3.Connection, channel_code: str
+) -> dict | None:
+    """channel_code に該当する ow_channels 1件を dict で返す。無ければ None。"""
+    row = conn.execute(
+        "SELECT * FROM ow_channels WHERE channel_code = ?", (channel_code,)
+    ).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def list_channels_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    topic_id: int | None = None,
+    include_deleted: bool = False,
+) -> list[dict]:
+    """ow_channels を一覧する。topic_id 指定時はそのtopic配下のみ。"""
+    clauses: list[str] = []
+    params: list = []
+    if topic_id is not None:
+        clauses.append("topic_id = ?")
+        params.append(topic_id)
+    if not include_deleted:
+        clauses.append("deleted_at IS NULL")
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    rows = conn.execute(
+        f"SELECT * FROM ow_channels {where} ORDER BY channel_code", params
+    ).fetchall()
+    return [row_to_dict(r) for r in rows]
+
+
+def update_channel_last_seen_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    last_seen_msg_id: int,
+    now: str,
+) -> None:
+    """last_seen_msg_id を単調増加で更新する。逆行更新は無視。"""
+    conn.execute(
+        """
+        UPDATE ow_channels
+        SET last_seen_msg_id = MAX(last_seen_msg_id, ?),
+            updated_at = ?
+        WHERE channel_code = ?
+        """,
+        (last_seen_msg_id, now, channel_code),
+    )
+
+
+def soft_delete_channel_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    deleted_at: str,
+) -> None:
+    """relay側channelの消失を反映するソフトデリート（行は残す）。"""
+    conn.execute(
+        "UPDATE ow_channels SET deleted_at = ?, updated_at = ? WHERE channel_code = ?",
+        (deleted_at, deleted_at, channel_code),
+    )
+
+
+def upsert_channel(
+    *,
+    channel_code: str,
+    topic_id: int,
+    orch_handle: str,
+    orch_activity_id: int | None = None,
+    orch_cwd: str | None = None,
+    orch_session_id: str | None = None,
+    now: str,
+) -> None:
+    """upsert_channel_with_conn の単独conn版ラッパー。"""
+    conn = get_connection()
+    try:
+        upsert_channel_with_conn(
+            conn,
+            channel_code=channel_code,
+            topic_id=topic_id,
+            orch_handle=orch_handle,
+            orch_activity_id=orch_activity_id,
+            orch_cwd=orch_cwd,
+            orch_session_id=orch_session_id,
+            now=now,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_channel(channel_code: str) -> dict | None:
+    conn = get_connection()
+    try:
+        return get_channel_with_conn(conn, channel_code)
+    finally:
+        conn.close()

--- a/src/services/ow/dashboard.py
+++ b/src/services/ow/dashboard.py
@@ -1,0 +1,373 @@
+"""ow_dashboard: relay履歴 → ow_workers MV → activities を経て生成する読み取り専用
+ビュー。SessionStart hook / orch tool / check_in summary / `.views/` ファイル / 人間 cat /
+CI log のすべてで同じ文字列を共有する単一レンダラ（M#288 R11）。
+
+スタイル指針 (M#288 §6.0):
+- UTF-8 LF / 行幅100文字以内 / カラーコード未出力 / 絵文字は ●◐○⚠✅ のみ / box-drawing禁止
+- activity 行: `<icon> [<activity_id>] [<intent>] <title> ─ <status>[ (<worker_presence>)]`
+- check_in からの行抽出ヘルパー `extract_activity_line` が正規表現で行を切り出すため、
+  activity_id は必ず `[<数字>]` 形式で出す
+"""
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.db import get_connection
+from src.services.ow import workers as wk
+from src.services.ow.projector import (
+    OW_MANAGED_TAG,
+    ow_project_activities_with_conn,
+)
+from src.services.ow.reducer import ow_apply_state_with_conn
+from src.services.tag_service import (
+    get_entity_tags,
+    get_entity_tags_batch,
+)
+
+
+_VIEWS_DIR_ENV = "OW_VIEWS_DIR"
+_DEFAULT_VIEWS_SUBPATH = Path(".cc-memory") / "ow" / ".views"
+
+# 一般ビューでの行幅上限 (M#288 §6.0)
+_MAX_LINE_WIDTH = 100
+
+_STATUS_ICON = {
+    "in_progress": "●",
+    "pending": "◐",
+    "completed": "○",
+    "snoozed": "◐",
+    "shelved": "◐",
+}
+_STALLED_ICON = "⚠"
+
+_INTENT_LABEL = {
+    "design": "[設計]",
+    "discuss": "[議論]",
+    "implement": "[作業]",
+    "investigate": "[調査]",
+    "review": "[レビュー]",
+}
+
+
+def _views_dir() -> Path:
+    """`.views/` 配下のパス。env で上書き可能。"""
+    override = os.environ.get(_VIEWS_DIR_ENV)
+    if override:
+        return Path(override)
+    return Path.home() / _DEFAULT_VIEWS_SUBPATH
+
+
+def view_file_path(topic_id: int) -> Path:
+    return _views_dir() / f"dashboard-t{topic_id}.md"
+
+
+def write_view_file_atomic(topic_id: int, content: str) -> Path:
+    """temp + atomic rename で `.views/dashboard-t<topic>.md` を書き出す。"""
+    target = view_file_path(topic_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f"dashboard-t{topic_id}.", suffix=".tmp", dir=target.parent
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+        os.replace(tmp_path, target)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+    return target
+
+
+def extract_activity_line(text: str, activity_id: int) -> str | None:
+    """render結果から activity_id を含む行を抽出する。
+
+    行頭は ●◐○⚠✅ のいずれかで、その後に `[<activity_id>]` が来る形式。
+    複数行マッチした場合は先頭を返す。マッチなしは None。
+    """
+    pattern = re.compile(
+        rf"^[●◐○⚠✅]\s+\[{activity_id}\]\s+.*$", re.MULTILINE
+    )
+    m = pattern.search(text)
+    return m.group(0) if m else None
+
+
+def _intent_label_for(tags: list[str]) -> str:
+    """activity tags から intent ラベル文字列を取り出す。なければ空文字。"""
+    for t in tags:
+        if t.startswith("intent:"):
+            intent = t.split(":", 1)[1]
+            return _INTENT_LABEL.get(intent, f"[{intent}]")
+    return ""
+
+
+def _format_age_seconds(now_iso: str, then_iso: str | None) -> str:
+    if not then_iso:
+        return ""
+    try:
+        now = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+        then = datetime.fromisoformat(then_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    delta = int((now - then).total_seconds())
+    if delta < 0:
+        delta = 0
+    if delta < 60:
+        return f"{delta}s"
+    if delta < 3600:
+        return f"{delta // 60}m"
+    return f"{delta // 3600}h"
+
+
+def _visual_width(text: str) -> int:
+    """全角を 2、半角を 1 として簡易幅計算する。"""
+    return sum(2 if ord(c) > 0x7F else 1 for c in text)
+
+
+def _truncate(text: str, max_width: int) -> str:
+    """全角を 2、半角を 1 として簡易計算で省略する。
+
+    末尾の `…` (幅2) を含めて max_width に収まるよう調整する。
+    """
+    if _visual_width(text) <= max_width:
+        return text
+    # `…` (幅2) を確保するため max_width - 2 まで詰める
+    budget = max(max_width - 2, 0)
+    width = 0
+    out = []
+    for ch in text:
+        w = 2 if ord(ch) > 0x7F else 1
+        if width + w > budget:
+            break
+        out.append(ch)
+        width += w
+    return "".join(out) + "…"
+
+
+def _format_activity_row(
+    activity: dict,
+    intent_label: str,
+    workers: list[dict],
+    now_iso: str,
+) -> str:
+    """1 activity の行を組み立てる。"""
+    status = activity["status"]
+    icon = _STATUS_ICON.get(status, _STALLED_ICON)
+    title = activity["title"] or ""
+    presence_parts: list[str] = []
+    for w in workers:
+        if w["workload_state"] == "terminated":
+            continue
+        age = _format_age_seconds(now_iso, w.get("last_heartbeat_at"))
+        if age:
+            presence_parts.append(
+                f"{w['alias']} {w['workload_state']}, hb {age} ago"
+            )
+        else:
+            presence_parts.append(f"{w['alias']} {w['workload_state']}")
+    presence = ""
+    if presence_parts:
+        presence = " (" + ", ".join(presence_parts) + ")"
+    intent_part = f"{intent_label} " if intent_label else ""
+    fixed_part = f"{icon} [{activity['id']}] {intent_part}"
+    suffix = f" ─ {status}{presence}"
+    title_budget = max(
+        _MAX_LINE_WIDTH - _visual_width(fixed_part) - _visual_width(suffix), 10,
+    )
+    truncated_title = _truncate(title, title_budget)
+    return f"{fixed_part}{truncated_title}{suffix}"
+
+
+def _format_orch_worker_detail(w: dict, now_iso: str) -> str:
+    age = _format_age_seconds(now_iso, w.get("last_heartbeat_at")) or "?"
+    state = w["workload_state"]
+    return (
+        f"- {w['alias']:<8} T{w['task_n']:<3} activity#{w.get('activity_id') or '?':<5} "
+        f"workload={state:<10} hb={age:<5} "
+        f"model={w.get('model') or '?'}  cwd={w.get('cwd') or '?'}"
+    )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _managed_activities_for_topic(
+    conn: sqlite3.Connection, topic_id: int
+) -> list[dict]:
+    """ow:managed 付きの activity を topic に紐づくぶんだけ返す。"""
+    rows = conn.execute(
+        """
+        SELECT DISTINCT a.id, a.title, a.status, a.last_heartbeat_at
+        FROM activities a
+        JOIN activity_tags at ON at.activity_id = a.id
+        JOIN tags t ON t.id = at.tag_id
+        JOIN relations r
+          ON r.source_type = 'activity' AND r.source_id = a.id
+         AND r.target_type = 'topic' AND r.target_id = ?
+        WHERE t.namespace = 'ow' AND t.name = 'managed'
+        ORDER BY a.id
+        """,
+        (topic_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _alive_workers_for_topic(
+    conn: sqlite3.Connection, topic_id: int
+) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT * FROM ow_workers
+        WHERE topic_id = ? AND workload_state != 'terminated'
+        ORDER BY task_n
+        """,
+        (topic_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _recently_terminated_workers_for_topic(
+    conn: sqlite3.Connection, topic_id: int, limit: int = 10
+) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT * FROM ow_workers
+        WHERE topic_id = ? AND workload_state = 'terminated'
+        ORDER BY terminated_at DESC, id DESC
+        LIMIT ?
+        """,
+        (topic_id, limit),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def render_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    topic_id: int,
+    role: str = "general",
+    now_iso: str | None = None,
+) -> str:
+    """ow:managed activity 一覧 + worker presence をレンダリングする。
+
+    role="general" は activity 一覧 + alive worker サマリ。
+    role="orch" は同一内容 + alive/terminated worker の詳細。
+    """
+    now = now_iso or _utc_now_iso()
+    activities = _managed_activities_for_topic(conn, topic_id)
+    workers_by_activity: dict[int, list[dict]] = {}
+    for w in _alive_workers_for_topic(conn, topic_id):
+        if w.get("activity_id"):
+            workers_by_activity.setdefault(w["activity_id"], []).append(w)
+    tags_batch = get_entity_tags_batch(
+        conn, "activity_tags", "activity_id", [a["id"] for a in activities]
+    ) if activities else {}
+
+    lines: list[str] = [f"## アクティビティ一覧（topic t{topic_id}）", ""]
+    if not activities:
+        lines.append("（ow:managed の activity がありません）")
+    for a in activities:
+        intent_label = _intent_label_for(tags_batch.get(a["id"], []))
+        workers = workers_by_activity.get(a["id"], [])
+        lines.append(_format_activity_row(a, intent_label, workers, now))
+
+    if role == "orch":
+        lines.append("")
+        lines.append(f"## orch詳細ビュー topic t{topic_id}")
+        lines.append("")
+        alive_all = _alive_workers_for_topic(conn, topic_id)
+        lines.append("### Alive workers (workload_state != terminated)")
+        if alive_all:
+            for w in alive_all:
+                lines.append(_format_orch_worker_detail(w, now))
+        else:
+            lines.append("(empty)")
+        lines.append("")
+        lines.append("### Recently terminated（直近10件）")
+        term = _recently_terminated_workers_for_topic(conn, topic_id)
+        if term:
+            for w in term:
+                cause = w.get("cause") or "?"
+                tat = w.get("terminated_at") or ""
+                lines.append(
+                    f"- {w['alias']:<8} T{w['task_n']:<3} "
+                    f"activity#{w.get('activity_id') or '?'}  "
+                    f"terminated({cause})  at {tat}"
+                )
+        else:
+            lines.append("(empty)")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_dashboard(
+    *,
+    topic_id: int,
+    role: str = "general",
+    history: list[dict] | None = None,
+    channel_code: str | None = None,
+    write_view: bool = True,
+    apply_state: bool = True,
+    now_iso: str | None = None,
+) -> dict:
+    """ダッシュボードレンダリングのエントリポイント。
+
+    動作:
+      1. apply_state=True かつ history が渡された場合は reducer を lazy 実行
+      2. projector を ow:managed activity に対して実行
+      3. role に応じてレンダー
+      4. write_view=True なら `.views/dashboard-t<topic>.md` を atomic write
+
+    Returns:
+        {
+            "topic_id": int,
+            "rendered": str,
+            "view_file": str | None,
+            "reduced": {...} | None,
+            "projected": [...] | None,
+        }
+    """
+    now = now_iso or _utc_now_iso()
+    conn = get_connection()
+    reduced = None
+    projected = None
+    try:
+        if apply_state and history and channel_code:
+            reduced = ow_apply_state_with_conn(
+                conn,
+                channel_code=channel_code,
+                topic_id=topic_id,
+                history=history,
+                now=now,
+            )
+        projected = ow_project_activities_with_conn(conn, topic_id=topic_id)
+        conn.commit()
+        rendered = render_with_conn(
+            conn, topic_id=topic_id, role=role, now_iso=now,
+        )
+    finally:
+        conn.close()
+    view_path = None
+    if write_view:
+        view_path = str(write_view_file_atomic(topic_id, rendered))
+    return {
+        "topic_id": topic_id,
+        "rendered": rendered,
+        "view_file": view_path,
+        "reduced": reduced,
+        "projected": projected,
+    }
+
+
+def is_ow_managed_activity_with_conn(
+    conn: sqlite3.Connection, activity_id: int
+) -> bool:
+    """activity が ow:managed タグを持つか。check_in 統合判定用。"""
+    tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+    return OW_MANAGED_TAG in tags

--- a/src/services/ow/fallback.py
+++ b/src/services/ow/fallback.py
@@ -1,0 +1,90 @@
+"""read-fallback シム（Phase 1 限定、Phase 2 で削除予定）。
+
+ow_workers MV にデータが入っていない過渡期に、旧 queue-t<topic_id>.md を読みに行く
+互換層。新schema切替（順序3）前後で、ow_status / ow_recover 等が「データ移行前」も
+「移行後」も同じインタフェースで読めるようにする。
+
+設計書 M#288 §3.6 Phase 1:
+- ow_workers が空 / 該当レコードなしの場合、旧 queue-t*.md にフォールバック
+- Phase 2 cutover 後にシム削除
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from src.services.ow import workers as wk
+
+
+def _read_legacy_queue_workers(topic_id: int | str) -> list[dict]:
+    """旧 queue-t<topic_id>.md から worker 相当のリストを返す。
+
+    ow_service.py の private ヘルパーを再利用する（Phase 1 限定の暫定依存）。
+    Phase 2 で queue ファイル自体が廃止される際にこの関数ごと削除する。
+
+    返却 dict は ow_workers 行に擬似的に整形した最低限の情報:
+      {"handle", "alias", "task_n", "workload_state", "term_ref", "title"}
+    """
+    # 局所 import で副作用（relayサーバー起動等）の発生を遅延させる
+    from src.services.ow_service import _get_queue_dir, _parse_queue_file
+
+    queue_dir = _get_queue_dir()
+    queue_file = Path(queue_dir) / f"queue-t{topic_id}.md"
+    if not queue_file.exists():
+        return []
+    _, tasks = _parse_queue_file(queue_file)
+    legacy: list[dict] = []
+    for t in tasks:
+        task_raw = t.get("task") or ""
+        try:
+            task_n = int(task_raw.lstrip("T") or "0")
+        except ValueError:
+            task_n = 0
+        worker = t.get("worker") or ""
+        # status (queued/spawning/in_progress/done) → workload_state 緩いマッピング
+        status = (t.get("status") or "").lower()
+        workload_state = {
+            "queued": "spawning",
+            "spawning": "spawning",
+            "in_progress": "working",
+            "working": "working",
+            "done": "terminated",
+            "awaiting_verify": "draining",
+        }.get(status, "spawning")
+        legacy.append({
+            "handle": worker,
+            "alias": worker,
+            "task_n": task_n,
+            "workload_state": workload_state,
+            "term_ref": t.get("term_ref"),
+            "title": t.get("title"),
+            "_source": "legacy_queue",
+        })
+    return legacy
+
+
+def read_workers_with_fallback_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    topic_id: int | str,
+    alive_only: bool = True,
+) -> dict:
+    """ow_workers を優先、空なら旧queue.mdへフォールバックする読み出し。
+
+    Returns:
+        {
+            "source": "ow_workers" | "legacy_queue",
+            "workers": list[dict],
+        }
+        source="ow_workers" の場合は ow_workers テーブル行をそのまま返す。
+        source="legacy_queue" の場合は queue.md パース結果を擬似 ow_workers 形式に
+        変換した dict のリストを返す。
+    """
+    rows = wk.list_workers_with_conn(
+        conn, channel_code=channel_code, alive_only=alive_only,
+    )
+    if rows:
+        return {"source": "ow_workers", "workers": rows}
+    legacy = _read_legacy_queue_workers(topic_id)
+    return {"source": "legacy_queue", "workers": legacy}

--- a/src/services/ow/projector.py
+++ b/src/services/ow/projector.py
@@ -1,0 +1,189 @@
+"""ow_project_activities: ow_workers の状態を activities テーブルに反映する projector。
+
+reducer (純粋・ow_*のみ書き込み) と分離した副作用許可レイヤ。`ow:managed` タグ付きの
+activity に限定して書き込むことで、人間が手動で update_activity した内容を踏み潰さない。
+
+遷移ルール:
+- alive worker が working/blocked/escalated/draining → activity.status = in_progress
+- 全 worker が terminated で cause=closed → activity.status = completed
+- terminated worker の最新 cause = cancelled → activity.status = completed + tag outcome:cancelled
+- terminated worker の最新 cause が crashed/dead/crashed-during-drain → completed + tag outcome:failed
+
+last_heartbeat_at: alive worker があればそのうち最大の last_heartbeat_at を activities に同期。
+"""
+import sqlite3
+
+from src.services.tag_service import (
+    ensure_tag_ids,
+    get_entity_tags,
+    link_tags,
+)
+
+OW_MANAGED_TAG = "ow:managed"
+
+# alive worker と判定する workload_state（terminated 以外）
+_ALIVE_STATES = (
+    "spawning", "loading", "ready", "working", "blocked", "escalated", "draining",
+)
+# activity を in_progress とみなす workload_state（spawning/loading/ready は worker 起動段階で
+# まだ実作業が始まっていないため除外）
+_PROGRESSING_STATES = ("working", "blocked", "escalated", "draining")
+
+_OUTCOME_TAG_BY_CAUSE = {
+    "cancelled": "outcome:cancelled",
+    "crashed": "outcome:failed",
+    "dead": "outcome:failed",
+    "crashed-during-drain": "outcome:failed",
+}
+
+
+def _has_tag(conn: sqlite3.Connection, activity_id: int, tag_str: str) -> bool:
+    tags = get_entity_tags(conn, "activity_tags", "activity_id", activity_id)
+    return tag_str in tags
+
+
+def _add_tag(conn: sqlite3.Connection, activity_id: int, tag_str: str) -> None:
+    if ":" in tag_str:
+        ns, name = tag_str.split(":", 1)
+        parsed = [(ns, name)]
+    else:
+        parsed = [("", tag_str)]
+    tag_ids = ensure_tag_ids(conn, parsed)
+    link_tags(conn, "activity_tags", "activity_id", activity_id, tag_ids)
+
+
+def _list_managed_activity_ids(
+    conn: sqlite3.Connection, *, topic_id: int | None = None
+) -> list[int]:
+    """ow:managed タグの付いた activity の id 一覧を返す。
+
+    topic_id 指定時は relations テーブルで topic↔activity 紐付け（source='activity'<
+    target='topic' の正規化）を経由して絞り込む（migration 0033 で polymorphic 化済み）。
+    """
+    if topic_id is None:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT a.id FROM activities a
+            JOIN activity_tags at ON at.activity_id = a.id
+            JOIN tags t ON t.id = at.tag_id
+            WHERE t.namespace = 'ow' AND t.name = 'managed'
+            """
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT a.id FROM activities a
+            JOIN activity_tags at ON at.activity_id = a.id
+            JOIN tags t ON t.id = at.tag_id
+            JOIN relations r
+              ON r.source_type = 'activity' AND r.source_id = a.id
+             AND r.target_type = 'topic' AND r.target_id = ?
+            WHERE t.namespace = 'ow' AND t.name = 'managed'
+            """,
+            (topic_id,),
+        ).fetchall()
+    return [r["id"] for r in rows]
+
+
+def _workers_for_activity(
+    conn: sqlite3.Connection, activity_id: int
+) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM ow_workers WHERE activity_id = ? "
+        "ORDER BY spawned_at, id",
+        (activity_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _derive_activity_status(workers: list[dict]) -> tuple[str | None, str | None]:
+    """workers から (next_status, outcome_tag) を導出する。
+
+    どちらも変更不要なら (None, None) を返す。
+    """
+    if not workers:
+        return (None, None)
+    alive = [w for w in workers if w["workload_state"] in _ALIVE_STATES]
+    progressing = [w for w in workers if w["workload_state"] in _PROGRESSING_STATES]
+    if progressing:
+        return ("in_progress", None)
+    if alive:
+        # spawning/loading/ready のみ。activityは pending のまま
+        return (None, None)
+    # 全員 terminated
+    # 最新の terminated_at を持つ worker の cause を採用
+    terminated = sorted(
+        [w for w in workers if w["workload_state"] == "terminated"],
+        key=lambda w: (w["terminated_at"] or "", w["id"]),
+        reverse=True,
+    )
+    latest_cause = terminated[0]["cause"] if terminated else None
+    outcome_tag = _OUTCOME_TAG_BY_CAUSE.get(latest_cause) if latest_cause else None
+    return ("completed", outcome_tag)
+
+
+def _project_one(
+    conn: sqlite3.Connection, activity_id: int
+) -> dict:
+    workers = _workers_for_activity(conn, activity_id)
+    next_status, outcome_tag = _derive_activity_status(workers)
+    row = conn.execute(
+        "SELECT status FROM activities WHERE id = ?", (activity_id,)
+    ).fetchone()
+    if row is None:
+        return {"changed_status": False, "added_tag": None, "heartbeat_synced": False}
+    current = row["status"]
+    changed = False
+    if next_status and next_status != current:
+        # downgrade を避ける（completed → in_progress は許さない）
+        if not (current == "completed" and next_status == "in_progress"):
+            conn.execute(
+                "UPDATE activities SET status = ? WHERE id = ?",
+                (next_status, activity_id),
+            )
+            changed = True
+    added_tag = None
+    if outcome_tag and not _has_tag(conn, activity_id, outcome_tag):
+        _add_tag(conn, activity_id, outcome_tag)
+        added_tag = outcome_tag
+
+    # heartbeat 同期: alive worker のうち最新の last_heartbeat_at
+    alive_hbs = [
+        w["last_heartbeat_at"] for w in workers
+        if w["workload_state"] in _ALIVE_STATES and w["last_heartbeat_at"]
+    ]
+    heartbeat_synced = False
+    if alive_hbs:
+        latest_hb = max(alive_hbs)
+        conn.execute(
+            "UPDATE activities SET last_heartbeat_at = ? WHERE id = ?",
+            (latest_hb, activity_id),
+        )
+        heartbeat_synced = True
+    return {
+        "activity_id": activity_id,
+        "changed_status": changed,
+        "added_tag": added_tag,
+        "heartbeat_synced": heartbeat_synced,
+    }
+
+
+def ow_project_activities_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    topic_id: int | None = None,
+) -> dict:
+    """ow:managed タグ付き activity を ow_workers の状態に基づいて更新する。
+
+    Args:
+        topic_id: 指定時はそのtopic配下のみ。None なら全 ow:managed activity が対象
+
+    Returns:
+        {"projected": [activity_id ...], "details": [...]}
+    """
+    activity_ids = _list_managed_activity_ids(conn, topic_id=topic_id)
+    details = [_project_one(conn, aid) for aid in activity_ids]
+    return {
+        "projected": [d.get("activity_id") for d in details if d.get("activity_id")],
+        "details": details,
+    }

--- a/src/services/ow/reducer.py
+++ b/src/services/ow/reducer.py
@@ -1,0 +1,357 @@
+"""ow_apply_state: relay history → ow_workers / ow_channels / ow_applied_msg_ids
+への純粋 reducer。
+
+設計原則:
+- CQS分離: ow_*テーブルへの書き込みのみ。activities への書き込みは projector が行う
+- idempotent: 同じ history を再適用しても結果は変わらない（ow_applied_msg_ids で管理）
+- 解釈不能な envelope は warning ログを残して outcome=skipped で記録（適用済み扱い、再試行しない）
+
+各 relay envelope が触る列の対応:
+- command:assign (orch → worker): ow_workers 行を find_or_insert し
+  activity_id / model / cwd / permission_mode / timeout_min / topic_id を反映
+- event:identity (worker → *): ow_workers 行を find_or_insert し
+  session_id / alias / model / cwd / activity_id を反映
+- event:state(<state>): ow_workers の workload_state / cause / ready_at / terminated_at /
+  last_state_msg_id / last_heartbeat_at を反映
+- event:heartbeat(alive): ow_workers.last_heartbeat_at を更新
+"""
+import logging
+from typing import Any
+
+from src.services.ow import applied_msgs as am
+from src.services.ow import channels as ch
+from src.services.ow import workers as wk
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_STATES = {
+    "spawning", "loading", "ready", "working",
+    "blocked", "escalated", "draining", "terminated",
+}
+_VALID_CAUSES = {"closed", "cancelled", "dead", "crashed", "crashed-during-drain"}
+
+
+def _parse_msg(msg: dict) -> dict | None:
+    """relay 1メッセージから ow envelope を取り出して dict として返す。
+
+    body が dict でない / v != 1 / kind が event/command でない場合は None を返し
+    呼び出し側で skipped 扱いとする。
+    """
+    body = msg.get("body")
+    if not isinstance(body, dict):
+        return None
+    if body.get("v") != 1:
+        return None
+    kind = body.get("kind")
+    if kind not in ("event", "command"):
+        return None
+    data = body.get("data")
+    if not isinstance(data, dict):
+        return None
+    return {
+        "msg_id": msg.get("msg_id"),
+        "handle": msg.get("handle"),
+        "created_at": msg.get("created_at"),
+        "kind": kind,
+        "from_": body.get("from"),
+        "to": body.get("to"),
+        "task": body.get("task"),
+        "data_type": data.get("type"),
+        "data": data,
+    }
+
+
+def _find_or_insert_worker(
+    conn,
+    *,
+    channel_code: str,
+    handle: str,
+    alias: str | None,
+    activity_id: int | None,
+    topic_id: int,
+    spawned_at: str,
+    workload_state: str = "spawning",
+) -> dict | None:
+    """alive worker を探し、無ければ INSERT。返却は ow_workers 1行 dict。
+
+    部分UNIQUE 違反（同 channel + handle で別 alive 行）が起きた場合は None を返す
+    （reducer は次の event を保留せず処理を継続する）。
+    """
+    existing = wk.get_alive_worker_by_handle_with_conn(
+        conn, channel_code=channel_code, handle=handle
+    )
+    if existing:
+        return existing
+    task_n = wk.allocate_task_n_with_conn(conn, channel_code)
+    wid = wk.insert_worker_with_conn(
+        conn,
+        channel_code=channel_code,
+        handle=handle,
+        alias=alias or handle,
+        activity_id=activity_id,
+        topic_id=topic_id,
+        task_n=task_n,
+        spawned_at=spawned_at,
+        workload_state=workload_state,
+    )
+    return wk.get_worker_by_id_with_conn(conn, wid)
+
+
+def _apply_command_assign(
+    conn, parsed: dict, *, channel_code: str, topic_id_default: int
+) -> bool:
+    data = parsed["data"]
+    to = parsed["to"]
+    if not isinstance(to, str) or to in ("*", "orch", ""):
+        return False
+    handle = to
+    activity_id = data.get("activity_id")
+    topic_id_raw = data.get("topic_id") or topic_id_default
+    try:
+        topic_id = int(topic_id_raw)
+    except (TypeError, ValueError):
+        return False
+    worker = _find_or_insert_worker(
+        conn,
+        channel_code=channel_code,
+        handle=handle,
+        alias=handle,
+        activity_id=activity_id,
+        topic_id=topic_id,
+        spawned_at=parsed["created_at"] or "",
+    )
+    if not worker:
+        return False
+    # assign metadata 反映（途中変更も許容）
+    conn.execute(
+        """
+        UPDATE ow_workers
+        SET activity_id = COALESCE(?, activity_id),
+            model = COALESCE(?, model),
+            cwd = COALESCE(?, cwd),
+            permission_mode = COALESCE(?, permission_mode),
+            timeout_min = COALESCE(?, timeout_min)
+        WHERE id = ?
+        """,
+        (
+            activity_id,
+            data.get("model"),
+            data.get("cwd"),
+            data.get("permission_mode"),
+            data.get("timeout_min"),
+            worker["id"],
+        ),
+    )
+    return True
+
+
+def _apply_event_identity(
+    conn, parsed: dict, *, channel_code: str, topic_id_default: int
+) -> bool:
+    data = parsed["data"]
+    handle = parsed["from_"]
+    if not isinstance(handle, str) or not handle:
+        return False
+    role = data.get("role")
+    if role and role != "worker":
+        # orch / user 等の identity は ow_workers の対象外
+        return True  # skip success
+    activity_id = data.get("activity_id")
+    topic_id_raw = data.get("topic_id") or topic_id_default
+    try:
+        topic_id = int(topic_id_raw)
+    except (TypeError, ValueError):
+        return False
+    worker = _find_or_insert_worker(
+        conn,
+        channel_code=channel_code,
+        handle=handle,
+        alias=data.get("alias") or handle,
+        activity_id=activity_id,
+        topic_id=topic_id,
+        spawned_at=data.get("started_at") or parsed["created_at"] or "",
+    )
+    if not worker:
+        return False
+    terminated_at = None
+    if data.get("terminated_at"):
+        terminated_at = data["terminated_at"]
+    wk.update_worker_identity_with_conn(
+        conn,
+        worker_id=worker["id"],
+        session_id=data.get("session_id"),
+        model=data.get("model"),
+        cwd=data.get("cwd"),
+    )
+    # identity 再 append (terminated_at 付き) の場合は terminated_at を反映
+    if terminated_at:
+        conn.execute(
+            "UPDATE ow_workers SET terminated_at = COALESCE(terminated_at, ?) WHERE id = ?",
+            (terminated_at, worker["id"]),
+        )
+    return True
+
+
+def _apply_event_state(
+    conn, parsed: dict, *, channel_code: str, topic_id_default: int
+) -> bool:
+    data = parsed["data"]
+    handle = parsed["from_"]
+    if not isinstance(handle, str) or not handle:
+        return False
+    state = data.get("state")
+    if state not in _VALID_STATES:
+        return False
+    cause = data.get("cause")
+    if cause is not None and cause not in _VALID_CAUSES:
+        cause = None
+    worker = _find_or_insert_worker(
+        conn,
+        channel_code=channel_code,
+        handle=handle,
+        alias=handle,
+        activity_id=None,
+        topic_id=topic_id_default,
+        spawned_at=parsed["created_at"] or "",
+        workload_state=state,
+    )
+    if not worker:
+        return False
+    ready_at = parsed["created_at"] if state == "ready" else None
+    terminated_at = parsed["created_at"] if state == "terminated" else None
+    wk.update_worker_state_with_conn(
+        conn,
+        worker_id=worker["id"],
+        workload_state=state,
+        cause=cause,
+        last_state_msg_id=parsed["msg_id"],
+        last_heartbeat_at=parsed["created_at"],
+        ready_at=ready_at,
+        terminated_at=terminated_at,
+        session_id=data.get("session_id"),
+    )
+    return True
+
+
+def _apply_event_heartbeat(
+    conn, parsed: dict, *, channel_code: str, topic_id_default: int
+) -> bool:
+    handle = parsed["from_"]
+    if not isinstance(handle, str) or not handle:
+        return False
+    worker = wk.get_alive_worker_by_handle_with_conn(
+        conn, channel_code=channel_code, handle=handle
+    )
+    if not worker:
+        # heartbeat 先行はあり得る（identity 前の alive 信号）。記録対象 worker が
+        # まだ無いだけなのでスキップ成功扱い。
+        return True
+    wk.update_worker_heartbeat_with_conn(
+        conn,
+        worker_id=worker["id"],
+        last_heartbeat_at=parsed["created_at"] or "",
+    )
+    return True
+
+
+def ow_apply_state_with_conn(
+    conn,
+    *,
+    channel_code: str,
+    topic_id: int,
+    history: list[dict],
+    now: str,
+) -> dict:
+    """relay history を消化して ow_* テーブルを更新する純粋 reducer。
+
+    Args:
+        history: relay /history の messages 配列。事前取得済みのものを渡す
+            （reducer をテスト可能にし、副作用範囲を呼び出し側に明示するため）
+        now: applied_at に使う現在時刻文字列（ISO8601 UTC）
+
+    Returns:
+        {
+            "applied": int,         # 新規に適用した msg 数
+            "skipped": int,         # 解釈不能で skipped 記録した数
+            "duplicate": int,       # 既適用で何もしなかった数
+            "last_msg_id": int,     # 入力 history の最大 msg_id（0 if empty）
+        }
+    """
+    applied_set = am.get_applied_msg_id_set_with_conn(
+        conn, channel_code=channel_code
+    )
+    counters = {"applied": 0, "skipped": 0, "duplicate": 0, "last_msg_id": 0}
+    # msg_id 昇順で安定処理（relay履歴は単調増加だが念のため）
+    for msg in sorted(history, key=lambda m: m.get("msg_id") or 0):
+        mid = msg.get("msg_id")
+        if not isinstance(mid, int):
+            continue
+        counters["last_msg_id"] = max(counters["last_msg_id"], mid)
+        if mid in applied_set:
+            counters["duplicate"] += 1
+            continue
+        parsed = _parse_msg(msg)
+        if parsed is None:
+            am.mark_msg_applied_with_conn(
+                conn, channel_code=channel_code,
+                msg_id=mid, applied_at=now, outcome="skipped",
+            )
+            counters["skipped"] += 1
+            continue
+        success = _dispatch(
+            conn, parsed,
+            channel_code=channel_code, topic_id_default=topic_id,
+        )
+        if success:
+            am.mark_msg_applied_with_conn(
+                conn, channel_code=channel_code,
+                msg_id=mid, applied_at=now, outcome="applied",
+            )
+            counters["applied"] += 1
+        else:
+            logger.warning(
+                "ow_apply_state: msg_id=%s dispatch failed (type=%s)",
+                mid, parsed.get("data_type"),
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code=channel_code,
+                msg_id=mid, applied_at=now, outcome="skipped",
+            )
+            counters["skipped"] += 1
+    if counters["last_msg_id"] > 0:
+        ch.update_channel_last_seen_with_conn(
+            conn, channel_code=channel_code,
+            last_seen_msg_id=counters["last_msg_id"], now=now,
+        )
+    return counters
+
+
+def _dispatch(
+    conn, parsed: dict, *, channel_code: str, topic_id_default: int
+) -> bool:
+    kind = parsed["kind"]
+    dtype = parsed["data_type"]
+    if kind == "command" and dtype == "assign":
+        return _apply_command_assign(
+            conn, parsed,
+            channel_code=channel_code, topic_id_default=topic_id_default,
+        )
+    if kind == "event":
+        if dtype == "identity":
+            return _apply_event_identity(
+                conn, parsed,
+                channel_code=channel_code, topic_id_default=topic_id_default,
+            )
+        if dtype == "state":
+            return _apply_event_state(
+                conn, parsed,
+                channel_code=channel_code, topic_id_default=topic_id_default,
+            )
+        if dtype == "heartbeat":
+            return _apply_event_heartbeat(
+                conn, parsed,
+                channel_code=channel_code, topic_id_default=topic_id_default,
+            )
+    # 未対応の type は skipped 扱い（reducer はビジネスロジックを持たない）
+    return False

--- a/src/services/ow/workers.py
+++ b/src/services/ow/workers.py
@@ -1,0 +1,194 @@
+"""ow_workers テーブルの CRUD ヘルパー。
+
+ow_workers は worker run instance を表す MV テーブル。同一activityに対して再spawnすると
+terminated行が履歴として残り、alive期間中のみ部分 UNIQUE INDEX で 1 worker = 1 activity
+を物理強制する。
+"""
+import sqlite3
+
+from src.db import get_connection, row_to_dict
+
+ALIVE_WORKLOAD_STATES = (
+    "spawning", "loading", "ready", "working", "blocked", "escalated", "draining",
+)
+
+
+def allocate_task_n_with_conn(conn: sqlite3.Connection, channel_code: str) -> int:
+    """channel単位の task_n 連番を採番する。
+
+    部分UNIQUE INDEX uq_ow_workers_task_n が衝突検知の保険。並行spawn時はリトライ前提。
+    """
+    row = conn.execute(
+        "SELECT COALESCE(MAX(task_n), 0) AS m FROM ow_workers WHERE channel_code = ?",
+        (channel_code,),
+    ).fetchone()
+    return (row["m"] or 0) + 1
+
+
+def insert_worker_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    handle: str,
+    alias: str,
+    activity_id: int | None,
+    topic_id: int,
+    task_n: int,
+    spawned_at: str,
+    model: str | None = None,
+    cwd: str | None = None,
+    permission_mode: str | None = None,
+    timeout_min: int | None = None,
+    task_material_id: int | None = None,
+    session_id: str | None = None,
+    workload_state: str = "spawning",
+) -> int:
+    """ow_workers に新規 worker 行を INSERT し id を返す。"""
+    cur = conn.execute(
+        """
+        INSERT INTO ow_workers
+          (channel_code, handle, alias, activity_id, topic_id, task_n,
+           model, cwd, permission_mode, timeout_min, task_material_id,
+           session_id, workload_state, spawned_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (channel_code, handle, alias, activity_id, topic_id, task_n,
+         model, cwd, permission_mode, timeout_min, task_material_id,
+         session_id, workload_state, spawned_at),
+    )
+    return cur.lastrowid
+
+
+def get_alive_worker_by_handle_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    handle: str,
+) -> dict | None:
+    """alive (非terminated) な worker を handle で1件取得する。
+
+    uq_ow_workers_alive_handle により alive 期間中は (channel, handle) が一意なので
+    返却は0件 or 1件。
+    """
+    row = conn.execute(
+        """
+        SELECT * FROM ow_workers
+        WHERE channel_code = ? AND handle = ? AND workload_state != 'terminated'
+        """,
+        (channel_code, handle),
+    ).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def get_worker_by_id_with_conn(
+    conn: sqlite3.Connection, worker_id: int
+) -> dict | None:
+    row = conn.execute(
+        "SELECT * FROM ow_workers WHERE id = ?", (worker_id,)
+    ).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def list_workers_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str | None = None,
+    topic_id: int | None = None,
+    activity_id: int | None = None,
+    alive_only: bool = True,
+) -> list[dict]:
+    clauses: list[str] = []
+    params: list = []
+    if channel_code is not None:
+        clauses.append("channel_code = ?")
+        params.append(channel_code)
+    if topic_id is not None:
+        clauses.append("topic_id = ?")
+        params.append(topic_id)
+    if activity_id is not None:
+        clauses.append("activity_id = ?")
+        params.append(activity_id)
+    if alive_only:
+        clauses.append("workload_state != 'terminated'")
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    rows = conn.execute(
+        f"SELECT * FROM ow_workers {where} ORDER BY task_n", params
+    ).fetchall()
+    return [row_to_dict(r) for r in rows]
+
+
+def update_worker_state_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    worker_id: int,
+    workload_state: str,
+    cause: str | None = None,
+    last_state_msg_id: int | None = None,
+    last_heartbeat_at: str | None = None,
+    ready_at: str | None = None,
+    terminated_at: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """worker の state とタイムスタンプを更新する。
+
+    各引数が None の項目は既存値を保持する（COALESCE）。workload_state は常に上書き。
+    """
+    conn.execute(
+        """
+        UPDATE ow_workers
+        SET workload_state = ?,
+            cause = COALESCE(?, cause),
+            last_state_msg_id = COALESCE(?, last_state_msg_id),
+            last_heartbeat_at = COALESCE(?, last_heartbeat_at),
+            ready_at = COALESCE(?, ready_at),
+            terminated_at = COALESCE(?, terminated_at),
+            session_id = COALESCE(?, session_id)
+        WHERE id = ?
+        """,
+        (workload_state, cause, last_state_msg_id, last_heartbeat_at,
+         ready_at, terminated_at, session_id, worker_id),
+    )
+
+
+def update_worker_heartbeat_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    worker_id: int,
+    last_heartbeat_at: str,
+) -> None:
+    """heartbeat のみ更新（state遷移を伴わない）。"""
+    conn.execute(
+        "UPDATE ow_workers SET last_heartbeat_at = ? WHERE id = ?",
+        (last_heartbeat_at, worker_id),
+    )
+
+
+def update_worker_identity_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    worker_id: int,
+    session_id: str | None = None,
+    model: str | None = None,
+    cwd: str | None = None,
+) -> None:
+    """identity event 受信時の身元情報を更新する（COALESCE で部分更新）。"""
+    conn.execute(
+        """
+        UPDATE ow_workers
+        SET session_id = COALESCE(?, session_id),
+            model = COALESCE(?, model),
+            cwd = COALESCE(?, cwd)
+        WHERE id = ?
+        """,
+        (session_id, model, cwd, worker_id),
+    )
+
+
+def get_alive_workers(channel_code: str) -> list[dict]:
+    conn = get_connection()
+    try:
+        return list_workers_with_conn(
+            conn, channel_code=channel_code, alive_only=True
+        )
+    finally:
+        conn.close()

--- a/tests/test_migrations/test_0040_add_ow_tables.py
+++ b/tests/test_migrations/test_0040_add_ow_tables.py
@@ -1,0 +1,521 @@
+"""migration 0040_add_ow_tables のテスト
+
+queue→activity管理化 Phase 1 の基盤テーブル3つを追加する migration の挙動を検証する:
+
+- ow_channels: relayチャネルとtopic/orchの紐づけ
+- ow_workers: workerランタイム状態MV（部分UNIQUE INDEX で alive 一意性を物理強制）
+- ow_applied_msg_ids: reducer idempotency 用
+
+ユーザー判断 Q10 で session_id は NULL 許容（identity未受信のready前workerをreducerで表現可能にするため）。
+1 worker = 1 activity の物理強制は uq_ow_workers_one_alive_per_activity 部分UNIQUE INDEX で実現する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0040含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0040():
+    """0037までのmigrationを適用したDBを提供する。0040の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0040 = MigrationList([m for m in all_migs if m.id < "0040"])
+        with backend.lock():
+            backend.apply_migrations(pre_0040)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _get_indexes(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA index_list({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _insert_topic(conn: sqlite3.Connection, title: str = "テストトピック") -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        (title, "説明"),
+    )
+    return cur.lastrowid
+
+
+def _insert_activity(conn: sqlite3.Connection, title: str = "テストアクティビティ") -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "説明", "pending"),
+    )
+    return cur.lastrowid
+
+
+def _insert_channel(conn: sqlite3.Connection, channel_code: str, topic_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO ow_channels
+          (channel_code, topic_id, orch_handle, last_seen_msg_id, created_at, updated_at)
+        VALUES (?, ?, 'orch', 0, '2026-06-17T00:00:00Z', '2026-06-17T00:00:00Z')
+        """,
+        (channel_code, topic_id),
+    )
+
+
+def _insert_worker(
+    conn: sqlite3.Connection,
+    *,
+    channel_code: str,
+    handle: str,
+    alias: str,
+    activity_id: int | None,
+    topic_id: int,
+    task_n: int,
+    workload_state: str = "spawning",
+    cause: str | None = None,
+    session_id: str | None = None,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO ow_workers
+          (channel_code, handle, alias, activity_id, topic_id, task_n,
+           session_id, workload_state, cause, spawned_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '2026-06-17T00:00:00Z')
+        """,
+        (channel_code, handle, alias, activity_id, topic_id, task_n,
+         session_id, workload_state, cause),
+    )
+    return cur.lastrowid
+
+
+class TestTablesCreated:
+    """3テーブルが migration 0040 適用後に存在することを確認"""
+
+    def test_ow_channels_exists_after_0040(self, migrated_db):
+        conn = get_connection()
+        try:
+            assert "channel_code" in _get_column_names(conn, "ow_channels")
+            assert "topic_id" in _get_column_names(conn, "ow_channels")
+            assert "orch_session_id" in _get_column_names(conn, "ow_channels")
+            assert "last_seen_msg_id" in _get_column_names(conn, "ow_channels")
+            assert "deleted_at" in _get_column_names(conn, "ow_channels")
+        finally:
+            conn.close()
+
+    def test_ow_workers_exists_after_0040(self, migrated_db):
+        conn = get_connection()
+        try:
+            cols = _get_column_names(conn, "ow_workers")
+            for col in [
+                "id", "channel_code", "handle", "alias", "activity_id",
+                "topic_id", "task_n", "model", "cwd", "permission_mode",
+                "timeout_min", "task_material_id", "session_id",
+                "workload_state", "cause", "last_state_msg_id",
+                "last_heartbeat_at", "spawned_at", "ready_at", "terminated_at",
+            ]:
+                assert col in cols, f"ow_workers.{col} が存在しない"
+        finally:
+            conn.close()
+
+    def test_ow_applied_msg_ids_exists_after_0040(self, migrated_db):
+        conn = get_connection()
+        try:
+            cols = _get_column_names(conn, "ow_applied_msg_ids")
+            for col in ["channel_code", "msg_id", "applied_at", "outcome"]:
+                assert col in cols, f"ow_applied_msg_ids.{col} が存在しない"
+        finally:
+            conn.close()
+
+    def test_tables_not_present_before_0040(self, db_before_0040):
+        """0037適用時点では3テーブルが存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name IN ('ow_channels','ow_workers','ow_applied_msg_ids')"
+            ).fetchall()
+            assert rows == [], (
+                f"0040適用前に owテーブルが既に存在: {[r['name'] for r in rows]}"
+            )
+        finally:
+            conn.close()
+
+
+class TestIndexes:
+    """部分UNIQUE INDEX を含む INDEX 群の存在確認"""
+
+    def test_unique_indexes_present(self, migrated_db):
+        conn = get_connection()
+        try:
+            idx = _get_indexes(conn, "ow_workers")
+            assert "uq_ow_workers_alive_handle" in idx
+            assert "uq_ow_workers_one_alive_per_activity" in idx
+            assert "uq_ow_workers_task_n" in idx
+            assert "idx_ow_workers_activity" in idx
+            assert "idx_ow_workers_state" in idx
+            assert "idx_ow_workers_alive" in idx
+        finally:
+            conn.close()
+
+
+class TestWorkloadStateCheck:
+    """workload_state CHECK 制約"""
+
+    def test_invalid_workload_state_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_worker(
+                    conn, channel_code="C1", handle="w-a", alias="w-a",
+                    activity_id=aid, topic_id=tid, task_n=1,
+                    workload_state="bogus",
+                )
+        finally:
+            conn.close()
+
+    def test_valid_workload_states_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            valid_states = [
+                "spawning", "loading", "ready", "working",
+                "blocked", "escalated", "draining", "terminated",
+            ]
+            for i, state in enumerate(valid_states):
+                aid = _insert_activity(conn, title=f"act-{state}")
+                _insert_worker(
+                    conn, channel_code="C1", handle=f"w-{i}", alias=f"w-{i}",
+                    activity_id=aid, topic_id=tid, task_n=i + 1,
+                    workload_state=state,
+                )
+        finally:
+            conn.close()
+
+
+class TestCauseCheck:
+    """cause CHECK 制約 (NULL許容 + enum)"""
+
+    def test_null_cause_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1, cause=None,
+            )
+        finally:
+            conn.close()
+
+    def test_invalid_cause_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_worker(
+                    conn, channel_code="C1", handle="w-a", alias="w-a",
+                    activity_id=aid, topic_id=tid, task_n=1,
+                    workload_state="terminated", cause="bogus",
+                )
+        finally:
+            conn.close()
+
+    def test_valid_causes_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            for i, cause in enumerate(
+                ["closed", "cancelled", "dead", "crashed", "crashed-during-drain"]
+            ):
+                aid = _insert_activity(conn, title=f"act-{cause}")
+                _insert_worker(
+                    conn, channel_code="C1", handle=f"w-{i}", alias=f"w-{i}",
+                    activity_id=aid, topic_id=tid, task_n=i + 1,
+                    workload_state="terminated", cause=cause,
+                )
+        finally:
+            conn.close()
+
+
+class TestSessionIdNullable:
+    """session_id NULL 許容（Q10 判断）"""
+
+    def test_null_session_id_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1, session_id=None,
+            )
+            row = conn.execute(
+                "SELECT session_id FROM ow_workers WHERE handle = 'w-a'"
+            ).fetchone()
+            assert row["session_id"] is None
+        finally:
+            conn.close()
+
+
+class TestAliveHandleUniqueness:
+    """uq_ow_workers_alive_handle: alive期間中 (channel, handle) 一意"""
+
+    def test_two_alive_same_handle_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid1 = _insert_activity(conn, title="a1")
+            aid2 = _insert_activity(conn, title="a2")
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a-1",
+                activity_id=aid1, topic_id=tid, task_n=1, workload_state="working",
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_worker(
+                    conn, channel_code="C1", handle="w-a", alias="w-a-2",
+                    activity_id=aid2, topic_id=tid, task_n=2,
+                    workload_state="working",
+                )
+        finally:
+            conn.close()
+
+    def test_terminated_handle_can_be_reused(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid1 = _insert_activity(conn, title="a1")
+            aid2 = _insert_activity(conn, title="a2")
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a-1",
+                activity_id=aid1, topic_id=tid, task_n=1,
+                workload_state="terminated", cause="closed",
+            )
+            # 同handleを再利用できる (terminatedはalive判定外)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a-2",
+                activity_id=aid2, topic_id=tid, task_n=2,
+                workload_state="working",
+            )
+        finally:
+            conn.close()
+
+
+class TestOneAliveWorkerPerActivity:
+    """uq_ow_workers_one_alive_per_activity: alive期間中 activity_id 一意"""
+
+    def test_two_alive_same_activity_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1, workload_state="working",
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_worker(
+                    conn, channel_code="C1", handle="w-b", alias="w-b",
+                    activity_id=aid, topic_id=tid, task_n=2,
+                    workload_state="working",
+                )
+        finally:
+            conn.close()
+
+    def test_alive_after_terminated_same_activity(self, migrated_db):
+        """同activityのworkerがterminated後、別workerをaliveで再立てられる（履歴あり再spawn）"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a-1",
+                activity_id=aid, topic_id=tid, task_n=1,
+                workload_state="terminated", cause="closed",
+            )
+            _insert_worker(
+                conn, channel_code="C1", handle="w-b", alias="w-b",
+                activity_id=aid, topic_id=tid, task_n=2,
+                workload_state="working",
+            )
+        finally:
+            conn.close()
+
+    def test_null_activity_id_not_constrained_by_unique(self, migrated_db):
+        """activity_id IS NULL のworkerは UNIQUE 制約対象外（複数同居可）"""
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=None, topic_id=tid, task_n=1, workload_state="working",
+            )
+            _insert_worker(
+                conn, channel_code="C1", handle="w-b", alias="w-b",
+                activity_id=None, topic_id=tid, task_n=2, workload_state="working",
+            )
+        finally:
+            conn.close()
+
+
+class TestTaskNUniqueness:
+    """uq_ow_workers_task_n: (channel_code, task_n) は全期間で一意（terminated含む）"""
+
+    def test_duplicate_task_n_rejected_even_terminated(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid1 = _insert_activity(conn, title="a1")
+            aid2 = _insert_activity(conn, title="a2")
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid1, topic_id=tid, task_n=1,
+                workload_state="terminated", cause="closed",
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_worker(
+                    conn, channel_code="C1", handle="w-b", alias="w-b",
+                    activity_id=aid2, topic_id=tid, task_n=1,
+                    workload_state="working",
+                )
+        finally:
+            conn.close()
+
+    def test_same_task_n_on_different_channels(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            _insert_channel(conn, "C2", tid)
+            aid1 = _insert_activity(conn, title="a1")
+            aid2 = _insert_activity(conn, title="a2")
+            _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid1, topic_id=tid, task_n=1, workload_state="working",
+            )
+            _insert_worker(
+                conn, channel_code="C2", handle="w-b", alias="w-b",
+                activity_id=aid2, topic_id=tid, task_n=1, workload_state="working",
+            )
+        finally:
+            conn.close()
+
+
+class TestAppliedMsgIdsOutcome:
+    """ow_applied_msg_ids.outcome CHECK 制約 ('applied','skipped')"""
+
+    def test_valid_outcomes_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            for outcome, mid in [("applied", 1), ("skipped", 2)]:
+                conn.execute(
+                    "INSERT INTO ow_applied_msg_ids "
+                    "(channel_code, msg_id, applied_at, outcome) "
+                    "VALUES (?, ?, '2026-06-17T00:00:00Z', ?)",
+                    ("C1", mid, outcome),
+                )
+        finally:
+            conn.close()
+
+    def test_invalid_outcome_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO ow_applied_msg_ids "
+                    "(channel_code, msg_id, applied_at, outcome) "
+                    "VALUES (?, ?, '2026-06-17T00:00:00Z', ?)",
+                    ("C1", 1, "rejected"),
+                )
+        finally:
+            conn.close()
+
+    def test_composite_pk_prevents_duplicate(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            conn.execute(
+                "INSERT INTO ow_applied_msg_ids "
+                "(channel_code, msg_id, applied_at, outcome) "
+                "VALUES ('C1', 1, '2026-06-17T00:00:00Z', 'applied')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO ow_applied_msg_ids "
+                    "(channel_code, msg_id, applied_at, outcome) "
+                    "VALUES ('C1', 1, '2026-06-17T00:00:00Z', 'applied')"
+                )
+        finally:
+            conn.close()
+
+
+class TestForeignKeysSetNull:
+    """activity_id / task_material_id の ON DELETE SET NULL"""
+
+    def test_activity_delete_sets_worker_activity_id_null(self, migrated_db):
+        conn = get_connection()
+        try:
+            tid = _insert_topic(conn)
+            _insert_channel(conn, "C1", tid)
+            aid = _insert_activity(conn)
+            wid = _insert_worker(
+                conn, channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1, workload_state="working",
+            )
+            conn.execute("DELETE FROM activities WHERE id = ?", (aid,))
+            row = conn.execute(
+                "SELECT activity_id FROM ow_workers WHERE id = ?", (wid,)
+            ).fetchone()
+            assert row["activity_id"] is None
+        finally:
+            conn.close()

--- a/tests/unit/test_ow_apply_state.py
+++ b/tests/unit/test_ow_apply_state.py
@@ -1,0 +1,420 @@
+"""src/services/ow/reducer.ow_apply_state_with_conn のユニットテスト。
+
+relay history を消化して ow_workers / ow_channels / ow_applied_msg_ids に書き込む純粋
+reducer の挙動を検証する。CQS分離原則のため、activities テーブルには書き込まない
+ことも確認する。
+"""
+import json
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.ow import applied_msgs as am
+from src.services.ow import channels as ch
+from src.services.ow import workers as wk
+from src.services.ow.reducer import ow_apply_state_with_conn
+
+
+NOW = "2026-06-17T10:00:00Z"
+CH = "C1"
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _setup_channel(conn, topic_id):
+    ch.upsert_channel_with_conn(
+        conn,
+        channel_code=CH,
+        topic_id=topic_id,
+        orch_handle="orch",
+        now=NOW,
+    )
+
+
+def _make_topic(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("t", "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity(conn, title: str = "a") -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "", "pending"),
+    )
+    return cur.lastrowid
+
+
+def _msg(msg_id, handle, body, created_at=NOW):
+    return {"msg_id": msg_id, "handle": handle, "body": body, "created_at": created_at}
+
+
+def _ev_identity(handle, *, activity_id, topic_id, session_id=None, alias=None,
+                  model="claude-opus-4-7", cwd="/tmp", terminated_at=None):
+    data = {
+        "type": "identity", "role": "worker", "handle": handle,
+        "alias": alias or handle, "activity_id": activity_id,
+        "topic_id": topic_id, "model": model, "cwd": cwd,
+        "started_at": NOW,
+    }
+    if session_id is not None:
+        data["session_id"] = session_id
+    if terminated_at is not None:
+        data["terminated_at"] = terminated_at
+    return {"v": 1, "kind": "event", "from": handle, "to": "*",
+            "task": "T1", "data": data}
+
+
+def _ev_state(handle, state, *, cause=None, session_id=None):
+    data = {"type": "state", "state": state}
+    if cause:
+        data["cause"] = cause
+    if session_id:
+        data["session_id"] = session_id
+    return {"v": 1, "kind": "event", "from": handle, "to": "orch",
+            "task": "T1", "data": data}
+
+
+def _ev_heartbeat(handle):
+    return {
+        "v": 1, "kind": "event", "from": handle, "to": "*", "task": "T1",
+        "data": {"type": "heartbeat", "phase": "alive"},
+    }
+
+
+def _cmd_assign(handle, *, activity_id, topic_id, model="claude-opus-4-7",
+                 cwd="/tmp", permission_mode="auto", timeout_min=240):
+    data = {
+        "type": "assign", "title": "task", "activity_id": activity_id,
+        "topic_id": str(topic_id), "model": model, "cwd": cwd,
+        "permission_mode": permission_mode, "timeout_min": timeout_min,
+    }
+    return {"v": 1, "kind": "command", "from": "orch", "to": handle,
+            "task": "T1", "data": data}
+
+
+class TestEmptyHistory:
+    def test_empty_history_returns_zero_counters(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=[], now=NOW,
+            )
+            assert r == {
+                "applied": 0, "skipped": 0, "duplicate": 0, "last_msg_id": 0,
+            }
+        finally:
+            conn.close()
+
+
+class TestAssignCreatesWorker:
+    def test_assign_inserts_worker_with_metadata(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [_msg(10, "orch",
+                            _cmd_assign("w-a", activity_id=aid, topic_id=tid))]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["applied"] == 1
+            workers = wk.list_workers_with_conn(conn, channel_code=CH, alive_only=False)
+            assert len(workers) == 1
+            w = workers[0]
+            assert w["handle"] == "w-a"
+            assert w["activity_id"] == aid
+            assert w["model"] == "claude-opus-4-7"
+            assert w["cwd"] == "/tmp"
+            assert w["permission_mode"] == "auto"
+            assert w["timeout_min"] == 240
+            assert w["task_n"] == 1
+        finally:
+            conn.close()
+
+
+class TestIdentityUpdatesSessionId:
+    def test_identity_after_assign_updates_session_id(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(11, "w-a", _ev_identity("w-a", activity_id=aid,
+                                              topic_id=tid, session_id="sess-1")),
+            ]
+            ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            w = wk.get_alive_worker_by_handle_with_conn(
+                conn, channel_code=CH, handle="w-a"
+            )
+            assert w["session_id"] == "sess-1"
+        finally:
+            conn.close()
+
+    def test_identity_first_creates_worker(self, db):
+        """worker が assign 前に identity を出した場合でも row が作られる"""
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "w-a", _ev_identity("w-a", activity_id=aid,
+                                              topic_id=tid, session_id="sess-x")),
+            ]
+            ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            w = wk.get_alive_worker_by_handle_with_conn(
+                conn, channel_code=CH, handle="w-a"
+            )
+            assert w is not None
+            assert w["session_id"] == "sess-x"
+            assert w["activity_id"] == aid
+        finally:
+            conn.close()
+
+
+class TestStateTransitions:
+    def test_full_lifecycle_progresses_state(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(11, "w-a", _ev_heartbeat("w-a")),
+                _msg(12, "w-a", _ev_identity("w-a", activity_id=aid,
+                                              topic_id=tid, session_id="sess-1")),
+                _msg(13, "w-a", _ev_state("w-a", "loading")),
+                _msg(14, "w-a", _ev_state("w-a", "ready")),
+                _msg(15, "w-a", _ev_state("w-a", "working")),
+                _msg(16, "w-a", _ev_state("w-a", "draining")),
+                _msg(17, "w-a", _ev_state("w-a", "terminated", cause="closed")),
+            ]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["applied"] == 8
+            # alive 0件, terminated 1件
+            assert wk.list_workers_with_conn(
+                conn, channel_code=CH, alive_only=True
+            ) == []
+            all_ = wk.list_workers_with_conn(
+                conn, channel_code=CH, alive_only=False
+            )
+            assert len(all_) == 1
+            w = all_[0]
+            assert w["workload_state"] == "terminated"
+            assert w["cause"] == "closed"
+            assert w["last_state_msg_id"] == 17
+            assert w["ready_at"] == NOW
+            assert w["terminated_at"] == NOW
+        finally:
+            conn.close()
+
+
+class TestIdempotency:
+    def test_re_apply_same_history_is_idempotent(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(11, "w-a", _ev_state("w-a", "working")),
+            ]
+            r1 = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            r2 = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r1["applied"] == 2
+            assert r2["applied"] == 0
+            assert r2["duplicate"] == 2
+            # workerはひとつだけ
+            assert len(wk.list_workers_with_conn(
+                conn, channel_code=CH, alive_only=False)) == 1
+        finally:
+            conn.close()
+
+
+class TestSkippedMessages:
+    def test_unknown_kind_is_skipped(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            history = [
+                {"msg_id": 10, "handle": "w-a",
+                 "body": {"v": 1, "kind": "noise", "data": {"type": "x"}},
+                 "created_at": NOW},
+            ]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["skipped"] == 1
+            assert am.is_msg_applied_with_conn(conn, channel_code=CH, msg_id=10)
+        finally:
+            conn.close()
+
+    def test_string_body_is_skipped(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            history = [{"msg_id": 10, "handle": "x", "body": "garbage",
+                         "created_at": NOW}]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["skipped"] == 1
+        finally:
+            conn.close()
+
+    def test_invalid_state_value_is_skipped(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            history = [_msg(10, "w-a", {
+                "v": 1, "kind": "event", "from": "w-a", "to": "orch",
+                "data": {"type": "state", "state": "bogus"},
+            })]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["skipped"] == 1
+        finally:
+            conn.close()
+
+
+class TestHeartbeatUpdates:
+    def test_heartbeat_updates_last_heartbeat_at(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(11, "w-a", _ev_heartbeat("w-a"), created_at="2026-06-17T10:05:00Z"),
+            ]
+            ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            w = wk.get_alive_worker_by_handle_with_conn(
+                conn, channel_code=CH, handle="w-a"
+            )
+            assert w["last_heartbeat_at"] == "2026-06-17T10:05:00Z"
+        finally:
+            conn.close()
+
+    def test_heartbeat_before_identity_is_silently_skipped(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            history = [_msg(10, "w-a", _ev_heartbeat("w-a"))]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            # 行が無い heartbeat は applied 扱いで黙って終わる
+            assert r["applied"] == 1
+            assert r["skipped"] == 0
+            assert wk.list_workers_with_conn(
+                conn, channel_code=CH, alive_only=False) == []
+        finally:
+            conn.close()
+
+
+class TestChannelLastSeen:
+    def test_last_seen_msg_id_advances(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(15, "w-a", _ev_state("w-a", "working")),
+            ]
+            ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            chan = ch.get_channel_with_conn(conn, CH)
+            assert chan["last_seen_msg_id"] == 15
+        finally:
+            conn.close()
+
+
+class TestCQSSeparation:
+    """reducer は activities テーブルに書き込まないことを保証"""
+
+    def test_activity_status_unchanged_after_reducer(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            _setup_channel(conn, tid)
+            history = [
+                _msg(10, "orch", _cmd_assign("w-a", activity_id=aid, topic_id=tid)),
+                _msg(11, "w-a", _ev_state("w-a", "working")),
+                _msg(12, "w-a", _ev_state("w-a", "terminated", cause="closed")),
+            ]
+            ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            row = conn.execute(
+                "SELECT status, last_heartbeat_at FROM activities WHERE id = ?",
+                (aid,),
+            ).fetchone()
+            # reducer は activity を触らない
+            assert row["status"] == "pending"
+            assert row["last_heartbeat_at"] is None
+        finally:
+            conn.close()
+
+
+class TestNonWorkerIdentitySkipped:
+    def test_orch_identity_does_not_create_worker(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            history = [_msg(10, "orch", {
+                "v": 1, "kind": "event", "from": "orch", "to": "*",
+                "data": {"type": "identity", "role": "orch", "handle": "orch"},
+            })]
+            r = ow_apply_state_with_conn(
+                conn, channel_code=CH, topic_id=tid, history=history, now=NOW,
+            )
+            assert r["applied"] == 1
+            assert wk.list_workers_with_conn(
+                conn, channel_code=CH, alive_only=False) == []
+        finally:
+            conn.close()

--- a/tests/unit/test_ow_checkin_integration.py
+++ b/tests/unit/test_ow_checkin_integration.py
@@ -1,0 +1,141 @@
+"""check_in と ow ダッシュボードの統合テスト（M#288 §3.8）
+
+ow:managed タグ付き activity に check_in すると、ダッシュボード render の
+該当行が summary に追加されることを検証する。非 ow activity への check_in は
+従来通りの summary のみを返す。
+"""
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.checkin_service import check_in
+from src.services.ow import channels as ch
+from src.services.tag_service import ensure_tag_ids, link_tags
+
+
+NOW = "2026-06-17T10:00:00Z"
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        os.environ["OW_VIEWS_DIR"] = os.path.join(tmpdir, "views")
+        init_database()
+        yield db_path
+        for k in ("DISCUSSION_DB_PATH", "OW_VIEWS_DIR"):
+            if k in os.environ:
+                del os.environ[k]
+
+
+def _make_topic(conn, title="t") -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        (title, "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity_with_topic(
+    conn, *, title="A", topic_id, with_ow_managed=True, intent="implement"
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "", "pending"),
+    )
+    aid = cur.lastrowid
+    if with_ow_managed:
+        link_tags(conn, "activity_tags", "activity_id", aid,
+                  ensure_tag_ids(conn, [("ow", "managed")]))
+    link_tags(conn, "activity_tags", "activity_id", aid,
+              ensure_tag_ids(conn, [("intent", intent)]))
+    # activity ↔ topic 紐付け（polymorphic）: 'activity' < 'topic'
+    conn.execute(
+        "INSERT INTO relations (source_type, source_id, target_type, target_id) "
+        "VALUES ('activity', ?, 'topic', ?)",
+        (aid, topic_id),
+    )
+    return aid
+
+
+def _insert_worker(
+    conn, *, channel_code, alias, activity_id, topic_id, task_n,
+    workload_state="working", last_heartbeat_at=None,
+):
+    conn.execute(
+        """
+        INSERT INTO ow_workers
+          (channel_code, handle, alias, activity_id, topic_id, task_n,
+           workload_state, last_heartbeat_at, spawned_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (channel_code, alias, alias, activity_id, topic_id, task_n,
+         workload_state, last_heartbeat_at, NOW),
+    )
+
+
+class TestOwSummaryAppend:
+    def test_ow_managed_activity_summary_contains_dashboard_line(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn, "T67 topic")
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            aid = _make_activity_with_topic(
+                conn, title="ow managed activity", topic_id=tid,
+            )
+            _insert_worker(
+                conn, channel_code="C1", alias="w-z",
+                activity_id=aid, topic_id=tid, task_n=1,
+                workload_state="working",
+                last_heartbeat_at="2026-06-17T09:59:58Z",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        result = check_in(aid)
+        assert "summary" in result
+        # ow行は "  ow: ●[空白] [aid] ..." の形で末尾に追加される
+        assert "\n  ow: " in result["summary"]
+        assert f"[{aid}]" in result["summary"]
+        # base summary（タイトル + intent）も残っている
+        assert "check-in:" in result["summary"]
+        assert "intent: implement" in result["summary"]
+
+    def test_non_ow_activity_summary_unchanged(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity_with_topic(
+                conn, topic_id=tid, with_ow_managed=False,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        result = check_in(aid)
+        assert "summary" in result
+        assert "\n  ow: " not in result["summary"]
+
+    def test_ow_managed_activity_without_topic_no_ow_line(self, db):
+        """ow:managed でも topic 紐付けが無い場合は ow 行追加しない"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                ("orphan", "", "pending"),
+            )
+            aid = cur.lastrowid
+            link_tags(conn, "activity_tags", "activity_id", aid,
+                      ensure_tag_ids(conn, [("ow", "managed")]))
+            link_tags(conn, "activity_tags", "activity_id", aid,
+                      ensure_tag_ids(conn, [("intent", "implement")]))
+            conn.commit()
+        finally:
+            conn.close()
+        result = check_in(aid)
+        assert "\n  ow: " not in result["summary"]

--- a/tests/unit/test_ow_dashboard.py
+++ b/tests/unit/test_ow_dashboard.py
@@ -1,0 +1,352 @@
+"""src/services/ow/dashboard のユニットテスト。
+
+ダッシュボード レンダラの出力形式が M#288 §6.0 スタイル指針（行幅100以内、カラー
+コード未出力、絵文字制限、UTF-8 LF、Markdown valid）を満たし、extract_activity_line
+が render 結果から activity_id 行を抜き出せ、`.views/dashboard-t<topic>.md` が
+atomic write されることを検証する。
+"""
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.ow import channels as ch
+from src.services.ow.dashboard import (
+    extract_activity_line,
+    is_ow_managed_activity_with_conn,
+    render_dashboard,
+    render_with_conn,
+    view_file_path,
+    write_view_file_atomic,
+)
+from src.services.tag_service import ensure_tag_ids, link_tags
+
+
+NOW = "2026-06-17T10:00:00Z"
+CH = "C1"
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        os.environ["OW_VIEWS_DIR"] = os.path.join(tmpdir, "views")
+        init_database()
+        yield db_path
+        for k in ("DISCUSSION_DB_PATH", "OW_VIEWS_DIR"):
+            if k in os.environ:
+                del os.environ[k]
+
+
+def _make_topic(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("t", "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity(
+    conn, *, title="アクティビティ", status="pending", with_ow_managed=True,
+    topic_id=None, intent: str | None = None,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "", status),
+    )
+    aid = cur.lastrowid
+    if with_ow_managed:
+        tag_ids = ensure_tag_ids(conn, [("ow", "managed")])
+        link_tags(conn, "activity_tags", "activity_id", aid, tag_ids)
+    if intent:
+        tag_ids = ensure_tag_ids(conn, [("intent", intent)])
+        link_tags(conn, "activity_tags", "activity_id", aid, tag_ids)
+    if topic_id is not None:
+        conn.execute(
+            "INSERT INTO relations (source_type, source_id, target_type, target_id) "
+            "VALUES ('activity', ?, 'topic', ?)",
+            (aid, topic_id),
+        )
+    return aid
+
+
+def _insert_worker(
+    conn, *, alias, activity_id, topic_id, task_n,
+    workload_state="working", last_heartbeat_at=None,
+    terminated_at=None, cause=None,
+):
+    conn.execute(
+        """
+        INSERT INTO ow_workers
+          (channel_code, handle, alias, activity_id, topic_id, task_n,
+           workload_state, cause, last_heartbeat_at, terminated_at, spawned_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (CH, alias, alias, activity_id, topic_id, task_n,
+         workload_state, cause, last_heartbeat_at, terminated_at, NOW),
+    )
+
+
+class TestRenderBasic:
+    def test_empty_topic_renders_placeholder(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            assert "アクティビティ一覧" in text
+            assert "ow:managed の activity がありません" in text
+        finally:
+            conn.close()
+
+    def test_single_activity_no_worker_renders_pending(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            aid = _make_activity(conn, intent="implement", topic_id=tid)
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            line = extract_activity_line(text, aid)
+            assert line is not None
+            assert "◐" in line
+            assert f"[{aid}]" in line
+            assert "[作業]" in line
+            assert "pending" in line
+        finally:
+            conn.close()
+
+    def test_activity_with_alive_worker_shows_presence(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            aid = _make_activity(
+                conn, intent="implement", status="in_progress", topic_id=tid,
+            )
+            _insert_worker(
+                conn, alias="w-z", activity_id=aid, topic_id=tid, task_n=1,
+                workload_state="working",
+                last_heartbeat_at="2026-06-17T09:59:57Z",
+            )
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            line = extract_activity_line(text, aid)
+            assert line is not None
+            assert "●" in line
+            assert "in_progress" in line
+            assert "w-z" in line
+            assert "working" in line
+            assert "hb 3s ago" in line
+        finally:
+            conn.close()
+
+
+class TestStyleCompliance:
+    """M#288 §6.0 スタイル指針への適合性"""
+
+    def test_no_color_escape_codes(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            _make_activity(conn, intent="implement", topic_id=tid)
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            assert "\x1b[" not in text
+        finally:
+            conn.close()
+
+    def test_no_box_drawing_chars(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            _make_activity(conn, intent="implement", topic_id=tid)
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            forbidden = "┌┐└┘─│├┤┬┴┼"
+            # `─` は U+2500 box-drawing だが、§6.0 でセパレータとして使用可と
+            # ガイドにある。それ以外の box-drawing 文字は出さない。
+            for ch_ in forbidden.replace("─", ""):
+                assert ch_ not in text, f"box-drawing文字 {ch_!r} が出力された"
+        finally:
+            conn.close()
+
+    def test_each_line_within_max_width(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            # 非常に長いタイトル
+            _make_activity(
+                conn, title="あ" * 200, intent="implement", topic_id=tid,
+            )
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            # 文字数ベースの素朴チェック。半角換算で 100 以内になっているか
+            # （全角は 2 換算で _truncate しているため、各行 100 文字以内）
+            for line in text.splitlines():
+                width = sum(2 if ord(c) > 0x7F else 1 for c in line)
+                assert width <= 100, f"行幅オーバー (width={width}): {line!r}"
+        finally:
+            conn.close()
+
+
+class TestExtractActivityLine:
+    def test_extract_returns_matching_line(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            a1 = _make_activity(conn, title="A1", intent="implement", topic_id=tid)
+            a2 = _make_activity(conn, title="A2", intent="implement", topic_id=tid)
+            text = render_with_conn(conn, topic_id=tid, role="general", now_iso=NOW)
+            line1 = extract_activity_line(text, a1)
+            line2 = extract_activity_line(text, a2)
+            assert line1 is not None and f"[{a1}]" in line1
+            assert line2 is not None and f"[{a2}]" in line2
+        finally:
+            conn.close()
+
+    def test_extract_returns_none_when_not_present(self):
+        text = "## ヘッダ\n（empty）\n"
+        assert extract_activity_line(text, 999) is None
+
+    def test_extract_ignores_substring_id_matches(self):
+        text = (
+            "## a\n"
+            "● [12] [作業] 部分一致テスト ─ pending\n"
+            "● [123] [作業] 全体一致テスト ─ pending\n"
+        )
+        line = extract_activity_line(text, 12)
+        assert line is not None
+        assert "[12]" in line
+        assert "[123]" not in line
+
+
+class TestViewFileWrite:
+    def test_atomic_write_creates_file_and_dir(self, db):
+        tid = 999
+        content = "## test\n● [1] [作業] x ─ pending\n"
+        path = write_view_file_atomic(tid, content)
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == content
+        assert path == view_file_path(tid)
+
+    def test_atomic_write_overwrites_existing(self, db):
+        tid = 998
+        write_view_file_atomic(tid, "old content\n")
+        write_view_file_atomic(tid, "new content\n")
+        assert view_file_path(tid).read_text(encoding="utf-8") == "new content\n"
+
+    def test_no_leftover_tmp_after_write(self, db):
+        tid = 997
+        path = write_view_file_atomic(tid, "content\n")
+        leftovers = [
+            p for p in path.parent.iterdir()
+            if p.name.startswith(f"dashboard-t{tid}.") and p.suffix == ".tmp"
+        ]
+        assert leftovers == []
+
+
+class TestRenderDashboardEntry:
+    def test_render_dashboard_writes_view_file(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            _make_activity(conn, intent="implement", topic_id=tid)
+            conn.commit()
+        finally:
+            conn.close()
+        result = render_dashboard(
+            topic_id=tid, role="general", apply_state=False, now_iso=NOW,
+        )
+        assert "rendered" in result
+        assert "アクティビティ一覧" in result["rendered"]
+        assert result["view_file"] is not None
+        assert Path(result["view_file"]).exists()
+
+    def test_render_dashboard_no_view_when_disabled(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            _make_activity(conn, intent="implement", topic_id=tid)
+            conn.commit()
+        finally:
+            conn.close()
+        result = render_dashboard(
+            topic_id=tid, role="general", write_view=False,
+            apply_state=False, now_iso=NOW,
+        )
+        assert result["view_file"] is None
+
+
+class TestRoleOrch:
+    def test_orch_role_includes_alive_workers_section(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code=CH, topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            aid = _make_activity(conn, intent="implement", topic_id=tid)
+            _insert_worker(
+                conn, alias="w-z", activity_id=aid, topic_id=tid, task_n=1,
+                workload_state="working",
+                last_heartbeat_at="2026-06-17T09:59:55Z",
+            )
+            text = render_with_conn(conn, topic_id=tid, role="orch", now_iso=NOW)
+            assert "## orch詳細ビュー" in text
+            assert "### Alive workers" in text
+            assert "w-z" in text
+        finally:
+            conn.close()
+
+
+class TestIsOwManaged:
+    def test_returns_true_for_ow_managed(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn, topic_id=tid)
+            assert is_ow_managed_activity_with_conn(conn, aid) is True
+        finally:
+            conn.close()
+
+    def test_returns_false_for_unmanaged(self, db):
+        conn = get_connection()
+        try:
+            aid = _make_activity(conn, with_ow_managed=False)
+            assert is_ow_managed_activity_with_conn(conn, aid) is False
+        finally:
+            conn.close()

--- a/tests/unit/test_ow_fallback.py
+++ b/tests/unit/test_ow_fallback.py
@@ -1,0 +1,140 @@
+"""read-fallback シムのユニットテスト（Phase 1 限定）。
+
+ow_workers にデータがあれば ow_workers をそのまま返し、空なら旧 queue-t<topic>.md
+パース結果を擬似 ow_workers 形式で返すことを検証する。
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.ow import channels as ch
+from src.services.ow.fallback import read_workers_with_fallback_with_conn
+
+
+NOW = "2026-06-17T10:00:00Z"
+
+
+@pytest.fixture
+def db_and_queue_dir(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        queue_dir = os.path.join(tmpdir, "queue")
+        os.makedirs(queue_dir, exist_ok=True)
+        monkeypatch.setenv("DISCUSSION_DB_PATH", db_path)
+        monkeypatch.setenv("OW_QUEUE_DIR", queue_dir)
+        # ow_service は OW_QUEUE_DIR をimport時にmodule変数へキャッシュするため、
+        # env変更だけでは _get_queue_dir() に反映されない。明示的に書き換える。
+        import src.services.ow_service as ows
+        monkeypatch.setattr(ows, "OW_QUEUE_DIR", queue_dir)
+        init_database()
+        yield db_path, queue_dir
+
+
+def _make_topic(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("t", "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        ("a", "", "pending"),
+    )
+    return cur.lastrowid
+
+
+class TestPreferOwWorkers:
+    def test_returns_ow_workers_when_present(self, db_and_queue_dir):
+        _, _ = db_and_queue_dir
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            aid = _make_activity(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            conn.execute(
+                """
+                INSERT INTO ow_workers
+                  (channel_code, handle, alias, activity_id, topic_id, task_n,
+                   workload_state, spawned_at)
+                VALUES ('C1', 'w-a', 'w-a', ?, ?, 1, 'working', ?)
+                """,
+                (aid, tid, NOW),
+            )
+            conn.commit()
+            result = read_workers_with_fallback_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+            )
+            assert result["source"] == "ow_workers"
+            assert len(result["workers"]) == 1
+            assert result["workers"][0]["handle"] == "w-a"
+        finally:
+            conn.close()
+
+
+class TestLegacyQueueFallback:
+    def test_falls_back_to_queue_md_when_ow_workers_empty(self, db_and_queue_dir):
+        _, queue_dir = db_and_queue_dir
+        # 旧 queue-t1.md を投入
+        queue_content = """---
+topic_id: 1
+orch_activity_id: 100
+channel_code: C1
+orch_cwd: /tmp
+last_seen_msg_id: 0
+---
+
+## T1 | sample task | working
+- worker: w-x / term_ref: iterm2-tab-1 / session: abc
+"""
+        Path(queue_dir, "queue-t1.md").write_text(queue_content)
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            conn.commit()
+            result = read_workers_with_fallback_with_conn(
+                conn, channel_code="C1", topic_id=1,
+            )
+            assert result["source"] == "legacy_queue"
+            assert len(result["workers"]) == 1
+            w = result["workers"][0]
+            assert w["handle"] == "w-x"
+            assert w["alias"] == "w-x"
+            assert w["task_n"] == 1
+            assert w["workload_state"] == "working"
+            assert w["term_ref"] == "iterm2-tab-1"
+            assert w["title"] == "sample task"
+            assert w["_source"] == "legacy_queue"
+        finally:
+            conn.close()
+
+    def test_returns_empty_when_no_ow_workers_and_no_queue_file(
+        self, db_and_queue_dir
+    ):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+                orch_handle="orch", now=NOW,
+            )
+            conn.commit()
+            result = read_workers_with_fallback_with_conn(
+                conn, channel_code="C1", topic_id=tid,
+            )
+            assert result["source"] == "legacy_queue"
+            assert result["workers"] == []
+        finally:
+            conn.close()

--- a/tests/unit/test_ow_project_activities.py
+++ b/tests/unit/test_ow_project_activities.py
@@ -1,0 +1,326 @@
+"""src/services/ow/projector.ow_project_activities_with_conn のユニットテスト。
+
+ow_workers のスナップショットを activities テーブルに反映する projector の挙動を検証。
+ow:managed タグの付かない activity は変更されないこと、status downgrade が起きないこと、
+outcome:cancelled / outcome:failed タグが cause に応じて追加されることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.ow import channels as ch
+from src.services.ow import workers as wk
+from src.services.ow.projector import ow_project_activities_with_conn
+from src.services.tag_service import (
+    ensure_tag_ids,
+    get_entity_tags,
+    link_tags,
+)
+
+
+NOW = "2026-06-17T10:00:00Z"
+LATER = "2026-06-17T11:00:00Z"
+CH = "C1"
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _make_topic(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("t", "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity(
+    conn, *, title="a", status="pending", with_ow_managed=True, topic_id=None
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "", status),
+    )
+    aid = cur.lastrowid
+    if with_ow_managed:
+        tag_ids = ensure_tag_ids(conn, [("ow", "managed")])
+        link_tags(conn, "activity_tags", "activity_id", aid, tag_ids)
+    if topic_id is not None:
+        # polymorphic relations: 'activity' < 'topic' なので source=activity, target=topic
+        conn.execute(
+            "INSERT INTO relations (source_type, source_id, target_type, target_id) "
+            "VALUES ('activity', ?, 'topic', ?)",
+            (aid, topic_id),
+        )
+    return aid
+
+
+def _setup_channel(conn, topic_id) -> None:
+    ch.upsert_channel_with_conn(
+        conn, channel_code=CH, topic_id=topic_id, orch_handle="orch", now=NOW
+    )
+
+
+def _insert_worker(
+    conn,
+    *,
+    handle,
+    activity_id,
+    topic_id,
+    task_n,
+    workload_state="working",
+    cause=None,
+    last_heartbeat_at=None,
+    terminated_at=None,
+):
+    cur = conn.execute(
+        """
+        INSERT INTO ow_workers
+          (channel_code, handle, alias, activity_id, topic_id, task_n,
+           workload_state, cause, last_heartbeat_at, terminated_at, spawned_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (CH, handle, handle, activity_id, topic_id, task_n,
+         workload_state, cause, last_heartbeat_at, terminated_at, NOW),
+    )
+    return cur.lastrowid
+
+
+class TestStatusTransitions:
+    def test_working_worker_moves_pending_to_in_progress(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="working",
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            assert row["status"] == "in_progress"
+        finally:
+            conn.close()
+
+    def test_terminated_closed_moves_in_progress_to_completed(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="in_progress", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="terminated", cause="closed",
+                terminated_at=LATER,
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            assert row["status"] == "completed"
+        finally:
+            conn.close()
+
+    def test_completed_not_downgraded_when_new_worker_appears(self, db):
+        """completed状態のactivityにworkingなworkerが現れても in_progress に戻さない"""
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="completed", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="working",
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            assert row["status"] == "completed"
+        finally:
+            conn.close()
+
+    def test_only_loading_worker_keeps_pending(self, db):
+        """loading/ready の worker しかなければ activity は pending のまま"""
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="loading",
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            assert row["status"] == "pending"
+        finally:
+            conn.close()
+
+
+class TestOutcomeTags:
+    def test_cancelled_cause_adds_outcome_cancelled_tag(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="in_progress", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="terminated", cause="cancelled",
+                terminated_at=LATER,
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", aid)
+            assert "outcome:cancelled" in tags
+        finally:
+            conn.close()
+
+    def test_crashed_cause_adds_outcome_failed_tag(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="in_progress", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="terminated", cause="crashed",
+                terminated_at=LATER,
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", aid)
+            assert "outcome:failed" in tags
+        finally:
+            conn.close()
+
+    def test_closed_cause_adds_no_outcome_tag(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="in_progress", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="terminated", cause="closed",
+                terminated_at=LATER,
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", aid)
+            assert not any(t.startswith("outcome:") for t in tags)
+        finally:
+            conn.close()
+
+    def test_outcome_tag_added_only_once(self, db):
+        """二度projectしてもoutcome:cancelledタグは1回だけ追加される（重複しない）"""
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, status="in_progress", topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="terminated", cause="cancelled",
+                terminated_at=LATER,
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            tags = get_entity_tags(conn, "activity_tags", "activity_id", aid)
+            assert tags.count("outcome:cancelled") == 1
+        finally:
+            conn.close()
+
+
+class TestSkipsNonManagedActivity:
+    def test_activity_without_ow_managed_tag_not_touched(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, with_ow_managed=False, topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="working",
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            # ow:managed が付いていないので projector は触らない
+            assert row["status"] == "pending"
+        finally:
+            conn.close()
+
+
+class TestHeartbeatSync:
+    def test_latest_alive_heartbeat_is_propagated(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            _setup_channel(conn, tid)
+            aid = _make_activity(conn, topic_id=tid)
+            _insert_worker(
+                conn, handle="w-a", activity_id=aid, topic_id=tid,
+                task_n=1, workload_state="working",
+                last_heartbeat_at="2026-06-17T10:30:00Z",
+            )
+            ow_project_activities_with_conn(conn, topic_id=tid)
+            row = conn.execute(
+                "SELECT last_heartbeat_at FROM activities WHERE id = ?", (aid,)
+            ).fetchone()
+            assert row["last_heartbeat_at"] == "2026-06-17T10:30:00Z"
+        finally:
+            conn.close()
+
+
+class TestTopicScope:
+    def test_topic_scoped_projection_skips_other_topics(self, db):
+        conn = get_connection()
+        try:
+            t1 = _make_topic(conn)
+            t2 = _make_topic(conn)
+            _setup_channel(conn, t1)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C2", topic_id=t2,
+                orch_handle="orch", now=NOW,
+            )
+            a1 = _make_activity(conn, topic_id=t1)
+            a2 = _make_activity(conn, topic_id=t2)
+            _insert_worker(
+                conn, handle="w-a", activity_id=a1, topic_id=t1,
+                task_n=1, workload_state="working",
+            )
+            conn.execute(
+                """
+                INSERT INTO ow_workers
+                  (channel_code, handle, alias, activity_id, topic_id, task_n,
+                   workload_state, spawned_at)
+                VALUES ('C2', 'w-b', 'w-b', ?, ?, 1, 'working', ?)
+                """,
+                (a2, t2, NOW),
+            )
+            ow_project_activities_with_conn(conn, topic_id=t1)
+            # t1 の activity だけ更新される
+            assert conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (a1,)
+            ).fetchone()["status"] == "in_progress"
+            assert conn.execute(
+                "SELECT status FROM activities WHERE id = ?", (a2,)
+            ).fetchone()["status"] == "pending"
+        finally:
+            conn.close()

--- a/tests/unit/test_ow_store.py
+++ b/tests/unit/test_ow_store.py
@@ -1,0 +1,383 @@
+"""src/services/ow/ store CRUD (channels / workers / applied_msgs) のユニットテスト。
+
+Phase 1 で新規追加した ow_channels / ow_workers / ow_applied_msg_ids 3テーブルに対する
+CRUDヘルパーが、conn共有版とラッパー版の両方で期待通りに動くことを検証する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.ow import applied_msgs as am
+from src.services.ow import channels as ch
+from src.services.ow import workers as wk
+
+
+NOW = "2026-06-17T00:00:00Z"
+LATER = "2026-06-17T01:00:00Z"
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _make_topic(conn: sqlite3.Connection) -> int:
+    cur = conn.execute(
+        "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+        ("t", "d"),
+    )
+    return cur.lastrowid
+
+
+def _make_activity(conn: sqlite3.Connection, title: str = "a") -> int:
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "", "pending"),
+    )
+    return cur.lastrowid
+
+
+class TestChannelsCRUD:
+    def test_upsert_inserts_new_row(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn,
+                channel_code="C1",
+                topic_id=tid,
+                orch_handle="orch",
+                orch_cwd="/tmp",
+                now=NOW,
+            )
+            conn.commit()
+            row = ch.get_channel_with_conn(conn, "C1")
+            assert row is not None
+            assert row["topic_id"] == tid
+            assert row["orch_handle"] == "orch"
+            assert row["orch_cwd"] == "/tmp"
+            assert row["last_seen_msg_id"] == 0
+            assert row["created_at"] == NOW
+        finally:
+            conn.close()
+
+    def test_upsert_updates_existing_row_preserves_immutables(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn,
+                channel_code="C1",
+                topic_id=tid,
+                orch_handle="orch",
+                orch_cwd="/tmp",
+                now=NOW,
+            )
+            ch.update_channel_last_seen_with_conn(
+                conn, channel_code="C1", last_seen_msg_id=42, now=NOW
+            )
+            # 2回目: orch_session_id だけ更新
+            ch.upsert_channel_with_conn(
+                conn,
+                channel_code="C1",
+                topic_id=tid,
+                orch_handle="orch",
+                orch_session_id="sess-123",
+                now=LATER,
+            )
+            conn.commit()
+            row = ch.get_channel_with_conn(conn, "C1")
+            assert row["orch_session_id"] == "sess-123"
+            assert row["orch_cwd"] == "/tmp"  # 保持
+            assert row["last_seen_msg_id"] == 42  # 保持
+            assert row["created_at"] == NOW  # 保持
+            assert row["updated_at"] == LATER
+        finally:
+            conn.close()
+
+    def test_update_last_seen_is_monotonic(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            ch.update_channel_last_seen_with_conn(
+                conn, channel_code="C1", last_seen_msg_id=10, now=NOW
+            )
+            ch.update_channel_last_seen_with_conn(
+                conn, channel_code="C1", last_seen_msg_id=5, now=LATER
+            )
+            assert ch.get_channel_with_conn(conn, "C1")["last_seen_msg_id"] == 10
+        finally:
+            conn.close()
+
+    def test_list_channels_filters_deleted_by_default(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C2", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            ch.soft_delete_channel_with_conn(
+                conn, channel_code="C2", deleted_at=LATER
+            )
+            assert len(ch.list_channels_with_conn(conn, topic_id=tid)) == 1
+            assert (
+                len(
+                    ch.list_channels_with_conn(
+                        conn, topic_id=tid, include_deleted=True
+                    )
+                )
+                == 2
+            )
+        finally:
+            conn.close()
+
+
+class TestWorkersCRUD:
+    def test_allocate_task_n_starts_at_one(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            assert wk.allocate_task_n_with_conn(conn, "C1") == 1
+        finally:
+            conn.close()
+
+    def test_allocate_task_n_increments(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            aid = _make_activity(conn)
+            wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid,
+                task_n=wk.allocate_task_n_with_conn(conn, "C1"),
+                spawned_at=NOW,
+            )
+            assert wk.allocate_task_n_with_conn(conn, "C1") == 2
+        finally:
+            conn.close()
+
+    def test_insert_and_fetch_worker(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            aid = _make_activity(conn)
+            wid = wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1,
+                model="claude-opus-4-7", cwd="/tmp",
+                spawned_at=NOW,
+            )
+            assert wid > 0
+            row = wk.get_worker_by_id_with_conn(conn, wid)
+            assert row["handle"] == "w-a"
+            assert row["workload_state"] == "spawning"
+            assert row["session_id"] is None  # Q10: NULL許容
+            assert wk.get_alive_worker_by_handle_with_conn(
+                conn, channel_code="C1", handle="w-a"
+            ) is not None
+        finally:
+            conn.close()
+
+    def test_update_worker_state_keeps_other_fields(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            aid = _make_activity(conn)
+            wid = wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1,
+                model="claude-opus-4-7",
+                spawned_at=NOW,
+            )
+            wk.update_worker_state_with_conn(
+                conn,
+                worker_id=wid,
+                workload_state="ready",
+                last_state_msg_id=10,
+                last_heartbeat_at=NOW,
+                ready_at=NOW,
+            )
+            row = wk.get_worker_by_id_with_conn(conn, wid)
+            assert row["workload_state"] == "ready"
+            assert row["last_state_msg_id"] == 10
+            assert row["ready_at"] == NOW
+            assert row["model"] == "claude-opus-4-7"  # 保持
+        finally:
+            conn.close()
+
+    def test_update_worker_identity_sets_session_id(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            aid = _make_activity(conn)
+            wid = wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=aid, topic_id=tid, task_n=1, spawned_at=NOW,
+            )
+            wk.update_worker_identity_with_conn(
+                conn, worker_id=wid, session_id="sess-1", model="claude-opus-4-7"
+            )
+            row = wk.get_worker_by_id_with_conn(conn, wid)
+            assert row["session_id"] == "sess-1"
+            assert row["model"] == "claude-opus-4-7"
+        finally:
+            conn.close()
+
+    def test_list_workers_alive_only_excludes_terminated(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            a1 = _make_activity(conn, "a1")
+            a2 = _make_activity(conn, "a2")
+            wid1 = wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-a", alias="w-a",
+                activity_id=a1, topic_id=tid, task_n=1, spawned_at=NOW,
+            )
+            wk.update_worker_state_with_conn(
+                conn, worker_id=wid1, workload_state="terminated",
+                cause="closed", terminated_at=LATER,
+            )
+            wk.insert_worker_with_conn(
+                conn,
+                channel_code="C1", handle="w-b", alias="w-b",
+                activity_id=a2, topic_id=tid, task_n=2,
+                workload_state="working", spawned_at=NOW,
+            )
+            alive = wk.list_workers_with_conn(
+                conn, channel_code="C1", alive_only=True
+            )
+            assert len(alive) == 1
+            assert alive[0]["handle"] == "w-b"
+            all_ = wk.list_workers_with_conn(
+                conn, channel_code="C1", alive_only=False
+            )
+            assert len(all_) == 2
+        finally:
+            conn.close()
+
+
+class TestAppliedMsgIds:
+    def test_mark_and_check_applied(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=10, applied_at=NOW
+            )
+            assert am.is_msg_applied_with_conn(conn, channel_code="C1", msg_id=10)
+            assert not am.is_msg_applied_with_conn(conn, channel_code="C1", msg_id=11)
+        finally:
+            conn.close()
+
+    def test_mark_msg_applied_is_idempotent(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=10, applied_at=NOW
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=10, applied_at=LATER
+            )  # 二度目はINSERT OR IGNORE で何もしない
+            # 1行のみ
+            row = conn.execute(
+                "SELECT COUNT(*) AS c FROM ow_applied_msg_ids WHERE channel_code = 'C1'"
+            ).fetchone()
+            assert row["c"] == 1
+        finally:
+            conn.close()
+
+    def test_invalid_outcome_raises(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            with pytest.raises(ValueError):
+                am.mark_msg_applied_with_conn(
+                    conn, channel_code="C1", msg_id=10,
+                    applied_at=NOW, outcome="rejected",
+                )
+        finally:
+            conn.close()
+
+    def test_get_max_applied_msg_id(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            assert am.get_max_applied_msg_id_with_conn(conn, channel_code="C1") == 0
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=5, applied_at=NOW
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=12, applied_at=NOW
+            )
+            am.mark_msg_applied_with_conn(
+                conn, channel_code="C1", msg_id=8, applied_at=NOW, outcome="skipped"
+            )
+            assert am.get_max_applied_msg_id_with_conn(conn, channel_code="C1") == 12
+        finally:
+            conn.close()
+
+    def test_get_applied_msg_id_set(self, db):
+        conn = get_connection()
+        try:
+            tid = _make_topic(conn)
+            ch.upsert_channel_with_conn(
+                conn, channel_code="C1", topic_id=tid, orch_handle="orch", now=NOW
+            )
+            for mid in [1, 3, 5]:
+                am.mark_msg_applied_with_conn(
+                    conn, channel_code="C1", msg_id=mid, applied_at=NOW
+                )
+            assert am.get_applied_msg_id_set_with_conn(conn, channel_code="C1") == {1, 3, 5}
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
- 旧 `queue-t<topic_id>.md` ファイルベースの worker queue 管理を廃止し、cc-memory 本体DB に event-sourcing reducer + projector の 2層モデルで ow ランタイム状態を集約する設計（T53 / M#288 v1.1）の **Phase 1 基盤**
- 並行運用可能な形まで実装し、既存 `ow_service.py` の queue.md 書き込みパスはそのまま残す（**Phase 2 で cutover 予定**）
- 前提: tags namespace CHECK 制約完全削除 (#383 merge済み)

## Phase 1 スコープ
- migration 0040: `ow_channels` / `ow_workers` / `ow_applied_msg_ids` 3テーブル追加
- store CRUD（conn 共有版 + ラッパー版、既存パターン踏襲）
- reducer (`ow_apply_state`): CQS 純粋関数（ow_*テーブルのみ書き込み）
- projector (`ow_project_activities`): ow_workers → activities 派生更新（`ow:managed` タグ付きのみ対象）
- dashboard (`render_dashboard`): 単一レンダラ。lazy reducer/projector + `.views/dashboard-t<topic>.md` atomic write
- `extract_activity_line` ヘルパー
- check_in 統合（§3.8）: ow:managed activity に対し dashboard render 該当行を summary に追加
- read-fallback シム（Phase 1 限定、Phase 2 で削除予定）

スコープ外（別タスク予定）:
- 順序3: `ow_spawn_worker` / `ow_close_worker` / `ow_status` の新schema切替
- 順序4: `session_start_hook` の `ow_dashboard` 切替 + `ow_recover` 書き換え + 旧queue.md 読み書きパス削除

## 確定事項（ユーザー判断反映）
- **Q1**: worker失敗・中止の表現は activity status enum を拡張せず、`outcome:cancelled` / `outcome:failed` タグで表現（§4.6 案A）
- **Q10**: `session_id` は **NULL 許容**（identity未受信のready前workerもreducerで表現可能に）
  - 部分UNIQUE INDEX は session_id を含まないため NULL穴問題は元から無し

## 実装ファイル
```
migrations/
  0040_add_ow_tables.sql
src/services/
  checkin_service.py       (修正: _build_ow_summary_line 追加)
  ow/__init__.py
  ow/channels.py
  ow/workers.py
  ow/applied_msgs.py
  ow/reducer.py            (ow_apply_state)
  ow/projector.py          (ow_project_activities)
  ow/dashboard.py          (render_dashboard / extract_activity_line / view 書き出し)
  ow/fallback.py           (read-fallback シム)
tests/
  test_migrations/test_0040_add_ow_tables.py
  unit/test_ow_store.py
  unit/test_ow_apply_state.py
  unit/test_ow_project_activities.py
  unit/test_ow_dashboard.py
  unit/test_ow_checkin_integration.py
  unit/test_ow_fallback.py
```

## ダッシュボード出力例

```
## アクティビティ一覧（topic t454）

● [880] [作業] T67 Phase 1 (migration + reducer/projector + dashboard + check_in統合) ─ in_progress (w-q1 working, hb 3s ago)
◐ [TBD] [作業] T68 ow_spawn_worker 新schema切替 ─ pending
○ [849] [作業] T46 model validation ─ completed
```

check_in 抜粋:
```
check-in: [作業] T67 Phase 1 ...
  intent: implement
  ow: ● [880] [作業] T67 Phase 1 ... ─ in_progress (w-q1 working, hb 3s ago)
```

## Test plan
- [x] migration 0040 単体 22件 全合格
- [x] store CRUD 15件 全合格
- [x] reducer (ow_apply_state) 14件 全合格（assign / identity / state / heartbeat 全種類、冪等性、CQS分離）
- [x] projector (ow_project_activities) 11件 全合格（status 遷移、outcome タグ、downgrade 不可、heartbeat 同期、topic スコープ）
- [x] dashboard 17件 全合格（スタイル指針: 行幅100, カラーコード未出力, 絵文字制限）
- [x] check_in 統合 3件 全合格
- [x] read-fallback シム 3件 全合格
- [x] **既存全テスト含む 1353件 全合格**（CI緑確認待ち）
- [ ] CI緑確認

## Notes
- PR分割: tag namespace CHECK 制約削除を独立PR #383 として先に merge 済み
- Phase 1 の境界は「並行運用可能」。既存 ow_service.py の queue 書き込みパスは無改修
- M#288 v1.1 §10 順序1+2 を本PRで完遂

🤖 Generated with [Claude Code](https://claude.com/claude-code)