### PR TITLE
feat: add_activityにIMPLEMENT_WORKFLOW_GUARD導入 (議論未経過バリデーション)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -179,7 +179,7 @@ def add_topic(
     """新しい議論トピックを追加する。
 
     tags: タグ配列(必須、1個以上)。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
-    related: 関連エンティティ（optional）。[{"type": "topic"|"activity", "ids": [int, ...]}] 形式。作成と同時にリレーションを張る
+    related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]。作成と同時にリレーションを張る
 
     レスポンスに類似トピック(similar_topics)が含まれる場合がある。重複トピックの防止やリレーション追加の参考にすること。"""
     result = topic_service.add_topic(title, description, tags, related=related)
@@ -533,13 +533,14 @@ def add_activity(
     - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search", "ranking"])
     - トピック紐付け: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], related=[{"type": "topic", "ids": [123]}])
     - 複数関連: add_activity("...", "...", [...], related=[{"type": "topic", "ids": [1, 2]}, {"type": "activity", "ids": [3]}])
+    - intent:implementは合意済みdecisionをrelateする: add_activity("...", "...", ["domain:cc-memory", "intent:implement"], related=[{"type": "decision", "ids": [10, 11]}])
     - check_inなしで作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], check_in=False)
 
     Args:
         title: アクティビティのタイトル
         description: アクティビティの詳細説明（必須）。スコアリングに活用されるため、以下の情報があれば記載を推奨: 締め切り、ブロッカー（自分が/外部）、影響度・緊急度
         tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
-        related: 関連エンティティ（optional）。[{"type": "topic"|"activity", "ids": [int, ...]}] 形式。作成と同時にリレーションを張る
+        related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1]}, {"type": "decision", "ids": [10, 11]}]。作成と同時にリレーションを張る。intent:implementタグを含む場合、relatedにtype='decision'のエントリを最低1件含めないとIMPLEMENT_WORKFLOW_GUARDエラーで弾かれる（議論・設計フェーズで合意したdecisionか、いきなりimplementする理由を記録したdecisionをrelateする）
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）。Trueの場合、返り値にcheck_in_resultが含まれる
 
     Returns:
@@ -655,7 +656,7 @@ def add_material(
         content: 資材の本文（マークダウン形式推奨）。先頭1-2文は内容の説明・要約を書くこと（check-in時にsnippetとして表示される）
         tags: タグ配列（必須、1個以上）。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)
         source: データの出自。典型的なソース種類: ユーザー発言、公式ドキュメント、コード調査、計測結果、外部記事、チーム議事録など。事実と推論が混在する場合はcontent内で明示的に区別すること
-        related: 関連エンティティ（optional）。[{"type": "topic"|"activity", "ids": [int, ...]}] 形式。作成と同時にリレーションを張る
+        related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "activity", "ids": [123]}, {"type": "decision", "ids": [10]}]。作成と同時にリレーションを張る
 
     Returns:
         作成された資材情報（material_id, title, content, source, tags, created_at）

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -30,6 +30,74 @@ ACTIVE_STATUSES = ("in_progress", "pending")
 VALID_STATUSES = REAL_STATUSES | {"active"}
 
 
