### PR TITLE
fix: ow_spawn_worker --add-dir を `=` 形式で渡しpromptの吸収を防ぐ

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1129,9 +1129,11 @@ def ow_spawn_worker(
     terminal = os.environ.get("OW_TERMINAL", "manual")
     adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
 
-    # --add-dir は variadic option (`<directories...>`) のため、続く positional prompt まで
-    # ディレクトリ引数として食ってしまう。`--` で variadic を打ち切って prompt を positional
-    # として確実に届ける。
+    # --add-dir は commander.js の variadic option (`<directories...>`) で、空白区切り形式
+    # (`--add-dir DIR PROMPT`) だと続く positional prompt を dir として吸収する。
+    # `=` 形式 (`--add-dir=DIR`) は単一値として確定的にパースされ、複数指定は
+    # `--add-dir=DIR1 --add-dir=DIR2` の append 形で渡せる。後続 prompt の吸収リスクが
+    # 構造的に発生しないため、`--` separator なしで positional が確実に届く。
     # --name はセッション表示名（プロンプトボックス・/resume picker・端末タイトル）。
     # workerはtask_titleをActivity名としてそのまま渡し、orch側で見分けやすくする。
     session_name = task_title or alias
@@ -1140,7 +1142,7 @@ def ow_spawn_worker(
         f'OW_TASK_FILE={shlex.quote(str(task_file))} '
         f'claude --model {shlex.quote(model)} --permission-mode auto '
         f'--name {shlex.quote(session_name)} '
-        f'--add-dir {shlex.quote(str(task_file.parent))} -- '
+        f'--add-dir={shlex.quote(str(task_file.parent))} '
         f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
     )
 

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -1,5 +1,7 @@
 """queueファイルのパース/シリアライズのユニットテスト"""
 import json
+import re
+import shlex
 from pathlib import Path
 
 import pytest
@@ -665,23 +667,10 @@ class TestOwSpawnWorkerManualFallback:
         assert result.get("manual") is True
         assert "command" in result
 
-    def test_worker_cmd_includes_add_dir_for_task_file_dir(self, tmp_path: Path, monkeypatch):
-        """worker起動コマンドにtask_fileディレクトリへの--add-dir=DIRが含まれる（CWD外task fileの許可プロンプト抑制）"""
-        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
-        monkeypatch.delenv("OW_TERMINAL", raising=False)
-
-        result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
-            task_title="test", acceptance="done", topic_id="99", task_n=1,
-        )
-        assert result.get("manual") is True
-        cmd = result["command"]
-        expected_task_dir = str(tmp_path / "tasks")
-        # `=` 形式で渡すことで commander.js variadic が後続 positional を吸わない
-        assert f"--add-dir={expected_task_dir}" in cmd
-
-    def test_worker_cmd_add_dir_does_not_absorb_prompt(self, tmp_path: Path, monkeypatch):
-        """--add-dir が `=` 形式で渡され、後続 positional prompt が claude CLI に独立して届く。
+    def test_worker_cmd_add_dir_uses_equals_form_and_does_not_absorb_prompt(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """worker起動コマンドの --add-dir が `=` 形式で、後続 positional prompt が独立して届く。
 
         claude CLI の `--add-dir <directories...>` は commander.js variadic option で、
         空白区切り `--add-dir DIR PROMPT` 形式は PROMPT を追加 dir として吸収する
@@ -690,8 +679,6 @@ class TestOwSpawnWorkerManualFallback:
         修正前: `--add-dir DIR -- PROMPT` (--で区切るが variadic の挙動次第)
         修正後: `--add-dir=DIR PROMPT` (= で単一値確定、`--` 不要)
         """
-        import shlex as _shlex
-
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
@@ -699,6 +686,7 @@ class TestOwSpawnWorkerManualFallback:
             alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", topic_id="99", task_n=1,
         )
+        assert result.get("manual") is True
         cmd = result["command"]
         expected_task_dir = str(tmp_path / "tasks")
 
@@ -713,10 +701,21 @@ class TestOwSpawnWorkerManualFallback:
         )
 
         # tokenize して claude argv を取り出し、`--add-dir=DIR` が1トークンに収まり、
-        # prompt token が直後に独立して並んでいることを検証する
-        tokens = _shlex.split(cmd)
-        idx = tokens.index("claude")
-        claude_args = tokens[idx + 1 :]
+        # prompt token が直後に独立して並んでいることを検証する。
+        # `claude` 文字列が env 値や --name 値として偶発的に現れる可能性があるため、
+        # 「先頭から env コマンド/VAR=VAL トークンを読み飛ばした直後の token を実行ファイル」
+        # と特定する。
+        tokens = shlex.split(cmd)
+        env_token_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+        claude_idx = 0
+        if tokens and tokens[0] == "env":
+            claude_idx = 1
+        while claude_idx < len(tokens) and env_token_re.match(tokens[claude_idx]):
+            claude_idx += 1
+        assert (
+            claude_idx < len(tokens) and tokens[claude_idx] == "claude"
+        ), f"expected 'claude' executable after env prefix, got tokens={tokens}"
+        claude_args = tokens[claude_idx + 1 :]
 
         add_dir_token = f"--add-dir={expected_task_dir}"
         assert add_dir_token in claude_args, (

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -666,7 +666,7 @@ class TestOwSpawnWorkerManualFallback:
         assert "command" in result
 
     def test_worker_cmd_includes_add_dir_for_task_file_dir(self, tmp_path: Path, monkeypatch):
-        """worker起動コマンドにtask_fileディレクトリへの--add-dirが含まれる（CWD外task fileの許可プロンプト抑制）"""
+        """worker起動コマンドにtask_fileディレクトリへの--add-dir=DIRが含まれる（CWD外task fileの許可プロンプト抑制）"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
@@ -677,7 +677,59 @@ class TestOwSpawnWorkerManualFallback:
         assert result.get("manual") is True
         cmd = result["command"]
         expected_task_dir = str(tmp_path / "tasks")
