### PR TITLE
feat: ow_spawn_worker呼び出しにPreToolUse hookでtmux_target_pane自動付与

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,6 +37,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__plugin_claude-code-memory_cc-memory__ow_spawn_worker",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/pretooluse_ow_spawn_worker.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__plugin_claude-code-memory_cc-memory__add_decisions",

--- a/hooks/pretooluse_ow_spawn_worker.py
+++ b/hooks/pretooluse_ow_spawn_worker.py
@@ -45,7 +45,7 @@ def main() -> None:
         event = json.loads(raw)
         tool_input = event.get("tool_input") or {}
 
-        if tool_input.get("tmux_target_pane"):
+        if "tmux_target_pane" in tool_input:
             print("{}")
             return
 

--- a/hooks/pretooluse_ow_spawn_worker.py
+++ b/hooks/pretooluse_ow_spawn_worker.py
@@ -1,0 +1,85 @@
+"""PreToolUse hook: ow_spawn_worker 呼び出しに tmux_target_pane を自動 inject する。
+
+クライアント側 (Claude Code) は TMUX_PANE 環境変数を持っているが、常駐 MCP server
+(`launchd com.isizono.cc-memory-remote` 等) は env がフリーズしているためサーバー側
+で参照できない (tag note ow / SKILL.md L373 の既知制約)。orch が毎 spawn で
+手動指定するのは LLM コンテキスト揮発により失念しがちで、worker が
+`ow-workers` 別 session に隔離され不可視化する事故が頻発する (本 hook 起票理由)。
+
+本 hook は PreToolUse の updatedInput 機能で tool_input を上書きし、
+`OW_TERMINAL=tmux` 環境かつ TMUX_PANE が存在する場合のみ、`tmux display-message`
+で正規化した pane_id を `tmux_target_pane` に注入する。tmux 以外の環境や
+既に明示指定されている呼び出しでは no-op。
+
+参考: https://code.claude.com/docs/en/hooks (PreToolUse hookSpecificOutput.updatedInput)
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def _resolve_pane_id(tmux_pane: str) -> str:
+    """TMUX_PANE 環境変数の値から実 pane_id を取得する。
+
+    tmux statusbar の表示文字列 (例: `0:2.1.181`) や古い値が紛れていても、
+    `tmux display-message` で現在の正規 pane_id (`%<n>`) に正規化する。
+    """
+    try:
+        return subprocess.check_output(
+            ["tmux", "display-message", "-p", "-t", tmux_pane, "#{pane_id}"],
+            text=True,
+            timeout=2,
+        ).strip()
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return tmux_pane
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            print("{}")
+            return
+
+        event = json.loads(raw)
+        tool_input = event.get("tool_input") or {}
+
+        if tool_input.get("tmux_target_pane"):
+            print("{}")
+            return
+
+        if os.environ.get("OW_TERMINAL") != "tmux":
+            print("{}")
+            return
+
+        tmux_pane = os.environ.get("TMUX_PANE")
+        if not tmux_pane:
+            print("{}")
+            return
+
+        pane_id = _resolve_pane_id(tmux_pane)
+        if not pane_id:
+            print("{}")
+            return
+
+        new_input = dict(tool_input)
+        new_input["tmux_target_pane"] = pane_id
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "updatedInput": new_input,
+                "additionalContext": f"auto-injected tmux_target_pane={pane_id}",
+            }
+        }
+        print(json.dumps(output, ensure_ascii=False))
+
+    except Exception as e:
+        print(f"pretooluse_ow_spawn_worker.py error: {e}", file=sys.stderr)
+        print("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_pretooluse_ow_spawn_worker.py
+++ b/tests/unit/test_pretooluse_ow_spawn_worker.py
@@ -3,19 +3,26 @@
 PreToolUse hook が ow_spawn_worker 呼び出しに tmux_target_pane を自動 inject する
 挙動を、tmux サブプロセスを mock した上でケース別に検証する。
 """
+import io
 import json
 import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from hooks import pretooluse_ow_spawn_worker as hook
