### PR TITLE
feat: OW_ROLE worker guard for add_decisions/add_logs/add_topic (P0-4)

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -8,6 +8,8 @@ import os
 import re
 from pathlib import Path
 
+from src.services import guard_service
+
 # --- cc-memory MCPツール判定用マーカー ---
 # ローカルプラグイン: mcp__plugin_claude-code-memory_cc-memory__*
 # リモートMCP:       mcp__claude_ai_cc-memory__*
@@ -33,11 +35,12 @@ _ORCH_MANAGED_TAG = "orch-managed"
 def _is_worker_session() -> bool:
     """ow workerとして起動されたセッションかを判定する。
 
-    ow_spawn_workerは worker起動時に環境変数 OW_ROLE=worker を設定する。
     workerはtask fileとcheck_inで文脈を得るため、個人フロー用の
     アクティビティ一覧注入・check-inブロック・nudgeは適用しない。
+    判定実体は guard_service.is_worker_session() に委譲する
+    (worker ガードと同じ env を見るための一元化)。
     """
-    return os.environ.get("OW_ROLE") == "worker"
+    return guard_service.is_worker_session()
 
 
 # --- 記録ツール ---

--- a/src/main.py
+++ b/src/main.py
@@ -202,7 +202,6 @@ def add_logs(items: list[dict]) -> dict:
 
     Returns: {created: [...], errors: [{index, error}]}
     """
-    guard_service.check_worker_guard("add_logs")
     result = discussion_log_service.add_logs(items)
     if "error" not in result:
         # tag_notes: 全アイテムのタグをUNIONして1回注入
@@ -846,7 +845,12 @@ def get_map(
 
 @mcp.tool()
 def add_habit(content: str) -> dict:
-    """エージェントの振る舞いを登録する。check-in時に自動注入され、以降の行動に反映される。"覚えといて"と言われた行動ルールはここに登録する"""
+    """エージェントの振る舞いを登録する。check-in時に自動注入され、以降の行動に反映される。"覚えといて"と言われた行動ルールはここに登録する
+
+    note: 現在は worker ガードの対象外。ユーザー承認を要する書き込みである点は
+    add_decisions / add_topic と同様なので、将来の議論によりガード対象に
+    含める余地がある。
+    """
     return habit_service.add_habit(content)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -847,10 +847,12 @@ def get_map(
 def add_habit(content: str) -> dict:
     """エージェントの振る舞いを登録する。check-in時に自動注入され、以降の行動に反映される。"覚えといて"と言われた行動ルールはここに登録する
 
-    note: 現在は worker ガードの対象外。ユーザー承認を要する書き込みである点は
-    add_decisions / add_topic と同様なので、将来の議論によりガード対象に
-    含める余地がある。
+    worker セッション (OW_ROLE=worker) からの直接呼び出しは
+    WorkerGuardError でブロックされる。ユーザー承認を要する書き込みなので
+    add_decisions / add_topic と同じ guard 対象。OW_ESCALATION=1 の
+    orch_proxy 経路でのみ通過する。
     """
+    guard_service.check_worker_guard("add_habit")
     return habit_service.add_habit(content)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.services import (
     timeline_service,
     harness_service,
     ow_service,
+    guard_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -182,6 +183,7 @@ def add_topic(
     related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]。作成と同時にリレーションを張る
 
     レスポンスに類似トピック(similar_topics)が含まれる場合がある。重複トピックの防止やリレーション追加の参考にすること。"""
+    guard_service.check_worker_guard("add_topic")
     result = topic_service.add_topic(title, description, tags, related=related)
     if "error" not in result:
         _maybe_inject_tag_notes(result, tags)
@@ -200,6 +202,7 @@ def add_logs(items: list[dict]) -> dict:
 
     Returns: {created: [...], errors: [{index, error}]}
     """
+    guard_service.check_worker_guard("add_logs")
     result = discussion_log_service.add_logs(items)
     if "error" not in result:
         # tag_notes: 全アイテムのタグをUNIONして1回注入
@@ -231,6 +234,7 @@ def add_decisions(items: list[dict], ctx: Context) -> dict:
         created各要素には related_decisions（同topic内の類似decision上位3件 [{id, title, distance}]）が付く。
         既存decisionとの矛盾・重複に気づくための導線。embeddingサーバー未起動時は空配列。
     """
