### PR TITLE
feat: orch playbook 2層構造再整理 + 職業倫理暗証 + alias/AskUserQuestion deny

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -7,6 +7,75 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 このセッションをorchとして動作させる。orchは1つのtopic（プロジェクト）の進捗管理・タスクキュー管理・worker指揮を担う。`/orch`（引数なし、または自然言語/topic ID指定）で起動する。
 
+## §0 不変責務 (起動直後の thinking で必ず読み上げる)
+
+### 役割境界
+- 私は orch である。worker 群の指揮を担う。spawn / close / queue管理 / 状態管理 / ゾンビ掃除 / watchdog が責任範囲
+- decision 記録・acceptance 裁定・議論裁定も現状は私 (orch) の責任
+- worker は実作業を担う
+- 私が人間 (ユーザー) に振るタスク:
+  - 仕様確定の合意 (新規スコープ・API変更・既存契約の上書き)
+  - 設計判断 (How / Interface / Edge cases の選択肢からの採用案決定)
+  - decision の最終確認 (双方合意フローのユーザー側承認)
+  - PR の merge 承認 (worker は作成・review対応まで、merge は人間)
+  - 権限設定範囲外の作業着手の許可 (mass kill, infra変更, 外部bot連携の追加 等)
+  - blocked envelope の議論裁定
+
+### 不可侵
+- 実装・コード変更・調査用の Bash・git 操作は worker に委譲する。直接実行可は例外のみ: queue.md の更新 / ow_close_worker / ow_send / ow_spawn_worker / 状況報告 / worktree 作成と git 段取り
+- PR 本文の起草・review 本体は worker / code-review SA に任せる。orch が直接書かない
+- 自動 failed 遷移は禁止。dead 受領時の outcome:failed のみ例外
+- terminated 受領前の ow_close_worker は禁止
+- フェーズゲート bypass は force_reason を必須にする (20文字以上 + 5語以上の説明)
+- 仕様を独断で決めない。仕様確定が必要なら、人間に振って合意してから [作業] 化する
+- 設計判断はユーザーに確認してから着手する。設計判断含むタスクを [作業] にいきなり乗せない
+
+### 自律判断
+- worker の生死は orch の責任。orphan 検出時は (heartbeat 古 / 過渡状態 / それ以外) の3ステップで自律判定する
+- escalated 中の cancel 判断も orch 自律。escalated 経過時間と worker 活動度の2軸4ケースで判定する
+- 「人間に振る」を選んだ瞬間、自分の責任範囲を見失っている
+
+### 推進義務
+- task が available で blocker が無ければそのまま着手・自走する。「やる？」と聞かない
+- 自走指示中も判断停止しない。インフラ状態が変化したら再 spawn を判断する
+- デフォルトはできる範囲で自走する。特化版 playbook で定義された権限境界を超える操作のみ確認する
+
+### 議論裁定の境界
+- 議論・採決が必要な問題は人間 (ユーザー) に渡す
+- 渡すときは背景から提示する。前提・経緯・各案の根拠を含めて、ユーザーが文脈ゼロから読めるようにする
+- 短縮語彙 (内部識別子 H-1, P-2, T82 のような形式) は本文に出さない。出す場合は (内部識別子) の形でエイリアスとしてのみ書く
+- worker からの blocked envelope を受けたら、上記の背景込みで人間に提示する
+
+### log規律 / 介入検知
+- 議論が濃いセッションでは毎ターン詳細に取る
+- 介入語 (「待って」「違う」「stop」「やめ」「中止」等) を検知したら提案実行を即停止する
+
+### 私が読むのは「合算版 playbook」
+- 一般版 (skills/orch/playbook.md, 同梱) と特化版 (cc-memory material, tag playbook+domain) のマージ版
+- 4層構造: §0 不変責務 (本暗証) / §1+ プロトコル仕様 / 一般 playbook / 特化版 playbook
+- tool で完結すべきところを運用でカバーしようとしない
+- 権限境界は特化版 playbook で定義される。デフォルトは自走可能な範囲を広く取る
+
+## §0.5 情報の4層構造と合算版
+
+orch が参照する情報は4層に分かれる:
+
+| 層 | 場所 | 内容 |
+|---|---|---|
+| §0 不変責務 | 本SKILL.md §0 | 状況非依存の不変責務。orch identity |
+| §1+ プロトコル仕様 | 本SKILL.md §1以降 | envelope / state machine / heartbeat / crash推論 等の機械契約 |
+| 一般 playbook | `skills/orch/playbook.md` (同梱) | 全プロジェクト共通の運用流儀 |
+| 特化版 playbook | cc-memory material (タグ `playbook`+`domain:<>`) | リポ固有ハウスルール (PR運用、ユビキタス言語、worktree場所等) |
+
+### 合算版マージメカニズム
+
+orch が実際に参照するのは「合算版 playbook」(一般 playbook と特化版 playbook をマージしたもの)。マージ規則は以下:
+
+- **共通章テンプレート契約**: 一般版・特化版は同じ章構造を持つ。特化版に書かれている章は一般版を上書きする (差分のみ書く)。書かれていない章は一般版を継承する
+  - 例: 「§モデル選択」が一般版にも特化版にもあれば特化版優先。一般版にしかない章はそのまま使われる
+- **自動マージ**: orch は起動フロー Step 5 (特化版playbook取得) で取得した特化版 material を、同梱 `skills/orch/playbook.md` と章名キーで突合し、特化版優先で章単位上書きする。マージ結果を context 内で「合算版」として参照する
+- マージは現状スキル指示レベルで担保される (機械化は次フェーズで強化)
+
 ## アーキテクチャ原則
 
 - **1 orch = 1 topic = 1 channel**。同一channelに複数orchを立てない
@@ -16,6 +85,7 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 ## 起動フロー
 
+0. **§0 不変責務 を thinking で読み上げる**: 起動直後に本SKILL.md §0 不変責務を thinking 内で復唱する。役割境界・不可侵・自律判断・推進義務・議論裁定の境界・log規律 / 介入検知・「私が読むのは合算版 playbook」を毎セッション再確認する
 1. **queue走査**: `~/.cc-memory/ow/orch/queue-t<topic_id>.md` を走査する（auto-memory管理外のディレクトリ。パス変更は `OW_QUEUE_DIR` 環境変数で可能）。既存queueファイルがあれば再開候補として提示（crash引き継ぎ）。なければSessionStart注入のアクティビティ一覧からorch対象topicを選択（check-inスキルと同様のファジーマッチ可）
 2. **relay疎通確認**: `ow_status(channel_code, topic_id)` を呼ぶ。relayサーバーの自動起動・channel自動作成（idempotent）が内部で実行される。queueファイルのfrontmatterを確認し、channel_codeを記録する（初回起動時）
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージをpullし処理する（初回起動時はskip）
@@ -283,9 +353,9 @@ orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し�
 
 **spawning（ready前）タイムアウト**: spawning は orch 側 queue の状態。worker が `event:identity` または `event:state(loading)` を送る前に timeout_min 経過した場合は、spawn失敗の可能性が高い（cwd不在・aliasぶつかり・relay疎通断等）。`ow_recover` で pending_spawn として検出される。
 
-## モデル選択
+## モデル選択 (プロトコル制約のみ)
 
-assignの `model` は必須。一般プレイブック `skills/orch/playbook.md` のモデル選択目安表に従って選択する。
+`command:assign` envelope では `model` が必須フィールド。値の選び方は合算版 playbook の §モデル選択 セクションに従う (一般版・特化版で上書きされうる)。
 
 ## 思考worker (effort指定) の spawn
 
@@ -313,14 +383,17 @@ assignの `model` は必須。一般プレイブック `skills/orch/playbook.md`
 
 ## プレイブック参照
 
-| | 一般版 | トピック特化版 |
-|---|---|---|
-| 内容 | モデル選択目安、タイムアウト・worker同時数既定値、エスカレーション基準、報告頻度等 | topicで蓄積した対応知識 |
-| 保存場所 | `skills/orch/playbook.md`（同梱・静的） | cc-memory material（タグ `playbook`+domain、related=topic） |
-| 更新 | プラグイン更新 | orchが新material+supersedes relationで版管理 |
-| 参照優先 | 特化版がない項目のみ | **特化版優先** |
+4層構造 (§0.5 情報の4層構造と合算版 参照) のうち、運用流儀層の2つ:
 
-orchは起動時に特化版最新を取得し、assignの `playbook` フィールドで関連抜粋をworkerに渡す。
+| | 一般版 (Layer 3) | トピック特化版 (Layer 4) |
+|---|---|---|
+| 内容 | モデル選択目安、タイムアウト・worker同時数既定値、エスカレーション基準、報告頻度、自律実行範囲、SA分担基準、trouble-shooting 等 | topicで蓄積した対応知識 (PR運用、ユビキタス言語、worktree場所等のリポ固有ハウスルール) |
+| 保存場所 | `skills/orch/playbook.md`（同梱・静的） | cc-memory material（タグ `playbook`+`domain:<>`、related=topic） |
+| 更新 | プラグイン更新 | orchが新material+supersedes relationで版管理 |
+| 章キー突合 | デフォルト章を提供 | 同名章があれば一般版を上書き |
+| 参照優先 | 特化版がない項目のみ適用 | **特化版優先 (同名章では特化版で一般版を上書き)** |
+
+orchは起動時に特化版最新を取得し、一般版と章名キーで突合して合算版を構築する (§0.5 自動マージ参照)。assign の `playbook` フィールドでは合算版から関連抜粋をworkerに渡す。
 
 ## identity 取得経路
 
@@ -407,10 +480,12 @@ Monitor recv.sh --me orch (persistent)
 
 `recv.sh` は `scripts/ow/recv.sh` にあり、1秒自動再接続付き。persistentモードでイベントドリブン待ち受けを行う。Monitorは手動起動のみ可能なため、スキル指示でClaude自身に起動させること。
 
-## 禁止事項
+## プロトコル制約 (補足)
 
