### PR TITLE
feat: update_materialにprepend/appendモード追加 (A#914)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import logging
 import random
 from fastmcp import FastMCP, Context
 from fastmcp.server.dependencies import get_context
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 from src.services import (
     topic_service,
     discussion_log_service,
@@ -670,16 +670,21 @@ def update_material(
     title: str | None = None,
     tags: list[str] | None = None,
     source: str | None = None,
+    mode: Literal["overwrite", "prepend", "append"] = "overwrite",
 ) -> dict:
     """
     既存の資材を更新する。content、title、tags、sourceを個別または同時に更新できる。
 
-    contentは全体置換（部分更新やappendではない）。
+    contentはmodeで動作を選べる。"overwrite"（既定）は上書き、"prepend"は新content+区切り+既存content、
+    "append"は既存content+区切り+新content。区切りは改行2つ("\n\n")。既存contentが空の場合はoverwrite相当。
+    contentを指定しない場合（None）はmodeは無視される。
     tagsは全置換（指定時は既存タグを全削除して新しいタグに置き換える）。
-    少なくとも1つのパラメータを指定する必要がある。
+    少なくとも1つのパラメータ（content/title/tags/source）を指定する必要がある。
 
     典型的な使い方:
-    - 内容を改訂: update_material(material_id=5, content="# 改訂版\n...")
+    - 内容を改訂（上書き）: update_material(material_id=5, content="# 改訂版\n...")
+    - 末尾に追記: update_material(material_id=5, content="## 追記\n...", mode="append")
+    - 先頭に追記: update_material(material_id=5, content="## TL;DR\n...", mode="prepend")
     - タイトル変更: update_material(material_id=5, title="新しいタイトル")
     - タグ変更: update_material(material_id=5, tags=["domain:cc-memory", "design"])
     - ソース更新: update_material(material_id=5, source="公式ドキュメント")
@@ -687,15 +692,16 @@ def update_material(
 
     Args:
         material_id: 資材のID
-        content: 新しい本文（全体置換。optional）。先頭1-2文は内容の説明・要約を書くこと（check-inやsearchのsnippetに使われるため）
+        content: 新しい本文（optional）。先頭1-2文は内容の説明・要約を書くこと（check-inやsearchのsnippetに使われるため）
         title: 新しいタイトル（optional）
         tags: 新しいタグ配列（指定時は全置換。1個以上必須。optional）
         source: 新しいソース（optional）
+        mode: content指定時の結合動作。"overwrite"=上書き(既定、後方互換)、"prepend"=新+"\n\n"+既存、"append"=既存+"\n\n"+新
 
     Returns:
         更新された資材情報
     """
-    return material_service.update_material(material_id, content=content, title=title, tags=tags, source=source)
+    return material_service.update_material(material_id, content=content, title=title, tags=tags, source=source, mode=mode)
 
 
 @mcp.tool()

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -200,7 +200,8 @@ def update_material(
             }
         }
 
-    if mode not in ("overwrite", "prepend", "append"):
+    # modeのバリデーション（content指定時のみ。content=Noneならmodeは無視されるため）
+    if content is not None and mode not in ("overwrite", "prepend", "append"):
         return {
             "error": {
                 "code": "VALIDATION_ERROR",

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -1,6 +1,7 @@
 """資材管理サービス"""
 import logging
 import sqlite3
+from typing import Literal
 
 from src.db import get_connection, row_to_dict
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
@@ -164,22 +165,29 @@ def get_materials_by_relation_with_conn(conn, activity_id: int) -> list[dict]:
     ]
 
 
+CONTENT_JOIN_SEPARATOR = "\n\n"
+
+
 def update_material(
     material_id: int,
     content: str | None = None,
     title: str | None = None,
     tags: list[str] | None = None,
     source: str | None = None,
+    mode: Literal["overwrite", "prepend", "append"] = "overwrite",
 ) -> dict:
     """
     Update an existing material's content, title, and/or tags.
 
     Args:
         material_id: ID of the material to update
-        content: New content (full replace, optional)
+        content: New content (optional)
         title: New title (optional)
         tags: New tags (full replace, optional. At least 1 required when specified)
         source: New source (optional)
+        mode: content指定時の結合動作。"overwrite"=既定で上書き、"prepend"=新+区切り+既存、
+              "append"=既存+区切り+新。区切りは "\n\n"。既存contentが空文字列の場合はoverwrite相当。
+              contentが未指定（None）の場合はmodeは無視される。
 
     Returns:
         Updated material info
@@ -189,6 +197,14 @@ def update_material(
             "error": {
                 "code": "VALIDATION_ERROR",
                 "message": "At least one of content, title, tags, or source must be provided",
+            }
+        }
+
+    if mode not in ("overwrite", "prepend", "append"):
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"mode must be one of 'overwrite', 'prepend', 'append', got {mode!r}",
             }
         }
 
@@ -237,6 +253,17 @@ def update_material(
                 }
             }
 
+        # content の値を mode に応じて結合する
+        effective_content = content
+        if content is not None and mode != "overwrite":
+            existing_content = row["content"] or ""
+            if existing_content == "":
+                effective_content = content
+            elif mode == "prepend":
+                effective_content = content + CONTENT_JOIN_SEPARATOR + existing_content
+            else:  # append
+                effective_content = existing_content + CONTENT_JOIN_SEPARATOR + content
+
         # Build dynamic SQL for title/content
         set_parts = []
         values = []
@@ -247,7 +274,7 @@ def update_material(
 
         if content is not None:
             set_parts.append("content = ?")
-            values.append(content)
+            values.append(effective_content)
 
         if source is not None:
             set_parts.append("source = ?")

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -2,7 +2,7 @@
 import os
 import tempfile
 import pytest
-from src.db import init_database
+from src.db import get_connection, init_database
 from src.services.activity_service import add_activity
 from src.services.material_service import add_material, get_material, update_material
 from src.services.search_service import get_by_id, get_by_ids
@@ -597,7 +597,6 @@ class TestUpdateMaterialMode:
         material_id = created["material_id"]
 
         # 既存contentを空に書き換える（バリデーションを通常経路では通れないためDB直接操作）
-        from src.db import get_connection
         conn = get_connection()
         try:
             conn.execute("UPDATE materials SET content = ? WHERE id = ?", ("", material_id))
@@ -616,7 +615,6 @@ class TestUpdateMaterialMode:
         created = self._create_material()
         material_id = created["material_id"]
 
-        from src.db import get_connection
         conn = get_connection()
         try:
             conn.execute("UPDATE materials SET content = ? WHERE id = ?", ("", material_id))
@@ -641,6 +639,28 @@ class TestUpdateMaterialMode:
         fetched = get_material(material_id)
         assert fetched["title"] == "New Title"
         assert fetched["content"] == "Original content"  # 既存contentは変わらない
+
+    def test_invalid_mode_ignored_when_content_not_specified(self, temp_db):
+        """contentを指定しない場合、modeが不正な値でもバリデーションは実行されず更新は成功する"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, title="New Title", mode="invalid")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["title"] == "New Title"
+        assert fetched["content"] == "Original content"
+
+    def test_invalid_mode_rejected_when_content_specified(self, temp_db):
+        """content指定時にmodeが不正な値の場合、VALIDATION_ERROR を返す"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="new", mode="invalid")
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "mode" in result["error"]["message"]
 
     def test_mode_prepend_multiline_preserves_structure(self, temp_db):
         """mode='prepend'で改行を含むcontentを結合しても、区切り '\\n\\n' が間に正しく入る"""

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -505,3 +505,150 @@ class TestUpdateMaterial:
 
         fetched = get_material(material_id)
         assert fetched["source"] == "テスト用データ"
+
+
+class TestUpdateMaterialMode:
+    """update_material の mode 引数 (overwrite/prepend/append) テスト"""
+
+    def _create_material(self, content: str = "Original content"):
+        return add_material(
+            title="Mode Test Material",
+            content=content,
+            tags=["domain:test"],
+            source="テスト用データ",
+        )
+
+    def test_mode_default_overwrites(self, temp_db):
+        """mode未指定の場合、contentは上書きされる（後方互換）"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="brand new")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "brand new"
+
+    def test_mode_overwrite_explicit(self, temp_db):
+        """mode='overwrite'を明示指定した場合、contentは上書きされる"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="explicit overwrite", mode="overwrite")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "explicit overwrite"
+
+    def test_mode_prepend_concatenates_new_then_existing(self, temp_db):
+        """mode='prepend'の場合、'新content\\n\\n既存content'の順で結合される"""
+        created = self._create_material(content="existing body")
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="new head", mode="prepend")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "new head\n\nexisting body"
+
+    def test_mode_append_concatenates_existing_then_new(self, temp_db):
+        """mode='append'の場合、'既存content\\n\\n新content'の順で結合される"""
+        created = self._create_material(content="existing body")
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="appended tail", mode="append")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "existing body\n\nappended tail"
+
+    def test_mode_invalid_returns_validation_error(self, temp_db):
+        """mode に invalid な値を指定した場合、VALIDATION_ERROR を返す"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="x", mode="merge")  # type: ignore[arg-type]
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "mode" in result["error"]["message"]
+
+    def test_mode_prepend_with_empty_new_content_returns_validation_error(self, temp_db):
+        """mode='prepend' で新contentが空文字列の場合、VALIDATION_ERROR を返す（content空チェック）"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="", mode="prepend")
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "content" in result["error"]["message"]
+
+    def test_mode_append_with_whitespace_new_content_returns_validation_error(self, temp_db):
+        """mode='append' で新contentが空白のみの場合、VALIDATION_ERROR を返す"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="   ", mode="append")
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_mode_prepend_with_existing_empty_falls_back_to_overwrite(self, temp_db):
+        """既存contentが空文字列の場合、prependでも区切りを挟まずoverwrite相当の動作になる"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        # 既存contentを空に書き換える（バリデーションを通常経路では通れないためDB直接操作）
+        from src.db import get_connection
+        conn = get_connection()
+        try:
+            conn.execute("UPDATE materials SET content = ? WHERE id = ?", ("", material_id))
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = update_material(material_id, content="only this", mode="prepend")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "only this"
+
+    def test_mode_append_with_existing_empty_falls_back_to_overwrite(self, temp_db):
+        """既存contentが空文字列の場合、appendでも区切りを挟まずoverwrite相当の動作になる"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        from src.db import get_connection
+        conn = get_connection()
+        try:
+            conn.execute("UPDATE materials SET content = ? WHERE id = ?", ("", material_id))
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = update_material(material_id, content="only this", mode="append")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "only this"
+
+    def test_mode_ignored_when_content_not_specified(self, temp_db):
+        """contentを指定せずmodeのみ指定した場合、modeは無視されtitle更新は成功する"""
+        created = self._create_material()
+        material_id = created["material_id"]
+
+        result = update_material(material_id, title="New Title", mode="prepend")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["title"] == "New Title"
+        assert fetched["content"] == "Original content"  # 既存contentは変わらない
+
+    def test_mode_prepend_multiline_preserves_structure(self, temp_db):
+        """mode='prepend'で改行を含むcontentを結合しても、区切り '\\n\\n' が間に正しく入る"""
+        created = self._create_material(content="line1\nline2")
+        material_id = created["material_id"]
+
+        result = update_material(material_id, content="head1\nhead2", mode="prepend")
+        assert "error" not in result
+
+        fetched = get_material(material_id)
+        assert fetched["content"] == "head1\nhead2\n\nline1\nline2"


### PR DESCRIPTION
## Summary
- `update_material` に `mode: Literal["overwrite","prepend","append"] = "overwrite"` 引数を追加
- `prepend`: 新content + `"\n\n"` + 既存content / `append`: 既存content + `"\n\n"` + 新content
- 既存contentが空文字列の場合は overwrite 相当として扱う（区切りを挟まない）
- content 未指定の場合は mode は無視

## 背景
- A#914（本実装アクティビティ）
- M#329 Item 1残（改善要望バックログ） → A#897 Triage Proposal-3 で採択
- 既定 `mode="overwrite"` で完全な後方互換

## 事前 docstring 確認結果 (P-3 採択条件)
- `src/services/material_service.py:update_material`: docstring は `content: New content (full replace, optional)` のみ。prepend/append への言及なし → 不整合なし
- `src/main.py:update_material` (MCP wrapper): 「contentは全体置換（部分更新やappendではない）」と**否定形で明示的に言及**あり。これは現実装と一致した記述で「不整合」ではないが、本PRで mode 追加に伴い該当行を撤回・更新する

## 変更内容
- `src/services/material_service.py`: `mode` 引数追加、`CONTENT_JOIN_SEPARATOR = "\n\n"`、結合ロジック追加、mode値バリデーション
- `src/main.py`: MCP wrapper に `mode` 引数を中継、docstring を3 mode 対応に更新、`typing.Literal` import 追加
- `tests/integration/test_material_service.py`: `TestUpdateMaterialMode` クラス（11 ケース）追加

## Test plan
- [x] `uv run pytest tests/integration/test_material_service.py` 45 passed
- [x] `uv run pytest tests/` 全 1692 tests passed
- [ ] CI 緑 + mergeable