+IMPLEMENT_WORKFLOW_GUARD_MESSAGE = (
+    "This implement has no decision in its related entities.\n\n"
+    "Add a decision recording either:\n"
+    "- the agreement reached through discussion, or\n"
+    "- the reason for proceeding without design (e.g., \"typo-only\", \"hotfix\").\n\n"
+    "Then retry add_activity."
+)
+
+
+def _has_intent_implement(conn, parsed_tags: list[tuple[str, str]]) -> bool:
+    """parsed_tags が intent:implement を（aliasを辿った上で）含むかを返す。
+
+    既存タグの canonical_id を SELECT して、エイリアス越しに
+    intent:implement に解決されるかを判定する。
+    """
+    intent_tags = [(ns, name) for ns, name in parsed_tags if ns == "intent"]
+    if not intent_tags:
+        return False
+    if any(name == "implement" for _, name in intent_tags):
+        return True
+    placeholders = " OR ".join("(t.namespace = ? AND t.name = ?)" for _ in intent_tags)
+    flat = [v for pair in intent_tags for v in pair]
+    rows = conn.execute(
+        f"""
+        SELECT ct.namespace AS canonical_ns, ct.name AS canonical_name
+        FROM tags t
+        LEFT JOIN tags ct ON t.canonical_id = ct.id
+        WHERE {placeholders}
+        """,
+        flat,
+    ).fetchall()
+    return any(
+        row["canonical_ns"] == "intent" and row["canonical_name"] == "implement"
+        for row in rows
+    )
+
+
+def _check_implement_workflow_guard(
+    conn, parsed_tags: list[tuple[str, str]], related: list[dict] | None
+) -> dict | None:
+    """intent:implement アクティビティに decision の direct relate を要求する。
+
+    通過条件:
+        - intent:implement を含まない、または
+        - related に type='decision' かつ ids が非空のエントリが1件以上ある
+
+    Returns:
+        通過時: None
+        ブロック時: {"error": {"code": "IMPLEMENT_WORKFLOW_GUARD", "message": ...}}
+    """
+    if not _has_intent_implement(conn, parsed_tags):
+        return None
+
+    has_decision_relate = any(
+        t.get("type") == "decision" and t.get("ids")
+        for t in (related or [])
+    )
+    if has_decision_relate:
+        return None
+
+    return {
+        "error": {
+            "code": "IMPLEMENT_WORKFLOW_GUARD",
+            "message": IMPLEMENT_WORKFLOW_GUARD_MESSAGE,
+        }
+    }
+
+
 def add_activity(
     title: str,
     description: str,
@@ -44,7 +112,12 @@ def add_activity(
         title: アクティビティのタイトル
         description: アクティビティの説明
         tags: タグ配列（必須、1個以上）
-        related: 関連エンティティ [{"type": "topic", "ids": [1, 2]}, ...] (optional)
+        related: 関連エンティティ（optional）。
+            [{"type": "topic" | "activity" | "material" | "decision" | "log", "ids": [int, ...]}, ...] 形式。
+            複数エンティティを配列で同時紐付け可能。
+            例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]
+            intent:implement タグを含む場合、related に type='decision' のエントリを
+            最低1件含めないと IMPLEMENT_WORKFLOW_GUARD エラーで弾かれる。
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）
 
     Returns:
@@ -63,6 +136,11 @@ def add_activity(
 
     conn = get_connection()
     try:
+        # Workflow guard: intent:implement アクティビティは related に decision を必須とする
+        guard_err = _check_implement_workflow_guard(conn, parsed_tags, related)
+        if guard_err:
+            return guard_err
+
         # アクティビティをINSERT
         cursor = conn.execute(
             "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -74,7 +74,7 @@ def _check_implement_workflow_guard(
 
     通過条件:
         - intent:implement を含まない、または
-        - related に type='decision' かつ ids が非空のエントリが1件以上ある
+        - related に type='decision' で実在する decision_id を1件以上含む
 
     Returns:
         通過時: None
@@ -83,12 +83,22 @@ def _check_implement_workflow_guard(
     if not _has_intent_implement(conn, parsed_tags):
         return None
 
-    has_decision_relate = any(
-        t.get("type") == "decision" and t.get("ids")
+    decision_ids = [
+        decision_id
         for t in (related or [])
-    )
-    if has_decision_relate:
-        return None
+        if t.get("type") == "decision"
+        for decision_id in (t.get("ids") or [])
+    ]
+    if decision_ids:
+        placeholders = ",".join("?" * len(decision_ids))
+        # retracted_at IS NULL: 取り消し済 decision はガード通過の根拠にしない
+        row = conn.execute(
+            f"SELECT COUNT(*) AS cnt FROM decisions "
+            f"WHERE id IN ({placeholders}) AND retracted_at IS NULL",
+            decision_ids,
+        ).fetchone()
+        if row["cnt"] > 0:
+            return None
 
     return {
         "error": {

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -40,7 +40,10 @@ def add_material(title: str, content: str, tags: list[str], source: str, related
         content: 資材の本文
         tags: タグ配列（必須、1個以上）
         source: データの出自
-        related: 関連エンティティ [{"type": "topic", "ids": [1, 2]}, ...] (optional)
+        related: 関連エンティティ（optional）。
+            [{"type": "topic" | "activity" | "material" | "decision" | "log", "ids": [int, ...]}, ...] 形式。
+            複数エンティティを配列で同時紐付け可能。
+            例: [{"type": "activity", "ids": [123]}, {"type": "decision", "ids": [10]}]
 
     Returns:
         作成された資材情報

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -103,7 +103,10 @@ def add_topic(
         title: トピックのタイトル
         description: トピックの説明（必須）
         tags: タグ配列（必須、1個以上）
-        related: 関連エンティティ [{"type": "topic", "ids": [1, 2]}, ...] (optional)
+        related: 関連エンティティ（optional）。
+            [{"type": "topic" | "activity" | "material" | "decision" | "log", "ids": [int, ...]}, ...] 形式。
+            複数エンティティを配列で同時紐付け可能。
+            例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]
 
     Returns:
         作成されたトピック情報

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ hookやサービス層がworkerフロー扱いになり、通常セッション�
 どの環境で実行してもテストが決定論的に振る舞うようにする。
 """
 import os
+import tempfile
 
 import pytest
 
@@ -21,3 +22,34 @@ def _clear_ow_env(monkeypatch):
     """
     for key in _OW_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化する共通フィクスチャ。
+
+    DBクエリだけで完結するロジックの検証で、embeddingサーバー未起動状態を
+    決定論的に再現するために使う。ファイル側で `autouse` ラップしたい場合は
+    各テストファイルでこのfixtureに依存する薄いautouse fixtureを定義する。
+    """
+    import src.services.embedding_service as emb
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時SQLite DBを作成する共通フィクスチャ。
+
+    DISCUSSION_DB_PATH 環境変数を一時パスに切り替え、init_database で
+    スキーマを構築する。テスト終了時にtmpdirごと破棄される。
+    """
+    from src.db import init_database
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]

--- a/tests/e2e/test_implement_workflow_guard.py
+++ b/tests/e2e/test_implement_workflow_guard.py
@@ -1,0 +1,70 @@
+"""IMPLEMENT_WORKFLOW_GUARD のE2E（MCP tool 呼び出し経由）
+
+src.main の add_activity（@mcp.tool() で公開される実体）を呼び、
+intent:implement かつ related に decision を含まないケースが
+IMPLEMENT_WORKFLOW_GUARD で弾かれることを確認する。
+"""
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database
+from src.main import add_activity as mcp_add_activity
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def test_mcp_add_activity_implement_without_decision_is_blocked(temp_db):
+    """MCP tool add_activity が intent:implement + decision relate なしで弾かれる"""
+    result = mcp_add_activity(
+        title="Implement without decision",
+        description="MCP-tool level call should reject bare implement.",
+        tags=["domain:test", "intent:implement"],
+        check_in=False,
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+
+def test_mcp_add_activity_implement_with_decision_passes(temp_db):
+    """MCP tool add_activity が intent:implement + decision relate ありで通過する"""
+    topic = add_topic(
+        title="E2E topic",
+        description="Topic for e2e guard test.",
+        tags=["domain:test"],
+    )
+    decision = add_decision(
+        decision="Agreed implementation approach.",
+        reason="Discussion completed.",
+        topic_id=topic["topic_id"],
+    )
+
+    result = mcp_add_activity(
+        title="Implement with decision",
+        description="MCP-tool level call should pass with decision related.",
+        tags=["domain:test", "intent:implement"],
+        related=[{"type": "decision", "ids": [decision["decision_id"]]}],
+        check_in=False,
+    )
+    assert "error" not in result
+    assert "activity_id" in result

--- a/tests/e2e/test_implement_workflow_guard.py
+++ b/tests/e2e/test_implement_workflow_guard.py
@@ -3,35 +3,19 @@
 src.main の add_activity（@mcp.tool() で公開される実体）を呼び、
 intent:implement かつ related に decision を含まないケースが
 IMPLEMENT_WORKFLOW_GUARD で弾かれることを確認する。
-"""
-import os
-import tempfile
 
+temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
+"""
 import pytest
 
-import src.services.embedding_service as emb
-from src.db import init_database
 from src.main import add_activity as mcp_add_activity
 from src.services.topic_service import add_topic
 from tests.helpers import add_decision
 
 
 @pytest.fixture(autouse=True)
-def disable_embedding(monkeypatch):
-    monkeypatch.setattr(emb, "_server_initialized", False)
-    monkeypatch.setattr(emb, "_backfill_done", True)
-    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
-
-
-@pytest.fixture
-def temp_db():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        os.environ["DISCUSSION_DB_PATH"] = db_path
-        init_database()
-        yield db_path
-        if "DISCUSSION_DB_PATH" in os.environ:
-            del os.environ["DISCUSSION_DB_PATH"]
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストでembedding服を無効化する"""
 
 
 def test_mcp_add_activity_implement_without_decision_is_blocked(temp_db):

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -1050,11 +1050,18 @@ def _set_decision_created_at(decision_id: int, ts: str) -> None:
 
 
 def _make_activity_with_plain_tag() -> int:
-    """素タグ PLAIN_TAG を持つアクティビティを作成しIDを返す。"""
+    """素タグ PLAIN_TAG を持つアクティビティを作成しIDを返す。
+
+    intent:implement を含むため IMPLEMENT_WORKFLOW_GUARD 用に
+    dummy decision を作って related に含める。
+    """
+    topic = add_topic(title="dummy topic", description="d", tags=["domain:test"])
+    dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
     result = add_activity(
         title="[作業] recompose対象タスク",
         description="recomposeナッジ判定の対象タスク",
         tags=["domain:test", "intent:implement", PLAIN_TAG],
+        related=[{"type": "decision", "ids": [dec["decision_id"]]}],
         check_in=False,
     )
     return result["activity_id"]
@@ -1238,10 +1245,18 @@ class TestRecomposeHints:
     def test_namespaced_tags_excluded_from_hints(self, temp_db):
         """domain:/intent:のnamespaceタグはhint判定対象外で、素タグが無ければhintは出ない"""
         # 素タグを持たず、domain:とintent:のみを持つアクティビティ
+        # intent:implement は IMPLEMENT_WORKFLOW_GUARD のため dummy decision を関連付け
+        ns_topic = add_topic(
+            title="dummy", description="d", tags=["domain:bootstrap-domain"],
+        )
+        ns_dec = add_decision(
+            decision="d", reason="r", topic_id=ns_topic["topic_id"],
+        )
         result_a = add_activity(
             title="[作業] namespaceのみ",
             description="素タグなし",
             tags=["domain:bootstrap-domain", "intent:implement"],
+            related=[{"type": "decision", "ids": [ns_dec["decision_id"]]}],
             check_in=False,
         )
         activity_id = result_a["activity_id"]

--- a/tests/unit/test_active_context.py
+++ b/tests/unit/test_active_context.py
@@ -18,6 +18,7 @@ from src.services.activity_service import (
     get_active_activities_by_tag,
 )
 import src.services.embedding_service as emb
+from tests.helpers import add_decision
 from hooks.session_start_hook import (
     _build_activities_section,
     _calc_elapsed_days,
@@ -468,9 +469,13 @@ def test_build_activities_section_scoring_instructions(temp_db):
 
 def test_build_activities_section_tags_in_metadata(temp_db):
     """メタデータ行にタグ情報が含まれる"""
+    topic = add_topic(title="t", description="d", tags=["domain:myapp"])
+    dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
     add_activity(
         title="[作業] Task", description="Desc",
-        tags=["domain:myapp", "intent:implement"], check_in=False,
+        tags=["domain:myapp", "intent:implement"],
+        related=[{"type": "decision", "ids": [dec["decision_id"]]}],
+        check_in=False,
     )
 
     result = _build_active_context_wrapper()

--- a/tests/unit/test_activity_workflow_guard.py
+++ b/tests/unit/test_activity_workflow_guard.py
@@ -1,39 +1,24 @@
 """add_activity の議論未経過バリデーション (IMPLEMENT_WORKFLOW_GUARD) のユニットテスト
 
 intent:implement を含む add_activity 呼び出しが related に decision タイプ直接
-1件以上を持たない場合に IMPLEMENT_WORKFLOW_GUARD で弾かれることを検証する。
-canonical_id を辿ったエイリアス intent タグの判定もカバーする。
-"""
-import os
-import tempfile
+1件以上（実在するdecision_id）を持たない場合に IMPLEMENT_WORKFLOW_GUARD で
+弾かれることを検証する。canonical_id を辿ったエイリアス intent タグの判定や、
+存在しない/取り消し済 decision_id によるバイパス試行のブロックもカバーする。
 
+temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
+"""
 import pytest
 
-import src.services.embedding_service as emb
-from src.db import init_database, get_connection
+from src.db import get_connection
 from src.services.activity_service import add_activity
 from src.services.topic_service import add_topic
+from src.services.retract_service import retract
 from tests.helpers import add_decision
 
 
 @pytest.fixture(autouse=True)
-def disable_embedding(monkeypatch):
-    """embeddingサービスを無効化する。判定はDBクエリだけで完結するためサーバー不要。"""
-    monkeypatch.setattr(emb, "_server_initialized", False)
-    monkeypatch.setattr(emb, "_backfill_done", True)
-    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
-
-
-@pytest.fixture
-def temp_db():
-    """テスト用の一時的なデータベースを作成する"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        os.environ["DISCUSSION_DB_PATH"] = db_path
-        init_database()
-        yield db_path
-        if "DISCUSSION_DB_PATH" in os.environ:
-            del os.environ["DISCUSSION_DB_PATH"]
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストでembedding服を無効化する"""
 
 
 @pytest.fixture
@@ -112,7 +97,7 @@ class TestImplementWorkflowGuard:
         assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
 
     def test_implement_with_decision_passes(self, topic_with_decision):
-        """intent:implement + related に decision 1件 → 通過する"""
+        """intent:implement + related に decision 1件（実在ID）→ 通過する"""
         _, decision_id = topic_with_decision
         result = add_activity(
             title="Implement with agreement",
@@ -214,10 +199,46 @@ class TestImplementWorkflowGuard:
         assert "error" in result
         assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
 
+    def test_nonexistent_decision_id_blocks(self, topic_with_decision):
+        """存在しない decision_id では通過させない（バイパス試行のブロック）"""
+        # 99999 のような未存在IDを並べてもガード通過しない。
+        # _validate_targets は構造のみ検証、relations テーブルは FK 制約を
+        # 持たないため、存在チェックをガード側で行う必要がある。
+        result = add_activity(
+            title="Bypass attempt with fake id",
+            description="Non-existent decision ID should not pass.",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [99999]}],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+    def test_retracted_decision_blocks(self, topic_with_decision):
+        """retract済 decision は通過の根拠にしない"""
+        _, decision_id = topic_with_decision
+        # 取り消し
+        retract_result = retract("decision", [decision_id])
+        assert "error" not in retract_result
+
+        result = add_activity(
+            title="Implement with retracted decision",
+            description="Retracted decisions should not pass the guard.",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
     def test_decision_with_empty_ids_blocks(self, topic_with_decision):
-        """related に decision タイプはあるが ids が空 → 弾かれる"""
-        # _validate_targets が空idsを許容するかは別問題。ここではガード側の判定を検証する。
-        # 直接 _check_implement_workflow_guard を呼んで確認する。
+        """related に decision タイプはあるが ids が空 → ガード単体で弾く
+
+        公開 API (add_activity) 経由だと _validate_targets が空idsを先に
+        VALIDATION_ERROR で弾くため、このシナリオは公開APIから直接は起きない。
+        ガード単体の仕様としての保証（直接呼び出しでも誤って通過しないこと）を
+        ここで明示する。
+        """
         from src.services.activity_service import _check_implement_workflow_guard
 
         conn = get_connection()

--- a/tests/unit/test_activity_workflow_guard.py
+++ b/tests/unit/test_activity_workflow_guard.py
@@ -1,0 +1,233 @@
+"""add_activity の議論未経過バリデーション (IMPLEMENT_WORKFLOW_GUARD) のユニットテスト
+
+intent:implement を含む add_activity 呼び出しが related に decision タイプ直接
+1件以上を持たない場合に IMPLEMENT_WORKFLOW_GUARD で弾かれることを検証する。
+canonical_id を辿ったエイリアス intent タグの判定もカバーする。
+"""
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database, get_connection
+from src.services.activity_service import add_activity
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """embeddingサービスを無効化する。判定はDBクエリだけで完結するためサーバー不要。"""
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic_with_decision(temp_db):
+    """テスト用にtopicとそこに紐づくdecisionを1件作成し、(topic_id, decision_id) を返す"""
+    topic = add_topic(
+        title="Topic for guard test",
+        description="Topic with a decision attached.",
+        tags=["domain:test"],
+    )
+    topic_id = topic["topic_id"]
+    decision = add_decision(
+        decision="Agreed approach for the implementation.",
+        reason="Reviewed alternatives and picked this one.",
+        topic_id=topic_id,
+    )
+    return topic_id, decision["decision_id"]
+
+
+def _set_canonical(conn, alias_id, canonical_id):
+    conn.execute(
+        "UPDATE tags SET canonical_id = ? WHERE id = ?",
+        (canonical_id, alias_id),
+    )
+
+
+def _create_tag(conn, namespace, name):
+    conn.execute(
+        "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+        (namespace, name),
+    )
+    row = conn.execute(
+        "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+        (namespace, name),
+    ).fetchone()
+    return row["id"]
+
+
+class TestImplementWorkflowGuard:
+    """IMPLEMENT_WORKFLOW_GUARD の通過・ブロック判定"""
+
+    def test_no_intent_implement_passes(self, topic_with_decision):
+        """intent:implement を含まない場合、related が無くても通過する"""
+        result = add_activity(
+            title="Discuss something",
+            description="Just a discussion activity.",
+            tags=["domain:test", "intent:discuss"],
+            check_in=False,
+        )
+        assert "error" not in result
+        assert "activity_id" in result
+
+    def test_implement_without_related_blocks(self, topic_with_decision):
+        """intent:implement かつ related なし → IMPLEMENT_WORKFLOW_GUARD で弾かれる"""
+        result = add_activity(
+            title="Naked implement",
+            description="Tries to implement without any decision.",
+            tags=["domain:test", "intent:implement"],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+        assert "decision" in result["error"]["message"]
+
+    def test_implement_with_only_topic_blocks(self, topic_with_decision):
+        """intent:implement + related に topic のみ → 弾かれる（間接decision参照は廃止）"""
+        topic_id, _ = topic_with_decision
+        result = add_activity(
+            title="Implement linked to topic only",
+            description="topic 経由の間接decisionでは通過しない。",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "topic", "ids": [topic_id]}],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+    def test_implement_with_decision_passes(self, topic_with_decision):
+        """intent:implement + related に decision 1件 → 通過する"""
+        _, decision_id = topic_with_decision
+        result = add_activity(
+            title="Implement with agreement",
+            description="Has a decision in related.",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        assert "error" not in result
+        assert "activity_id" in result
+
+    def test_implement_with_topic_and_decision_passes(self, topic_with_decision):
+        """intent:implement + related に topic + decision 複数タイプ → 通過する"""
+        topic_id, decision_id = topic_with_decision
+        result = add_activity(
+            title="Implement with both",
+            description="Mix of topic and decision in related.",
+            tags=["domain:test", "intent:implement"],
+            related=[
+                {"type": "topic", "ids": [topic_id]},
+                {"type": "decision", "ids": [decision_id]},
+            ],
+            check_in=False,
+        )
+        assert "error" not in result
+        assert "activity_id" in result
+
+    def test_multiple_intent_tags_with_implement_blocks(self, topic_with_decision):
+        """複数 intent tag のうち intent:implement が含まれる → 判定対象でブロックされる"""
+        result = add_activity(
+            title="Mixed intents implement",
+            description="Both review and implement intents, no decision related.",
+            tags=["domain:test", "intent:review", "intent:implement"],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+    def test_multiple_intent_tags_without_implement_passes(self, topic_with_decision):
+        """複数 intent tag に intent:implement が無ければ通過する"""
+        result = add_activity(
+            title="Design + discuss",
+            description="No implement intent here.",
+            tags=["domain:test", "intent:design", "intent:discuss"],
+            check_in=False,
+        )
+        assert "error" not in result
+
+    def test_aliased_intent_resolves_to_implement_and_blocks(self, topic_with_decision):
+        """エイリアス intent タグ (canonical_id 経由) も intent:implement として判定される"""
+        conn = get_connection()
+        try:
+            canonical_id = _create_tag(conn, "intent", "implement")
+            alias_id = _create_tag(conn, "intent", "impl")
+            _set_canonical(conn, alias_id, canonical_id)
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = add_activity(
+            title="Implement via alias",
+            description="Uses intent:impl which aliases to intent:implement.",
+            tags=["domain:test", "intent:impl"],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+    def test_aliased_intent_passes_with_decision(self, topic_with_decision):
+        """エイリアス intent タグでも related に decision があれば通過する"""
+        _, decision_id = topic_with_decision
+        conn = get_connection()
+        try:
+            canonical_id = _create_tag(conn, "intent", "implement")
+            alias_id = _create_tag(conn, "intent", "impl")
+            _set_canonical(conn, alias_id, canonical_id)
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = add_activity(
+            title="Implement via alias with decision",
+            description="Alias + decision relate → passes.",
+            tags=["domain:test", "intent:impl"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        assert "error" not in result
+
+    def test_empty_related_treated_same_as_none(self, topic_with_decision):
+        """related=[] は related なしと同じ扱いで弾かれる"""
+        result = add_activity(
+            title="Implement empty related",
+            description="Empty list still blocks.",
+            tags=["domain:test", "intent:implement"],
+            related=[],
+            check_in=False,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"
+
+    def test_decision_with_empty_ids_blocks(self, topic_with_decision):
+        """related に decision タイプはあるが ids が空 → 弾かれる"""
+        # _validate_targets が空idsを許容するかは別問題。ここではガード側の判定を検証する。
+        # 直接 _check_implement_workflow_guard を呼んで確認する。
+        from src.services.activity_service import _check_implement_workflow_guard
+
+        conn = get_connection()
+        try:
+            err = _check_implement_workflow_guard(
+                conn,
+                [("intent", "implement"), ("domain", "test")],
+                [{"type": "decision", "ids": []}],
+            )
+        finally:
+            conn.close()
+        assert err is not None
+        assert err["error"]["code"] == "IMPLEMENT_WORKFLOW_GUARD"

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -19,6 +19,7 @@ from src.services.decision_service import add_decisions
 from src.services.discussion_log_service import add_logs
 from src.services.activity_service import add_activity
 from src.services.search_service import get_by_ids
+from tests.helpers import add_decision
 import src.services.embedding_service as emb
 
 
@@ -449,9 +450,13 @@ class TestGetActivitiesResultBasedInjection:
         """タグフィルタなしでも結果内のタグからtag_notesが注入される"""
         from src.services.activity_service import get_activities
 
+        topic = add_topic(title="t", description="d", tags=["domain:test"])
+        dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
         add_activity(
             title="Test Activity", description="Desc",
-            tags=["domain:test", "intent:implement"], check_in=False,
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [dec["decision_id"]]}],
+            check_in=False,
         )
         update_tag("domain:test", "テスト教訓")
 


### PR DESCRIPTION
## Summary

cc-memory で intent:implement アクティビティが議論・設計を経ずに立てられる問題への構造的対処として、`add_activity` に IMPLEMENT_WORKFLOW_GUARD を導入する。

- 新規 `add_activity` 呼び出しで `intent:implement` タグが含まれかつ `related` に **実在する** decision の直接relate が0件のとき、`IMPLEMENT_WORKFLOW_GUARD` エラーで弾く
- 通過させたいときは、議論で合意した decision か、いきなり implement する理由（typo修正・hotfix等）を decision として記録して related に含める
- エイリアス intent タグ（canonical_id 経由で `intent:implement` に解決される）も判定対象
- `related` 引数の docstring を `VALID_ENTITY_TYPES` 5タイプ全列挙 (topic/activity/material/decision/log) に統一

## 決定根拠

- バリデーションを通す指標を「related に type='decision' を直接1件以上（**実在ID**、retract済除く）」と定義（旧「topic配下+activity配下のdecision合算」は不採用）。理由: M#315 計測で activity→decision の直接リレートが現状1%しかなく、判定で要求することで議論実体を 100% に近づけられるため。間接参照ではサブテーマ識別が構造的に取れない
- 判定軸はタグ (`intent:implement`) ベースで割り切る。embedding類似度ベースのadaptive判定はデータ駆動の閾値選定ができないため不採用
- bypass引数は作らない。正当な「いきなり implement」は decision として理由を記録して通過させる設計
- エラー形式は完全エラー（ValueError相当のerrordict返却）。warning返却ではない
- 対象範囲は `intent:implement` のみ。`intent:design` は対象外
- `update_activity` はノーチェック（新規作成時のみ）
- decisions テーブルへの存在確認 SELECT 1回追加。relations テーブルに外部キー制約がなく `_validate_targets` も構造のみ検証するため、ガード側で存在チェックを行わないと存在しないdecision_idでのバイパスが可能になる

## Edge cases

- 複数 intent tag → `intent:implement` が含まれれば対象
- update_activity → ノーチェック
- intent:design → 対象外
- `related=[] / None` → 同等扱い、decision件数0扱いでブロック
- aliased intent tag → canonical_id 辿って判定（既存ロジック流用）
- `related=[{"type":"decision","ids":[]}]` のように decision タイプはあるが ids が空 → ブロック
- 存在しない decision_id（例: `ids:[99999]`）→ ブロック
- retract 済 decision_id → ブロック（取り消し済を通過根拠にしない）
- **DB 未登録エイリアスタグ**: エイリアス intent タグが `tags` テーブルに `canonical_id` 付きで未登録の場合、SQL クエリは 0 行を返すためエイリアスとして認識されない（このパターンはエイリアスがDB登録された時点で次回以降ブロックされるが、登録前の最初の1回はガード非対象）。アンチパターンというより、運用ミスとしての見落とし注意点
- embedding server 未起動 → 無関係（DBクエリ不要）

## docstring 統一の対象

acceptance は `add_activity/add_topic/add_material/add_logs/add_decisions` 5 service の `related` docstring 統一を指示しているが、`add_logs` / `add_decisions` は items dict ベースAPIで `related` パラメータが存在しないため、実際に docstring を更新したのは `related` を受け取る 3 toolのみ:
- `src/main.py` の `add_topic` / `add_activity` / `add_material` MCP tool description
- `src/services/topic_service.add_topic` / `activity_service.add_activity` / `material_service.add_material` docstring

旧: `[{"type": "topic" | "activity", "ids": [int, ...]}]`
新: `[{"type": "topic" | "activity" | "material" | "decision" | "log", "ids": [int, ...]}, ...]` + 複数エンティティ同時紐付けの例示

## テスト

ユニット (`tests/unit/test_activity_workflow_guard.py`, 13ケース):
- intent:implement なし → 通過
- intent:implement + related なし → ブロック
- intent:implement + related に topic のみ → ブロック
- intent:implement + related に decision 1件（実在ID）→ 通過
- intent:implement + related に topic + decision → 通過
- 複数 intent tag (implement含む) → ブロック
- 複数 intent tag (implement無し) → 通過
- aliased intent tag → canonical 辿ってブロック
- aliased intent tag + decision relate → 通過
- `related=[]` → ブロック
- 存在しない decision_id（バイパス試行）→ ブロック
- retract 済 decision_id → ブロック
- `related=[{"type":"decision","ids":[]}]` → ブロック（ガード単体仕様）

E2E (`tests/e2e/test_implement_workflow_guard.py`, 2ケース): MCP tool 経由 (`src.main.add_activity`) でブロック/通過確認

リグレッション修正: `tests/` 配下で `intent:implement` を作っているテスト4箇所に dummy decision relate を追加
- `tests/unit/test_tag_notes.py`
- `tests/unit/test_active_context.py`
- `tests/integration/test_checkin_service.py` (2箇所)

共通フィクスチャ: `tests/conftest.py` に `temp_db` / `disable_embedding` を追加し、guard用 unit/e2e テストの重複を解消

## Test plan

- [x] uv run pytest 全件 pass (1696 passed)
- [x] CI 全緑（commit 6c1865c時点）
- [ ] レビュー対応後のCI 全緑（commit b993dab）
- [ ] PRレビューコメント全対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)