### PR TITLE
feat: Literal types for entity_type/source_type/target_type (typo defense, P0-5)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -283,7 +283,7 @@ def get_topics(
 
 @mcp.tool()
 def get_logs(
-    entity_type: str,
+    entity_type: Literal["topic", "activity"],
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
@@ -313,7 +313,7 @@ def get_logs(
 
 @mcp.tool()
 def get_decisions(
-    entity_type: str,
+    entity_type: Literal["topic", "activity"],
     entity_id: int,
     start_id: Optional[int] = None,
     limit: int = 30,
@@ -345,7 +345,7 @@ def get_decisions(
 def search(
     keyword: str | list[str],
     tags: Optional[list[str]] = None,
-    entity_type: Optional[str] = None,
+    entity_type: Optional[Literal["topic", "decision", "activity", "log", "material"]] = None,
     limit: int = 10,
     offset: int = 0,
     keyword_mode: str = "and",
@@ -753,7 +753,7 @@ def check_in(
 
 @mcp.tool()
 def add_relation(
-    source_type: str,
+    source_type: Literal["topic", "activity", "material", "decision", "log"],
     source_id: int,
     targets: list[dict],
     relation_type: str = "related",
@@ -786,7 +786,7 @@ def add_relation(
 
 @mcp.tool()
 def remove_relation(
-    source_type: str,
+    source_type: Literal["topic", "activity", "material", "decision", "log"],
     source_id: int,
     targets: list[dict],
     relation_type: str = "related",
@@ -815,7 +815,7 @@ def remove_relation(
 
 @mcp.tool()
 def get_map(
-    entity_type: str,
+    entity_type: Literal["topic", "activity", "material", "decision", "log"],
     entity_id: int,
     min_depth: int = 0,
     max_depth: int = 2,
@@ -860,9 +860,9 @@ def update_habit(habit_id: int, content: Optional[str] = None, active: Optional[
 
 @mcp.tool()
 def add_pin(
-    source_type: str,
+    source_type: Literal["tag", "activity", "topic", "decision", "log", "material"],
     source_ref: Union[int, str],
-    target_type: str,
+    target_type: Literal["tag", "activity", "topic", "decision", "log", "material"],
     target_ref: Union[int, str],
 ) -> dict:
     """pinを追加する（source → target）。
@@ -904,9 +904,9 @@ def add_pin(
 
 @mcp.tool()
 def remove_pin(
-    source_type: str,
+    source_type: Literal["tag", "activity", "topic", "decision", "log", "material"],
     source_ref: Union[int, str],
-    target_type: str,
+    target_type: Literal["tag", "activity", "topic", "decision", "log", "material"],
     target_ref: Union[int, str],
 ) -> dict:
     """pinを削除する（source → target）。
@@ -932,7 +932,7 @@ def remove_pin(
 
 
 @mcp.tool()
-def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
+def retract(entity_type: Literal["decision", "log"], ids: list[int], undo: bool = False) -> dict:
     """決定事項やログを取り消す（論理削除）。取り消し済みエンティティは検索・取得でデフォルト除外される。
 
     Args:
@@ -947,7 +947,7 @@ def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
 def get_timeline(
     topic_id: int | None = None,
     activity_id: int | None = None,
-    entity_types: list[str] | None = None,
+    entity_types: list[Literal["decision", "log", "material"]] | None = None,
     before: str | None = None,
     limit: int = 50,
     order: str = "desc",

--- a/tests/unit/test_literal_type_validation.py
+++ b/tests/unit/test_literal_type_validation.py
@@ -9,6 +9,8 @@ src/main.py の entity_type / source_type / target_type / entity_types
 
 を確認する。
 """
+import asyncio
+import functools
 import json
 
 import pytest
@@ -17,23 +19,28 @@ from pydantic import ValidationError
 from src.main import mcp
 from src.services.activity_service import add_activity
 from src.services.topic_service import add_topic
+from tests.helpers import add_decision
 
 
 DEFAULT_TAGS = ["domain:test"]
 
 
-def _schema_for(name: str) -> dict:
-    """指定ツールの入力スキーマ（properties）を取り出す。"""
-    import asyncio
+@functools.lru_cache(maxsize=1)
+def _all_schemas() -> dict[str, dict]:
+    """全ツールのスキーマを一括取得しキャッシュする（list_tools を 1 回に抑える）。"""
 
     async def _fetch():
-        tools = await mcp.list_tools()
-        for t in tools:
-            if t.name == name:
-                return t.parameters
-        raise AssertionError(f"tool not found: {name}")
+        return {t.name: t.parameters for t in await mcp.list_tools()}
 
     return asyncio.run(_fetch())
+
+
+def _schema_for(name: str) -> dict:
+    """指定ツールの入力スキーマ（properties）を取り出す。"""
+    schemas = _all_schemas()
+    if name not in schemas:
+        raise AssertionError(f"tool not found: {name}")
+    return schemas[name]
 
 
 def _enum_of(schema: dict, prop: str) -> list[str]:
@@ -159,7 +166,6 @@ INVALID_CASES = [
 @pytest.mark.parametrize("tool_name,args,target_key", INVALID_CASES)
 def test_invalid_literal_value_raises_validation_error(tool_name, args, target_key):
     """許容値以外の文字列を渡すと ValidationError で弾かれる。"""
-    import asyncio
 
     async def _call():
         return await mcp.call_tool(tool_name, args)
@@ -179,7 +185,6 @@ class TestValidLiteralValuePassesThrough:
 
     def test_get_logs_valid_topic(self, temp_db):
         topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
-        import asyncio
 
         async def _call():
             return await mcp.call_tool(
@@ -195,7 +200,6 @@ class TestValidLiteralValuePassesThrough:
         act = add_activity(
             title="a", description="d", tags=["intent:discuss", "domain:test"]
         )
-        import asyncio
 
         async def _call():
             return await mcp.call_tool(
@@ -208,8 +212,6 @@ class TestValidLiteralValuePassesThrough:
         assert isinstance(payload, dict)
 
     def test_search_valid_entity_type(self, temp_db, disable_embedding):
-        import asyncio
-
         async def _call():
             return await mcp.call_tool(
                 "search", {"keyword": "xx", "entity_type": "topic"}
@@ -220,20 +222,30 @@ class TestValidLiteralValuePassesThrough:
         assert isinstance(payload, dict)
 
     def test_retract_valid_decision(self, temp_db):
-        import asyncio
+        """実 decision を作って valid な ids でツール本体が成功実行されることを確認する。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        dec = add_decision(
+            decision="d",
+            reason="r",
+            topic_id=topic["topic_id"],
+            tags=DEFAULT_TAGS,
+        )
+        decision_id = dec["decision_id"]
 
         async def _call():
-            return await mcp.call_tool("retract", {"entity_type": "decision", "ids": []})
+            return await mcp.call_tool(
+                "retract", {"entity_type": "decision", "ids": [decision_id]}
+            )
 
         result = asyncio.run(_call())
         payload = result.structured_content or result.content
-        # ids=[] は service 側でバリデーションエラー dict が返るが、それは ValidationError ではなく
-        # 「型検証は通った」ことを意味する。
+        # service 層が成功時に返す形（success リストに対象 id を含む）であること
         assert isinstance(payload, dict)
+        assert "error" not in payload
+        assert decision_id in payload.get("success", [])
 
     def test_get_timeline_valid_subset(self, temp_db, disable_embedding):
         topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
-        import asyncio
 
         async def _call():
             return await mcp.call_tool(

--- a/tests/unit/test_literal_type_validation.py
+++ b/tests/unit/test_literal_type_validation.py
@@ -1,0 +1,246 @@
+"""MCPツール引数の Literal 型バリデーションのテスト。
+
+src/main.py の entity_type / source_type / target_type / entity_types
+引数が Literal[...] になっていることで、
+
+- スキーマ JSON で enum が伝播していること
+- 許容値以外を渡したとき pydantic ValidationError で弾かれること
+- 許容値を渡したときは型検証を通過し、ツール本体が実行されること
+
+を確認する。
+"""
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from src.main import mcp
+from src.services.activity_service import add_activity
+from src.services.topic_service import add_topic
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+def _schema_for(name: str) -> dict:
+    """指定ツールの入力スキーマ（properties）を取り出す。"""
+    import asyncio
+
+    async def _fetch():
+        tools = await mcp.list_tools()
+        for t in tools:
+            if t.name == name:
+                return t.parameters
+        raise AssertionError(f"tool not found: {name}")
+
+    return asyncio.run(_fetch())
+
+
+def _enum_of(schema: dict, prop: str) -> list[str]:
+    """properties[prop] の enum を抽出する（anyOf/items 経由含む）。"""
+    p = schema["properties"][prop]
+    if "enum" in p:
+        return list(p["enum"])
+    if "anyOf" in p:
+        for branch in p["anyOf"]:
+            if "enum" in branch:
+                return list(branch["enum"])
+            if branch.get("type") == "array" and "items" in branch:
+                items = branch["items"]
+                if "enum" in items:
+                    return list(items["enum"])
+    if p.get("type") == "array" and "items" in p:
+        items = p["items"]
+        if "enum" in items:
+            return list(items["enum"])
+    raise AssertionError(
+        f"enum not found in property {prop}: {json.dumps(p)}"
+    )
+
+
+class TestSchemaEnumPropagation:
+    """各ツールの入力スキーマで Literal が enum として出力されること。"""
+
+    def test_get_logs_entity_type_enum(self):
+        schema = _schema_for("get_logs")
+        assert sorted(_enum_of(schema, "entity_type")) == sorted(["topic", "activity"])
+
+    def test_get_decisions_entity_type_enum(self):
+        schema = _schema_for("get_decisions")
+        assert sorted(_enum_of(schema, "entity_type")) == sorted(["topic", "activity"])
+
+    def test_search_entity_type_enum(self):
+        schema = _schema_for("search")
+        assert sorted(_enum_of(schema, "entity_type")) == sorted(
+            ["topic", "decision", "activity", "log", "material"]
+        )
+
+    def test_add_relation_source_type_enum(self):
+        schema = _schema_for("add_relation")
+        assert sorted(_enum_of(schema, "source_type")) == sorted(
+            ["topic", "activity", "material", "decision", "log"]
+        )
+
+    def test_remove_relation_source_type_enum(self):
+        schema = _schema_for("remove_relation")
+        assert sorted(_enum_of(schema, "source_type")) == sorted(
+            ["topic", "activity", "material", "decision", "log"]
+        )
+
+    def test_get_map_entity_type_enum(self):
+        schema = _schema_for("get_map")
+        assert sorted(_enum_of(schema, "entity_type")) == sorted(
+            ["topic", "activity", "material", "decision", "log"]
+        )
+
+    def test_add_pin_source_target_enum(self):
+        schema = _schema_for("add_pin")
+        expected = sorted(["tag", "activity", "topic", "decision", "log", "material"])
+        assert sorted(_enum_of(schema, "source_type")) == expected
+        assert sorted(_enum_of(schema, "target_type")) == expected
+
+    def test_remove_pin_source_target_enum(self):
+        schema = _schema_for("remove_pin")
+        expected = sorted(["tag", "activity", "topic", "decision", "log", "material"])
+        assert sorted(_enum_of(schema, "source_type")) == expected
+        assert sorted(_enum_of(schema, "target_type")) == expected
+
+    def test_retract_entity_type_enum(self):
+        schema = _schema_for("retract")
+        assert sorted(_enum_of(schema, "entity_type")) == sorted(["decision", "log"])
+
+    def test_get_timeline_entity_types_enum(self):
+        schema = _schema_for("get_timeline")
+        assert sorted(_enum_of(schema, "entity_types")) == sorted(
+            ["decision", "log", "material"]
+        )
+
+
+# --- 不正値での ValidationError 検証 -------------------------------------
+
+INVALID_CASES = [
+    # (tool_name, args, typo を含むキー)
+    ("get_logs", {"entity_type": "decisin", "entity_id": 1}, "entity_type"),
+    ("get_logs", {"entity_type": "log", "entity_id": 1}, "entity_type"),  # 許容外（topic/activityのみ）
+    ("get_decisions", {"entity_type": "decisin", "entity_id": 1}, "entity_type"),
+    ("search", {"keyword": "foo", "entity_type": "decisin"}, "entity_type"),
+    (
+        "add_relation",
+        {"source_type": "topik", "source_id": 1, "targets": []},
+        "source_type",
+    ),
+    (
+        "remove_relation",
+        {"source_type": "topik", "source_id": 1, "targets": []},
+        "source_type",
+    ),
+    ("get_map", {"entity_type": "tag", "entity_id": 1}, "entity_type"),  # tag は不可
+    (
+        "add_pin",
+        {"source_type": "decisin", "source_ref": 1, "target_type": "log", "target_ref": 2},
+        "source_type",
+    ),
+    (
+        "add_pin",
+        {"source_type": "log", "source_ref": 1, "target_type": "decisin", "target_ref": 2},
+        "target_type",
+    ),
+    (
+        "remove_pin",
+        {"source_type": "logg", "source_ref": 1, "target_type": "tag", "target_ref": 2},
+        "source_type",
+    ),
+    ("retract", {"entity_type": "decisin", "ids": [1]}, "entity_type"),
+    ("retract", {"entity_type": "material", "ids": [1]}, "entity_type"),
+    ("get_timeline", {"entity_types": ["decision", "topik"]}, "entity_types"),
+]
+
+
+@pytest.mark.parametrize("tool_name,args,target_key", INVALID_CASES)
+def test_invalid_literal_value_raises_validation_error(tool_name, args, target_key):
+    """許容値以外の文字列を渡すと ValidationError で弾かれる。"""
+    import asyncio
+
+    async def _call():
+        return await mcp.call_tool(tool_name, args)
+
+    with pytest.raises(ValidationError) as excinfo:
+        asyncio.run(_call())
+
+    msg = str(excinfo.value)
+    assert "Input should be" in msg
+    assert target_key in msg
+
+
+# --- 正常値で従来通り動作 -------------------------------------------------
+
+class TestValidLiteralValuePassesThrough:
+    """許容値を渡したときは型検証を通過し、ツール本体が実行されること。"""
+
+    def test_get_logs_valid_topic(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        import asyncio
+
+        async def _call():
+            return await mcp.call_tool(
+                "get_logs", {"entity_type": "topic", "entity_id": topic["topic_id"]}
+            )
+
+        result = asyncio.run(_call())
+        payload = result.structured_content or result.content
+        # ツール本体が呼ばれた=ValidationErrorが出ていない。logs/error いずれかのキーが含まれる。
+        assert isinstance(payload, dict)
+
+    def test_get_decisions_valid_activity(self, temp_db):
+        act = add_activity(
+            title="a", description="d", tags=["intent:discuss", "domain:test"]
+        )
+        import asyncio
+
+        async def _call():
+            return await mcp.call_tool(
+                "get_decisions",
+                {"entity_type": "activity", "entity_id": act["activity_id"]},
+            )
+
+        result = asyncio.run(_call())
+        payload = result.structured_content or result.content
+        assert isinstance(payload, dict)
+
+    def test_search_valid_entity_type(self, temp_db, disable_embedding):
+        import asyncio
+
+        async def _call():
+            return await mcp.call_tool(
+                "search", {"keyword": "xx", "entity_type": "topic"}
+            )
+
+        result = asyncio.run(_call())
+        payload = result.structured_content or result.content
+        assert isinstance(payload, dict)
+
+    def test_retract_valid_decision(self, temp_db):
+        import asyncio
+
+        async def _call():
+            return await mcp.call_tool("retract", {"entity_type": "decision", "ids": []})
+
+        result = asyncio.run(_call())
+        payload = result.structured_content or result.content
+        # ids=[] は service 側でバリデーションエラー dict が返るが、それは ValidationError ではなく
+        # 「型検証は通った」ことを意味する。
+        assert isinstance(payload, dict)
+
+    def test_get_timeline_valid_subset(self, temp_db, disable_embedding):
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        import asyncio
+
+        async def _call():
+            return await mcp.call_tool(
+                "get_timeline",
+                {"topic_id": topic["topic_id"], "entity_types": ["decision", "log"]},
+            )
+
+        result = asyncio.run(_call())
+        payload = result.structured_content or result.content
+        assert isinstance(payload, dict)


### PR DESCRIPTION
## Summary

- MCPツール引数 `entity_type` / `source_type` / `target_type` / `entity_types` を文字列型から `Literal[...]` に変更。FastMCP がスキーマに enum を伝播するため、AIエージェントから許容値が見える。
- 不正値（typo含む）はツール呼出時に pydantic `ValidationError` で弾かれる。これまでサービス層に到達してから VALIDATION_ERROR dict を返していた経路が、スキーマ層で即拒否される。
- 対象ツール (10件): `get_logs` / `get_decisions` / `search` / `add_relation` / `remove_relation` / `get_map` / `add_pin` / `remove_pin` / `retract` / `get_timeline`

## 許容値（各ツール、サービス層の既存バリデーション集合と一致）

| tool | param | values |
|---|---|---|
| get_logs / get_decisions | entity_type | topic, activity |
| search (Optional) | entity_type | topic, decision, activity, log, material |
| add_relation / remove_relation | source_type | topic, activity, material, decision, log |
| get_map | entity_type | topic, activity, material, decision, log |
| add_pin / remove_pin | source_type, target_type | tag, activity, topic, decision, log, material |
| retract | entity_type | decision, log |
| get_timeline (Optional list) | entity_types | decision, log, material |

## スキーマ確認 (FastMCP の enum 伝播)

実装前: `{"type": "string"}`
実装後: `{"enum": ["topic", "decision", "activity", "log", "material"], "type": "string"}`

Optional のケースは `anyOf` 内、`list[Literal[...]]` のケースは `items.enum` に enum が伝播することを確認。

## Test plan

- [x] `tests/unit/test_literal_type_validation.py` 追加（28テスト）
  - 10ツール全部のスキーマで enum が期待値どおりに伝播することを検証
  - 13ケースで typo / 範囲外値が `ValidationError` で弾かれることを検証
  - 5ケースで許容値が型検証を通過しツール本体が実行されることを検証
- [x] 既存 unit テスト 1397件 全パス
- [ ] integration / e2e は CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)