### PR TITLE
feat: ow_spawn_workerで--nameにtask_titleを渡す

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1102,10 +1102,14 @@ def ow_spawn_worker(
     # --add-dir は variadic option (`<directories...>`) のため、続く positional prompt まで
     # ディレクトリ引数として食ってしまう。`--` で variadic を打ち切って prompt を positional
     # として確実に届ける。
+    # --name はセッション表示名（プロンプトボックス・/resume picker・端末タイトル）。
+    # workerはtask_titleをActivity名としてそのまま渡し、orch側で見分けやすくする。
+    session_name = task_title or alias
     worker_cmd = (
         f'env OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
         f'OW_TASK_FILE={shlex.quote(str(task_file))} '
         f'claude --model {shlex.quote(model)} --permission-mode auto '
+        f'--name {shlex.quote(session_name)} '
         f'--add-dir {shlex.quote(str(task_file.parent))} -- '
         f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
     )

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -679,6 +679,33 @@ class TestOwSpawnWorkerManualFallback:
         expected_task_dir = str(tmp_path / "tasks")
         assert f"--add-dir {expected_task_dir}" in cmd
 
+    def test_worker_cmd_includes_name_from_task_title(self, tmp_path: Path, monkeypatch):
+        """worker起動コマンドにtask_titleが--nameで渡される（セッション表示名）"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="議論: relation循環依存解消",
+            acceptance="done", topic_id="99", task_n=1,
+        )
+        cmd = result["command"]
+        assert "--name '議論: relation循環依存解消'" in cmd
+
+    def test_worker_cmd_name_falls_back_to_alias_when_title_empty(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """task_titleが空のとき--nameはaliasにフォールバックする"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-fallback", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="", acceptance="done", topic_id="99", task_n=1,
+        )
+        cmd = result["command"]
+        assert "--name w-fallback" in cmd
+
 
 class TestOwSpawnWorkerAdapter:
     """アダプタ経由でworkerを起動し、stdoutからterm_refを取得する"""


### PR DESCRIPTION
## Summary

- ow_spawn_worker が起動する `claude` CLI に `--name <task_title>` を追加。worker セッションの表示名（プロンプトボックス・/resume picker・端末タイトル）から Activity を識別できるようにする。
- `task_title` が空のときは `alias` にフォールバック。

## Why

これまでは worker セッションを開いても「どの作業の worker か」がタイトルだけでは分からず、複数 worker を並行起動した際に取り違えのリスクがあった。`claude -n/--name` で渡すだけで、3 つの可視化箇所（プロンプトボックス・/resume picker・端末タイトル）に一気に出るので最小コストでの改善。

## Test plan

- [x] `tests/unit/test_ow_queue.py` 全 102 件パス
- [x] `--name '<task_title>'` がコマンド文字列に含まれることをテスト追加
- [x] `task_title=""` のとき `--name <alias>` にフォールバックすることをテスト追加
- [ ] 実 worker spawn 時にプロンプトボックスへ task_title が表示されること（手動確認）