+    guard_service.check_worker_guard("add_decisions")
     result = decision_service.add_decisions(items)
     if "error" not in result:
         # tag_notes: 全アイテムのタグをUNIONして1回注入

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -8,6 +8,7 @@ from . import (
     tag_service,
     pin_service,
     timeline_service,
+    guard_service,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "tag_service",
     "pin_service",
     "timeline_service",
+    "guard_service",
 ]

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -1,12 +1,13 @@
 """worker セッション向けの構造的ガード。
 
 ow worker として起動されたセッションが、ユーザー合意を必要とする記録系ツール
-(add_decisions / add_logs / add_topic) を直接呼び出すのを構造的に阻止する。
-worker は task に集中するため、自由な記録はせずに以下のいずれかを経由する:
+(add_decisions / add_topic) を直接呼び出すのを構造的に阻止する。
+worker は task に集中するため、これらの記録はユーザー合意に基づいて
+orch 経由で行う。判断を orch に仰ぐためのエスカレーション通路では
+OW_ESCALATION=1 を立てて通過させる。
 
-- recording skill 経由でユーザー合意プロセスを伴って記録する
-- 判断を仰ぐ場合は orch にエスカレーションし、orch が代行する
-  (orch_proxy 経路では OW_ESCALATION=1 を立てて通過させる)
+note: add_logs は worker-sync の退場処理で必須呼び出しなのでガード対象外。
+add_habit も現状ガード対象外 (将来議論で拡張余地あり)。
 """
 import os
 
@@ -37,8 +38,7 @@ def is_escalation_mode() -> bool:
 
 _WORKER_GUARD_MESSAGE_TMPL = (
     "{tool_name} は worker セッションから直接呼び出せません。"
-    "ユーザー合意プロセスを伴う記録は recording skill 経由で行うか、"
-    "判断を仰ぐ場合は orch にエスカレーションしてください "
+    "ユーザー合意に基づいて orch 経由で記録してください "
     "(orch_proxy 経路では OW_ESCALATION=1 で通過します)。"
 )
 