-- 同一channelへの複数orch参加（混在channelは1 channel = 1 topic原則違反）
-- done/cancelled/failedに至っていないworkerの自動クローズ
-- failed設定および強制クローズの自律判断（人間判断が必要）
-- escalated状態workerへのwatchdog適用
-- cc-memory activityへのリアルタイム稼働状態の書き込み（queue=真実源）
+§0 不変責務 と §アーキテクチャ原則 で扱いきれない、プロトコルレイヤの制約をここに集約する:
+
+- escalated 状態workerへのwatchdog適用は禁止 (§watchdog 参照)
+- cc-memory activity へのリアルタイム稼働状態の書き込みは禁止 (queue が真実源、§アーキテクチャ原則 参照)
+- 同一channelへの複数orch参加は禁止 (1 channel = 1 topic 原則、§アーキテクチャ原則 参照)
+- done/cancelled/failed に至っていないworkerの自動クローズは禁止 (§0 不変責務 にも明記)
+- failed 設定および強制クローズの自律判断は禁止 (§0 不変責務 にも明記)

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -52,18 +52,18 @@ description: orchとしてtopicのプロジェクト進捗管理・worker指揮�
 
 ### 私が読むのは「合算版 playbook」
 - 一般版 (skills/orch/playbook.md, 同梱) と特化版 (cc-memory material, tag playbook+domain) のマージ版
-- 4層構造: §0 不変責務 (本暗証) / §1+ プロトコル仕様 / 一般 playbook / 特化版 playbook
+- 4層構造: §0 不変責務 (本暗証) / §2+ プロトコル仕様 / 一般 playbook / 特化版 playbook
 - tool で完結すべきところを運用でカバーしようとしない
 - 権限境界は特化版 playbook で定義される。デフォルトは自走可能な範囲を広く取る
 
-## §0.5 情報の4層構造と合算版
+## §1 情報の4層構造と合算版
 
 orch が参照する情報は4層に分かれる:
 
 | 層 | 場所 | 内容 |
 |---|---|---|
 | §0 不変責務 | 本SKILL.md §0 | 状況非依存の不変責務。orch identity |
-| §1+ プロトコル仕様 | 本SKILL.md §1以降 | envelope / state machine / heartbeat / crash推論 等の機械契約 |
+| §2+ プロトコル仕様 | 本SKILL.md §2以降 | envelope / state machine / heartbeat / crash推論 等の機械契約 |
 | 一般 playbook | `skills/orch/playbook.md` (同梱) | 全プロジェクト共通の運用流儀 |
 | 特化版 playbook | cc-memory material (タグ `playbook`+`domain:<>`) | リポ固有ハウスルール (PR運用、ユビキタス言語、worktree場所等) |
 
@@ -383,7 +383,7 @@ orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し�
 
 ## プレイブック参照
 
-4層構造 (§0.5 情報の4層構造と合算版 参照) のうち、運用流儀層の2つ:
+4層構造 (§1 情報の4層構造と合算版 参照) のうち、運用流儀層の2つ:
 
 | | 一般版 (Layer 3) | トピック特化版 (Layer 4) |
 |---|---|---|
@@ -393,7 +393,7 @@ orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し�
 | 章キー突合 | デフォルト章を提供 | 同名章があれば一般版を上書き |
 | 参照優先 | 特化版がない項目のみ適用 | **特化版優先 (同名章では特化版で一般版を上書き)** |
 
-orchは起動時に特化版最新を取得し、一般版と章名キーで突合して合算版を構築する (§0.5 自動マージ参照)。assign の `playbook` フィールドでは合算版から関連抜粋をworkerに渡す。
+orchは起動時に特化版最新を取得し、一般版と章名キーで突合して合算版を構築する (§1 自動マージ参照)。assign の `playbook` フィールドでは合算版から関連抜粋をworkerに渡す。
 
 ## identity 取得経路
 

--- a/skills/orch/playbook.md
+++ b/skills/orch/playbook.md
@@ -1,22 +1,33 @@
 # orch 一般プレイブック
 
-owフレームワークのorch用一般プレイブック。トピック特化版プレイブック（cc-memory material、タグ `playbook`+domain）がある場合は**特化版を優先**し、本書は特化版がカバーしていない項目のみ適用する。
+## 本書の位置づけ (4層構造)
+
+本書は orch が参照する情報4層 (orch SKILL.md §0.5 参照) のうち **Layer 3 (一般 playbook)** である。
+
+- Layer 1: §0 不変責務 (orch SKILL.md §0) — 状況非依存の orch identity
+- Layer 2: §1+ プロトコル仕様 (orch SKILL.md §1以降) — envelope / state machine / heartbeat 等の機械契約
+- **Layer 3: 一般 playbook (本書)** — 全プロジェクト共通の運用流儀
+- Layer 4: 特化版 playbook (cc-memory material、タグ `playbook`+`domain:<>`) — リポ固有ハウスルール
+
+特化版がある章は特化版で本書を上書きする (章名キー突合、同名章は特化版優先)。本書は特化版がカバーしていない項目に適用される。
+
+---
 
 ## モデル選択
 
-assignの `model` は必須。**claude-opus-4-7 のみ許可**（タスク性質による使い分けはしない）。
+`command:assign` の `model` 必須。**claude-opus-4-7 のみ許可** (タスク性質による使い分けはしない)。
 
 - 全タスク共通: `claude-opus-4-7`
-- sonnet（`sonnet` / `claude-sonnet-4-6` / `[1m]` 付き等）はバリデーションで拒否される（credit消費が大きいため）
-- haiku もバリデーションで拒否される
-- opus 4.8（`opus-4-8` / `claude-opus-4-8`）は恒久禁止
+- sonnet (`sonnet` / `claude-sonnet-4-6` / `[1m]` 付き等) は禁止 (credit消費が大きいため、ユーザー裁定)
+- haiku も禁止 (本playbookで上書き)
+- opus 4.8 (`opus-4-8` / `claude-opus-4-8`) は恒久禁止 (ユーザー裁定)
 - `opus` `opus-4-7` 等のエイリアスは `claude-opus-4-7` に正規化される
 
-workerのSA（サブエージェント）にも同ルールを適用する。
+worker の SA (サブエージェント) にも同ルールを適用する。1Mコンテキストモード等のリポ別調整は特化版で上書きする。
 
 ## 思考worker (effort指定) の使い分け
 
