### PR TITLE
feat: ow_service cacheレイヤー基盤追加 (A#911 SP-1)

### DIFF
--- a/src/services/ow/__init__.py
+++ b/src/services/ow/__init__.py
@@ -1,0 +1,20 @@
+"""ow runtime state cache layer (C-2案 / A#911, D#2654-2657).
+
+真実源は relay events。本パッケージが管理する JSON ファイルキャッシュは
+relay から再生成可能な派生データに過ぎず、破損・schema mismatch時には
+削除して呼び出し側に full pull を促す。
+"""
+
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    OwState,
+    load_state,
+    save_state,
+)
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "OwState",
+    "load_state",
+    "save_state",
+]

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -1,0 +1,131 @@
+"""ow runtime state ファイルキャッシュ (C-2案, A#911 SP-1, D#2654-2657).
+
+真実源は relay events (`ow_history`)。本モジュールが書き出す JSON ファイルは
+relay から再生成可能な派生キャッシュであり、破損・schema mismatch・channel
+mismatch を検出した場合は即削除して None を返す (cache は再生成可能なので
+backup は取らない、裁定 L3)。
+
+配置:
+    $OW_STATE_DIR (未設定時は ~/.cc-memory/ow/cache/)
+
+ファイル名:
+    topic-<id>.json  (1 topic = 1 file、最小粒度開始 / D#2655)
+
+JSON 構造:
+    schema_version をJSON先頭フィールドに置き (裁定 L4)、cat 観測で即座に
+    schema 世代が分かる形にする。schema 変更時は CURRENT_SCHEMA_VERSION を
+    bump → mismatch fallback で自動再構築する forward-only 戦略。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+class OwState(TypedDict):
+    """topic 単位の ow ランタイム状態キャッシュ。"""
+
+    schema_version: int
+    channel: str
+    last_msg_id: int
+    workers: dict[str, dict]
+    identities: dict[str, dict]
+    presence: list[str]
+    updated_at: str
+
+
+def _get_state_dir() -> Path:
+    """cache ディレクトリのパスを返す。
+
+    OW_STATE_DIR 環境変数が設定されていればそのパスを使用する。
+    未設定の場合は ~/.cc-memory/ow/cache/ をデフォルトとして返す (裁定 L5)。
+    """
+    env = os.environ.get("OW_STATE_DIR", "")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".cc-memory" / "ow" / "cache"
+
+
+def _state_file_path(topic_id: int) -> Path:
+    return _get_state_dir() / f"topic-{topic_id}.json"
+
+
+def load_state(topic_id: int, channel: str | None = None) -> OwState | None:
+    """topic_id の state を JSON キャッシュから読む。
+
+    以下4条件のいずれかに該当した場合は None を返す:
+      1. キャッシュファイルが存在しない (削除はしない)
+      2. JSON corruption (JSONDecodeError) — ファイル削除して None
+      3. schema_version mismatch — ファイル削除して None
+      4. channel 引数が指定され、cache 内 channel と不一致 — ファイル削除して None
+
+    呼び出し側は None を受けたら relay full pull → save_state し直すこと。
+    """
+    path = _state_file_path(topic_id)
+    if not path.exists():
+        return None
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        logger.warning("ow state cache corruption at %s, deleting", path)
+        path.unlink(missing_ok=True)
+        return None
+
+    cached_version = data.get("schema_version")
+    if cached_version != CURRENT_SCHEMA_VERSION:
+        logger.warning(
+            "ow state cache schema_version mismatch at %s (got %r, expected %d), deleting",
+            path,
+            cached_version,
+            CURRENT_SCHEMA_VERSION,
+        )
+        path.unlink(missing_ok=True)
+        return None
+
+    if channel is not None and data.get("channel") != channel:
+        logger.warning(
+            "ow state cache channel mismatch at %s (got %r, expected %r), deleting",
+            path,
+            data.get("channel"),
+            channel,
+        )
+        path.unlink(missing_ok=True)
+        return None
+
+    return data  # type: ignore[return-value]
+
+
+def save_state(topic_id: int, state: OwState) -> None:
+    """state を JSON として書き出す。
+
+    schema_version は呼び出し側の値より CURRENT_SCHEMA_VERSION を優先し、
+    JSON 先頭フィールドに配置する (裁定 L4)。updated_at が未設定の場合は
+    現在時刻 (UTC ISO8601) を埋める。
+
+    書き込みは temp file + rename によるアトミック書き換え。
+    """
+    path = _state_file_path(topic_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    ordered: dict = {"schema_version": CURRENT_SCHEMA_VERSION}
+    for key in ("channel", "last_msg_id", "workers", "identities", "presence", "updated_at"):
+        if key in state:
+            ordered[key] = state[key]
+    if "updated_at" not in ordered:
+        ordered["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(ordered, f, ensure_ascii=False, indent=2)
+    tmp.replace(path)

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -24,7 +24,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,8 @@ class OwState(TypedDict):
     schema_version: int
     channel: str
     last_msg_id: int
-    workers: dict[str, dict]
-    identities: dict[str, dict]
+    workers: dict[str, Any]
+    identities: dict[str, Any]
     presence: list[str]
     updated_at: str
 
@@ -77,7 +77,11 @@ def load_state(topic_id: int, channel: str | None = None) -> OwState | None:
     try:
         with path.open("r", encoding="utf-8") as f:
             data = json.load(f)
-    except json.JSONDecodeError:
+    except FileNotFoundError:
+        # exists() 後 open() 前に別プロセスが削除した競合 (TOCTOU)。
+        # 不存在扱いで None を返し、ファイル削除は行わない。
+        return None
+    except (json.JSONDecodeError, OSError):
         logger.warning("ow state cache corruption at %s, deleting", path)
         path.unlink(missing_ok=True)
         return None
@@ -126,6 +130,11 @@ def save_state(topic_id: int, state: OwState) -> None:
         ordered["updated_at"] = datetime.now(timezone.utc).isoformat()
 
     tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
-        json.dump(ordered, f, ensure_ascii=False, indent=2)
-    tmp.replace(path)
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(ordered, f, ensure_ascii=False, indent=2)
+        tmp.replace(path)
+    finally:
+        # json.dump TypeError や tmp.replace OSError で例外が出た場合に
+        # .tmp ファイルが残らないようにする (成功時は replace 済みで既に存在しない)。
+        tmp.unlink(missing_ok=True)

--- a/tests/unit/test_ow_cache.py
+++ b/tests/unit/test_ow_cache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -187,6 +188,86 @@ class TestFallbackChannelMismatch:
 
         assert result is not None
         assert result["channel"] == "P_whatever"
+
+
+class TestLoadStateRaceConditions:
+    """TOCTOU 競合 (path.exists() 後の削除) と OSError 系の取り扱い."""
+
+    def test_load_returns_none_when_file_deleted_between_exists_and_open(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """exists() True 後 open() 前に別プロセスが削除した競合では None を返す.
+
+        FileNotFoundError は corruption 扱いではないので、ファイル削除 (missing_ok) も
+        warning ログも出さずに静かに None を返す。
+        """
+        # exists() が True を返すよう実ファイルを置く
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(
+            json.dumps({"schema_version": CURRENT_SCHEMA_VERSION}), encoding="utf-8"
+        )
+
+        original_open = Path.open
+
+        def open_then_raise(self: Path, *args: object, **kwargs: object) -> object:
+            # 最初の open 呼び出しで FileNotFoundError を投げる (TOCTOU シミュレート)
+            if self == path:
+                raise FileNotFoundError(2, "No such file or directory", str(self))
+            return original_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "open", open_then_raise):
+            result = load_state(topic_id=454)
+
+        assert result is None
+
+    def test_load_handles_oserror_during_open(self, _isolated_state_dir: Path) -> None:
+        """open() が PermissionError 等の OSError を投げた場合は corruption 扱いで削除して None を返す."""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(
+            json.dumps({"schema_version": CURRENT_SCHEMA_VERSION}), encoding="utf-8"
+        )
+
+        original_open = Path.open
+
+        def open_then_raise(self: Path, *args: object, **kwargs: object) -> object:
+            if self == path:
+                raise PermissionError(13, "Permission denied", str(self))
+            return original_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "open", open_then_raise):
+            result = load_state(topic_id=454)
+
+        assert result is None
+        # OSError 経路は corruption と同じ扱いでファイル削除されている
+        assert not path.exists()
+
+
+class TestSaveStateTmpFileCleanup:
+    """save_state で json.dump / tmp.replace が失敗しても .tmp が残らない."""
+
+    def test_save_removes_tmp_when_json_dump_raises_typeerror(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """JSON 非対応型 (set など) を含む state で json.dump が TypeError → .tmp 削除済み."""
+        # set は JSON 非対応 → json.dump で TypeError
+        bad_state: dict = {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "channel": "P_bad",
+            "last_msg_id": 0,
+            "workers": {"w-a": {"tags": {"x", "y"}}},  # set is not JSON serializable
+            "identities": {},
+            "presence": [],
+            "updated_at": "2026-06-18T11:00:00+00:00",
+        }
+
+        with pytest.raises(TypeError):
+            save_state(topic_id=454, state=bad_state)  # type: ignore[arg-type]
+
+        # .tmp ファイルが残っていない
+        tmp_path = _isolated_state_dir / "topic-454.json.tmp"
+        assert not tmp_path.exists()
+        # 本ファイルも作られていない (replace まで到達していない)
+        assert not (_isolated_state_dir / "topic-454.json").exists()
 
 
 class TestOwStateDirOverride:

--- a/tests/unit/test_ow_cache.py
+++ b/tests/unit/test_ow_cache.py
@@ -1,0 +1,224 @@
+"""ow runtime state ファイルキャッシュ (src/services/ow/cache.py) のユニットテスト.
+
+裁定 L3 (corruption 時は backup なし即削除) を含む 4 フォールバック条件と
+正常系 round-trip、OW_STATE_DIR override (tmp_path) を検証する。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services.ow import cache
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    OwState,
+    load_state,
+    save_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """各テストで OW_STATE_DIR を tmp_path に向ける (ホーム汚染防止)."""
+    monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _make_state(channel: str = "P_test", last_msg_id: int = 42) -> OwState:
+    return OwState(
+        schema_version=CURRENT_SCHEMA_VERSION,
+        channel=channel,
+        last_msg_id=last_msg_id,
+        workers={"w-a": {"state": "working", "last_heartbeat_at": "2026-06-18T11:00:00Z"}},
+        identities={"w-a": {"role": "worker", "alias": "w-a"}},
+        presence=["w-a", "orch"],
+        updated_at="2026-06-18T11:00:00+00:00",
+    )
+
+
+class TestRoundTrip:
+    def test_save_then_load_returns_equal_state(self, _isolated_state_dir: Path) -> None:
+        """save_state で書いた state を load_state で読み戻すと全フィールドが一致する."""
+        state = _make_state(channel="P_round", last_msg_id=123)
+        save_state(topic_id=454, state=state)
+
+        loaded = load_state(topic_id=454)
+
+        assert loaded is not None
+        assert loaded["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert loaded["channel"] == "P_round"
+        assert loaded["last_msg_id"] == 123
+        assert loaded["workers"] == state["workers"]
+        assert loaded["identities"] == state["identities"]
+        assert loaded["presence"] == state["presence"]
+        assert loaded["updated_at"] == state["updated_at"]
+
+    def test_save_writes_schema_version_as_first_key(self, _isolated_state_dir: Path) -> None:
+        """JSON 出力で schema_version が先頭フィールドに来る (裁定 L4)."""
+        save_state(topic_id=454, state=_make_state())
+
+        path = _isolated_state_dir / "topic-454.json"
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+        assert next(iter(data.keys())) == "schema_version"
+
+    def test_save_fills_updated_at_when_missing(self, _isolated_state_dir: Path) -> None:
+        """updated_at が未指定の state でも save_state が現在時刻を埋める."""
+        state_without_updated_at: dict = {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "channel": "P_test",
+            "last_msg_id": 0,
+            "workers": {},
+            "identities": {},
+            "presence": [],
+        }
+        save_state(topic_id=454, state=state_without_updated_at)  # type: ignore[arg-type]
+
+        loaded = load_state(topic_id=454)
+        assert loaded is not None
+        assert loaded["updated_at"]  # 何らかの非空 ISO8601 文字列
+
+
+class TestFallbackCacheMissing:
+    """フォールバック条件 1: キャッシュファイルが存在しない."""
+
+    def test_load_returns_none_when_file_absent(self, _isolated_state_dir: Path) -> None:
+        """ファイル不存在では None を返し、ファイル作成も削除もしない."""
+        result = load_state(topic_id=999)
+
+        assert result is None
+        assert not (_isolated_state_dir / "topic-999.json").exists()
+
+
+class TestFallbackCorruption:
+    """フォールバック条件 2: JSON corruption (JSONDecodeError) → ファイル削除して None."""
+
+    def test_load_deletes_corrupt_file_and_returns_none(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """壊れた JSON は load_state 内で削除され None が返る (裁定 L3: backup なし)."""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text("{ this is not valid json ::: ", encoding="utf-8")
+
+        result = load_state(topic_id=454)
+
+        assert result is None
+        assert not path.exists()
+
+    def test_load_deletes_empty_file_and_returns_none(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """空ファイルも JSONDecodeError 扱いで削除して None を返す."""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text("", encoding="utf-8")
+
+        result = load_state(topic_id=454)
+
+        assert result is None
+        assert not path.exists()
+
+
+class TestFallbackSchemaVersionMismatch:
+    """フォールバック条件 3: schema_version mismatch → ファイル削除して None."""
+
+    def test_load_deletes_file_when_schema_version_higher(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """CURRENT_SCHEMA_VERSION より大きいバージョンの cache は削除される."""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(
+            json.dumps({"schema_version": CURRENT_SCHEMA_VERSION + 99, "channel": "P_x"}),
+            encoding="utf-8",
+        )
+
+        result = load_state(topic_id=454)
+
+        assert result is None
+        assert not path.exists()
+
+    def test_load_deletes_file_when_schema_version_missing(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """schema_version フィールド自体が無い cache も mismatch 扱いで削除される."""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(json.dumps({"channel": "P_x", "last_msg_id": 0}), encoding="utf-8")
+
+        result = load_state(topic_id=454)
+
+        assert result is None
+        assert not path.exists()
+
+
+class TestFallbackChannelMismatch:
+    """フォールバック条件 4: channel mismatch (引数指定時のみ) → ファイル削除して None."""
+
+    def test_load_deletes_file_on_channel_mismatch(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """channel 引数と cache 内 channel が異なる場合は削除して None を返す."""
+        save_state(topic_id=454, state=_make_state(channel="P_old"))
+        path = _isolated_state_dir / "topic-454.json"
+        assert path.exists()
+
+        result = load_state(topic_id=454, channel="P_new")
+
+        assert result is None
+        assert not path.exists()
+
+    def test_load_accepts_when_channel_matches(self, _isolated_state_dir: Path) -> None:
+        """channel 一致時は state を返す."""
+        save_state(topic_id=454, state=_make_state(channel="P_same"))
+
+        result = load_state(topic_id=454, channel="P_same")
+
+        assert result is not None
+        assert result["channel"] == "P_same"
+
+    def test_load_skips_channel_check_when_arg_none(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """channel 引数 None なら channel mismatch チェックはスキップされる."""
+        save_state(topic_id=454, state=_make_state(channel="P_whatever"))
+
+        result = load_state(topic_id=454, channel=None)
+
+        assert result is not None
+        assert result["channel"] == "P_whatever"
+
+
+class TestOwStateDirOverride:
+    """OW_STATE_DIR 環境変数で書き込み先を override できる (裁定 L5)."""
+
+    def test_env_var_directs_file_to_override_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OW_STATE_DIR が指す tmp_path 配下に topic-<id>.json が作られる."""
+        override_dir = tmp_path / "custom-cache"
+        monkeypatch.setenv("OW_STATE_DIR", str(override_dir))
+
+        save_state(topic_id=777, state=_make_state())
+
+        assert (override_dir / "topic-777.json").exists()
+
+    def test_get_state_dir_falls_back_to_home_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OW_STATE_DIR 未設定時は ~/.cc-memory/ow/cache/ が返る."""
+        monkeypatch.delenv("OW_STATE_DIR", raising=False)
+
+        result = cache._get_state_dir()
+
+        assert result == Path.home() / ".cc-memory" / "ow" / "cache"
+
+    def test_get_state_dir_expands_user_in_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OW_STATE_DIR に ~ を含めても expanduser される."""
+        monkeypatch.setenv("OW_STATE_DIR", "~/some/cache")
+
+        result = cache._get_state_dir()
+
+        assert result == Path.home() / "some" / "cache"


### PR DESCRIPTION
## Summary

A#911 (C-2 ファイルキャッシュ実装) の最小粒度 PR (SP-1)。`src/services/ow/` パッケージを新規作成し、ow ランタイム状態の topic 単位 JSON キャッシュ層スケルトン (`OwState` TypedDict / `load_state` / `save_state` / `_get_state_dir` / `CURRENT_SCHEMA_VERSION=1`) と単体テスト 14 ケースを追加する。

## スコープ (SP-1 のみ / D#2654-2657)

- ✅ `src/services/ow/__init__.py` 新規 — `load_state` / `save_state` / `OwState` / `CURRENT_SCHEMA_VERSION` を公開
- ✅ `src/services/ow/cache.py` 新規 — `OwState` TypedDict (`schema_version`, `channel`, `last_msg_id`, `workers`, `identities`, `presence`, `updated_at`) と 2 関数 + `_get_state_dir` (env `OW_STATE_DIR` override, default `~/.cc-memory/ow/cache/`)
- ✅ `tests/unit/test_ow_cache.py` 新規 — 4 フォールバック条件 (キャッシュ無 → `None` / corruption (`JSONDecodeError`) → ファイル削除+`None` / `schema_version` mismatch → 削除+`None` / `channel` mismatch → 削除+`None`) + roundtrip + `OW_STATE_DIR` override (`tmp_path`)
- 既存 `src/services/ow_service.py` には触らない（SP-2 以降の別 activity で接続）

## 設計裁定 (ユーザー裁定 2026-06-18 / D#2654-2657 派生)

- **L1**: `OwState` は **TypedDict** (既存慣習に合う)
- **L3**: corruption 時は **即削除** (backup なし、再生成可)
- **L4**: `schema_version` は **JSON 先頭フィールド**
- **L5**: `OW_STATE_DIR` デフォルトは `~/.cc-memory/ow/cache/`、ファイル名 `topic-<id>.json`
- **L6**: PR 粒度は **SP-1 単独 PR** (最小粒度原則)

## 次フェーズで対応 (本 PR 対象外)

- **SP-2**: `reconstruct_state_from_relay` を cache 経由 (差分 pull) 化
- **SP-3**: `_latest_events_by_type` を cache 経由化
- **L2**: 未使用 `_query_latest_event` / `_query_events_since` 削除 (SP-2/SP-3 と同時に実施)

## Test plan

- [x] `uv run pytest tests/unit/test_ow_cache.py -v` ローカル緑 (14/14)
- [ ] CI 緑 (lint / format / pytest / hooks)
- [ ] mergeable 到達

## 関連

- A#911 (本 activity / intent:implement)
- A#897 (親 / 設計 completed)
- D#2654 (B案 → C-2 方針切替) / D#2655 (採用条件 6 点) / D#2656 (段階導入なし直行) / D#2657 (JSON 採用)
- M#337 (統合結論) / M#341 (plan.md material)

🤖 Generated with [Claude Code](https://claude.com/claude-code)