@@ -46,8 +46,8 @@ _WORKER_GUARD_MESSAGE_TMPL = (
 def check_worker_guard(tool_name: str) -> None:
     """worker セッションかつ非エスカレーション時に WorkerGuardError を raise する。
 
-    add_decisions / add_logs / add_topic 等、worker が直接呼んではならない
-    ツールの冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
+    add_decisions / add_topic 等、worker が直接呼んではならないツールの
+    冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
     """
     if is_worker_session() and not is_escalation_mode():
         raise WorkerGuardError(_WORKER_GUARD_MESSAGE_TMPL.format(tool_name=tool_name))

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -1,13 +1,12 @@
 """worker セッション向けの構造的ガード。
 
 ow worker として起動されたセッションが、ユーザー合意を必要とする記録系ツール
-(add_decisions / add_topic) を直接呼び出すのを構造的に阻止する。
+(add_decisions / add_topic / add_habit) を直接呼び出すのを構造的に阻止する。
 worker は task に集中するため、これらの記録はユーザー合意に基づいて
 orch 経由で行う。判断を orch に仰ぐためのエスカレーション通路では
 OW_ESCALATION=1 を立てて通過させる。
 
 note: add_logs は worker-sync の退場処理で必須呼び出しなのでガード対象外。
-add_habit も現状ガード対象外 (将来議論で拡張余地あり)。
 """
 import os
 
@@ -46,8 +45,8 @@ _WORKER_GUARD_MESSAGE_TMPL = (
 def check_worker_guard(tool_name: str) -> None:
     """worker セッションかつ非エスカレーション時に WorkerGuardError を raise する。
 
-    add_decisions / add_topic 等、worker が直接呼んではならないツールの
-    冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
+    add_decisions / add_topic / add_habit 等、worker が直接呼んではならない
+    ツールの冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
     """
     if is_worker_session() and not is_escalation_mode():
         raise WorkerGuardError(_WORKER_GUARD_MESSAGE_TMPL.format(tool_name=tool_name))

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -1,0 +1,53 @@
+"""worker セッション向けの構造的ガード。
+
+ow worker として起動されたセッションが、ユーザー合意を必要とする記録系ツール
+(add_decisions / add_logs / add_topic) を直接呼び出すのを構造的に阻止する。
+worker は task に集中するため、自由な記録はせずに以下のいずれかを経由する:
+
+- recording skill 経由でユーザー合意プロセスを伴って記録する
+- 判断を仰ぐ場合は orch にエスカレーションし、orch が代行する
+  (orch_proxy 経路では OW_ESCALATION=1 を立てて通過させる)
+"""
+import os
+
+
+class WorkerGuardError(RuntimeError):
+    """worker セッションが直接呼び出せないツールを呼んだときに raise される。"""
+
+
+_ROLE_ENV = "OW_ROLE"
+_ROLE_WORKER = "worker"
+_ESCALATION_ENV = "OW_ESCALATION"
+_ESCALATION_PASS = "1"
+
+
+def is_worker_session() -> bool:
+    """ow worker として起動されたセッションかを判定する。
+
+    ow_spawn_worker は worker 起動時に環境変数 OW_ROLE=worker を設定する。
+    エスカレーション状態 (OW_ESCALATION) はここでは見ない。
+    """
+    return os.environ.get(_ROLE_ENV) == _ROLE_WORKER
+
+
+def is_escalation_mode() -> bool:
+    """orch_proxy 経由でエスカレーション通路に乗っているかを判定する。"""
+    return os.environ.get(_ESCALATION_ENV) == _ESCALATION_PASS
+
+
+_WORKER_GUARD_MESSAGE_TMPL = (
+    "{tool_name} は worker セッションから直接呼び出せません。"
+    "ユーザー合意プロセスを伴う記録は recording skill 経由で行うか、"
+    "判断を仰ぐ場合は orch にエスカレーションしてください "
+    "(orch_proxy 経路では OW_ESCALATION=1 で通過します)。"
+)
+
+
+def check_worker_guard(tool_name: str) -> None:
+    """worker セッションかつ非エスカレーション時に WorkerGuardError を raise する。
+
+    add_decisions / add_logs / add_topic 等、worker が直接呼んではならない
+    ツールの冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
+    """
+    if is_worker_session() and not is_escalation_mode():
+        raise WorkerGuardError(_WORKER_GUARD_MESSAGE_TMPL.format(tool_name=tool_name))

--- a/tests/integration/test_worker_guard_tools.py
+++ b/tests/integration/test_worker_guard_tools.py
@@ -1,0 +1,246 @@
+"""add_decisions / add_logs / add_topic MCPツールの worker ガード統合テスト。
+
+guard_service.check_worker_guard が main.py の MCP ツール冒頭で正しく実行され、
+worker セッションから直接呼ばれた場合に WorkerGuardError が raise されること、
+OW_ESCALATION=1 / OW_ROLE 未設定 / OW_ROLE=orch の場合は通過してツール本体が
+実行されることを検証する。
+"""
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.db import init_database
+from src.services.guard_service import WorkerGuardError
+from src.services.topic_service import add_topic as service_add_topic
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時SQLite DB。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture(autouse=True)
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストで embedding を無効化する。"""
+
+
+@pytest.fixture
+def existing_topic(temp_db):
+    """ガード通過後の本体実行で使う既存トピックを1件用意し、id を返す。"""
+    result = service_add_topic(
+        title="Guard test topic",
+        description="Topic prepared for guard pass-through tests.",
+        tags=["domain:test"],
+    )
+    return result["topic_id"]
+
+
+class TestAddTopicWorkerGuard:
+    """add_topic への worker ガード。"""
+
+    def test_worker_session_raises(self, temp_db, monkeypatch):
+        """OW_ROLE=worker のとき WorkerGuardError を raise する。"""
+        from src.main import add_topic
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            add_topic(
+                title="Should fail",
+                description="Worker must not write directly.",
+                tags=["domain:test"],
+            )
+        assert "add_topic" in str(exc_info.value)
+
+    def test_worker_with_escalation_passes(self, temp_db, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION=1 → ガード通過して topic 作成。"""
+        from src.main import add_topic
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        result = add_topic(
+            title="Escalation passes",
+            description="orch_proxy escalation should pass through.",
+            tags=["domain:test"],
+        )
+        assert "error" not in result
+        assert "topic_id" in result
+
+    def test_orch_role_passes(self, temp_db, monkeypatch):
+        """OW_ROLE=orch → ガード通過。"""
+        from src.main import add_topic
+
+        monkeypatch.setenv("OW_ROLE", "orch")
+        result = add_topic(
+            title="Orch passes",
+            description="orch may write directly.",
+            tags=["domain:test"],
+        )
+        assert "error" not in result
+        assert "topic_id" in result
+
+    def test_no_role_passes(self, temp_db, monkeypatch):
+        """OW_ROLE 未設定 (通常セッション) → ガード通過。"""
+        from src.main import add_topic
+
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        result = add_topic(
+            title="Normal session",
+            description="No OW_ROLE: regular write path.",
+            tags=["domain:test"],
+        )
+        assert "error" not in result
+        assert "topic_id" in result
+
+
+class TestAddLogsWorkerGuard:
+    """add_logs への worker ガード。"""
+
+    def test_worker_session_raises(self, temp_db, monkeypatch):
+        """OW_ROLE=worker のとき WorkerGuardError を raise する。"""
+        from src.main import add_logs
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            add_logs(items=[{"topic_id": 1, "content": "blocked write"}])
+        assert "add_logs" in str(exc_info.value)
+
+    def test_worker_with_escalation_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION=1 → ガード通過。"""
+        from src.main import add_logs
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        result = add_logs(items=[{
+            "topic_id": existing_topic,
+            "content": "Escalation log payload.",
+        }])
+        assert "error" not in result
+        assert "created" in result
+
+    def test_orch_role_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE=orch → ガード通過。"""
+        from src.main import add_logs
+
+        monkeypatch.setenv("OW_ROLE", "orch")
+        result = add_logs(items=[{
+            "topic_id": existing_topic,
+            "content": "Orch direct log.",
+        }])
+        assert "error" not in result
+        assert "created" in result
+
+    def test_no_role_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE 未設定 → ガード通過。"""
+        from src.main import add_logs
+
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        result = add_logs(items=[{
+            "topic_id": existing_topic,
+            "content": "Normal session log.",
+        }])
+        assert "error" not in result
+        assert "created" in result
+
+
+class TestAddDecisionsWorkerGuard:
+    """add_decisions への worker ガード。"""
+
+    def _make_ctx(self):
+        """add_decisions は ctx.session_id を参照するため最小ダミーを渡す。"""
+        ctx = MagicMock()
+        ctx.session_id = "test-session"
+        return ctx
+
+    def test_worker_session_raises(self, temp_db, monkeypatch):
+        """OW_ROLE=worker のとき WorkerGuardError を raise する。
+
+        ctx は guard 通過前に raise されるため参照されない。
+        """
+        from src.main import add_decisions
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            add_decisions(
+                items=[{
+                    "topic_id": 1,
+                    "decision": "blocked",
+                    "reason": "blocked",
+                }],
+                ctx=self._make_ctx(),
+            )
+        assert "add_decisions" in str(exc_info.value)
+
+    def test_worker_with_escalation_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION=1 → ガード通過。"""
+        from src.main import add_decisions
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        result = add_decisions(
+            items=[{
+                "topic_id": existing_topic,
+                "decision": "Pass through under escalation.",
+                "reason": "orch_proxy escalation path.",
+            }],
+            ctx=self._make_ctx(),
+        )
+        assert "error" not in result
+        assert "created" in result
+
+    def test_orch_role_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE=orch → ガード通過。"""
+        from src.main import add_decisions
+
+        monkeypatch.setenv("OW_ROLE", "orch")
+        result = add_decisions(
+            items=[{
+                "topic_id": existing_topic,
+                "decision": "Orch decision.",
+                "reason": "Orch may record directly.",
+            }],
+            ctx=self._make_ctx(),
+        )
+        assert "error" not in result
+        assert "created" in result
+
+    def test_no_role_passes(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE 未設定 → ガード通過。"""
+        from src.main import add_decisions
+
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        result = add_decisions(
+            items=[{
+                "topic_id": existing_topic,
+                "decision": "Normal decision.",
+                "reason": "Regular session.",
+            }],
+            ctx=self._make_ctx(),
+        )
+        assert "error" not in result
+        assert "created" in result
+
+
+class TestGuardMessageContent:
+    """raise されたメッセージで案内文言が含まれることを統合経由で確認する。"""
+
+    def test_message_includes_recording_skill_guidance(self, temp_db, monkeypatch):
+        """recording skill 経由の記録方法を案内する。"""
+        from src.main import add_topic
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            add_topic(title="x", description="x", tags=["domain:test"])
+        message = str(exc_info.value)
+        assert "recording skill" in message
+        assert "orch" in message
+        assert "エスカレーション" in message
+        assert "OW_ESCALATION=1" in message

--- a/tests/integration/test_worker_guard_tools.py
+++ b/tests/integration/test_worker_guard_tools.py
@@ -1,9 +1,12 @@
-"""add_decisions / add_logs / add_topic MCPツールの worker ガード統合テスト。
+"""add_decisions / add_topic MCPツールの worker ガード統合テスト。
 
 guard_service.check_worker_guard が main.py の MCP ツール冒頭で正しく実行され、
 worker セッションから直接呼ばれた場合に WorkerGuardError が raise されること、
 OW_ESCALATION=1 / OW_ROLE 未設定 / OW_ROLE=orch の場合は通過してツール本体が
 実行されることを検証する。
+
+add_logs は worker-sync の退場処理で必須の直接呼び出しになるためガード対象外。
+本テストでも add_logs はカバーしない (回帰検出は既存 batch logs テストに任せる)。
 """
 import os
 import tempfile
@@ -101,51 +104,18 @@ class TestAddTopicWorkerGuard:
         assert "topic_id" in result
 
 
-class TestAddLogsWorkerGuard:
-    """add_logs への worker ガード。"""
+class TestAddLogsBypassesGuard:
+    """add_logs はガード対象外 (worker-sync 退場処理で必須直接呼び出し)。"""
 
-    def test_worker_session_raises(self, temp_db, monkeypatch):
-        """OW_ROLE=worker のとき WorkerGuardError を raise する。"""
+    def test_worker_session_passes_through(self, temp_db, existing_topic, monkeypatch):
+        """OW_ROLE=worker でも add_logs はガードに引っかからず通過する。"""
         from src.main import add_logs
 
         monkeypatch.setenv("OW_ROLE", "worker")
-        with pytest.raises(WorkerGuardError) as exc_info:
-            add_logs(items=[{"topic_id": 1, "content": "blocked write"}])
-        assert "add_logs" in str(exc_info.value)
-
-    def test_worker_with_escalation_passes(self, temp_db, existing_topic, monkeypatch):
-        """OW_ROLE=worker かつ OW_ESCALATION=1 → ガード通過。"""
-        from src.main import add_logs
-
-        monkeypatch.setenv("OW_ROLE", "worker")
-        monkeypatch.setenv("OW_ESCALATION", "1")
+        monkeypatch.delenv("OW_ESCALATION", raising=False)
         result = add_logs(items=[{
             "topic_id": existing_topic,
-            "content": "Escalation log payload.",
-        }])
-        assert "error" not in result
-        assert "created" in result
-
-    def test_orch_role_passes(self, temp_db, existing_topic, monkeypatch):
-        """OW_ROLE=orch → ガード通過。"""
-        from src.main import add_logs
-
-        monkeypatch.setenv("OW_ROLE", "orch")
-        result = add_logs(items=[{
-            "topic_id": existing_topic,
-            "content": "Orch direct log.",
-        }])
-        assert "error" not in result
-        assert "created" in result
-
-    def test_no_role_passes(self, temp_db, existing_topic, monkeypatch):
-        """OW_ROLE 未設定 → ガード通過。"""
-        from src.main import add_logs
-
-        monkeypatch.delenv("OW_ROLE", raising=False)
-        result = add_logs(items=[{
-            "topic_id": existing_topic,
-            "content": "Normal session log.",
+            "content": "worker-sync exit log payload.",
         }])
         assert "error" not in result
         assert "created" in result
@@ -232,15 +202,13 @@ class TestAddDecisionsWorkerGuard:
 class TestGuardMessageContent:
     """raise されたメッセージで案内文言が含まれることを統合経由で確認する。"""
 
-    def test_message_includes_recording_skill_guidance(self, temp_db, monkeypatch):
-        """recording skill 経由の記録方法を案内する。"""
+    def test_message_includes_guidance(self, temp_db, monkeypatch):
+        """メッセージで orch 経由の記録と OW_ESCALATION=1 通過手段を案内する。"""
         from src.main import add_topic
 
         monkeypatch.setenv("OW_ROLE", "worker")
         with pytest.raises(WorkerGuardError) as exc_info:
             add_topic(title="x", description="x", tags=["domain:test"])
         message = str(exc_info.value)
-        assert "recording skill" in message
         assert "orch" in message
-        assert "エスカレーション" in message
         assert "OW_ESCALATION=1" in message

--- a/tests/integration/test_worker_guard_tools.py
+++ b/tests/integration/test_worker_guard_tools.py
@@ -1,4 +1,4 @@
-"""add_decisions / add_topic MCPツールの worker ガード統合テスト。
+"""add_decisions / add_topic / add_habit MCPツールの worker ガード統合テスト。
 
 guard_service.check_worker_guard が main.py の MCP ツール冒頭で正しく実行され、
 worker セッションから直接呼ばれた場合に WorkerGuardError が raise されること、
@@ -197,6 +197,47 @@ class TestAddDecisionsWorkerGuard:
         )
         assert "error" not in result
         assert "created" in result
+
+
+class TestAddHabitWorkerGuard:
+    """add_habit への worker ガード。"""
+
+    def test_worker_session_raises(self, temp_db, monkeypatch):
+        """OW_ROLE=worker のとき WorkerGuardError を raise する。"""
+        from src.main import add_habit
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            add_habit(content="Should fail under worker role.")
+        assert "add_habit" in str(exc_info.value)
+
+    def test_worker_with_escalation_passes(self, temp_db, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION=1 → ガード通過して habit 作成。"""
+        from src.main import add_habit
+
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        result = add_habit(content="Escalation passes for habit.")
+        assert "error" not in result
+        assert "habit_id" in result
+
+    def test_orch_role_passes(self, temp_db, monkeypatch):
+        """OW_ROLE=orch → ガード通過。"""
+        from src.main import add_habit
+
+        monkeypatch.setenv("OW_ROLE", "orch")
+        result = add_habit(content="Orch may register habit directly.")
+        assert "error" not in result
+        assert "habit_id" in result
+
+    def test_no_role_passes(self, temp_db, monkeypatch):
+        """OW_ROLE 未設定 (通常セッション) → ガード通過。"""
+        from src.main import add_habit
+
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        result = add_habit(content="Regular session habit registration.")
+        assert "error" not in result
+        assert "habit_id" in result
 
 
 class TestGuardMessageContent:

--- a/tests/unit/test_guard_service.py
+++ b/tests/unit/test_guard_service.py
@@ -1,0 +1,159 @@
+"""guard_service の単体テスト。
+
+OW_ROLE=worker と OW_ESCALATION の組み合わせに対する判定・例外送出を検証する。
+
+- OW_ROLE=worker 単独 → is_worker_session=True, check_worker_guard で raise
+- OW_ROLE=worker かつ OW_ESCALATION=1 → check_worker_guard 通過
+- OW_ROLE 未設定 → is_worker_session=False, check_worker_guard 通過
+- OW_ROLE=orch → check_worker_guard 通過
+- raise されるメッセージに tool_name と「recording skill」「orch」「OW_ESCALATION」案内が含まれる
+"""
+import pytest
+
+from src.services import guard_service
+from src.services.guard_service import (
+    WorkerGuardError,
+    check_worker_guard,
+    is_escalation_mode,
+    is_worker_session,
+)
+
+
+class TestIsWorkerSession:
+    """is_worker_session() の OW_ROLE 判定。"""
+
+    def test_role_worker_true(self, monkeypatch):
+        """OW_ROLE=worker が立っているとき True を返す。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        assert is_worker_session() is True
+
+    def test_role_orch_false(self, monkeypatch):
+        """OW_ROLE=orch のとき worker 扱いしない。"""
+        monkeypatch.setenv("OW_ROLE", "orch")
+        assert is_worker_session() is False
+
+    def test_role_unset_false(self, monkeypatch):
+        """OW_ROLE 未設定のとき worker 扱いしない (通常セッション)。"""
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        assert is_worker_session() is False
+
+    def test_role_empty_false(self, monkeypatch):
+        """OW_ROLE が空文字のとき worker 扱いしない。"""
+        monkeypatch.setenv("OW_ROLE", "")
+        assert is_worker_session() is False
+
+    def test_escalation_does_not_affect_role_check(self, monkeypatch):
+        """OW_ESCALATION=1 でも OW_ROLE=worker なら is_worker_session は True。
+
+        is_worker_session() は OW_ROLE だけを見る (役割の判定)。
+        エスカレーションによる通過判定は check_worker_guard 側で行う。
+        """
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        assert is_worker_session() is True
+
+
+class TestIsEscalationMode:
+    """is_escalation_mode() の OW_ESCALATION 判定。"""
+
+    def test_escalation_one_true(self, monkeypatch):
+        """OW_ESCALATION=1 のとき True を返す。"""
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        assert is_escalation_mode() is True
+
+    def test_escalation_zero_false(self, monkeypatch):
+        """OW_ESCALATION=0 のときは通過させない。"""
+        monkeypatch.setenv("OW_ESCALATION", "0")
+        assert is_escalation_mode() is False
+
+    def test_escalation_true_string_false(self, monkeypatch):
+        """OW_ESCALATION='true' のような値も通過対象外 (厳格に '1' のみ)。"""
+        monkeypatch.setenv("OW_ESCALATION", "true")
+        assert is_escalation_mode() is False
+
+    def test_escalation_unset_false(self, monkeypatch):
+        """OW_ESCALATION 未設定のとき False を返す。"""
+        monkeypatch.delenv("OW_ESCALATION", raising=False)
+        assert is_escalation_mode() is False
+
+
+class TestCheckWorkerGuard:
+    """check_worker_guard() の通過・例外送出。"""
+
+    def test_worker_without_escalation_raises(self, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION 未設定 → WorkerGuardError を raise。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.delenv("OW_ESCALATION", raising=False)
+        with pytest.raises(WorkerGuardError):
+            check_worker_guard("add_decisions")
+
+    def test_worker_with_escalation_passes(self, monkeypatch):
+        """OW_ROLE=worker かつ OW_ESCALATION=1 → 通過 (orch_proxy 経路)。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        check_worker_guard("add_decisions")
+
+    def test_orch_passes(self, monkeypatch):
+        """OW_ROLE=orch → 通過。"""
+        monkeypatch.setenv("OW_ROLE", "orch")
+        monkeypatch.delenv("OW_ESCALATION", raising=False)
+        check_worker_guard("add_decisions")
+
+    def test_unset_passes(self, monkeypatch):
+        """OW_ROLE 未設定 (通常セッション) → 通過。"""
+        monkeypatch.delenv("OW_ROLE", raising=False)
+        monkeypatch.delenv("OW_ESCALATION", raising=False)
+        check_worker_guard("add_decisions")
+
+    def test_worker_with_escalation_zero_raises(self, monkeypatch):
+        """OW_ESCALATION=0 では通過しない (厳格に '1' のみ通過)。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "0")
+        with pytest.raises(WorkerGuardError):
+            check_worker_guard("add_decisions")
+
+
+class TestWorkerGuardErrorMessage:
+    """WorkerGuardError のメッセージ内容を検証する。"""
+
+    def test_message_includes_tool_name(self, monkeypatch):
+        """raise されるメッセージに tool_name 引数が埋め込まれる。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            check_worker_guard("add_topic")
+        assert "add_topic" in str(exc_info.value)
+
+    def test_message_guides_to_recording_skill(self, monkeypatch):
+        """メッセージで recording skill 経由の記録方法を案内する。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            check_worker_guard("add_logs")
+        assert "recording skill" in str(exc_info.value)
+
+    def test_message_guides_to_orch_escalation(self, monkeypatch):
+        """メッセージで orch エスカレーション経路を案内する。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            check_worker_guard("add_decisions")
+        message = str(exc_info.value)
+        assert "orch" in message
+        assert "エスカレーション" in message
+
+    def test_message_mentions_escalation_env(self, monkeypatch):
+        """メッセージで OW_ESCALATION=1 通過手段を明示する。"""
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError) as exc_info:
+            check_worker_guard("add_decisions")
+        assert "OW_ESCALATION=1" in str(exc_info.value)
+
+
+class TestWorkerGuardErrorClass:
+    """WorkerGuardError の class 性質。"""
+
+    def test_is_runtime_error(self):
+        """WorkerGuardError は RuntimeError サブクラス (broad except に拾われやすくする)。"""
+        assert issubclass(WorkerGuardError, RuntimeError)
+
+    def test_exported_from_guard_service(self):
+        """guard_service モジュールから直接参照できる。"""
+        assert guard_service.WorkerGuardError is WorkerGuardError

--- a/tests/unit/test_guard_service.py
+++ b/tests/unit/test_guard_service.py
@@ -123,21 +123,14 @@ class TestWorkerGuardErrorMessage:
             check_worker_guard("add_topic")
         assert "add_topic" in str(exc_info.value)
 
-    def test_message_guides_to_recording_skill(self, monkeypatch):
-        """メッセージで recording skill 経由の記録方法を案内する。"""
-        monkeypatch.setenv("OW_ROLE", "worker")
-        with pytest.raises(WorkerGuardError) as exc_info:
-            check_worker_guard("add_logs")
-        assert "recording skill" in str(exc_info.value)
-
-    def test_message_guides_to_orch_escalation(self, monkeypatch):
-        """メッセージで orch エスカレーション経路を案内する。"""
+    def test_message_guides_to_orch(self, monkeypatch):
+        """メッセージで orch 経由でユーザー合意を取って記録する方針を案内する。"""
         monkeypatch.setenv("OW_ROLE", "worker")
         with pytest.raises(WorkerGuardError) as exc_info:
             check_worker_guard("add_decisions")
         message = str(exc_info.value)
         assert "orch" in message
-        assert "エスカレーション" in message
+        assert "ユーザー合意" in message
 
     def test_message_mentions_escalation_env(self, monkeypatch):
         """メッセージで OW_ESCALATION=1 通過手段を明示する。"""


### PR DESCRIPTION
## Summary

worker セッション (OW_ROLE=worker) から `add_decisions` / `add_logs` / `add_topic` の 3 つの記録系 MCP ツールが直接呼ばれた場合に `WorkerGuardError` を raise する構造的ガードを導入する。

- `OW_ESCALATION=1` のときは orch_proxy 経路として通過させる
- worker は task に集中する役割なので、ユーザー合意プロセスを伴う記録は recording skill 経由か、判断を仰ぐ場合は orch にエスカレートさせる
- これまで worker SKILL.md の policy として書かれていただけの契約を、コード側の mechanism として降ろす

## Changes

- `src/services/guard_service.py` 新設: `is_worker_session()` / `is_escalation_mode()` / `check_worker_guard(tool_name)` / `WorkerGuardError`
- `src/main.py` の 3 ツール冒頭で `guard_service.check_worker_guard(...)` を呼び出し
- `hooks/hook_transcript.py` の `_is_worker_session()` を `guard_service.is_worker_session()` へ委譲 (env 判定の一元化)
- 新規テスト 33 件を追加 (unit 20 + integration 13)

## Acceptance

1. ✅ `src/main.py` の 3 関数冒頭で `OW_ROLE=worker` のとき構造的に拒否
2. ✅ 例外: `OW_ESCALATION=1` のとき通過 (orch_proxy 用)
3. ✅ `_is_worker_session()` を `src/services/guard_service.py` に集約して再利用可能化
4. ✅ 拒否時のエラーメッセージで「recording skill 経由 or orch にエスカレートしろ」案内
5. ✅ テスト: worker 拒否 / OW_ESCALATION=1 通過 / OW_ROLE 未設定・orch 通過 / メッセージ内容検証

## Test plan

- [x] `uv run pytest tests/unit/test_guard_service.py tests/integration/test_worker_guard_tools.py` (33 passed)
- [x] `uv run pytest tests/unit/test_hook_transcript.py tests/e2e/test_stop_hook.py tests/e2e/test_session_start_hook.py` (87 passed, 既存 hook 回帰なし)
- [x] `uv run pytest tests/unit/test_batch_logs_decisions.py tests/unit/test_tag_notes.py tests/unit/test_topic_write.py tests/unit/test_decision_title.py tests/unit/test_propagate_to.py` (133 passed, 3 ツール本体への回帰なし)
- [ ] CI 全緑確認
- [ ] claude-review bot 含むレビューコメント対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)