+
+
+def _make_stdin(payload: dict):
+    return io.StringIO(json.dumps(payload))
+
+
+def _make_stdin_raw(raw: str):
+    return io.StringIO(raw)
 
 
 def _run_hook(stdin_data: dict, env: dict, monkeypatch, capsys) -> dict:
@@ -33,11 +40,6 @@ def _run_hook(stdin_data: dict, env: dict, monkeypatch, capsys) -> dict:
     hook.main()
     captured = capsys.readouterr()
     return json.loads(captured.out)
-
-
-def _make_stdin(payload: dict):
-    import io
-    return io.StringIO(json.dumps(payload))
 
 
 class TestNoOp:
@@ -83,11 +85,6 @@ class TestNoOp:
         hook.main()
         captured = capsys.readouterr()
         assert json.loads(captured.out) == {}
-
-
-def _make_stdin_raw(raw: str):
-    import io
-    return io.StringIO(raw)
 
 
 class TestInject:

--- a/tests/unit/test_pretooluse_ow_spawn_worker.py
+++ b/tests/unit/test_pretooluse_ow_spawn_worker.py
@@ -1,0 +1,220 @@
+"""hooks/pretooluse_ow_spawn_worker.py のユニットテスト
+
+PreToolUse hook が ow_spawn_worker 呼び出しに tmux_target_pane を自動 inject する
+挙動を、tmux サブプロセスを mock した上でケース別に検証する。
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from hooks import pretooluse_ow_spawn_worker as hook
+
+
+def _run_hook(stdin_data: dict, env: dict, monkeypatch, capsys) -> dict:
+    """hook を 1 回実行し、stdout を JSON parse して返す。
+
+    env は os.environ に対する monkeypatch 上書き値。stdin は JSON エンコードして
+    sys.stdin に差し込む。
+    """
+    monkeypatch.setattr(sys, "stdin", _make_stdin(stdin_data))
+    for k, v in env.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+    hook.main()
+    captured = capsys.readouterr()
+    return json.loads(captured.out)
+
+
+def _make_stdin(payload: dict):
+    import io
+    return io.StringIO(json.dumps(payload))
+
+
+class TestNoOp:
+    """no-op になるべき条件 (空 JSON 出力)"""
+
+    def test_ow_terminal_not_tmux(self, monkeypatch, capsys):
+        result = _run_hook(
+            {"tool_input": {"alias": "w-a"}},
+            {"OW_TERMINAL": "iterm2", "TMUX_PANE": "%81"},
+            monkeypatch, capsys,
+        )
+        assert result == {}
+
+    def test_ow_terminal_unset(self, monkeypatch, capsys):
+        result = _run_hook(
+            {"tool_input": {"alias": "w-a"}},
+            {"OW_TERMINAL": None, "TMUX_PANE": "%81"},
+            monkeypatch, capsys,
+        )
+        assert result == {}
+
+    def test_tmux_pane_unset(self, monkeypatch, capsys):
+        result = _run_hook(
+            {"tool_input": {"alias": "w-a"}},
+            {"OW_TERMINAL": "tmux", "TMUX_PANE": None},
+            monkeypatch, capsys,
+        )
+        assert result == {}
+
+    def test_tmux_target_pane_already_specified(self, monkeypatch, capsys):
+        """tool_input.tmux_target_pane が既に指定されていれば上書きしない"""
+        result = _run_hook(
+            {"tool_input": {"alias": "w-a", "tmux_target_pane": "%99"}},
+            {"OW_TERMINAL": "tmux", "TMUX_PANE": "%81"},
+            monkeypatch, capsys,
+        )
+        assert result == {}
+
+    def test_empty_stdin(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", _make_stdin_raw(""))
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+        monkeypatch.setenv("TMUX_PANE", "%81")
+        hook.main()
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {}
+
+
+def _make_stdin_raw(raw: str):
+    import io
+    return io.StringIO(raw)
+
+
+class TestInject:
+    """正常 inject 条件"""
+
+    def test_inject_pane_id_normalized(self, monkeypatch, capsys):
+        """tmux display-message で正規化された pane_id が注入される"""
+        def fake_check_output(args, text=False, timeout=None):
+            assert args == ["tmux", "display-message", "-p", "-t", "%81", "#{pane_id}"]
+            return "%81\n"
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {"tool_input": {"alias": "w-a", "channel": "C1"}},
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "%81"},
+                monkeypatch, capsys,
+            )
+
+        spec = result["hookSpecificOutput"]
+        assert spec["hookEventName"] == "PreToolUse"
+        assert spec["permissionDecision"] == "allow"
+        assert spec["updatedInput"] == {
+            "alias": "w-a",
+            "channel": "C1",
+            "tmux_target_pane": "%81",
+        }
+        assert "auto-injected" in spec["additionalContext"]
+        assert "%81" in spec["additionalContext"]
+
+    def test_inject_with_normalization_diff(self, monkeypatch, capsys):
+        """env の値 (例: statusbar 文字列) と実 pane_id が異なる場合、正規化結果を注入する"""
+        def fake_check_output(args, text=False, timeout=None):
+            return "%81\n"
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {"tool_input": {"alias": "w-a"}},
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "0:2.1.181"},
+                monkeypatch, capsys,
+            )
+
+        assert result["hookSpecificOutput"]["updatedInput"]["tmux_target_pane"] == "%81"
+
+    def test_inject_preserves_other_args(self, monkeypatch, capsys):
+        """tool_input の他フィールドは保持される"""
+        def fake_check_output(args, text=False, timeout=None):
+            return "%88\n"
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {
+                    "tool_input": {
+                        "alias": "w-b",
+                        "channel": "C2",
+                        "cwd": "/tmp",
+                        "model": "claude-opus-4-7",
+                        "effort": "high",
+                    }
+                },
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "%88"},
+                monkeypatch, capsys,
+            )
+
+        updated = result["hookSpecificOutput"]["updatedInput"]
+        assert updated == {
+            "alias": "w-b",
+            "channel": "C2",
+            "cwd": "/tmp",
+            "model": "claude-opus-4-7",
+            "effort": "high",
+            "tmux_target_pane": "%88",
+        }
+
+
+class TestFallback:
+    """tmux display-message 失敗時のフォールバック"""
+
+    def test_subprocess_error_falls_back_to_env(self, monkeypatch, capsys):
+        """tmux display-message 失敗時は TMUX_PANE 値をそのまま使う"""
+        def fake_check_output(args, text=False, timeout=None):
+            raise subprocess.CalledProcessError(1, args, "")
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {"tool_input": {"alias": "w-a"}},
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "%81"},
+                monkeypatch, capsys,
+            )
+
+        assert result["hookSpecificOutput"]["updatedInput"]["tmux_target_pane"] == "%81"
+
+    def test_file_not_found_falls_back_to_env(self, monkeypatch, capsys):
+        """tmux コマンド不在時 (FileNotFoundError) も TMUX_PANE 値で代用する"""
+        def fake_check_output(args, text=False, timeout=None):
+            raise FileNotFoundError("tmux not found")
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {"tool_input": {"alias": "w-a"}},
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "%81"},
+                monkeypatch, capsys,
+            )
+
+        assert result["hookSpecificOutput"]["updatedInput"]["tmux_target_pane"] == "%81"
+
+    def test_timeout_falls_back_to_env(self, monkeypatch, capsys):
+        def fake_check_output(args, text=False, timeout=None):
+            raise subprocess.TimeoutExpired(args, timeout)
+
+        with patch.object(subprocess, "check_output", side_effect=fake_check_output):
+            result = _run_hook(
+                {"tool_input": {"alias": "w-a"}},
+                {"OW_TERMINAL": "tmux", "TMUX_PANE": "%81"},
+                monkeypatch, capsys,
+            )
+
+        assert result["hookSpecificOutput"]["updatedInput"]["tmux_target_pane"] == "%81"
+
+
+class TestFailOpen:
+    """例外時はフェイルオープン (空 JSON + stderr ログ)"""
+
+    def test_invalid_json_stdin(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", _make_stdin_raw("not valid json"))
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+        monkeypatch.setenv("TMUX_PANE", "%81")
+        hook.main()
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {}
+        assert "error" in captured.err


### PR DESCRIPTION
## Summary

- `OW_TERMINAL=tmux` 環境で `ow_spawn_worker` 呼び出し時に `tmux_target_pane` を PreToolUse hook で自動 inject
- LLM コンテキスト揮発による失念で worker が `ow-workers` 別 session に流出する事故を構造的に防止
- `tmux display-message` で pane_id を正規化 (D 案を内包)。tmux 以外環境 / 明示指定済み / TMUX_PANE 未設定は全て no-op

## Background

ユーザー裁定 (T82):
> tool の中で完結してないのが問題。運用でカバーしようとするな。tmux Session 内で Claude Code 起動時に勝手に取れて、worker spawn を orch が叩いたら勝手にそうなるようになれ。orch がそれを考えるな

既存の `tag note (ow)` / `skills/orch/SKILL.md` L373 で明文化された運用ルール (orch がクライアント側で `os.environ['TMUX_PANE']` を読んで明示渡し) が、LLM 失念により守られない事故が頻発していた (M#350 参照)。

構造的解決として、Claude Code 公式の PreToolUse hook の `updatedInput` 機能 ([docs](https://code.claude.com/docs/en/hooks)) で tool_input を上書きし、引数指定なしでも自動付与する。

## Why C 案 (hook 自動 inject) を採用

- A 案 (SKILL.md 明文化強化): 既に同等明文化があり守られていない → 効果限界が実証済
- B 案 (server 側 env fallback): MCP server プロセスの env は起動時 freeze、HTTP transport 経由の常駐 server には orch claude の env が届かない → 構造的不可
- C 案 (PreToolUse hook): LLM 自律記憶に依存せず構造的に解決 ← **採用**
- D 案 (pane_id 取得補助スクリプト): 単独成立せず → C 案実装内に shell out として内包

## 修正前症状の再現 (本 PR の動機)

session 17/18/19 を attach 中、過去 `ow_spawn_worker` で `tmux_target_pane` を渡し忘れて起動された 7 workers が `ow-workers` 別 session に隔離されていた (M#350 §2 詳細)。ユーザー attach 側からは不可視で運用障害になっていた。

## 修正後動作確認

実コマンド出力 (worktree 内):

```
===Case A: tmux_target_pane未指定 (注入されるはず)===
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow",
 "updatedInput": {"alias": "w-test", "channel": "C1", "model": "claude-opus-4-7",
 "cwd": "/tmp", "tmux_target_pane": "%88"},
 "additionalContext": "auto-injected tmux_target_pane=%88"}}

===Case B: tmux_target_pane既指定 (no-op)===
{}

===Case C: OW_TERMINAL≠tmux (no-op)===
{}

===Case D: TMUX_PANE 未設定 (no-op)===
{}
```

実環境で確認した CWD: `/Users/babajunichi/workspace/cc-memory/.trees/feature-tmux-pane-auto-inject` (TMUX_PANE=%88, OW_TERMINAL=tmux)。

## 変更内容

- `hooks/pretooluse_ow_spawn_worker.py` (new): stdin から PreToolUse event を読み、条件成立時に `updatedInput` で `tmux_target_pane` 注入。例外時は空 JSON でフェイルオープン
- `hooks/hooks.json`: PreToolUse エントリ追加 (matcher: `mcp__plugin_claude-code-memory_cc-memory__ow_spawn_worker`)
- `tests/unit/test_pretooluse_ow_spawn_worker.py` (new): no-op 5 ケース + 正常 inject 3 ケース + tmux 失敗フォールバック 3 ケース + フェイルオープン 1 ケース = 計 12 テスト

## Test plan

- [x] ユニットテスト 12 件 pass (`uv run pytest tests/unit/test_pretooluse_ow_spawn_worker.py`)
- [x] 実 tmux 環境で 4 ケース動作確認 (上記 Case A-D)
- [ ] CI 緑確認
- [ ] マージ後、orch から `tmux_target_pane` 指定なしで `ow_spawn_worker` 呼び出し → worker が orch attach pane と同 window に分割表示される

## Related

- topic 454 (ow 実装)
- activity #949 ([作業] orch起動時 TMUX_PANE 自動取得→ow_spawn_worker自動付与の実装)
- M#350 (v0 設計提案: 修正案A/B/C/D比較+再現実例)
- tag note `ow` / `tmux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)