-        assert f"--add-dir {expected_task_dir}" in cmd
+        # `=` 形式で渡すことで commander.js variadic が後続 positional を吸わない
+        assert f"--add-dir={expected_task_dir}" in cmd
+
+    def test_worker_cmd_add_dir_does_not_absorb_prompt(self, tmp_path: Path, monkeypatch):
+        """--add-dir が `=` 形式で渡され、後続 positional prompt が claude CLI に独立して届く。
+
+        claude CLI の `--add-dir <directories...>` は commander.js variadic option で、
+        空白区切り `--add-dir DIR PROMPT` 形式は PROMPT を追加 dir として吸収する
+        (PR#374で `--` separator対応も入れたが、より明示的な `=` 形式に統一)。
+
+        修正前: `--add-dir DIR -- PROMPT` (--で区切るが variadic の挙動次第)
+        修正後: `--add-dir=DIR PROMPT` (= で単一値確定、`--` 不要)
+        """
+        import shlex as _shlex
+
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            task_title="test", acceptance="done", topic_id="99", task_n=1,
+        )
+        cmd = result["command"]
+        expected_task_dir = str(tmp_path / "tasks")
+
+        # `=` 形式で含まれる
+        assert f"--add-dir={expected_task_dir}" in cmd, (
+            f"--add-dir should use equals form, got: {cmd}"
+        )
+
+        # 空白区切り形式 (`--add-dir DIR`) は含まれない (variadic 吸収を構造的に避ける)
+        assert f"--add-dir {expected_task_dir}" not in cmd, (
+            f"--add-dir should NOT use space-separated form (variadic absorbs prompt), got: {cmd}"
+        )
+
+        # tokenize して claude argv を取り出し、`--add-dir=DIR` が1トークンに収まり、
+        # prompt token が直後に独立して並んでいることを検証する
+        tokens = _shlex.split(cmd)
+        idx = tokens.index("claude")
+        claude_args = tokens[idx + 1 :]
+
+        add_dir_token = f"--add-dir={expected_task_dir}"
+        assert add_dir_token in claude_args, (
+            f"expected single token {add_dir_token!r} in claude_args, got: {claude_args}"
+        )
+        add_dir_idx = claude_args.index(add_dir_token)
+
+        # add-dir の後続に prompt が独立トークンとして存在する (吸収されていない)
+        after_add_dir = claude_args[add_dir_idx + 1 :]
+        prompt_marker = "workerスキルに従って作業を開始して。"
+        assert any(
+            prompt_marker in tok for tok in after_add_dir
+        ), f"prompt token not found after --add-dir=, claude_args={claude_args}"
 
     def test_worker_cmd_includes_name_from_task_title(self, tmp_path: Path, monkeypatch):
         """worker起動コマンドにtask_titleが--nameで渡される（セッション表示名）"""


### PR DESCRIPTION
## 背景

`ow_spawn_worker` で組み立てる worker 起動コマンドの `--add-dir` 引数が、claude CLI の commander.js variadic option (`--add-dir <directories...>`) として後続の positional prompt を吸収するバグ (M#329 改善要望 item 19、L#2653、2026-06-16 再現)。

PR #374 で `--` separator (`--add-dir DIR -- PROMPT`) を入れて一旦回避したが、variadic の挙動依存の暗黙の打ち切りで脆い。本PRでは `=` 形式 (`--add-dir=DIR PROMPT`) に変更し、commander.js に単一値として確定的にパースさせる。

## 修正方針

- `--add-dir <DIR> -- <PROMPT>` (空白形式 + `--` separator)
- → `--add-dir=<DIR> <PROMPT>` (`=` 形式・separator 不要)

複数 dir 指定が必要になった場合は `--add-dir=DIR1 --add-dir=DIR2` の append 形で渡せる。

## 修正前後の argv

```diff
- claude --model X --permission-mode auto --name 'NAME' --add-dir '/path/to/dir' -- 'workerスキル...'
+ claude --model X --permission-mode auto --name 'NAME' --add-dir=/path/to/dir 'workerスキル...'
```

## 再現コマンド (claude CLI で直接検証)

| 形式 | コマンド | 結果 |
|---|---|---|
| 旧 (空白) | `claude --add-dir /tmp/dir "hello"` | \`Error: Input must be provided either through stdin or as a prompt argument\` (prompt が dir として吸収) |
| 旧 (`--`付) | `claude --add-dir /tmp/dir -- "hello"` | promptが届く (variadicが\`--\`で打ち切り) |
| 新 (`=`) | `claude --add-dir=/tmp/dir "hello"` | promptが届く (単一値確定パース) |

## テスト

- `test_worker_cmd_add_dir_does_not_absorb_prompt` 追加
  - cmd中に `--add-dir=<dir>` が単一トークンとして含まれ、後続に prompt トークンが独立して並ぶことを `shlex.split` で検証
  - 修正前 (空白形式) はこのassertで fail、修正後は pass
- `test_worker_cmd_includes_add_dir_for_task_file_dir` のアサーション更新
  - \`--add-dir DIR\` → \`--add-dir=DIR\`

## Test plan

- [x] `tests/unit/test_ow_queue.py` 全件 pass
- [x] 全テスト suite (1682件) pass
- [x] claude CLI で `=` 形式の動作を実機検証 (上記再現コマンド)

🤖 Generated with [Claude Code](https://claude.com/claude-code)