### PR TITLE
feat: P0-7 pending_spawn auto_stalled 化

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1151,7 +1151,12 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
 
 
 @mcp.tool()
-def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
+def ow_recover(
+    channel: str,
+    topic_id: str,
+    dry_run: bool = False,
+    pending_spawn_stalled_threshold_min: int | None = None,
+) -> dict:
     """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正。
 
     relay履歴を since=0 で全件再走査して各worker毎の最新state宣言を集計し、queueと
@@ -1160,7 +1165,8 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
     - ghost_active: queue=assigned/working なのに presence offline
       → relay 最新state宣言から queue ステータスを自動再構築（dry_run=Falseのみ）
     - pending_spawn: queue=spawning なのに presence offline
-      → relay履歴に当該workerのstate宣言があれば自動更新、なければ起動進行中として放置
+      → relay履歴に当該workerのstate宣言があれば自動更新、無く `pending_spawn_stalled_threshold_min`
+        を超えた経過時間なら `auto_stalled` 化、それ未満なら起動進行中として放置
     - stalled_done: queue=done/closed/cancelled/failed なのに worker が presence onlineで残存
       → cmd:ping を送信して素性照会
     - orphans: presence online だが queue に登場しない w-* handle
@@ -1174,6 +1180,10 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
         channel: channelコード
         topic_id: トピックID（queue-t<topic_id>.md 特定に使用）
         dry_run: Trueなら検出のみ・修正/ping送信なし
+        pending_spawn_stalled_threshold_min: pending_spawn (has_relay_history=False) を
+            `auto_stalled` 化する経過時間閾値（分）。None なら従来挙動（自動更新対象外）。
+            P0-7 で導入。「2日経っても failed 化されない pending_spawn」を orch が
+            強制終端するために使う。
 
     Returns:
         成功時:
@@ -1187,7 +1197,12 @@ def ow_recover(channel: str, topic_id: str, dry_run: bool = False) -> dict:
             }
         relay/channel不可時: {"error": {"code": ..., "message": ...}}
     """
-    return ow_service.ow_recover(channel, topic_id, dry_run)
+    return ow_service.ow_recover(
+        channel,
+        topic_id,
+        dry_run,
+        pending_spawn_stalled_threshold_min=pending_spawn_stalled_threshold_min,
+    )
 
 
 # セッションエンドポイント（HTTPモード用カスタムルート）

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1322,6 +1322,7 @@ def _parse_queue_file(queue_file: Path) -> tuple[dict, list[dict]]:
                 "status": task_status,
                 "worker": None,
                 "term_ref": None,
+                "spawning_at": None,
             }
         elif current_task is not None and line.startswith("- worker:"):
             # "- worker: w-a / term_ref: iterm2:xxx / session: <uuid>"
@@ -1332,6 +1333,8 @@ def _parse_queue_file(queue_file: Path) -> tuple[dict, list[dict]]:
                     current_task["term_ref"] = part[len("term_ref:"):].strip()
                 elif not part.startswith("session:"):
                     current_task["worker"] = part
+        elif current_task is not None and line.startswith("- spawning:"):
+            current_task["spawning_at"] = line[len("- spawning:"):].strip()
 
     if current_task is not None:
         tasks.append(current_task)
@@ -1645,10 +1648,29 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
     return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id, "truncated": truncated}
 
 