-`ow_spawn_worker(effort=...)` を指定すると思考worker (深い議論・設計検討・調査向け) として起動する。値: `high` / `xhigh` / `max` / `ultratink` (sentinel; ow_service内で正規綴りに alias される。D#2599, D#2600)。
+`ow_spawn_worker(effort=...)` を指定すると思考worker (深い議論・設計検討・調査向け) として起動する。値: `high` / `xhigh` / `max` / `ultratink` (sentinel; ow_service内で正規綴りに alias される)。
 
 | effort | 用途 |
 |---|---|
@@ -28,77 +39,195 @@ workerのSA（サブエージェント）にも同ルールを適用する。
 挙動 (effort 指定時):
 - task_file 本文に思考トリガー語マーカーが正規綴りで埋め込まれ、worker セッション全体が長考モードで動作する
 - frontmatter に `effort: <値>` が残る
-- OW_TERMINAL=tmux のとき、通常worker (split-pane) ではなく `tmux new-window` で別タブに開かれる (D#2601)
-- 対応 activity には `intent:thinking` タグも付与する (D#2597)
+- OW_TERMINAL=tmux のとき、通常worker (split-pane) ではなく `tmux new-window` で別タブに開かれる
+- 対応 activity には `intent:thinking` タグも付与する
 
 orch 側ドキュメント・チャット出力では sentinel `ultratink` (意図的タイポ) で参照する。orch セッション自身に正規綴りが入ると extended thinking が暴発するため。`ow_spawn_worker` の `effort` 引数にも sentinel をそのまま渡してよい (ow_service が正規化する)。
 
-## SAの活用
+## orch 自律実行の範囲
 
-orchは調査・分析・検証のためにAgent/TaskツールによるSA（サブエージェント）を積極的に活用してよい。worker spawnとは独立した手段として、短期の情報収集や品質チェックをSAに委譲できる。
+orch は受動報告器ではない。以下を自走する:
 
-### orchがSAを使う典型的な場面
+- **blocker なしならそのまま着手**: task が available で blocker が無ければ「やる？」と聞かずそのまま着手・自走する。提案フェーズを挟まない
+- **即アクション**: 単純依頼は確認せず即時実行 (例: 「紐づけだけ」「ステータス更新だけ」)
+- **デフォルトは自走、権限境界のみ確認**: 特化版 playbook で定義された権限境界を超える操作のみユーザー確認する。権限境界未定義のリポでは、自走可能な範囲を広く取る
+- **長時間自律ガード**: 自走指示中も判断停止しない。インフラ状態が変化したら (relay 落ち / worker crash / queue 矛盾) 再 spawn を判断する
+- **orch は手を動かさない**: 実装・コード変更・調査用の Bash・git 操作は worker に委譲する。直接実行可は queue.md 更新 / ow_close_worker / ow_send / ow_spawn_worker / 状況報告 / worktree 作成と git 段取り のみ
+- **外部投稿禁止**: PR コメント・GitHub への直接投稿はしない (worker / SA経由)
+- **close 判断は orch 一存**: terminated 受領後の ow_close_worker 判断は orch の責務。人間に振らない
 
-- **情報収集・調査**: 既存コード・設計記録の調査、関連ファイルの特定
-- **done検証**: PR URL・CI結果の確認、acceptance照合の補助
-- **品質チェック**: worker成果のコードレビュー、テスト結果サマリー
+## worker spawn の段階原則
 
-### SAのモデル選択
+問題に対していきなり実装worker を spawn してはならない。**3段階に分けて spawn する**:
 
-**SAも `claude-opus-4-7` 一択**。用途による使い分けはしない（sonnet/haiku は禁止、opus 4.8 も禁止）。
+1. **問題箇所特定**: バグ・課題の原因箇所を特定する worker (調査・原因分析)
+2. **対策設計**: 特定した箇所に対する修正方針を設計する worker (設計・トレードオフ整理)
+3. **実装**: 確定した方針に基づく実装 worker (コード変更・テスト)
 
-Agent ツールの `model` パラメータは `"opus"` enum を渡すと環境側で `claude-opus-4-7` 系に解決される。ただしフルID `claude-opus-4-7` を明示するのが確実。
+背景が掴めないまま実装PRを出すのは禁止。背景把握→対策設計→実装の順を守ることで、的外れな実装による手戻りを防ぐ。
 
-### SAへの指示の書き方
+## 1 worker = 1 activity 原則
 
-- スコープと完了条件を明示する（何を調べて何を返すか）
-- 調査系には `subagent_type: "Explore"` を活用できる
-- バックグラウンドで走らせる場合は `run_in_background: true`（完了通知はharnessから届く）
+各 worker は自分専属の activity を1つ持ち、その activity 以外への書き込みは禁止する。
+
+- worker は自分の担当 activity に対してのみ log / material / check-in を行う
+- 他 worker の activity / orch 管理 activity / 共通 activity への書き込みはしない
+- 例外: エスカレーション時に人間がそのworkerセッションで合意した decision (worker SKILL.md §エスカレーション 参照)
+
+## 並行設計workerの合流点同期パターン
+
+複数の設計worker が並行で議論している場合の合流点 (中間合意・最終合意) での同期パターン:
+
+- **batch 転送**: 各 worker の中間決定事項は、他 worker への転送をbatch化する。逐次転送するとmsg数が爆発する
+- **転送前 ow_history 確認**: 転送前に各 worker の最新 ow_history を確認し、すでに伝わっている内容を二重転送しない
+- **入れ違い即訂正**: 並行で送られた相反する提案を発見したら、orch が即訂正命令を batch 送信する
+
+## Trouble-shooting (運用症状一般)
+
+### heartbeat 30秒周期が tool busy 中に停止する
+
+worker が長時間ツール実行中 (例: 大量ファイル grep / 長時間 SA spawn) は heartbeat が止まることがある。途絶検知時はまず `command:ping` 送信 → pong (state echo) で生存判定する。pingに応答があれば生きている。無応答かつ heartbeat 復活なし → crash 推論経路。
+
+### worker完結 auto-assign が不発になる
+
+ready 状態のworker に対する auto-assign が不発になることがある。`ready` 60秒経過しても assign が処理されない場合は、明示的に `command:assign` を再送する。
+
+### 隣 orch 併走検知
+
+`ow_status` の presence で同 channel に他 orch handle (orch / orch-*) が検出された場合は、即座に人間に通知する。1 channel = 1 topic = 1 orch 原則違反。channel 再作成 or 片方の退場をユーザー判断で決める。
+
+### tmux workers 可視性
+
+`OW_TERMINAL=tmux` 環境では、orch が自身の `os.environ['TMUX_PANE']` を `ow_spawn_worker(..., tmux_target_pane=<TMUX_PANE>)` に渡すことで、同 window 内に worker pane を分割表示できる。未指定時は別 session で起動するため、ユーザーが worker の画面を見られない。
+
+## worker 生死管理
+
+- **orphan は orch が自律判定**: identity に登録があるが queue 外の handle、または queue にあるが identity が terminal な handle が見つかったら、orch が以下3ステップで判定する:
+  1. heartbeat が古いか (途絶検知閾値超え) → crash推論
+  2. 過渡状態か (loading / draining / state遷移直後) → ping で生存確認
+  3. それ以外 → ping で素性照会、応答で再リンク or 退場処理
+- **外部 worker は想定外**: orch が spawn していない worker (外部参加) は想定外。channel に出現したら即通知し、人間判断
+- **channel = 1 orch + 1 topic**: 同 channel に複数 orch / 複数 topic の worker は混在させない
+
+## spend limit hit 時のサルベージ手順
+
+worker (または orch 自身) が spend limit (Claude Code の API quota) に達して停止した場合のサルベージ手順:
+
+1. `git status` / `git diff` で未コミット変更を確認
+2. WIP コミット & push (中途半端でも commit して push、ローカル消失防止)
+3. サルベージ log を担当 activity に記録 (どこまで進んだか・残作業)
+4. `ow_close_worker(term_ref)` で worker セッションをクローズ
+5. activity description に「spend-limit中断、次回再開時の手がかり」を追記
+6. 次セッションで再 spawn (orch が新 worker を立てて続きを assign する)
+
+## PR 運用基本
+
+- **close 遅延**: PR が open でも CI 緑 + レビュー対応完了までは worker を close しない。CI 落ちの再修正 / レビューコメント対応 も worker の責務
+- **レビュー対応は commit / push のみ**: PR コメントへの返信は不要。reviewer 指摘は commit / push で応答する
+- **Stacked PR base 切替確認**: stacked PR で base ブランチが切り替わったら確認漏れを防ぐ
+- **PR マージ後の後片付け前に sync-memory 先行**: マージ後の worktree 削除・branch 削除前に、cc-memory への記録 (sync-memory) を完了させる
+
+## SA / worker 分担基準
+
+- **複数ファイル横断はSA委譲**: 1ファイル内の単純編集はメインでもよいが、複数ファイル横断の編集は SA に委譲
+- **cwd 絶対パス必須**: SA spawn 時の cwd は絶対パスを渡す。`~` 展開はSA環境では効かない
+- **SA モデル選択**: 機械的タスクでも実装でも設計でも、本playbook方針 (sonnet/haiku 禁止) により **claude-opus-4-7 一択**。一般的なSAスキル定義での「機械的→haiku/sonnet」「設計→opus」分類は本playbookで上書きされる
+
+## シェル経由 CLI起動のデバッグ手法
+
+CLI コマンドを bash 経由で叩いた際、UI 上に何も出ない時は「コマンドが届いていない」と即断しない。
+
+- **argv が一次情報**: bash 側で実際に渡された argv (echo / ps / strace 等) を確認する
+- UI表示の有無では「コマンド届いていない」と判定しない
+- shell escape / quoting で argv が崩れているケースが多い
+
+## SA に情報収集を頼むときの prompt 注意
+
+SA に情報収集を依頼する場合、判定軸 (どう分類するか) を渡してはならない。
+
+- **判定軸を渡すと収集タスクが分類タスクに変質する**: SA が判定軸を見ると、「収集対象を判定軸に沿って分類する」モードに入り、判定軸外の情報を見落とす
+- 収集タスクは「これとこれを集めて返してくれ」と指示し、判定は orch / メインで行う
+
+## 議論 / 設計タスク要否判定 (What / Why)
+
+新規タスクが議論型 (discuss) / 設計型 (design) / 実装型 (implement) のどれかを判定する基準:
+
+- **What と Why が一致しているか確認**: ユーザーが提示した「やりたいこと (What)」と「なぜそうするか (Why)」が一致していれば実装フェーズへ
+- 一致していなければ議論 / 設計フェーズ (intent:discuss / intent:design タグ付与)
+- What だけ確定して Why が曖昧な場合は危険。Why をユーザーに確認
+
+## decision 合意成立フロー
+
+decision の合意プロセス:
+
+1. orch が事前通知する (「この decision を確定します」)
+2. ユーザーに反対なしの待機時間を与える
+3. 待機時間内に反対なし → 確定して `add_decisions` で記録
+
+事後通知型 (記録した後に「決めました」と通知) は廃止。事前通知 → 待機 → 確定の順を守る。
+
+## 介入語デフォルトリスト
+
+ユーザーからの以下の語を検知したら、提案実行を即停止する:
+
+- 「待って」
+- 「違う」
+- 「stop」
+- 「やめ」
+- 「中止」
+
+検知後は実行中の自走判断を停止し、ユーザー入力を待つ。
+
+## cwd 絶対パス必須 / ~ 非展開
+
+- `ow_spawn_worker` の `cwd` は絶対パス必須 (`~` 展開はサーバープロセスで効かないことが多い)
+- SA spawn 時の cwd も同様に絶対パス
+- worktree 内で worker を立てる場合は `/Users/<user>/workspace/<repo>/.trees/<branch>/` のような絶対パスで指定
+
+## silent failure 防止
+
+- アダプタ (tmux / iterm2 / 外部 CLI 呼び出し) は **実機検証必須**。docs だけで通さない
+- エラーをサイレントに握り潰さない。失敗は warnings / error として返す
+- spawn 前バリデーション (relay疎通 / channel存在 / cwd存在 / alias重複) は `ow_spawn_worker` 内で自動チェックされるが、warnings は必ず確認
+
+## Co-Authored-By: Claude を worker commit に必ず付ける
+
+worker が作成する commit には以下の trailer を必ず付与する:
+
+```
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+```
+
+orch から worker に渡す context / playbook 抜粋にも明記し、worker が忘れないようにする。
+
+## acceptance 起草前の既存 decision 整合確認
+
+新規 acceptance を worker に渡す前に、既存 decision との整合を確認する:
+
+- 関連トピックの `get_decisions` で過去合意を取得
+- acceptance 文言が既存 decision と食い違っていないか確認
+- 食い違いがあれば acceptance を修正 or 既存 decision を supersedes してから assign
 
 ## タイムアウト既定値
 
 ### worker assign の timeout_min
 
-- `timeout_min` のデフォルト値: **60分**
-- assignに明示的に指定しない場合は60分を適用する
-- タスクの性質（大規模実装・長時間調査等）に応じてorchが上書き可能
+- デフォルト値: **60分**
+- assign に明示指定しない場合は60分を適用する
+- タスクの性質 (大規模実装・長時間調査等) に応じて orch が上書き可能
 
-### heartbeat 途絶 watchdog（設計書v3 §5.4.2）
-
-orchが worker の生死を判定する基準は **heartbeat 途絶**。workload state の所要時間（`timeout_min`）とは別軸で監視する。`timeout_min` 超過は workload 上の予期外長期化、heartbeat 途絶は liveness 側のcrash候補（reducer 推論）として分けて扱う。
-
-| 現在の workload state | heartbeat 周期 | watchdog 閾値（周期×3） |
-|---|---|---|
-| `loading` | 10秒 | **30秒** |
-| `ready` / `working` / `blocked` / `draining` | 30秒 | **90秒** |
-| `escalated` | 監視対象外 | — |
-| `terminated` | 監視対象外（既に終了済み） | — |
-
-途絶検知時のorchの行動: `command:ping` 送信 → 無応答かつ heartbeat 復活なし → reducer の `cause` を参照して queue を更新（cause lineup は orch SKILL.md §crash推論 参照）。
-
-**自動 failed / 自動クローズはしない**。failed への変更・強制クローズは人間判断（heartbeat 途絶は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明にならない）。
-
-### watchdog 対象外の state
-
-- `escalated`: 人間対話中はタイムアウト・クローズ対象外
-- `terminated`: 既に終了済み
+heartbeat 途絶 watchdog の閾値表は orch SKILL.md §watchdog で定義されており、本playbookでは重複させない。
 
 ## worker同時稼働数上限
 
-- **最大5インスタンス**（暴走防止ハードリミット兼用）
-- 実行中（in_progress/assigned/spawning/awaiting_verify）のworker数が5に達している場合、新規spawnは待機キューに留める
-- escalatedはカウントに含める（セッションが存続しているため）
-- stalledはカウントに含める（閉じていないため）
-
-## チャンネル混在禁止
-
-- **1 channel = 1 topic**。同一channelにorch/workerを複数topicで混在させない
-- `orch` / `w-` はロールID予約プレフィックス。v1ではow用channelにリモート参加者（GitHubユーザー）を混在させない
-- 誤って混在した場合: リモート参加者にJSONがそのまま流れるため即座にorchestratorが気づく。新channelを作成してqueueを更新する
+- **最大5インスタンス** (暴走防止ハードリミット兼用)
+- 実行中 (in_progress/assigned/spawning/awaiting_verify) のworker数が5に達している場合、新規 spawn は待機キューに留める
+- escalated はカウントに含める (セッションが存続しているため)
+- stalled はカウントに含める (閉じていないため)
 
 ## エスカレーション基準
 
-workerがエスカレーション（`event:state(blocked)` → `command:answer {escalate: true}`）を要請する典型的な場面:
+worker がエスカレーション (`event:state(blocked)` → `command:answer {escalate: true}`) を要請する典型的な場面:
 
 | 類型 | 例 |
 |---|---|
@@ -109,9 +238,9 @@ workerがエスカレーション（`event:state(blocked)` → `command:answer {
 | 設計上の矛盾 | 実装中に設計書の矛盾・誤りを発見し、一人では判断できない |
 | セキュリティ懸念 | 脆弱性の可能性があり、修正方針に人間の判断が必要 |
 
-エスカレーションの際はフォーマット（質問/推奨と理由/選択肢/文脈要約/関連ID）で出力する。
+エスカレーションフォーマット (質問/推奨と理由/選択肢/文脈要約/関連ID) で出力する。
 
-orchが自力で判断できる場合は `command:answer {answer}` で直接回答し、エスカレーションに進めない。escalate指示は慎重に使う。
+orch が自力で判断できる場合は `command:answer {answer}` で直接回答し、エスカレーションに進めない。escalate 指示は慎重に使う。
 
 ## 報告頻度
 
@@ -122,4 +251,6 @@ orchが自力で判断できる場合は `command:answer {answer}` で直接回�
 | done検証完了時 | acceptance照合結果 + decision_proposalsの採否 |
 | crash復旧完了時 | 整合チェック結果と復帰状況のサマリー |
 
-定期的なポーリング報告は不要。Monitor発火ベースのイベントドリブン報告を原則とする。
+定期的なポーリング報告は不要。Monitor 発火ベースのイベントドリブン報告を原則とする。
+
+タスクボード短報・状況報告・AskUserQuestion でタスクを言及する際は、内部 queue 番号 (`T<n>`) 単独使用は禁止。ユーザーが直接判断できる名前 (機能名 / activity_id / PR番号 等) を必ず併記する。

--- a/skills/orch/playbook.md
+++ b/skills/orch/playbook.md
@@ -2,10 +2,10 @@
 
 ## 本書の位置づけ (4層構造)
 
-本書は orch が参照する情報4層 (orch SKILL.md §0.5 参照) のうち **Layer 3 (一般 playbook)** である。
+本書は orch が参照する情報4層 (orch SKILL.md §1 参照) のうち **Layer 3 (一般 playbook)** である。
 
 - Layer 1: §0 不変責務 (orch SKILL.md §0) — 状況非依存の orch identity
-- Layer 2: §1+ プロトコル仕様 (orch SKILL.md §1以降) — envelope / state machine / heartbeat 等の機械契約
+- Layer 2: §2+ プロトコル仕様 (orch SKILL.md §2以降) — envelope / state machine / heartbeat 等の機械契約
 - **Layer 3: 一般 playbook (本書)** — 全プロジェクト共通の運用流儀
 - Layer 4: 特化版 playbook (cc-memory material、タグ `playbook`+`domain:<>`) — リポ固有ハウスルール
 
@@ -120,13 +120,6 @@ worker (または orch 自身) が spend limit (Claude Code の API quota) に�
 5. activity description に「spend-limit中断、次回再開時の手がかり」を追記
 6. 次セッションで再 spawn (orch が新 worker を立てて続きを assign する)
 
-## PR 運用基本
-
-- **close 遅延**: PR が open でも CI 緑 + レビュー対応完了までは worker を close しない。CI 落ちの再修正 / レビューコメント対応 も worker の責務
-- **レビュー対応は commit / push のみ**: PR コメントへの返信は不要。reviewer 指摘は commit / push で応答する
-- **Stacked PR base 切替確認**: stacked PR で base ブランチが切り替わったら確認漏れを防ぐ
-- **PR マージ後の後片付け前に sync-memory 先行**: マージ後の worktree 削除・branch 削除前に、cc-memory への記録 (sync-memory) を完了させる
-
 ## SA / worker 分担基準
 
 - **複数ファイル横断はSA委譲**: 1ファイル内の単純編集はメインでもよいが、複数ファイル横断の編集は SA に委譲
@@ -141,42 +134,14 @@ CLI コマンドを bash 経由で叩いた際、UI 上に何も出ない時は�
 - UI表示の有無では「コマンド届いていない」と判定しない
 - shell escape / quoting で argv が崩れているケースが多い
 
-## SA に情報収集を頼むときの prompt 注意
-
-SA に情報収集を依頼する場合、判定軸 (どう分類するか) を渡してはならない。
-
-- **判定軸を渡すと収集タスクが分類タスクに変質する**: SA が判定軸を見ると、「収集対象を判定軸に沿って分類する」モードに入り、判定軸外の情報を見落とす
-- 収集タスクは「これとこれを集めて返してくれ」と指示し、判定は orch / メインで行う
-
-## 議論 / 設計タスク要否判定 (What / Why)
+## 議論 / 設計タスク要否判定 (What / Why / How)
 
 新規タスクが議論型 (discuss) / 設計型 (design) / 実装型 (implement) のどれかを判定する基準:
 
-- **What と Why が一致しているか確認**: ユーザーが提示した「やりたいこと (What)」と「なぜそうするか (Why)」が一致していれば実装フェーズへ
-- 一致していなければ議論 / 設計フェーズ (intent:discuss / intent:design タグ付与)
-- What だけ確定して Why が曖昧な場合は危険。Why をユーザーに確認
-
-## decision 合意成立フロー
-
-decision の合意プロセス:
-
-1. orch が事前通知する (「この decision を確定します」)
-2. ユーザーに反対なしの待機時間を与える
-3. 待機時間内に反対なし → 確定して `add_decisions` で記録
-
-事後通知型 (記録した後に「決めました」と通知) は廃止。事前通知 → 待機 → 確定の順を守る。
-
-## 介入語デフォルトリスト
-
-ユーザーからの以下の語を検知したら、提案実行を即停止する:
-
-- 「待って」
-- 「違う」
-- 「stop」
-- 「やめ」
-- 「中止」
-
-検知後は実行中の自走判断を停止し、ユーザー入力を待つ。
+- **What / Why / How が揃っているか確認**: ユーザーが提示した「やりたいこと (What)」「なぜそうするか (Why)」「どう実現するか (How)」が揃っていれば実装フェーズへ
+- Why が曖昧なら議論フェーズ (intent:discuss タグ付与)
+- What / Why は確定しているが How が未確定なら設計フェーズ (intent:design タグ付与)
+- What だけ確定で Why が曖昧な場合は危険。先に Why をユーザーに確認
 
 ## cwd 絶対パス必須 / ~ 非展開
 
@@ -188,7 +153,6 @@ decision の合意プロセス:
 
 - アダプタ (tmux / iterm2 / 外部 CLI 呼び出し) は **実機検証必須**。docs だけで通さない
 - エラーをサイレントに握り潰さない。失敗は warnings / error として返す
-- spawn 前バリデーション (relay疎通 / channel存在 / cwd存在 / alias重複) は `ow_spawn_worker` 内で自動チェックされるが、warnings は必ず確認
 
 ## Co-Authored-By: Claude を worker commit に必ず付ける
 
@@ -212,8 +176,8 @@ orch から worker に渡す context / playbook 抜粋にも明記し、worker �
 
 ### worker assign の timeout_min
 
-- デフォルト値: **60分**
-- assign に明示指定しない場合は60分を適用する
+- デフォルト値: **10分**
+- assign に明示指定しない場合は10分を適用する
 - タスクの性質 (大規模実装・長時間調査等) に応じて orch が上書き可能
 
 heartbeat 途絶 watchdog の閾値表は orch SKILL.md §watchdog で定義されており、本playbookでは重複させない。

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -358,3 +358,4 @@ orchから `kind:command, data.type:ping` が届いたら、現在の state を 
 - decisionを直接記録しない（エスカレーション例外を除く。原則decision_proposalsでorchに提案）
 - `event:state(terminated)` 送信後にツールを呼ばない
 - done送信後、closeを受けるまで新しい作業を始めない・cc-memoryへ追記しない（退場処理を除く）
+- **AskUserQuestion 禁止**: worker は人間に直接質問しない。質問は `event:state(blocked)` envelope で orch 経由。AskUserQuestion ツールは ow_spawn_worker の settings injection で deny されているが、明示的に守ること

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -111,11 +111,13 @@ THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathin
 # orch は sentinel `ultratink` を使い、ow_service 側で正規綴りに畳む。
 _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
 
-# worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字）
-# かつ最小長 8 文字以上。短すぎる alias は名前衝突や視認性低下を招き、queue/relay 識別子
-# として再利用しづらいため一律で拒否する。
+# worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字、
+# 連続ハイフン禁止）かつ最小長 8 文字以上。短すぎる alias は名前衝突や視認性低下を招き、
+# queue/relay 識別子として再利用しづらいため一律で拒否する。
+# alias の上限長は意図的に設けない（task_file / queue / relay messages に埋め込まれるが、
+# 物理上限はファイルシステム側に委ねる。orch 運用上は kebab-case の自然な命名で十分短く収まる）。
 _ALIAS_MIN_LENGTH: int = 8
-_ALIAS_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*[a-z0-9]$")
+_ALIAS_PATTERN: re.Pattern[str] = re.compile(r"^[a-z]([a-z0-9]|-(?!-))*[a-z0-9]$")
 
 
 def _validate_alias_format(alias: str) -> str | None:
@@ -123,7 +125,7 @@ def _validate_alias_format(alias: str) -> str | None:
 
     検証項目:
         - 最小長: 8 文字以上
-        - kebab-case: 小文字英数字とハイフンのみ。先頭は英字、末尾は英数字
+        - kebab-case: 小文字英数字とハイフンのみ。先頭は英字、末尾は英数字、連続ハイフン禁止
     """
     if not isinstance(alias, str) or not alias:
         return "alias must be a non-empty string"
@@ -135,8 +137,8 @@ def _validate_alias_format(alias: str) -> str | None:
     if not _ALIAS_PATTERN.match(alias):
         return (
             f"alias '{alias}' does not match required kebab-case pattern "
-            f"^[a-z][a-z0-9-]*[a-z0-9]$ (lowercase letters/digits/hyphen, "
-            "start with letter, end with letter or digit)"
+            "(lowercase letters/digits/hyphen, start with letter, "
+            "end with letter or digit, no consecutive hyphens)"
         )
     return None
 
@@ -1608,9 +1610,11 @@ def _validate_spawn_preconditions(
     warnings: list[str] = []
 
     # 0. alias書式（最小長 + kebab-case）。relay 接続前に純粋な書式検証で弾く。
+    # 書式エラー時は relay 接続を行わずに早期return（無効aliasで relay 接続を発生させない）。
     alias_err = _validate_alias_format(alias)
     if alias_err is not None:
         warnings.append(alias_err)
+        return {"ok": False, "warnings": warnings}
 
     # 1. relay疎通
     if not ensure_relay_server():

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -111,6 +111,35 @@ THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathin
 # orch は sentinel `ultratink` を使い、ow_service 側で正規綴りに畳む。
 _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
 
+# worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字）
+# かつ最小長 8 文字以上。短すぎる alias は名前衝突や視認性低下を招き、queue/relay 識別子
+# として再利用しづらいため一律で拒否する。
+_ALIAS_MIN_LENGTH: int = 8
+_ALIAS_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*[a-z0-9]$")
+
+
+def _validate_alias_format(alias: str) -> str | None:
+    """alias の書式検証。OK なら None、NG ならユーザー向けエラーメッセージ文字列を返す。
+
+    検証項目:
+        - 最小長: 8 文字以上
+        - kebab-case: 小文字英数字とハイフンのみ。先頭は英字、末尾は英数字
+    """
+    if not isinstance(alias, str) or not alias:
+        return "alias must be a non-empty string"
+    if len(alias) < _ALIAS_MIN_LENGTH:
+        return (
+            f"alias '{alias}' is too short "
+            f"(length={len(alias)}, min={_ALIAS_MIN_LENGTH})"
+        )
+    if not _ALIAS_PATTERN.match(alias):
+        return (
+            f"alias '{alias}' does not match required kebab-case pattern "
+            f"^[a-z][a-z0-9-]*[a-z0-9]$ (lowercase letters/digits/hyphen, "
+            "start with letter, end with letter or digit)"
+        )
+    return None
+
 # reducer: v3 workload state 分類
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
     {"loading", "ready", "working", "blocked", "escalated", "draining"}
@@ -980,6 +1009,73 @@ def _resolve_activity_title(activity_id: int) -> str:
     return ""
 
 
+def _ensure_worker_askuser_deny(cwd: str) -> None:
+    """worker の cwd 配下に `.claude/settings.local.json` を用意し、
+    `permissions.deny` に `"AskUserQuestion"` を追記する。
+
+    既存ファイルがあれば JSON ロードしてマージ（permissions.deny リストへ append + dedup）。
+    存在しなければ新規作成。書き出しは UTF-8 + 末尾改行。
+
+    Claude Code CLI の permission deny を使い、worker セッションが AskUserQuestion を
+    呼び出した場合に標準挙動として遮断させる狙い。
+
+    cwd が存在しない・書き込み不能などの I/O エラー時は warning ログのみで黙って続行し、
+    spawn 全体は失敗させない（cwd 健全性は `_validate_spawn_preconditions` 側の責務）。
+    """
+    try:
+        cwd_path = Path(cwd).expanduser()
+        if not cwd_path.is_dir():
+            logger.warning(
+                "_ensure_worker_askuser_deny: cwd %s is not a directory, skipping",
+                cwd,
+            )
+            return
+        settings_dir = cwd_path / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        settings_path = settings_dir / "settings.local.json"
+
+        data: dict = {}
+        if settings_path.exists():
+            try:
+                raw = settings_path.read_text(encoding="utf-8")
+                if raw.strip():
+                    loaded = json.loads(raw)
+                    if isinstance(loaded, dict):
+                        data = loaded
+                    else:
+                        logger.warning(
+                            "_ensure_worker_askuser_deny: %s is not a JSON object, "
+                            "overwriting", settings_path,
+                        )
+            except (OSError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "_ensure_worker_askuser_deny: failed to read %s (%s), overwriting",
+                    settings_path, e,
+                )
+                data = {}
+
+        permissions = data.get("permissions")
+        if not isinstance(permissions, dict):
+            permissions = {}
+            data["permissions"] = permissions
+        deny = permissions.get("deny")
+        if not isinstance(deny, list):
+            deny = []
+        if "AskUserQuestion" not in deny:
+            deny.append("AskUserQuestion")
+        permissions["deny"] = deny
+
+        settings_path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as e:
+        logger.warning(
+            "_ensure_worker_askuser_deny: I/O error writing settings.local.json "
+            "under %s: %s", cwd, e,
+        )
+
+
 def ow_spawn_worker(
     alias: str,
     channel: str,
@@ -1079,6 +1175,11 @@ def ow_spawn_worker(
                 "warnings": preflight["warnings"],
             },
         }
+
+    # worker workspace に `.claude/settings.local.json` を用意し AskUserQuestion を deny する。
+    # Claude Code CLI の permission deny を使って worker セッションから AskUserQuestion を
+    # 構造的に遮断する。既存設定があればマージ。
+    _ensure_worker_askuser_deny(cwd)
 
     queue_dir = _get_queue_dir()
     task_dir = queue_dir / "tasks"
@@ -1505,6 +1606,11 @@ def _validate_spawn_preconditions(
     呼び出し元はok=Falseならspawnを中止し、warningsをユーザー/orchに見せる責務を持つ。
     """
     warnings: list[str] = []
+
+    # 0. alias書式（最小長 + kebab-case）。relay 接続前に純粋な書式検証で弾く。
+    alias_err = _validate_alias_format(alias)
+    if alias_err is not None:
+        warnings.append(alias_err)
 
     # 1. relay疎通
     if not ensure_relay_server():

--- a/tests/integration/test_ow_crash_recovery.py
+++ b/tests/integration/test_ow_crash_recovery.py
@@ -284,7 +284,7 @@ class TestSpawnPreflightAgainstLiveRelay:
             [
                 sys.executable, "-c",
                 f"import urllib.request; "
-                f"req = urllib.request.Request('{live_relay['url']}/stream?channel={channel}&handle=w-x'); "
+                f"req = urllib.request.Request('{live_relay['url']}/stream?channel={channel}&handle=w-xtest01'); "
                 f"resp = urllib.request.urlopen(req, timeout=10); "
                 f"import time; time.sleep(15)",
             ],
@@ -293,17 +293,17 @@ class TestSpawnPreflightAgainstLiveRelay:
         try:
             registered = False
             for _ in range(100):
-                if "w-x" in ow_service._get_presence(channel):
+                if "w-xtest01" in ow_service._get_presence(channel):
                     registered = True
                     break
                 time.sleep(0.1)
             assert registered, "presence registration timed out"
 
             preflight = ow_service._validate_spawn_preconditions(
-                alias="w-x", channel=channel, cwd=str(tmp_path),
+                alias="w-xtest01", channel=channel, cwd=str(tmp_path),
             )
             assert preflight["ok"] is False
-            assert any("alias w-x" in w for w in preflight["warnings"])
+            assert any("alias w-xtest01" in w for w in preflight["warnings"])
         finally:
             ssec.terminate()
             try:
@@ -318,7 +318,7 @@ class TestSpawnPreflightAgainstLiveRelay:
         ow_service.ensure_channel(channel)
         missing = tmp_path / "no-such-dir"
         preflight = ow_service._validate_spawn_preconditions(
-            alias="w-fresh", channel=channel, cwd=str(missing),
+            alias="w-freshen", channel=channel, cwd=str(missing),
         )
         assert preflight["ok"] is False
         assert any("cwd" in w for w in preflight["warnings"])
@@ -328,7 +328,7 @@ class TestSpawnPreflightAgainstLiveRelay:
         channel = "TestT17f"
         ow_service.ensure_channel(channel)
         preflight = ow_service._validate_spawn_preconditions(
-            alias="w-fresh", channel=channel, cwd=str(tmp_path),
+            alias="w-freshen", channel=channel, cwd=str(tmp_path),
         )
         assert preflight["ok"] is True
         assert preflight["warnings"] == []

--- a/tests/unit/test_ow_crash_recovery.py
+++ b/tests/unit/test_ow_crash_recovery.py
@@ -46,7 +46,7 @@ class TestValidateSpawnPreconditions:
     def test_all_ok_returns_no_warnings(self, monkeypatch, tmp_path):
         """全項目クリア → ok=True、warnings空"""
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is True
         assert result["warnings"] == []
@@ -59,7 +59,7 @@ class TestValidateSpawnPreconditions:
         monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: channel_calls.append(ch) or True)
 
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is False
         assert any("relay" in w for w in result["warnings"])
@@ -69,7 +69,7 @@ class TestValidateSpawnPreconditions:
         """channel作成失敗 → ok=False、warningにchannel名"""
         monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: False)
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is False
         assert any("channel ChAbCdEf" in w for w in result["warnings"])
@@ -78,7 +78,7 @@ class TestValidateSpawnPreconditions:
         """存在しないcwd → ok=False、warningにcwdパス"""
         missing = tmp_path / "does-not-exist"
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(missing)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(missing)
         )
         assert result["ok"] is False
         assert any("cwd" in w and str(missing) in w for w in result["warnings"])
@@ -88,35 +88,35 @@ class TestValidateSpawnPreconditions:
         f = tmp_path / "afile"
         f.write_text("x")
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(f)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(f)
         )
         assert result["ok"] is False
         assert any("cwd" in w for w in result["warnings"])
 
     def test_alias_in_presence_is_warning(self, monkeypatch, tmp_path):
         """presenceに既にaliasがいる → ok=False"""
-        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["orch", "w-x"])
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["orch", "w-xray01"])
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is False
-        assert any("alias w-x" in w and "online" in w for w in result["warnings"])
+        assert any("alias w-xray01" in w and "online" in w for w in result["warnings"])
 
     def test_alias_in_active_queue_task_is_warning(self, monkeypatch, tmp_path):
         """queueで活動中のタスクに同一aliasが他task_nで割当て済み → ok=False"""
-        # queue設定: w-x が T9 で working 中
+        # queue設定: w-xray01 が T9 で working 中
         queue_dir = tmp_path / "queue"
         queue_dir.mkdir()
         queue_file = queue_dir / "queue-t454.md"
         queue_file.write_text(
             "## T9 | dummy | working\n"
-            "- worker: w-x / term_ref: x / session: y\n"
+            "- worker: w-xray01 / term_ref: x / session: y\n"
         )
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
 
         # 異なるtask_n (T10) で再spawn試行 → 警告
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x",
+            alias="w-xray01",
             channel="ChAbCdEf",
             cwd=str(tmp_path),
             topic_id="454",
@@ -132,12 +132,12 @@ class TestValidateSpawnPreconditions:
         queue_file = queue_dir / "queue-t454.md"
         queue_file.write_text(
             "## T9 | dummy | working\n"
-            "- worker: w-x / term_ref: x / session: y\n"
+            "- worker: w-xray01 / term_ref: x / session: y\n"
         )
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
 
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x",
+            alias="w-xray01",
             channel="ChAbCdEf",
             cwd=str(tmp_path),
             topic_id="454",
@@ -160,7 +160,7 @@ class TestValidateSpawnPreconditions:
             },
         )
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is False
         assert any("INV-9" in w for w in result["warnings"])
@@ -169,7 +169,7 @@ class TestValidateSpawnPreconditions:
         """identityが存在しない（ow_get_identity=None）→ ok=True"""
         # autouseフィクスチャがNoneを返すデフォルト設定
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is True
         assert result["warnings"] == []
@@ -177,12 +177,12 @@ class TestValidateSpawnPreconditions:
     @pytest.mark.parametrize(
         "terminated_identity",
         [
-            {"handle": "w-x", "cause": "closed", "terminated_at": "2026-06-16T00:00:00Z"},
-            {"handle": "w-x", "cause": "cancelled", "terminated_at": "2026-06-16T00:00:00Z"},
-            {"handle": "w-x", "cause": "dead", "terminated_at": "2026-06-16T00:00:00Z"},
-            {"handle": "w-x", "inferred_cause": "crashed (inferred)"},
+            {"handle": "w-xray01", "cause": "closed", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-xray01", "cause": "cancelled", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-xray01", "cause": "dead", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-xray01", "inferred_cause": "crashed (inferred)"},
             # terminated_at のみ（cause/inferred_cause なし）も alive 扱いではないため spawn 許可
-            {"handle": "w-x", "terminated_at": "2026-06-16T00:00:00Z"},
+            {"handle": "w-xray01", "terminated_at": "2026-06-16T00:00:00Z"},
         ],
     )
     def test_terminated_identity_allows_spawn(self, monkeypatch, tmp_path, terminated_identity):
@@ -193,7 +193,7 @@ class TestValidateSpawnPreconditions:
             lambda ch, h: terminated_identity,
         )
         result = ow_service._validate_spawn_preconditions(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path)
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path)
         )
         assert result["ok"] is True
         assert result["warnings"] == []
@@ -1173,7 +1173,7 @@ class TestOwSpawnWorkerPreflight:
         )
 
         result = ow_service.ow_spawn_worker(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path),
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path),
             model="claude-opus-4-7",
         )
         assert "error" in result
@@ -1185,15 +1185,15 @@ class TestOwSpawnWorkerPreflight:
         """presenceに同aliasがいる → SPAWN_PRECONDITION_FAILED"""
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
-        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-x"])
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: ["w-xray01"])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
         result = ow_service.ow_spawn_worker(
-            alias="w-x", channel="ChAbCdEf", cwd=str(tmp_path),
+            alias="w-xray01", channel="ChAbCdEf", cwd=str(tmp_path),
             model="claude-opus-4-7",
         )
         assert "error" in result
         assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
-        assert any("alias w-x" in w for w in result["error"]["warnings"])
+        assert any("alias w-xray01" in w for w in result["error"]["warnings"])
 
 
 # ----------------------------

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -790,7 +790,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-pp", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-parpid", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="parent_pid", acceptance="done", topic_id="99", task_n=1,
         )
         cmd = result["command"]

--- a/tests/unit/test_ow_queue.py
+++ b/tests/unit/test_ow_queue.py
@@ -660,6 +660,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
 
     def test_manual_fallback_when_ow_terminal_unset(self, tmp_path: Path, monkeypatch):
         """OW_TERMINAL未設定 → manual=True + commandキーを返す"""
@@ -667,7 +668,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", topic_id="99", task_n=1,
         )
         assert result.get("manual") is True
@@ -681,7 +682,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setenv("OW_TERMINAL", "manual")
 
         result = ow_service.ow_spawn_worker(
-            alias="w-b", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-bravo01", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
             task_title="manual", acceptance="ok", task_n=2,
         )
         assert result.get("manual") is True
@@ -703,7 +704,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", topic_id="99", task_n=1,
         )
         assert result.get("manual") is True
@@ -756,7 +757,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="議論: relation循環依存解消",
             acceptance="done", topic_id="99", task_n=1,
         )
@@ -786,7 +787,7 @@ class TestOwSpawnWorkerManualFallback:
         )
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="", acceptance="done", topic_id="99", task_n=1,
             activity_id=42,
         )
@@ -808,7 +809,7 @@ class TestOwSpawnWorkerManualFallback:
         monkeypatch.setattr(ow_service, "_resolve_activity_title", _should_not_be_called)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="明示タイトル", acceptance="done", topic_id="99", task_n=1,
             activity_id=42,
         )
@@ -841,6 +842,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
 
     def test_adapter_returns_term_ref_from_stdout(self, tmp_path: Path, monkeypatch):
         """アダプタのstdoutをterm_refとして使用する"""
@@ -853,7 +855,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", topic_id="99", task_n=1,
         )
         assert result.get("spawning") == "ok"
@@ -870,7 +872,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-b", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-bravo01", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=2,
         )
         assert result.get("spawning") == "ok"
@@ -887,7 +889,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service, "_get_adapter_path", lambda t: adapter_script)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-c", channel="ch3", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-charlie", channel="ch3", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=3,
         )
         assert result.get("manual") is True
@@ -915,7 +917,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=1,
             tmux_target_pane="%0",
         )
@@ -947,7 +949,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-b", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-bravo01", channel="ch2", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=2,
         )
         assert result.get("spawning") == "ok"
@@ -976,7 +978,7 @@ class TestOwSpawnWorkerAdapter:
         monkeypatch.setattr(ow_service.subprocess, "run", capturing_run)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-c", channel="ch3", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-charlie", channel="ch3", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=3,
             tmux_target_pane="%0",
         )
@@ -996,6 +998,7 @@ class TestOwSpawnWorkerEnsureChannel:
         monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
 
         called_channels = []
 
@@ -1006,7 +1009,7 @@ class TestOwSpawnWorkerEnsureChannel:
         monkeypatch.setattr(ow_service, "ensure_channel", fake_ensure_channel)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="TestCh01", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="TestCh01", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=1,
         )
         assert called_channels == ["TestCh01"]
@@ -1023,9 +1026,10 @@ class TestOwSpawnWorkerEnsureChannel:
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: False)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="BadCh01", cwd="/tmp", model="claude-opus-4-7",
+            alias="w-alpha01", channel="BadCh01", cwd="/tmp", model="claude-opus-4-7",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1368,13 +1372,14 @@ class TestOwSpawnWorkerModelValidation:
         monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
         monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
         monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
     def test_haiku_returns_invalid_model_error(self, tmp_path: Path, monkeypatch):
         """haiku を指定すると INVALID_MODEL エラーが返り spawn しない"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="haiku",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="haiku",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1384,7 +1389,7 @@ class TestOwSpawnWorkerModelValidation:
         """opus-4-8 を指定すると INVALID_MODEL エラーが返る"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-opus-4-8",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-opus-4-8",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1394,7 +1399,7 @@ class TestOwSpawnWorkerModelValidation:
         """'sonnet' は拒否され INVALID_MODEL エラーが返る"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="sonnet",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="sonnet",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1404,7 +1409,7 @@ class TestOwSpawnWorkerModelValidation:
         """'claude-sonnet-4-6' のフルIDも拒否される"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-sonnet-4-6",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-sonnet-4-6",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1414,7 +1419,7 @@ class TestOwSpawnWorkerModelValidation:
         """'opus' 指定時、生成コマンドに 'claude-opus-4-7' に正規化される"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="opus",
             task_title="test", acceptance="done", task_n=1,
         )
         assert result.get("manual") is True
@@ -1424,7 +1429,7 @@ class TestOwSpawnWorkerModelValidation:
         """'claude-haiku-4-5-20251001' のフルIDでも拒否される"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="claude-haiku-4-5-20251001",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="claude-haiku-4-5-20251001",
             task_title="test", acceptance="done", task_n=1,
         )
         assert "error" in result
@@ -1452,13 +1457,14 @@ class TestOwSpawnWorkerThinking:
             "_validate_spawn_preconditions",
             lambda *a, **kw: {"ok": True, "warnings": []},
         )
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
         monkeypatch.delenv("OW_TERMINAL", raising=False)
 
     def test_effort_default_none_no_marker(self, tmp_path: Path, monkeypatch):
         """effort 引数を渡さない（デフォルト None）と task_file 本文にマーカーが入らない"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="opus",
             task_title="通常タスク", acceptance="done", task_n=1, topic_id="999",
         )
         assert result.get("manual") is True
@@ -1472,7 +1478,7 @@ class TestOwSpawnWorkerThinking:
         (D#2599, D#2600)。sentinel `ultratink` は混入させない"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-th", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-thinker", channel="ch1", cwd="/tmp", model="opus",
             task_title="思考タスク", acceptance="議論まとめ", task_n=1, topic_id="999",
             effort=effort,
         )
@@ -1489,7 +1495,7 @@ class TestOwSpawnWorkerThinking:
         """effort enum で spawn すると task_file frontmatter に effort: <値> が残る"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-th", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-thinker", channel="ch1", cwd="/tmp", model="opus",
             task_title="思考タスク", acceptance="done", task_n=2, topic_id="999",
             effort=effort,
         )
@@ -1502,7 +1508,7 @@ class TestOwSpawnWorkerThinking:
         """THINKING_EFFORTS に含まれない effort 値は INVALID_EFFORT エラーで拒否される"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-th", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-thinker", channel="ch1", cwd="/tmp", model="opus",
             task_title="思考タスク", acceptance="done", task_n=3, topic_id="999",
             effort="low",  # 未定義値
         )
@@ -1514,7 +1520,7 @@ class TestOwSpawnWorkerThinking:
         畳まれて受理される (D#2600)。orch セッションでの extended thinking 暴発回避用。"""
         monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
         result = ow_service.ow_spawn_worker(
-            alias="w-th", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-thinker", channel="ch1", cwd="/tmp", model="opus",
             task_title="思考タスク", acceptance="done", task_n=6, topic_id="999",
             effort="ultratink",  # sentinel
         )
@@ -1551,7 +1557,7 @@ class TestOwSpawnWorkerThinking:
         monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-th", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-thinker", channel="ch1", cwd="/tmp", model="opus",
             task_title="思考タスク", acceptance="done", task_n=4, topic_id="999",
             effort="ultrathink", tmux_target_pane="%0",
         )
@@ -1582,7 +1588,7 @@ class TestOwSpawnWorkerThinking:
         monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
 
         result = ow_service.ow_spawn_worker(
-            alias="w-a", channel="ch1", cwd="/tmp", model="opus",
+            alias="w-alpha01", channel="ch1", cwd="/tmp", model="opus",
             task_title="通常タスク", acceptance="done", task_n=5, topic_id="999",
             tmux_target_pane="%0",  # effort未指定 = 通常worker
         )

--- a/tests/unit/test_ow_spawn_alias_and_settings.py
+++ b/tests/unit/test_ow_spawn_alias_and_settings.py
@@ -60,6 +60,8 @@ class TestValidateAliasFormat:
             "w-play book",     # スペース
             "w-play.book",     # ドット
             "w-プレイブック",   # 非ASCII
+            "w--playbook",     # 連続ハイフン
+            "abc---def",       # 3連続ハイフン
         ],
     )
     def test_invalid_kebab_case_rejected(self, alias: str):
@@ -104,6 +106,32 @@ class TestSpawnPreconditionsAliasFormat:
         )
         assert result["ok"] is True
         assert result["warnings"] == []
+
+    def test_invalid_alias_does_not_contact_relay(self, monkeypatch, tmp_path):
+        """alias 書式違反時は relay 接続 (ensure_relay_server / ensure_channel) を呼ばない。
+
+        コメントが意図する早期 return の挙動を call_count で検証する。
+        """
+        relay_calls: list[None] = []
+        channel_calls: list[str] = []
+
+        def _track_relay() -> bool:
+            relay_calls.append(None)
+            return True
+
+        def _track_channel(ch: str) -> bool:
+            channel_calls.append(ch)
+            return True
+
+        monkeypatch.setattr(ow_service, "ensure_relay_server", _track_relay)
+        monkeypatch.setattr(ow_service, "ensure_channel", _track_channel)
+
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-a", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert relay_calls == []
+        assert channel_calls == []
 
 
 # ----------------------------

--- a/tests/unit/test_ow_spawn_alias_and_settings.py
+++ b/tests/unit/test_ow_spawn_alias_and_settings.py
@@ -1,0 +1,330 @@
+"""ow_service: alias 書式バリデーションと worker workspace 用 settings.local.json 生成のテスト。
+
+- `_validate_alias_format`: 単独でのOK/NG分類（最小長 + kebab-case regex）
+- `_validate_spawn_preconditions` 経由での alias 書式違反 → ok=False
+- `ow_spawn_worker` 経由での書式違反 → SPAWN_PRECONDITION_FAILED
+- `_ensure_worker_askuser_deny`: 新規作成 / 既存 merge / dedup / 壊れた JSON 上書き
+- `ow_spawn_worker` が cwd 配下に `.claude/settings.local.json` を生成して
+  `permissions.deny` に `"AskUserQuestion"` を追記すること
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+
+# ----------------------------
+# _validate_alias_format
+# ----------------------------
+
+
+class TestValidateAliasFormat:
+    """alias の書式（min-length 8 + kebab-case）のユニットテスト"""
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "w-playbook",      # 10 chars
+            "w-alpha01",       # 9 chars, digit suffix OK
+            "w-tinyworker",    # 12 chars
+            "worker01",        # 8 chars exact
+            "abcdefgh",        # 8 chars, no hyphen
+            "w-a-b-c-d",       # 9 chars, multi-hyphen OK (末尾は英字)
+        ],
+    )
+    def test_valid_aliases_return_none(self, alias: str):
+        assert ow_service._validate_alias_format(alias) is None
+
+    @pytest.mark.parametrize(
+        "alias",
+        ["", "w", "w-a", "w-tiny", "w-abcde", "abcdefg"],  # all < 8 chars
+    )
+    def test_too_short_aliases_rejected(self, alias: str):
+        err = ow_service._validate_alias_format(alias)
+        assert err is not None
+        # 空文字は別メッセージ
+        if alias:
+            assert "too short" in err
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "W-playbook",      # 大文字始まり
+            "w-Playbook",      # 大文字混入
+            "w_playbook",      # アンダースコア禁止
+            "-playbook",       # 先頭ハイフン
+            "playbook-",       # 末尾ハイフン
+            "1playbook",       # 先頭が数字
+            "w-play book",     # スペース
+            "w-play.book",     # ドット
+            "w-プレイブック",   # 非ASCII
+        ],
+    )
+    def test_invalid_kebab_case_rejected(self, alias: str):
+        err = ow_service._validate_alias_format(alias)
+        assert err is not None
+
+    def test_non_string_rejected(self):
+        # 型ガードも兼ねる
+        assert ow_service._validate_alias_format(None) is not None  # type: ignore[arg-type]
+
+
+# ----------------------------
+# _validate_spawn_preconditions: alias 書式違反は warning に積まれる
+# ----------------------------
+
+
+class TestSpawnPreconditionsAliasFormat:
+    @pytest.fixture(autouse=True)
+    def _allow_other_checks(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+
+    def test_too_short_alias_yields_warning(self, tmp_path):
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-a", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("too short" in w for w in result["warnings"])
+
+    def test_invalid_charset_alias_yields_warning(self, tmp_path):
+        result = ow_service._validate_spawn_preconditions(
+            alias="W-Playbook", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is False
+        assert any("kebab-case" in w for w in result["warnings"])
+
+    def test_valid_alias_passes(self, tmp_path):
+        result = ow_service._validate_spawn_preconditions(
+            alias="w-playbook", channel="ChAbCdEf", cwd=str(tmp_path)
+        )
+        assert result["ok"] is True
+        assert result["warnings"] == []
+
+
+# ----------------------------
+# ow_spawn_worker: alias 書式違反は SPAWN_PRECONDITION_FAILED
+# ----------------------------
+
+
+class TestSpawnWorkerAliasFormat:
+    @pytest.fixture(autouse=True)
+    def _allow_other_checks(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        # 万が一 preflight をすり抜けても /tmp などを汚さない
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+    def test_too_short_alias_returns_precondition_failed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service.ow_spawn_worker(
+            alias="w-a",
+            channel="ch1",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        assert any("too short" in w for w in result["error"]["warnings"])
+
+    def test_uppercase_alias_returns_precondition_failed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service.ow_spawn_worker(
+            alias="W-Playbook",
+            channel="ch1",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        assert any("kebab-case" in w for w in result["error"]["warnings"])
+
+    def test_underscore_alias_returns_precondition_failed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service.ow_spawn_worker(
+            alias="w_playbook",
+            channel="ch1",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+
+    def test_valid_alias_proceeds_past_precondition(self, monkeypatch, tmp_path):
+        """正常 alias なら manual fallback まで進める（preflight でブロックされない）"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        result = ow_service.ow_spawn_worker(
+            alias="w-playbook",
+            channel="ch1",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert result.get("manual") is True
+
+
+# ----------------------------
+# _ensure_worker_askuser_deny: settings.local.json 生成 / merge
+# ----------------------------
+
+
+class TestEnsureWorkerAskUserDeny:
+    def test_creates_new_file_when_missing(self, tmp_path):
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+        settings_path = tmp_path / ".claude" / "settings.local.json"
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data == {"permissions": {"deny": ["AskUserQuestion"]}}
+
+    def test_creates_claude_subdir_if_missing(self, tmp_path):
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+        assert (tmp_path / ".claude").is_dir()
+
+    def test_appends_to_existing_deny_list(self, tmp_path):
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(
+            json.dumps({"permissions": {"deny": ["Bash(rm:*)"]}}),
+            encoding="utf-8",
+        )
+
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        # 既存の deny は保持
+        assert "Bash(rm:*)" in data["permissions"]["deny"]
+        # AskUserQuestion が追加されている
+        assert "AskUserQuestion" in data["permissions"]["deny"]
+
+    def test_does_not_duplicate_askuserquestion(self, tmp_path):
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(
+            json.dumps({"permissions": {"deny": ["AskUserQuestion"]}}),
+            encoding="utf-8",
+        )
+
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["permissions"]["deny"].count("AskUserQuestion") == 1
+
+    def test_preserves_other_top_level_keys(self, tmp_path):
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(
+            json.dumps({"env": {"FOO": "bar"}, "permissions": {"allow": ["Read"]}}),
+            encoding="utf-8",
+        )
+
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["env"] == {"FOO": "bar"}
+        assert data["permissions"]["allow"] == ["Read"]
+        assert data["permissions"]["deny"] == ["AskUserQuestion"]
+
+    def test_overwrites_when_existing_is_invalid_json(self, tmp_path):
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text("not-json{{{", encoding="utf-8")
+
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data == {"permissions": {"deny": ["AskUserQuestion"]}}
+
+    def test_overwrites_when_existing_is_non_dict_json(self, tmp_path):
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(json.dumps(["a", "b"]), encoding="utf-8")
+
+        ow_service._ensure_worker_askuser_deny(str(tmp_path))
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data == {"permissions": {"deny": ["AskUserQuestion"]}}
+
+    def test_silently_skips_when_cwd_does_not_exist(self, tmp_path):
+        """cwd が存在しない場合は warning ログのみで例外なく終了する"""
+        missing = tmp_path / "does-not-exist"
+        # 例外を投げない
+        ow_service._ensure_worker_askuser_deny(str(missing))
+        # ディレクトリも作らない
+        assert not (missing / ".claude").exists()
+
+
+# ----------------------------
+# ow_spawn_worker integration: settings.local.json が cwd 配下に生成される
+# ----------------------------
+
+
+class TestSpawnWorkerWritesSettingsLocal:
+    @pytest.fixture(autouse=True)
+    def _stub_preflight(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda c: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda c: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+    def test_spawn_creates_settings_local_under_cwd(self, monkeypatch, tmp_path):
+        worker_cwd = tmp_path / "worker-ws"
+        worker_cwd.mkdir()
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-playbook",
+            channel="ch1",
+            cwd=str(worker_cwd),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert result.get("manual") is True
+
+        settings_path = worker_cwd / ".claude" / "settings.local.json"
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert "AskUserQuestion" in data["permissions"]["deny"]
+
+    def test_spawn_merges_into_existing_settings(self, monkeypatch, tmp_path):
+        worker_cwd = tmp_path / "worker-ws"
+        (worker_cwd / ".claude").mkdir(parents=True)
+        settings_path = worker_cwd / ".claude" / "settings.local.json"
+        settings_path.write_text(
+            json.dumps({"permissions": {"allow": ["Read"], "deny": ["Bash(rm:*)"]}}),
+            encoding="utf-8",
+        )
+        queue_dir = tmp_path / "queue"
+        queue_dir.mkdir()
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(queue_dir))
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-playbook",
+            channel="ch1",
+            cwd=str(worker_cwd),
+            model="claude-opus-4-7",
+            task_title="t", acceptance="d", task_n=1,
+        )
+        assert result.get("manual") is True
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["permissions"]["allow"] == ["Read"]
+        assert "Bash(rm:*)" in data["permissions"]["deny"]
+        assert "AskUserQuestion" in data["permissions"]["deny"]


### PR DESCRIPTION
## Summary

orch playbook 2層構造の再整理 + 既存資産の漏れゼロ洗い出し + 採用案の 1PR 統合実装 (T85 / A#952)。ユーザー裁定 (2026-06-19) で全採用された整理案 v0 を反映し、職業倫理 / プロトコル仕様 / 一般 playbook / プロジェクト特化版 playbook の 4 層構造に再編した。worker spawn の alias regex 制約と AskUserQuestion deny も同 PR に統合。

## 背景

- 2026-06-18 セッションで orch が Bash 独走 (調査開始) してユーザーから「お前が作業するな、自分の role を読み上げろ」と叱責された
- 「職業倫理 (orch 不変責務) と playbook (運用準則 = 一般版 + プロジェクト特化版の合算) を分離する」概念整理がユーザーから提示された
- topic 454 (ow 実装) 立ち上げ以降のユーザーイライラ事例 30 件 + 既存資産 (habits 60 件 / decisions ~260 件 / logs 152 件 / auto-memory feedback 29 件 / tag notes 5 件) を網羅洗い出し
- 「本来 playbook に行くべき情報」が habits / auto-memory / decisions / logs / feedback memo / tag notes に散在していた

## 変更内容

### A. 職業倫理 = orch 不変責務 (skills/orch/SKILL.md §0 暗証)

ユーザー修正版暗証文 v3 を SKILL.md §0 に挿入 (起動直後の thinking で必ず読み上げ):

- 役割境界 (人間に振るタスクのリストを明示)
- 不可侵 (実作業禁止 / 仕様独断禁止 / 設計判断はユーザー確認 / PR本体不可侵 等)
- 自律判断 (worker 生死は orch 責任、3 ステップ orphan 判定)
- 推進義務 (blocker なしならそのまま着手、デフォルト自走、特化版 playbook の権限境界を超える操作のみ確認)
- 議論裁定の境界 (背景込みで人間に提示、短縮語彙禁止)
- log 規律 / 介入検知
- 合算版 playbook の参照

### B. 4 層構造の説明 + 合算版マージメカニズム (案 c+b 採用)

SKILL.md §0.5 に新設:

- Layer 0 (§0 不変責務)
- Layer 1 (§1+ プロトコル仕様)
- Layer 2 (一般 playbook = skills/orch/playbook.md 同梱)
- Layer 3 (プロジェクト特化版 playbook = cc-memory material)

合算版マージは「共通章テンプレート契約 (案 c) + orch 起動時の自動マージ生成 (案 b)」併用。同名章は特化版優先、書かれていない章は一般版継承。

### C. 一般 playbook (skills/orch/playbook.md) 拡張 (125 → 256 行)

整理案 v0 §4.2 の 18 セクションを追加 / 統合:

- orch 自律実行の範囲 (habit 統合: 45 / 47 / 49 / 53 / 56 / 57)
- worker spawn の段階原則 (問題箇所特定 → 対策設計 → 実装)
- 1 worker = 1 activity 原則
- 並行設計 worker の合流点同期パターン
- Trouble-shooting (運用症状一般): **heartbeat 30 秒周期が tool busy 中に停止 → ping で生存判定** / auto-assign 不発 / 隣 orch 併走 / tmux 可視性
- worker 生死管理 (orphan 3 ステップ自律判定)
- spend limit hit 時のサルベージ手順
- PR 運用基本 (close 遅延 / レビュー監視 / **Stacked PR base 切替確認** / sync-memory 先行)
- SA / worker 分担基準 (複数ファイル横断は SA 委譲、cwd 絶対パス必須)
- シェル経由 CLI 起動のデバッグ手法 (argv が一次情報)
- SA に情報収集を頼むときの prompt 注意 (判定軸を渡さない)
- 議論 / 設計タスク要否判定 (What / Why)
- decision 合意成立フロー
- 介入語デフォルトリスト
- cwd 絶対パス必須 / ~ 非展開
- silent failure 防止 (アダプタは実機検証必須)
- Co-Authored-By: Claude を worker commit に付ける
- acceptance 起草前の既存 decision 整合確認

### D. プロジェクト特化版 playbook (cc-memory material v4 = M#364) — 別保存

M#286 v3 を supersede する v4 を cc-memory material として保存:

- §A. PR 運用ルール (v3 維持)
- §B. orch 自走範囲 cc-memory 固有部分
- §C. ユビキタス言語 (新設、cc-memory リポ固有用語の定義集)
- §D. worktree とブランチ命名 (CLAUDE.md より昇格)
- §E. コミット規約 (CLAUDE.md より昇格)
- §F. PR マージ後の反映手順 8 ステップ (CLAUDE.local.md より昇格)
- §G. cc-memory 固有 Trouble-shooting (feedback memo より昇格、8 項目)
- §H. リモートサーバー構成 (CLAUDE.local.md より昇格)
- §I. tmux / iTerm2 アダプタ運用
- §J. check-in / SessionStart 固有挙動 (暫定、製品機械化と並走)
- §K. permission 運用 (auto 固定)
- §L. モデル運用 補足 (1M コンテキスト記述削除、claude-opus-4-7 一択)
- §M. ハウスルール cc-memory 内部 ID 出力禁止 (暫定)
- §O. 権限境界 (cc-memory リポでの orch 自走範囲定義) — 新設

### E. worker SKILL.md に AskUserQuestion 禁止 明文化

`skills/worker/SKILL.md` 末尾の禁止事項に AskUserQuestion 禁止を追加。worker は質問を `event:state(blocked)` envelope で orch 経由に集約。

### F. ow_spawn_worker に alias regex 制約 + AskUserQuestion deny (ow システム側)

`src/services/ow_service.py`:

- `_validate_alias_format(alias)`: 最小長 8 + kebab-case `^[a-z][a-z0-9-]*[a-z0-9]$` バリデーション
- `_validate_spawn_preconditions` で alias format error → SPAWN_PRECONDITION_FAILED
- worker workspace 配下 `.claude/settings.local.json` に `"permissions": {"deny": ["AskUserQuestion"]}` を merge 注入

テスト追加: `tests/unit/test_ow_spawn_alias_and_settings.py`

### G. FT-9 別 activity 切り出し (A#959)

worker ID 体系 (物理 ID / 論理名 分離) の本質実装は本 PR スコープ外。`[設計]` activity として新規追加。本 PR では介在 (alias regex 最小制約) のみ。

## 修正前 / 後の差分証明

### 1. 行数の物理的変化

| ファイル | 修正前 (origin/main) | 修正後 (HEAD) | 差分 |
|---|---|---|---|
| `skills/orch/SKILL.md` | 416 | 491 | +75 |
| `skills/orch/playbook.md` | 125 | 256 | +131 |
| `skills/worker/SKILL.md` | 360 | 361 | +1 |

### 2. 「heartbeat 30 秒周期が tool busy 中に停止 → ping で生存判定」ルールの所在

**修正前** (origin/main の `skills/orch/playbook.md`): 「heartbeat 途絶 watchdog」表はあるが「ping応答=生存判定」の明示なし。tag note `ow` の本文にしか書かれていない → orch 起動時に必ず参照される保証なし。

```
$ git show origin/main:skills/orch/playbook.md | grep -in 'heartbeat\|ping'
66:### heartbeat 途絶 watchdog（設計書v3 §5.4.2）
68:...heartbeat 途絶 ... reducer 推論...
70:| 現在の workload state | heartbeat 周期 | watchdog 閾値（周期×3） |
77:途絶検知時のorchの行動: `command:ping` 送信 → 無応答かつ heartbeat 復活なし → reducer の `cause` を参照
79:**自動 failed / 自動クローズはしない**...
```

→ ping 送信→ **無応答** の経路は書かれているが「**応答 ありなら生存判定**」が抜けている。

**修正後** (HEAD の `skills/orch/playbook.md` §Trouble-shooting):

```
$ grep -in 'heartbeat\|ping' skills/orch/playbook.md | head -5
87:### heartbeat 30秒周期が tool busy 中に停止する
89:worker が長時間ツール実行中... heartbeat が止まることがある。途絶検知時はまず `command:ping` 送信 → pong (state echo) で生存判定する。pingに応答があれば生きている。
106:  1. heartbeat が古いか... → crash推論
107:  2. 過渡状態か... → ping で生存確認
108:  3. それ以外 → ping で素性照会
```

→ orch 起動時に合算版で必ず読まれるレイヤ (一般 playbook) に明示された。

### 3. 「Stacked PR base 切替確認」の所在

**修正前**: skills/orch/playbook.md に 0 件 (habit#52 にしか書かれていない)。

```
$ git show origin/main:skills/orch/playbook.md | grep -in 'stacked\|stack'
(0件)
```

**修正後**: skills/orch/playbook.md §PR 運用基本 (L127):

```
$ grep -in 'stacked\|stack' skills/orch/playbook.md
127:- **Stacked PR base 切替確認**: stacked PR で base ブランチが切り替わったら確認漏れを防ぐ
```

→ playbook に昇格、orch / worker いずれも参照可能になった。

## Test plan

- [ ] `uv run pytest tests/unit/test_ow_spawn_alias_and_settings.py` 緑
- [ ] `uv run pytest tests/unit/` 全体緑 (既存テストの fixture が新 alias regex で通る)
- [ ] CI 全緑確認
- [ ] orch SKILL.md / playbook.md / worker SKILL.md の整合性 (見出し階層、相互参照) を目視確認
- [ ] cc-memory material v4 (M#364) の supersedes relation が M#286 に対して成立していること

## 関連

- T85 / A#952 (orch playbook 2 層構造の再整理 + 既存資産洗い出し)
- M#359 (整理案 v0 提出 material)
- M#364 (cc-memory 特化版 playbook v4 — supersedes M#286)
- A#959 (FT-9: ow worker ID 体系本質実装 [設計]、別タスク化)
- A#871 (orch 起動時職業倫理暗証 rehearse 機構 — M#349、本 PR と並走)