### PR TITLE
feat: ow_spawn_workerでtask_titleをactivity_idから自動解決

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -957,6 +957,29 @@ def _get_adapter_path(terminal: str) -> Path | None:
     return None
 
 
+def _resolve_activity_title(activity_id: int) -> str:
+    """activities.id → title を返す。見つからない/エラー時は空文字。
+
+    spawn時にtask_title未指定でもactivity_idがあればAPI呼び出しを増やさずタイトルを引ける。
+    DBアクセス失敗はspawn全体を止めない（best-effort）。
+    """
+    try:
+        from src.db import get_connection
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT title FROM activities WHERE id = ?", (activity_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        if row and row[0]:
+            return str(row[0])
+    except Exception as e:
+        logger.warning("activity title lookup failed for id=%s: %s", activity_id, e)
+    return ""
+
+
 def ow_spawn_worker(
     alias: str,
     channel: str,
@@ -1038,6 +1061,13 @@ def ow_spawn_worker(
                 "message": model_error,
             },
         }
+
+    # task_title未指定 かつ activity_id指定時は activities.title を自動解決する。
+    # 呼び出し側（orch等）に task_title を毎回詰めさせず、activity名と一貫させる。
+    # この task_title は task file frontmatter / ファイル名スラッグ / worker_cmd の
+    # --name（セッション表示名）すべてに伝播する。
+    if not task_title and activity_id is not None:
+        task_title = _resolve_activity_title(activity_id)
 
     # spawn前ヘルスチェック (relay疎通・channel存在・cwd存在・alias重複)
     preflight = _validate_spawn_preconditions(alias, channel, cwd, topic_id=topic_id, task_n=task_n)

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -706,6 +706,60 @@ class TestOwSpawnWorkerManualFallback:
         cmd = result["command"]
         assert "--name w-fallback" in cmd
 
+    def test_task_title_auto_resolved_from_activity_id(self, tmp_path: Path, monkeypatch):
+        """task_title未指定 かつ activity_id指定時、activities.title が --name に乗る"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+        monkeypatch.setattr(
+            ow_service, "_resolve_activity_title", lambda aid: "解決された Activity 名"
+        )
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="", acceptance="done", topic_id="99", task_n=1,
+            activity_id=42,
+        )
+        cmd = result["command"]
+        assert "--name '解決された Activity 名'" in cmd
+
+    def test_explicit_task_title_overrides_activity_lookup(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """task_title明示指定時はactivity_idがあってもDB lookupせず明示値を使う"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        def _should_not_be_called(aid):
+            raise AssertionError(
+                f"_resolve_activity_title called with id={aid} despite explicit task_title"
+            )
+
+        monkeypatch.setattr(ow_service, "_resolve_activity_title", _should_not_be_called)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="明示タイトル", acceptance="done", topic_id="99", task_n=1,
+            activity_id=42,
+        )
+        cmd = result["command"]
+        assert "--name '明示タイトル'" in cmd
+
+    def test_task_title_remains_empty_when_activity_lookup_fails(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """activity lookupが空文字を返したとき task_title は空のまま → --name は alias"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+        monkeypatch.setattr(ow_service, "_resolve_activity_title", lambda aid: "")
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-fallback", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="", acceptance="done", topic_id="99", task_n=1,
+            activity_id=999,
+        )
+        cmd = result["command"]
+        assert "--name w-fallback" in cmd
+
 
 class TestOwSpawnWorkerAdapter:
     """アダプタ経由でworkerを起動し、stdoutからterm_refを取得する"""


### PR DESCRIPTION
## Summary

PR #385 で `claude --name <task_title>` の配管を通したが、`task_title` の中身は呼び出し側（orch のAI agent）が毎回詰める必要があり、Activity名との一貫性は規約頼みだった。

本PRでは `task_title` 未指定 かつ `activity_id` 指定時に `activities.title` をDBから引いて自動で詰めるようにする。これで呼び出し側は `activity_id` だけ渡せば、`--name`（セッション表示名・/resume picker・端末タイトル）・task file frontmatter・ファイル名スラッグすべてに Activity 名が反映される。

## 設計判断

- **task_title 明示 > 自動解決**: `task_title` を渡せば従来通りそれを使う（明示値を優先）
- **DB lookup失敗で spawn を止めない**: best-effort。lookup失敗時は `task_title=""` のまま進み、`--name` は alias にフォールバック（PR #385 既存挙動）
- **直接 SQL**: `activity_service` には id→title 単発取得関数がないため、`ow_service` 内に `_resolve_activity_title` ヘルパーを追加してDB直クエリ。循環import回避のため `from src.db import get_connection` は関数内で行う

## Test plan

- [x] `tests/unit/test_ow_queue.py` 全 105 件パス（既存102 + 新規3）
- [x] `test_task_title_auto_resolved_from_activity_id`: 未指定時のDB解決
- [x] `test_explicit_task_title_overrides_activity_lookup`: 明示値優先（lookup呼ばれない）
- [x] `test_task_title_remains_empty_when_activity_lookup_fails`: lookup失敗時のフォールバック
- [ ] 実 worker spawn 時に `--name` が Activity 名で表示されること（手動確認）

## 関連

- PR #385（配管追加・マージ済み）
- A#825「[設計] worker表示の改善 — window隔離・tmux・タブタイトル」