+def _parse_spawning_at(value: str | None) -> datetime | None:
+    """`- spawning: <iso>` フィールドからdatetime（tz-aware）を取り出す。
+
+    queueファイルが手編集で壊れていても例外を投げない（fail-soft）。
+    naive datetime はUTCとみなして tz-awareに格上げする。
+    """
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.strip())
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def detect_crash_inconsistencies(
     queue_tasks: list[dict],
     reconstructed: dict,
     presence: list[str],
+    pending_spawn_stalled_threshold_min: int | None = None,
+    now: datetime | None = None,
 ) -> dict:
     """queue状態 × relay最新state × presence の3つを突合し、不整合を4カテゴリに分類する。
 
@@ -1656,9 +1678,14 @@ def detect_crash_inconsistencies(
 
     Args:
         queue_tasks: `_parse_queue_file` の返り値相当
-            （[{task, title, status, worker, term_ref}, ...]）
+            （[{task, title, status, worker, term_ref, spawning_at}, ...]）
         reconstructed: `reconstruct_state_from_relay` の返り値
         presence: `_get_presence` の返り値
+        pending_spawn_stalled_threshold_min: pending_spawn (has_relay_history=False) を
+            `auto_stalled` 化する経過時間閾値（分）。None または `spawning_at` 不在/不正
+            なら自動更新対象外（従来挙動）。閾値以上経過していれば
+            `suggested_status="auto_stalled"` を入れる。
+        now: 経過時間判定の基準時刻。テスト用にinject可能。Noneなら datetime.now(UTC)。
 
     Returns:
         {
@@ -1667,7 +1694,8 @@ def detect_crash_inconsistencies(
                 ...
             ],
             "pending_spawn": [   # queue=spawning。relay履歴の有無で2通りに分かれる
-                {task, alias, queue_status, has_relay_history, latest_state, latest_msg_id, latest_at, suggested_status},
+                {task, alias, queue_status, has_relay_history, latest_state, latest_msg_id, latest_at,
+                 spawning_at, age_min, suggested_status},
                 ...
             ],
             "stalled_done": [    # queue終端だがworkerがpresenceに残存
@@ -1683,11 +1711,16 @@ def detect_crash_inconsistencies(
     pending_spawn の解釈（C1対応）:
         - has_relay_history=True: workerが起動してstate宣言を送ったがpresence offline → ghost_active相当の
             扱いで `suggested_status` を入れる（ow_recoverは自動更新する）
-        - has_relay_history=False: workerはまだ何も送っていない＝起動進行中の可能性が高い。
-            ow_recoverは自動更新せず、orchに「pending_spawn 残留」を伝えるだけにする。
+        - has_relay_history=False:
+            - 閾値未指定 or spawning_at 取れない or 閾値未満: 起動進行中の可能性が高い。
+                ow_recoverは自動更新せず、orchに「pending_spawn 残留」を伝えるだけにする
+                （suggested_status=None）。
+            - 閾値以上経過: suggested_status="auto_stalled"。ow_recoverが queue を自動更新する。
+              （P0-7: T5 自身が実証した「2日間 failed 化されなかった pending_spawn」を解消）
     """
     by_wt = reconstructed.get("by_worker_task", {}) or {}
     presence_set = set(presence or [])
+    now_dt = now or datetime.now(timezone.utc)
 
     ghost_active: list[dict] = []
     pending_spawn: list[dict] = []
