### PR TITLE
feat: identity term_ref 段階① — reducer 透過保持＋ヘルパー (T69続行/T77)

### DIFF
--- a/scripts/ow/get_term_ref.sh
+++ b/scripts/ow/get_term_ref.sh
@@ -30,7 +30,10 @@ case "$ADAPTER" in
       || printf '\n'
     ;;
   manual)
-    printf 'manual:%s:%s\n' "$(hostname -s)" "$$"
+    # manual モードでは安定 ID を提供できないため空を返す。
+    # ($$ はこのスクリプト実行ごとに別 bash プロセスとなるため、worker terminal
+    #  peer の逆引き ID として安定しない。呼び出し側で term_ref フィールドを省略させる。)
+    printf '\n'
     ;;
   *)
     printf '\n'

--- a/scripts/ow/get_term_ref.sh
+++ b/scripts/ow/get_term_ref.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# get_term_ref.sh — worker 自身の term_ref を取得して stdout に echo する。
+#
+# 用途: worker が event:identity を append する際、自身の安定 ID (term_ref)
+#       を identity bundle の term_ref フィールドに乗せるために使う。
+#       term_ref の値は ow_spawn_worker が adapter から取得する spawn 戻り値の
+#       term_ref と同一形式で揃える (tmux:pane_id、iterm2:session UUID)。
+#
+# 使い方:
+#   TERM_REF=$(bash scripts/ow/get_term_ref.sh)
+#
+# 環境変数:
+#   OW_TERMINAL  tmux | iterm2 | manual (default: tmux)
+#
+# 出力:
+#   stdout に term_ref を1行 echo する。取得不能時は空文字を返す (exit 0)。
+
+set -euo pipefail
+
+ADAPTER="${OW_TERMINAL:-tmux}"
+
+case "$ADAPTER" in
+  tmux)
+    # TMUX_PANE は tmux 配下のシェルで自動 export される pane_id (例: %5)
+    printf '%s\n' "${TMUX_PANE:-}"
+    ;;
+  iterm2)
+    # current session の id (UUID) を取得。iTerm2 が起動していない / セッション無しなら空
+    /usr/bin/osascript -e 'tell application "iTerm2" to return id of current session of current window' 2>/dev/null \
+      || printf '\n'
+    ;;
+  manual)
+    printf 'manual:%s:%s\n' "$(hostname -s)" "$$"
+    ;;
+  *)
+    printf '\n'
+    ;;
+esac

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -156,12 +156,13 @@ worker 起動時と terminated 直前に append される身元情報。orchは 
    "model":"...",
    "cwd":"...",
    "session_id":"...",
+   "term_ref":"<tmux pane_id / iterm2 session UUID 等>",  // worker が scripts/ow/get_term_ref.sh で取得
    "terminated_at":"<UTC ISO8601>",   // terminated 直前の再 append でのみ set
    "cause":"closed|cancelled|dead"     // terminated 直前の再 append でのみ set
  }}
 ```
 
-identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。設計書v3 §6.3.1 参照。
+identity から **削除された属性**: `task_n`（activity_id から逆引き可能）、`permission_mode`（auto 固定）、`user`（relay 非参加者）。`term_ref` は `ow_spawn_worker` の spawn 戻り値と同形式で、orch が当該 worker のターミナル peer を逆引きする際の安定 ID として機能する（FT-X self-close 機構の前提情報、D#2608/D#2610）。設計書v3 §6.3.1 参照。
 
 ### heartbeat（event:heartbeat）
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -83,6 +83,14 @@ ow_sendで1回だけ送信:
 
 ### 4. event:identity を送信
 
+送信前に自分の `term_ref`（ターミナル安定ID、tmux pane_id / iterm2 session UUID 等）を取得する:
+
+```bash
+TERM_REF=$(bash scripts/ow/get_term_ref.sh)
+```
+
+取得できなかった場合（`OW_TERMINAL=manual` 環境などで空が返るケース）は `term_ref` フィールドを省略してよい。
+
 ```json
 {
   "v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>",
@@ -97,12 +105,13 @@ ow_sendで1回だけ送信:
     "activity_id":<activity_id>,
     "model":"<model>",
     "cwd":"<cwd>",
-    "session_id":"<session_id>"
+    "session_id":"<session_id>",
+    "term_ref":"<term_ref>"
   }
 }
 ```
 
-identity から **除外する属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。設計詳細は設計書 v3 §6.3.1 参照。
+identity から **除外する属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。`term_ref` は `ow_spawn_worker` が adapter から取得する spawn 戻り値の `term_ref` と同形式で揃える。設計詳細は設計書 v3 §6.3.1 参照。
 
 ### 5. event:state(loading) を送信
 
@@ -286,7 +295,7 @@ heartbeatループは draining フェーズで 30秒間隔を維持する（work
 
 ### Step 3: event:identity 再 append（terminated情報付き）
 
-terminated_atと cause を付与してidentityを再送する:
+terminated_atと cause を付与してidentityを再送する。起動時に取得した `term_ref` をそのまま乗せる（同じ値を維持）:
 
 ```json
 {
@@ -303,6 +312,7 @@ terminated_atと cause を付与してidentityを再送する:
     "model":"<model>",
     "cwd":"<cwd>",
     "session_id":"<session_id>",
+    "term_ref":"<term_ref（起動時と同じ値）>",
     "terminated_at":"<現在時刻 UTC ISO8601>",
     "cause":"closed"
   }

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -89,7 +89,7 @@ ow_sendで1回だけ送信:
 TERM_REF=$(bash scripts/ow/get_term_ref.sh)
 ```
 
-取得できなかった場合（`OW_TERMINAL=manual` 環境などで空が返るケース）は `term_ref` フィールドを省略してよい。
+取得できなかった場合（`OW_TERMINAL=manual` モードや tmux/iTerm2 セッション外での実行など、安定 ID が取れず空が返るケース）は `term_ref` フィールドを省略してよい。
 
 ```json
 {

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -2095,6 +2095,55 @@ def ow_recover(
 
 
 # ----------------------------
+# identity bundle ヘルパー: term_ref（端末・セッション安定 ID）
+# ----------------------------
+#
+# term_ref は worker セッションが住む物理単位（tmux pane / iTerm2 session 等）の安定 ID。
+# event:identity.data.term_ref として worker 自身が宣言する（scripts/ow/get_term_ref.sh
+# が取得元）。reducer（ow_get_identity / ow_list_identities）は dict(data) で透過的に
+# 保持するため、reducer 側に追加ロジックは不要。本ヘルパーは「観測値の形式分類」と
+# 「妥当性判定」を提供する純関数で、診断・ow_recover 用途に利用する。
+#
+# 認める形式:
+#   - tmux:    "%N"                  例: "%5", "%123"     (tmux pane_id 規約)
+#   - iterm2:  RFC4122 UUID 表記      例: "12345678-1234-...-123456789ABC"
+#   - manual:  "manual:host:pid"      例: "manual:mac-mini:12345"
+#
+# 段階① のスコープ:
+#   - reducer が term_ref を破棄しないことを担保するテストを追加（test_ow_reducer）
+#   - is_valid_term_ref() / classify_term_ref() を診断ヘルパーとして提供
+#
+# 段階②③（relay-side ow_recover での term_ref キー再リンク等）は D#2608 によりスコープ外。
+
+_TERM_REF_PATTERNS: dict[str, "re.Pattern[str]"] = {
+    "tmux": re.compile(r"^%\d+$"),
+    "iterm2": re.compile(
+        r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+    ),
+    "manual": re.compile(r"^manual:[^:\s]+:\d+$"),
+}
+
+
+def classify_term_ref(value: object) -> str | None:
+    """term_ref 値の形式を分類して種別名（"tmux"/"iterm2"/"manual"）を返す。
+
+    値が文字列でない、空文字、未知形式のいずれかなら None を返す。
+    形式チェックは _TERM_REF_PATTERNS の辞書順（tmux→iterm2→manual）で先勝ち。
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    for name, pattern in _TERM_REF_PATTERNS.items():
+        if pattern.match(value):
+            return name
+    return None
+
+
+def is_valid_term_ref(value: object) -> bool:
+    """term_ref 値が認められた形式のいずれかに合致するかを判定する。"""
+    return classify_term_ref(value) is not None
+
+
+# ----------------------------
 # reducer: v3 event sourcing
 # ----------------------------
 
@@ -2279,6 +2328,10 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
                escalated/draining）かつ最後の event:heartbeat 受信時刻から閾値超過 →
                メモリ上で inferred_cause を付与（DB 不変）。
 
+    term_ref 透過保持: event:identity.data に term_ref が含まれていれば dict(data) で
+                      そのまま戻り値に乗る（reducer 側の加工なし）。形式判定が必要なら
+                      is_valid_term_ref() / classify_term_ref() を別途呼び出す。
+
     Returns:
         dict | None: identity bundle ＋ {msg_id, identity_at, inferred_cause?}
     """
@@ -2313,6 +2366,9 @@ def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
     - 加えて、ow_get_identity と同様の crash 推論（state が non-terminal + heartbeat 途絶）
       で inferred_cause が付与される entry も除外する
     handle フィールドが欠落した event は集約キーが None になるためスキップする。
+
+    term_ref 透過保持: ow_get_identity と同様、entry = dict(data) により term_ref も
+                      そのまま保持される。
     """
     history = ow_history(channel, since=0, limit=10000)
     if "error" in history:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -2115,7 +2115,7 @@ def ow_recover(
 #
 # 段階②③（relay-side ow_recover での term_ref キー再リンク等）は D#2608 によりスコープ外。
 
-_TERM_REF_PATTERNS: dict[str, "re.Pattern[str]"] = {
+_TERM_REF_PATTERNS: dict[str, re.Pattern[str]] = {
     "tmux": re.compile(r"^%\d+$"),
     "iterm2": re.compile(
         r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
@@ -2128,7 +2128,7 @@ def classify_term_ref(value: object) -> str | None:
     """term_ref 値の形式を分類して種別名（"tmux"/"iterm2"/"manual"）を返す。
 
     値が文字列でない、空文字、未知形式のいずれかなら None を返す。
-    形式チェックは _TERM_REF_PATTERNS の辞書順（tmux→iterm2→manual）で先勝ち。
+    形式チェックは _TERM_REF_PATTERNS の定義順（tmux→iterm2→manual）で先勝ち。
     """
     if not isinstance(value, str) or not value:
         return None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -288,6 +288,34 @@ class TestOwGetIdentity:
         assert result is not None
         assert result.get("inferred_cause") == "crashed (inferred)"
 
+    @pytest.mark.parametrize(
+        "term_ref_value",
+        [
+            "%5",  # tmux pane_id
+            "12345678-1234-1234-1234-123456789ABC",  # iterm2 UUID
+            "manual:mac-mini:12345",  # manual fallback
+        ],
+    )
+    def test_term_ref_round_trip(self, monkeypatch, term_ref_value):
+        """段階①: event:identity の term_ref が ow_get_identity 戻り値にそのまま乗る。
+
+        reducer は dict(data) で透過保持する。tmux %N / iterm2 UUID / manual いずれの
+        形式でも値は加工せず保存される。
+        """
+        msgs = [
+            _make_msg(
+                1, "w-h",
+                _event_body("identity", {"alias": "worker-1", "term_ref": term_ref_value}),
+                "2026-06-14T10:00:00+00:00",
+            ),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result.get("term_ref") == term_ref_value
+        # validator が呼び出し側で利用できることを担保（reducer 自体は加工しない）。
+        assert ow_service.is_valid_term_ref(term_ref_value) is True
+
 
 # ----------------------------
 # TestOwListIdentities
@@ -329,6 +357,81 @@ class TestOwListIdentities:
         result = ow_service.ow_list_identities("ch", alive_only=True)
         assert len(result) == 1
         assert result[0]["alias"] == "worker-a"
+
+    def test_term_ref_preserved_per_handle(self, monkeypatch):
+        """段階①: 複数 handle の identity に term_ref が個別に乗る。
+
+        ow_list_identities は handle 単位で最新 identity を集約するが、各 entry の
+        term_ref は元 event のものをそのまま保持し、混線しない。
+        """
+        msgs = [
+            _make_msg(
+                1, "w-a",
+                _event_body("identity", {"alias": "worker-a", "term_ref": "%5"}, handle="w-a"),
+            ),
+            _make_msg(
+                2, "w-b",
+                _event_body(
+                    "identity",
+                    {
+                        "alias": "worker-b",
+                        "term_ref": "12345678-1234-1234-1234-123456789ABC",
+                    },
+                    handle="w-b",
+                ),
+            ),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch")
+        by_handle = {e["alias"]: e for e in result}
+        assert by_handle["worker-a"]["term_ref"] == "%5"
+        assert by_handle["worker-b"]["term_ref"] == "12345678-1234-1234-1234-123456789ABC"
+
+
+# ----------------------------
+# TestTermRefValidation
+# ----------------------------
+
+
+class TestTermRefValidation:
+    """段階① identity bundle ヘルパー: is_valid_term_ref / classify_term_ref のテスト。"""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("%0", "tmux"),
+            ("%5", "tmux"),
+            ("%123", "tmux"),
+            ("12345678-1234-1234-1234-123456789ABC", "iterm2"),
+            ("abcdef01-2345-6789-abcd-ef0123456789", "iterm2"),
+            ("manual:mac-mini:12345", "manual"),
+            ("manual:host-with-dash:1", "manual"),
+        ],
+    )
+    def test_classify_valid_formats(self, value, expected):
+        """tmux %N / iterm2 UUID / manual:host:pid を正しく分類する。"""
+        assert ow_service.classify_term_ref(value) == expected
+        assert ow_service.is_valid_term_ref(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "abc",  # 未知形式
+            "%",  # tmux pattern に %N の数字部が無い
+            "%abc",  # tmux pattern は数字のみ
+            "12345678-1234-1234-1234",  # UUID truncated
+            "12345678-1234-1234-1234-123456789ABCDEF",  # UUID 末尾過多
+            "manual:host:abc",  # pid が数字でない
+            "manual::123",  # host 部が空
+            123,  # 非文字列
+        ],
+    )
+    def test_invalid_formats_return_none_and_false(self, value):
+        """未知形式・None・空文字・非文字列は classify=None / is_valid=False。"""
+        assert ow_service.classify_term_ref(value) is None
+        assert ow_service.is_valid_term_ref(value) is False
 
 
 # ----------------------------

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -316,6 +316,29 @@ class TestOwGetIdentity:
         # validator が呼び出し側で利用できることを担保（reducer 自体は加工しない）。
         assert ow_service.is_valid_term_ref(term_ref_value) is True
 
+    def test_identity_without_term_ref_works(self, monkeypatch):
+        """後方互換: term_ref フィールドを持たない identity event でも reducer は正常動作する。
+
+        worker が manual モードや term_ref 取得失敗時に term_ref を省略するケースを想定。
+        戻り値には term_ref キーが存在しない（または None）状態となり、他のフィールドは
+        通常通り取り出せる。
+        """
+        msgs = [
+            _make_msg(
+                1, "w-h",
+                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
+                "2026-06-14T10:00:00+00:00",
+            ),
+        ]
+        self._setup_history(monkeypatch, msgs)
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is not None
+        assert result["alias"] == "worker-1"
+        # term_ref キーは無いか、あっても None
+        assert result.get("term_ref") is None
+        # validator は欠落値を invalid と判定する
+        assert ow_service.is_valid_term_ref(result.get("term_ref")) is False
+
 
 # ----------------------------
 # TestOwListIdentities
@@ -386,6 +409,23 @@ class TestOwListIdentities:
         by_handle = {e["alias"]: e for e in result}
         assert by_handle["worker-a"]["term_ref"] == "%5"
         assert by_handle["worker-b"]["term_ref"] == "12345678-1234-1234-1234-123456789ABC"
+
+    def test_identities_without_term_ref_work(self, monkeypatch):
+        """後方互換: term_ref を持たない identity event でも ow_list_identities は正常動作する。
+
+        term_ref 省略はあくまで「フィールドが無い」状態であり、reducer は他のフィールドを
+        通常通り集約する。term_ref キーは戻り値に存在しない（None）。
+        """
+        msgs = [
+            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
+            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
+        ]
+        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        result = ow_service.ow_list_identities("ch")
+        by_handle = {e["alias"]: e for e in result}
+        assert set(by_handle.keys()) == {"worker-a", "worker-b"}
+        assert by_handle["worker-a"].get("term_ref") is None
+        assert by_handle["worker-b"].get("term_ref") is None
 
 
 # ----------------------------


### PR DESCRIPTION
## Summary

- ow worker 完結方式の前提となる **identity bundle への term_ref 拡張 段階①** を実装。
  - reducer (ow_get_identity / ow_list_identities) は既に `dict(data)` で全フィールド透過保持しているため、コード変更なしで term_ref が戻り値に乗ることを **docstring で明文化** し、テストで担保。
  - 診断・将来段階向けのヘルパー `classify_term_ref()` / `is_valid_term_ref()` を新設。tmux `%N` / iterm2 UUID / manual `host:pid` の 3 形式を識別。
- e51cb20 (w-ac サルベージ時点 WIP / 70% 完成) の残作業を完成させ、T69 続行タスク T77 として確定。
- 段階② FT (relay-side ow_recover の term_ref キー再リンク) 等は **D#2608** によりスコープ外。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/services/ow_service.py` | `_TERM_REF_PATTERNS` 定数 / `classify_term_ref()` / `is_valid_term_ref()` 追加。ow_get_identity と ow_list_identities の docstring に「term_ref 透過保持」を明記 |
| `tests/unit/test_ow_reducer.py` | term_ref round-trip テスト (3 形式 parametrize)、複数 handle 跨ぎ保持テスト、`TestTermRefValidation` クラス (正常 7 + 異常 10 ケース) を追加 |

なお、e51cb20 に含まれる `scripts/ow/get_term_ref.sh` (38 行) と `skills/orch/SKILL.md` / `skills/worker/SKILL.md` のドキュメント追記は引き続き取り込み済み。

## 設計根拠

- **A#888** 本実装 activity (T69続行)
- **D#2608**: identity term_ref は段階① のみ実装、段階②③ は不要
- **D#2609**: ow worker 完結方式 (auto-close + auto-assign) — relay/orch 依存切離し (supersedes D#2605)
- **D#2610**: identity term_ref 拡張は段階① で独立価値あり (診断 / ow_recover 安定性向上 / dashboard 表現力)
- **M#342**: 本 PR の設計ノート (運用ノート程度)

T69 議論 (M#320 orch役割境界 v2 由来) → 本 PR で段階① の reducer/projector 取り込み + テスト完成。

## Test plan

- [x] `uv run pytest tests/unit/test_ow_reducer.py` — 54/54 緑
- [x] `uv run pytest tests/unit/` (全 1270 件) — 全件緑、所要約 4 分
- [ ] CI 緑 + mergeable 到達 (本 PR で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)