@@ -1706,11 +1739,26 @@ def detect_crash_inconsistencies(
         if status == "spawning" and worker and worker not in presence_set:
             has_history = relay_entry is not None
             latest_state = relay_entry["latest_state"] if relay_entry else None
-            suggested = (
-                _RELAY_STATE_TO_QUEUE_STATUS.get(latest_state, "stalled")
-                if has_history
-                else None  # 起動進行中の可能性 → ow_recoverは触らない
-            )
+            spawning_at_str = task.get("spawning_at") or ""
+            spawning_at_dt = _parse_spawning_at(spawning_at_str)
+            age_min: float | None = None
+            if spawning_at_dt is not None:
+                age_min = (now_dt - spawning_at_dt).total_seconds() / 60.0
+
+            if has_history:
+                suggested = _RELAY_STATE_TO_QUEUE_STATUS.get(latest_state, "stalled")
+            elif (
+                pending_spawn_stalled_threshold_min is not None
+                and age_min is not None
+                and age_min >= pending_spawn_stalled_threshold_min
+            ):
+                # P0-7: spawning が閾値以上経過しても relay 履歴が無い
+                # → terminal adapter 起動失敗等で worker が実体化しなかった可能性が高い。
+                # auto_stalled に倒して人間判断の俎上に乗せる。
+                suggested = "auto_stalled"
+            else:
+                # 起動進行中の可能性 → ow_recoverは触らない
+                suggested = None
             pending_spawn.append(
                 {
                     "task": task_id,
@@ -1720,6 +1768,8 @@ def detect_crash_inconsistencies(
                     "latest_state": latest_state,
                     "latest_msg_id": relay_entry["latest_msg_id"] if relay_entry else 0,
                     "latest_at": relay_entry["latest_at"] if relay_entry else "",
+                    "spawning_at": spawning_at_str,
+                    "age_min": age_min,
                     "suggested_status": suggested,
                 }
             )
@@ -1919,6 +1969,7 @@ def ow_recover(
     topic_id: str,
     dry_run: bool = False,
     pending_pings: list[dict] | None = None,
+    pending_spawn_stalled_threshold_min: int | None = None,
 ) -> dict:
     """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正のエントリポイント。
 
@@ -1945,6 +1996,10 @@ def ow_recover(
         pending_pings: 前回のping送信情報。各要素は:
             {alias: str, task: str, nonce: str, sent_after_msg_id: int}
             sent_after_msg_idより大きいmsg_idのrelayメッセージでnonce echoを探す。
+        pending_spawn_stalled_threshold_min: pending_spawn (has_relay_history=False) を
+            `auto_stalled` 化する経過時間閾値（分）。None なら従来挙動（自動更新対象外）。
+            P0-7 で導入。orch が「2日経っても failed 化されない pending_spawn」を強制終端
+            するために使う。
 
     Returns:
         {
@@ -2008,27 +2063,45 @@ def ow_recover(
         )
 
     presence = _get_presence(channel)
-    detected = detect_crash_inconsistencies(queue_tasks, reconstructed, presence)
+    detected = detect_crash_inconsistencies(
+        queue_tasks,
+        reconstructed,
+        presence,
+        pending_spawn_stalled_threshold_min=pending_spawn_stalled_threshold_min,
+    )
 
     applied: dict = {"queue_updates": [], "pings_sent": []}
 
     if not dry_run:
-        # ghost_active + pending_spawn(has_relay_history=True) を自動更新対象とする。
-        # spawning だが relay履歴ゼロ (起動進行中の可能性) は触らない。
+        # ghost_active + pending_spawn(suggested_status が決まっているもの) を自動更新対象とする。
+        # suggested_status が None の pending_spawn (起動進行中の可能性) は触らない。
+        # suggested_status は以下のいずれかで決まる:
+        #   - has_relay_history=True: relay最新stateに基づく
+        #   - has_relay_history=False & pending_spawn_stalled_threshold_min 経過: "auto_stalled"
         auto_update_targets = list(detected["ghost_active"]) + [
-            p for p in detected["pending_spawn"] if p["has_relay_history"]
+            p for p in detected["pending_spawn"] if p.get("suggested_status")
         ]
         for ghost in auto_update_targets:
+            if ghost["suggested_status"] == "auto_stalled":
+                age_min = ghost.get("age_min")
+                age_str = f"{age_min:.1f}min" if isinstance(age_min, (int, float)) else "unknown"
+                note = (
+                    f"crash-recovery: pending_spawn が relay履歴なしのまま "
+                    f"{age_str} 経過 (threshold={pending_spawn_stalled_threshold_min}min) "
+                    f"→ auto_stalled"
+                )
+            else:
+                note = (
+                    f"crash-recovery: relay最新state={ghost['latest_state']} "
+                    f"(msg_id={ghost['latest_msg_id']})で再構築"
+                )
             try:
                 _apply_queue_status_update(
                     queue_dir=queue_dir,
                     topic_id=topic_id_str,
                     task=ghost["task"],
                     new_status=ghost["suggested_status"],
-                    note=(
-                        f"crash-recovery: relay最新state={ghost['latest_state']} "
-                        f"(msg_id={ghost['latest_msg_id']})で再構築"
-                    ),
+                    note=note,
                 )
                 applied["queue_updates"].append(
                     {

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1697,7 +1697,8 @@ def detect_crash_inconsistencies(
                 {task, alias, queue_status, has_relay_history, latest_state, latest_msg_id, latest_at,
                  spawning_at, age_min, suggested_status},
                 ...
-            ],
+            ]
+            # spawning_at は常に str（queue で取れなかった場合は ""）。age_min は float または None。
             "stalled_done": [    # queue終端だがworkerがpresenceに残存
                 {task, alias, queue_status},
                 ...
@@ -1970,6 +1971,7 @@ def ow_recover(
     dry_run: bool = False,
     pending_pings: list[dict] | None = None,
     pending_spawn_stalled_threshold_min: int | None = None,
+    now: datetime | None = None,
 ) -> dict:
     """orch crash後のqueue × relay履歴 × presence整合チェック・自動修正のエントリポイント。
 
@@ -2000,6 +2002,8 @@ def ow_recover(
             `auto_stalled` 化する経過時間閾値（分）。None なら従来挙動（自動更新対象外）。
             P0-7 で導入。orch が「2日経っても failed 化されない pending_spawn」を強制終端
             するために使う。
+        now: 経過時間判定の基準時刻。テスト用に時刻を注入するため `detect_crash_inconsistencies` に
+            そのまま伝搬する。None なら datetime.now(UTC)。
 
     Returns:
         {
@@ -2068,6 +2072,7 @@ def ow_recover(
         reconstructed,
         presence,
         pending_spawn_stalled_threshold_min=pending_spawn_stalled_threshold_min,
+        now=now,
     )
 
     applied: dict = {"queue_updates": [], "pings_sent": []}
@@ -2083,8 +2088,11 @@ def ow_recover(
         ]
         for ghost in auto_update_targets:
             if ghost["suggested_status"] == "auto_stalled":
-                age_min = ghost.get("age_min")
-                age_str = f"{age_min:.1f}min" if isinstance(age_min, (int, float)) else "unknown"
+                # auto_stalled は detect_crash_inconsistencies で
+                # age_min is not None and age_min >= threshold が成立したときのみ付与される。
+                # したがってここで age_min は float であることが保証される。
+                age_min = ghost["age_min"]
+                age_str = f"{age_min:.1f}min"
                 note = (
                     f"crash-recovery: pending_spawn が relay履歴なしのまま "
                     f"{age_str} 経過 (threshold={pending_spawn_stalled_threshold_min}min) "

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -544,7 +544,10 @@ class TestDetectCrashInconsistencies:
         assert detected["pending_spawn"][0]["suggested_status"] is None
 
     def test_pending_spawn_missing_spawning_at_keeps_none(self):
-        """spawning_at が無い queue エントリ → 閾値判定不能 → suggested=None"""
+        """spawning_at が無い queue エントリ → 閾値判定不能 → suggested=None。
+
+        pending_spawn 出力の spawning_at は常に str 型（取れない場合は ""）であることを保証する。
+        """
         now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)
         queue_tasks = [
             {
@@ -561,6 +564,34 @@ class TestDetectCrashInconsistencies:
         p = detected["pending_spawn"][0]
         assert p["suggested_status"] is None
         assert p["age_min"] is None
+        # 仕様: spawning_at は常に str (キー欠落時は "")
+        assert p["spawning_at"] == ""
+        assert isinstance(p["spawning_at"], str)
+
+    def test_pending_spawn_none_spawning_at_normalized_to_empty_string(self):
+        """spawning_at が None の queue エントリ → 出力の spawning_at は "" に正規化される。
+
+        _parse_queue_file のデフォルトが None なのに対し、pending_spawn 辞書では
+        常に str ("" if missing) で表現する仕様であることを担保する。
+        """
+        now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": None,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        p = detected["pending_spawn"][0]
+        assert p["suggested_status"] is None
+        assert p["age_min"] is None
+        assert p["spawning_at"] == ""
+        assert isinstance(p["spawning_at"], str)
 
     def test_pending_spawn_malformed_spawning_at_keeps_none(self):
         """spawning_at が ISO 形式でない → fail-soft で suggested=None"""
@@ -960,11 +991,15 @@ class TestOwRecover:
         assert (queue_dir / "queue-t454.md").read_text() == before
 
     def test_pending_spawn_auto_stalled_updates_queue(self, monkeypatch, tmp_path):
-        """P0-7: pending_spawn_stalled_threshold_min を渡し、spawning_at が閾値以上 → queue=auto_stalled"""
+        """P0-7: pending_spawn_stalled_threshold_min を渡し、spawning_at が閾値以上 → queue=auto_stalled。
+
+        ow_recover に now を注入することで実時刻に依存しない hermetic テストになっている。
+        """
         queue_dir = tmp_path / "queue"
         queue_dir.mkdir()
-        # 古い spawning_at: 24時間前
-        old_ts = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        # 固定基準時刻と、それより 24 時間前の spawning_at で hermetic に組む
+        fixed_now = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+        old_ts = (fixed_now - timedelta(hours=24)).isoformat()
         (queue_dir / "queue-t454.md").write_text(
             f"## T1 | mytask | spawning\n"
             f"- worker: w-a / term_ref: (pending) / session: (pending)\n"
@@ -978,6 +1013,7 @@ class TestOwRecover:
             channel="ChAbCdEf",
             topic_id="454",
             pending_spawn_stalled_threshold_min=15,
+            now=fixed_now,
         )
         assert result["dry_run"] is False
         assert len(result["applied"]["queue_updates"]) == 1

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -3,9 +3,10 @@
 カバー範囲:
 - `_validate_spawn_preconditions`: relay/channel/cwd/alias 各失敗ケース + 全クリア
 - `reconstruct_state_from_relay`: 単一 worker / 複数 worker / 重複 state / 非state混在
-- `detect_crash_inconsistencies`: ghost_active / stalled_done / orphans 各分類
+- `detect_crash_inconsistencies`: ghost_active / stalled_done / orphans 各分類 +
+    pending_spawn auto_stalled 閾値ロジック (P0-7)
 - `_apply_queue_status_update`: header status 置換 / note 追加・上書き / 不在 task
-- `ow_recover`: dry_run / 自動修正適用 / relay不可
+- `ow_recover`: dry_run / 自動修正適用 / relay不可 / pending_spawn auto_stalled (P0-7)
 - `_send_recovery_ping`: nonce生成と envelope 形式 (FT-2)
 - `_check_nonce_echo`: nonce echo 判定ロジック (FT-3)
 - `ow_recover` pending_pings: nonce echo 結果の統合 (FT-3)
@@ -16,6 +17,7 @@ relay HTTP接点（ow_history / _get_presence / ow_send 等）はmonkeypatchで�
 import json
 import urllib.error
 import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -443,6 +445,188 @@ class TestDetectCrashInconsistencies:
         assert detected["ghost_active"] == []
         assert detected["pending_spawn"] == []
 
+    # P0-7: pending_spawn → auto_stalled 閾値ロジック
+    def test_pending_spawn_auto_stalled_above_threshold(self):
+        """spawning & 履歴なし & offline & spawning_at から閾値以上経過 → auto_stalled"""
+        spawning_at = "2026-06-18T00:00:00+00:00"
+        now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)  # +30min
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        assert len(detected["pending_spawn"]) == 1
+        p = detected["pending_spawn"][0]
+        assert p["has_relay_history"] is False
+        assert p["suggested_status"] == "auto_stalled"
+        assert p["spawning_at"] == spawning_at
+        assert p["age_min"] == pytest.approx(30.0)
+
+    def test_pending_spawn_auto_stalled_below_threshold(self):
+        """spawning & 履歴なし & offline & 閾値未満 → suggested=None (起動進行中扱い)"""
+        spawning_at = "2026-06-18T00:00:00+00:00"
+        now = datetime(2026, 6, 18, 0, 10, 0, tzinfo=timezone.utc)  # +10min
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        p = detected["pending_spawn"][0]
+        assert p["suggested_status"] is None
+        assert p["age_min"] == pytest.approx(10.0)
+
+    def test_pending_spawn_auto_stalled_boundary_exact_threshold(self):
+        """境界: 経過時間 == 閾値 → auto_stalled (>= 判定)"""
+        spawning_at = "2026-06-18T00:00:00+00:00"
+        now = datetime(2026, 6, 18, 0, 15, 0, tzinfo=timezone.utc)  # ちょうど +15min
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        assert detected["pending_spawn"][0]["suggested_status"] == "auto_stalled"
+
+    def test_pending_spawn_auto_stalled_boundary_just_below(self):
+        """境界: 経過時間が閾値より1秒少ない → None"""
+        spawning_at = "2026-06-18T00:00:00+00:00"
+        now = datetime(2026, 6, 18, 0, 14, 59, tzinfo=timezone.utc)  # 14min59sec
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        assert detected["pending_spawn"][0]["suggested_status"] is None
+
+    def test_pending_spawn_threshold_none_keeps_legacy_behavior(self):
+        """閾値=None (デフォルト) なら spawning_at がいくら古くても suggested=None"""
+        spawning_at = "2024-01-01T00:00:00+00:00"  # 2年以上前
+        now = datetime(2026, 6, 18, 0, 0, 0, tzinfo=timezone.utc)
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            now=now,
+        )
+        # threshold 未指定 → 閾値ロジック動かない → 従来挙動 (None)
+        assert detected["pending_spawn"][0]["suggested_status"] is None
+
+    def test_pending_spawn_missing_spawning_at_keeps_none(self):
+        """spawning_at が無い queue エントリ → 閾値判定不能 → suggested=None"""
+        now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                # spawning_at キーなし (古いフォーマットや手編集破損のシミュレート)
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        p = detected["pending_spawn"][0]
+        assert p["suggested_status"] is None
+        assert p["age_min"] is None
+
+    def test_pending_spawn_malformed_spawning_at_keeps_none(self):
+        """spawning_at が ISO 形式でない → fail-soft で suggested=None"""
+        now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": "not-a-timestamp",
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        assert detected["pending_spawn"][0]["suggested_status"] is None
+
+    def test_pending_spawn_naive_spawning_at_treated_as_utc(self):
+        """naive (tzなし) spawning_at は UTC として解釈される"""
+        spawning_at = "2026-06-18T00:00:00"  # naive
+        now = datetime(2026, 6, 18, 0, 30, 0, tzinfo=timezone.utc)
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": spawning_at,
+            },
+        ]
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, {"by_worker_task": {}, "max_msg_id": 0}, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        assert detected["pending_spawn"][0]["suggested_status"] == "auto_stalled"
+
+    def test_pending_spawn_with_history_unaffected_by_threshold(self):
+        """has_relay_history=True の場合は閾値ロジック関係なく従来通り suggested を入れる"""
+        queue_tasks = [
+            {
+                "task": "T1", "title": "x", "status": "spawning",
+                "worker": "w-a", "term_ref": "(pending)",
+                "spawning_at": "2026-06-18T00:00:00+00:00",
+            },
+        ]
+        reconstructed = {
+            "by_worker_task": {
+                "w-a:T1": {
+                    "alias": "w-a", "task": "T1",
+                    "latest_state": "working", "latest_msg_id": 5, "latest_at": "t5",
+                    "history_count": 1,
+                }
+            },
+            "max_msg_id": 5,
+        }
+        now = datetime(2026, 6, 18, 0, 1, 0, tzinfo=timezone.utc)  # 1min
+        detected = ow_service.detect_crash_inconsistencies(
+            queue_tasks, reconstructed, presence=[],
+            pending_spawn_stalled_threshold_min=15,
+            now=now,
+        )
+        p = detected["pending_spawn"][0]
+        assert p["has_relay_history"] is True
+        # has_relay_history=True の経路は relay 最新state 優先 → "stalled"
+        assert p["suggested_status"] == "stalled"
+
     def test_stalled_done_detected(self):
         """queue=done & worker presence online → stalled_done"""
         queue_tasks = [
@@ -774,6 +958,56 @@ class TestOwRecover:
         assert result["applied"]["queue_updates"] == []
         # queueファイルは無変更
         assert (queue_dir / "queue-t454.md").read_text() == before
+
+    def test_pending_spawn_auto_stalled_updates_queue(self, monkeypatch, tmp_path):
+        """P0-7: pending_spawn_stalled_threshold_min を渡し、spawning_at が閾値以上 → queue=auto_stalled"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        # 古い spawning_at: 24時間前
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        (queue_dir / "queue-t454.md").write_text(
+            f"## T1 | mytask | spawning\n"
+            f"- worker: w-a / term_ref: (pending) / session: (pending)\n"
+            f"- spawning: {old_ts}\n"
+            f"- note: spawning write-ahead\n"
+        )
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+        # 履歴は空（worker は relay に何も送らないまま消えたシナリオ）
+
+        result = ow_service.ow_recover(
+            channel="ChAbCdEf",
+            topic_id="454",
+            pending_spawn_stalled_threshold_min=15,
+        )
+        assert result["dry_run"] is False
+        assert len(result["applied"]["queue_updates"]) == 1
+        update = result["applied"]["queue_updates"][0]
+        assert update == {
+            "task": "T1", "alias": "w-a",
+            "from": "spawning", "to": "auto_stalled",
+        }
+        content = (queue_dir / "queue-t454.md").read_text()
+        assert "## T1 | mytask | auto_stalled\n" in content
+        # note も auto_stalled 用の文言になっている
+        assert "auto_stalled" in content
+        assert "pending_spawn が relay履歴なし" in content
+
+    def test_pending_spawn_auto_stalled_threshold_not_passed_keeps_legacy(self, monkeypatch, tmp_path):
+        """P0-7: pending_spawn_stalled_threshold_min を渡さなければ古い pending_spawn でも触らない (後方互換)"""
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+        original = (
+            f"## T1 | mytask | spawning\n"
+            f"- worker: w-a / term_ref: (pending) / session: (pending)\n"
+            f"- spawning: {old_ts}\n"
+        )
+        (queue_dir / "queue-t454.md").write_text(original)
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        result = ow_service.ow_recover(channel="ChAbCdEf", topic_id="454")
+        assert result["applied"]["queue_updates"] == []
+        assert (queue_dir / "queue-t454.md").read_text() == original
 
     def test_pending_spawn_with_history_is_updated(self, monkeypatch, tmp_path):
         """spawning & relay最新=done → pending_spawn (has_relay_history=True) → queue=done"""

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -108,6 +108,26 @@ class TestParseQueueFile:
         assert len(tasks) == 1
         assert tasks[0]["status"] == "spawning"
 
+    def test_parses_spawning_at_timestamp(self, tmp_path: Path):
+        """`- spawning: <iso>` 行から spawning_at を抽出する (P0-7)"""
+        content = (
+            "## T3 | new task | spawning\n"
+            "- worker: w-b / term_ref: (pending) / session: (pending)\n"
+            "- spawning: 2026-06-18T00:00:00+00:00\n"
+        )
+        queue_file = tmp_path / "queue-t1.md"
+        queue_file.write_text(content, encoding="utf-8")
+        _, tasks = ow_service._parse_queue_file(queue_file)
+        assert tasks[0]["spawning_at"] == "2026-06-18T00:00:00+00:00"
+
+    def test_spawning_at_absent_returns_none(self, tmp_path: Path):
+        """`- spawning:` 行が無いタスクは spawning_at=None (P0-7 後方互換)"""
+        content = "## T1 | x | working\n- worker: w-a / term_ref: r / session: s\n"
+        queue_file = tmp_path / "queue-t1.md"
+        queue_file.write_text(content, encoding="utf-8")
+        _, tasks = ow_service._parse_queue_file(queue_file)
+        assert tasks[0]["spawning_at"] is None
+
 
 class TestParseQueueFileFrontmatter:
     """エッジケース#1-#8: frontmatter対応テスト"""


### PR DESCRIPTION
## Summary

- P0-7 / activity A#923。relay 履歴が空のまま N 分以上経過した pending_spawn を `auto_stalled` に倒すルールを `detect_crash_inconsistencies` に追加。
- `ow_recover` に新引数 `pending_spawn_stalled_threshold_min` を追加し、orch が「2日経っても failed 化されなかった pending_spawn」（T5 PR#373 で実証された病理2）を強制終端できるようにする。
- 既存の正常 spawn 完了経路は完全に影響を受けない（閾値 = None がデフォルト＝従来挙動を完全保存）。

## 設計

- **検出ロジック**: `status=spawning` & `has_relay_history=False` & 経過時間 ≥ 閾値 → `suggested_status="auto_stalled"`。
- **時間源**: queue の `- spawning: <iso>` 行から `_parse_queue_file` が `spawning_at` を抽出。`_parse_spawning_at` が ISO 文字列を tz-aware datetime に格上げする（naive は UTC とみなす）。
- **純粋関数の testability**: `detect_crash_inconsistencies` に `now: datetime | None = None` を追加（None なら `datetime.now(UTC)`）。境界テストはこの引数で時間を inject する。
- **後方互換**: 閾値=None なら従来挙動と完全一致（`suggested_status=None`、`auto_update_targets` 対象外）。
- **note 文言**: `_apply_queue_status_update` の note は auto_stalled 用に分岐し、relay 履歴がないことと経過時間を明記。

## 変更点

- `src/services/ow_service.py`:
  - `_parse_queue_file`: `- spawning:` 行から `spawning_at` を抽出
  - `_parse_spawning_at` helper を追加（fail-soft、naive → UTC 格上げ）
  - `detect_crash_inconsistencies`: `pending_spawn_stalled_threshold_min`, `now` 引数追加。pending_spawn dict に `spawning_at`, `age_min` を追加
  - `ow_recover`: 同名引数を追加、`auto_update_targets` の選別条件を `suggested_status` 有無に変更（ghost_active と pending_spawn (with-history or auto_stalled) の両方を網羅）
- `src/main.py`: MCP tool `ow_recover` に同名引数を中継
- `tests/unit/test_ow_crash_recovery.py`: P0-7 用テストを 9 件追加（閾値超過、未満、境界（==閾値, -1秒）、閾値=None、spawning_at 不在、ISO 不正、naive 解釈、has_relay_history=True との非干渉、ow_recover の end-to-end 2 件）
- `tests/unit/test_ow_queue.py`: `_parse_queue_file` の spawning_at 抽出テスト 2 件追加

## Test plan

- [x] `pytest tests/unit/test_ow_crash_recovery.py tests/unit/test_ow_queue.py` — 191 passed
- [x] `pytest`（全テスト）— 1694 passed, 0 failed
- [ ] CI 緑確認