### PR TITLE
fix: HTTP server cwd 強制 + manual fallback observability 改善 (T82)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 """MCPサーバーのメインエントリーポイント"""
 import logging
+import os
 import random
+from pathlib import Path
 from fastmcp import FastMCP, Context
 from fastmcp.server.dependencies import get_context
 from typing import Literal, Optional, Union
@@ -1271,9 +1273,25 @@ async def session_unregister(request: Request) -> JSONResponse:
 from src.http_config import HTTP_HOST, HTTP_PORT
 
 
+def _ensure_project_root_cwd() -> Path:
+    """HTTPサーバー起動時にcwdをプロジェクトルートに固定する。
+
+    `uv run python -m src.main --transport http` をworktree内など任意の場所から
+    起動すると、HTTPサーバープロセスはその場所をcwdとして固定する。当該cwdが
+    後から削除・移動されると、ow_service内のsubprocess呼び出しや相対パス操作が
+    存在しないパスを参照し続けるリスクがある（worker spawn失敗・診断困難）。
+    cwdをこの関数の `__file__` 由来のプロジェクトルートへ強制し、構造的に防ぐ。
+
+    Returns:
+        固定後のproject_rootパス（Path）。
+    """
+    project_root = Path(__file__).resolve().parent.parent
+    os.chdir(project_root)
+    return project_root
+
+
 if __name__ == "__main__":
     import argparse
-    import os
     import signal
 
     parser = argparse.ArgumentParser(description="cc-memory MCP server")
@@ -1293,6 +1311,11 @@ if __name__ == "__main__":
         import socket
         from src.services.lock_file import acquire, release
         from src.services.session_manager import SessionManager
+
+        # 起動時cwdをプロジェクトルートに固定する。worktree内などからの起動による
+        # cwd差し替えリスクを構造的に潰す（詳細は _ensure_project_root_cwd 参照）。
+        _fixed_root = _ensure_project_root_cwd()
+        logger.info("HTTP server cwd fixed to %s", _fixed_root)
 
         # ポートの空き確認
         try:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1262,11 +1262,22 @@ def ow_spawn_worker(
 
     if adapter_path is None:
         # manualフォールバック: 起動コマンドを返す
+        # adapter_path不在のとき、payloadだけ見ると後段の追跡で原因が分からなくなる。
+        # adapter_errorに「どのterminalで・どこを探したか」を明示する。
+        expected_adapter = (
+            Path(__file__).resolve().parent.parent.parent
+            / "scripts" / "ow" / "adapters" / f"{terminal}.sh"
+        )
+        adapter_error = (
+            f"adapter not found at {expected_adapter} (OW_TERMINAL={terminal!r})"
+        )
+        logger.error("ow_spawn_worker manual fallback: %s", adapter_error)
         return {
             "command": worker_cmd,
             "manual": True,
             "task_file": str(task_file),
             "alias": alias,
+            "adapter_error": adapter_error,
         }
 
     # アダプタ呼び出し — stdoutから安定IDを取得する
@@ -1293,7 +1304,7 @@ def ow_spawn_worker(
             term_ref = str(uuid.uuid4())
             logger.warning("adapter returned empty term_ref, using fallback UUID: %s", term_ref)
     except subprocess.TimeoutExpired:
-        logger.warning("adapter spawn timed out after 30s")
+        logger.error("ow_spawn_worker manual fallback: adapter spawn timed out after 30s")
         return {
             "command": worker_cmd,
             "manual": True,
@@ -1302,7 +1313,7 @@ def ow_spawn_worker(
             "adapter_error": "adapter spawn timed out",
         }
     except subprocess.CalledProcessError as e:
-        logger.warning("adapter spawn failed: %s", e.stderr)
+        logger.error("ow_spawn_worker manual fallback: adapter spawn failed: %s", e.stderr)
         return {
             "command": worker_cmd,
             "manual": True,
@@ -1332,9 +1343,18 @@ def ow_close_worker(term_ref: str) -> dict:
     adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
 
     if adapter_path is None:
+        expected_adapter = (
+            Path(__file__).resolve().parent.parent.parent
+            / "scripts" / "ow" / "adapters" / f"{terminal}.sh"
+        )
+        adapter_error = (
+            f"adapter not found at {expected_adapter} (OW_TERMINAL={terminal!r})"
+        )
+        logger.error("ow_close_worker manual fallback: %s", adapter_error)
         return {
             "manual": True,
             "message": f"手動でterm_ref={term_ref}のセッションをクローズしてください",
+            "adapter_error": adapter_error,
         }
 
     try:
@@ -1347,13 +1367,13 @@ def ow_close_worker(term_ref: str) -> dict:
         )
         return {"closed": True, "term_ref": term_ref}
     except subprocess.TimeoutExpired:
-        logger.warning("adapter close timed out after 15s")
+        logger.error("ow_close_worker adapter close timed out after 15s")
         return {
             "error": {"code": "ADAPTER_CLOSE_TIMEOUT", "message": "adapter close timed out"},
             "term_ref": term_ref,
         }
     except subprocess.CalledProcessError as e:
-        logger.warning("adapter close failed: %s", e.stderr)
+        logger.error("ow_close_worker adapter close failed: %s", e.stderr)
         return {
             "error": {"code": "ADAPTER_CLOSE_FAILED", "message": e.stderr},
             "term_ref": term_ref,

--- a/tests/unit/test_main_http_cwd.py
+++ b/tests/unit/test_main_http_cwd.py
@@ -1,0 +1,38 @@
+"""src.main._ensure_project_root_cwd の動作テスト。
+
+HTTP server 起動時に cwd をプロジェクトルートへ強制固定する関数。
+起動時 cwd (e.g. worktree内) に残置されると当該パスが消えたとき
+subprocess呼び出しが失敗するため、構造的に project_root へ寄せる。
+"""
+from pathlib import Path
+
+from src import main as main_module
+
+
+class TestEnsureProjectRootCwd:
+    def test_chdir_invoked_with_project_root(self, monkeypatch):
+        """os.chdir が _ensure_project_root_cwd 内で1回、project_root を引数に呼ばれる。"""
+        called_with: list = []
+
+        def fake_chdir(path):
+            called_with.append(path)
+
+        monkeypatch.setattr(main_module.os, "chdir", fake_chdir)
+        returned = main_module._ensure_project_root_cwd()
+
+        assert len(called_with) == 1
+        assert called_with[0] == returned
+
+    def test_returns_path_corresponding_to_src_main_parent_parent(self, monkeypatch):
+        """戻り値が src/main.py の親の親 (= リポジトリ root) になる。"""
+        monkeypatch.setattr(main_module.os, "chdir", lambda _path: None)
+        returned = main_module._ensure_project_root_cwd()
+        expected = Path(main_module.__file__).resolve().parent.parent
+        assert returned == expected
+
+    def test_returned_path_contains_src_directory(self, monkeypatch):
+        """戻り値の直下に src/ ディレクトリが存在する (project_root の妥当性)。"""
+        monkeypatch.setattr(main_module.os, "chdir", lambda _path: None)
+        returned = main_module._ensure_project_root_cwd()
+        assert (returned / "src").is_dir()
+        assert (returned / "src" / "main.py").is_file()

--- a/tests/unit/test_ow_spawn_manual_fallback_observability.py
+++ b/tests/unit/test_ow_spawn_manual_fallback_observability.py
@@ -1,0 +1,255 @@
+"""ow_service の manual fallback observability テスト。
+
+ow_spawn_worker / ow_close_worker が manual:true を返すすべての分岐で:
+- adapter_error フィールドが必ず含まれる
+- logger.error が呼ばれる (warning ではない)
+
+ow_spawn_worker が原因不明で manual:true を返したとき、payload に手掛かりが
+無いと運用側で原因を辿れない。adapter_error と error ログを構造的に必須化する。
+"""
+import logging
+import subprocess
+
+import pytest
+
+from src.services import ow_service
+
+
+OW_SERVICE_LOGGER = "src.services.ow_service"
+
+
+@pytest.fixture(autouse=True)
+def _bypass_preflight(monkeypatch):
+    """relay/channel/presence/identity の preflight check を全部素通しにする。"""
+    monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+    monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+    monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+    monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+    monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
+
+
+def _build_fake_adapter(tmp_path, terminal: str = "tmux"):
+    """tmp_path 配下に terminal アダプタの実体を1つだけ作る。"""
+    scripts_dir = tmp_path / "scripts" / "ow" / "adapters"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    adapter = scripts_dir / f"{terminal}.sh"
+    adapter.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    adapter.chmod(0o755)
+    return adapter
+
+
+class TestSpawnManualFallbackAdapterPathNone:
+    """OW_TERMINAL に対応するアダプタが存在しないとき manual:true を返す分岐。"""
+
+    def test_terminal_unset_payload_contains_adapter_error(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """OW_TERMINAL 未設定 (= 内部的に 'manual') → manual:true + adapter_error。"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+
+        with caplog.at_level(logging.ERROR, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_spawn_worker(
+                alias="w-playbook",
+                channel="ch1",
+                cwd=str(tmp_path),
+                model="claude-opus-4-7",
+                task_title="t", acceptance="d", task_n=1,
+            )
+
+        assert result.get("manual") is True
+        assert "adapter_error" in result
+        assert "adapter not found" in result["adapter_error"]
+        assert "OW_TERMINAL='manual'" in result["adapter_error"]
+        assert any(
+            r.levelno == logging.ERROR and "manual fallback" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_unknown_terminal_payload_contains_terminal_name(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """OW_TERMINAL に登録外の値 → adapter_error に terminal 名が出る。"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        monkeypatch.setenv("OW_TERMINAL", "unknown-terminal-xyz")
+
+        with caplog.at_level(logging.ERROR, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_spawn_worker(
+                alias="w-playbook",
+                channel="ch1",
+                cwd=str(tmp_path),
+                model="claude-opus-4-7",
+                task_title="t", acceptance="d", task_n=1,
+            )
+
+        assert result.get("manual") is True
+        assert "adapter_error" in result
+        assert "unknown-terminal-xyz" in result["adapter_error"]
+
+
+class TestSpawnManualFallbackSubprocessFailure:
+    """adapter は存在するが subprocess.run が失敗するときの manual fallback。"""
+
+    def test_called_process_error_passes_stderr_to_adapter_error_and_logs_error(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """CalledProcessError → adapter_error=stderr, level=ERROR (warning でない)。"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        fake_adapter = _build_fake_adapter(tmp_path, terminal="tmux")
+        monkeypatch.setattr(
+            ow_service,
+            "_get_adapter_path",
+            lambda terminal: fake_adapter if terminal == "tmux" else None,
+        )
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(
+                returncode=2, cmd=args, stderr="boom from adapter"
+            )
+
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+
+        with caplog.at_level(logging.WARNING, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_spawn_worker(
+                alias="w-playbook",
+                channel="ch1",
+                cwd=str(tmp_path),
+                model="claude-opus-4-7",
+                task_title="t", acceptance="d", task_n=1,
+            )
+
+        assert result.get("manual") is True
+        assert result.get("adapter_error") == "boom from adapter"
+        # logger.error に格上げされている (manual fallback の warning は残さない)
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any("adapter spawn failed" in m for m in warn_msgs)
+        assert any(
+            r.levelno == logging.ERROR and "adapter spawn failed" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_timeout_passes_message_to_adapter_error_and_logs_error(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """TimeoutExpired → adapter_error 固定文言, level=ERROR。"""
+        monkeypatch.setattr(ow_service, "OW_QUEUE_DIR", str(tmp_path))
+        fake_adapter = _build_fake_adapter(tmp_path, terminal="tmux")
+        monkeypatch.setattr(
+            ow_service,
+            "_get_adapter_path",
+            lambda terminal: fake_adapter if terminal == "tmux" else None,
+        )
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        def fake_run(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=30)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+
+        with caplog.at_level(logging.WARNING, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_spawn_worker(
+                alias="w-playbook",
+                channel="ch1",
+                cwd=str(tmp_path),
+                model="claude-opus-4-7",
+                task_title="t", acceptance="d", task_n=1,
+            )
+
+        assert result.get("manual") is True
+        assert result.get("adapter_error") == "adapter spawn timed out"
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any("timed out" in m for m in warn_msgs)
+        assert any(
+            r.levelno == logging.ERROR and "timed out" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+class TestCloseManualFallback:
+    """ow_close_worker: アダプタ不在時の manual:true と adapter_error。"""
+
+    def test_terminal_unset_payload_contains_adapter_error(self, monkeypatch, caplog):
+        monkeypatch.delenv("OW_TERMINAL", raising=False)
+        with caplog.at_level(logging.ERROR, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_close_worker(term_ref="%99")
+        assert result.get("manual") is True
+        assert "adapter_error" in result
+        assert "adapter not found" in result["adapter_error"]
+        assert any(
+            r.levelno == logging.ERROR and "manual fallback" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_unknown_terminal_payload_contains_terminal_name(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("OW_TERMINAL", "unknown-terminal-xyz")
+        with caplog.at_level(logging.ERROR, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_close_worker(term_ref="%99")
+        assert result.get("manual") is True
+        assert "unknown-terminal-xyz" in result["adapter_error"]
+
+
+class TestCloseAdapterFailureLogs:
+    """ow_close_worker の adapter 起動失敗時の logger.error 格上げ検証。"""
+
+    def test_called_process_error_logs_error(self, monkeypatch, tmp_path, caplog):
+        fake_adapter = _build_fake_adapter(tmp_path, terminal="tmux")
+        monkeypatch.setattr(
+            ow_service,
+            "_get_adapter_path",
+            lambda terminal: fake_adapter if terminal == "tmux" else None,
+        )
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(
+                returncode=3, cmd=args, stderr="close failed"
+            )
+
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+
+        with caplog.at_level(logging.WARNING, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_close_worker(term_ref="%99")
+
+        assert result["error"]["code"] == "ADAPTER_CLOSE_FAILED"
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any("adapter close failed" in m for m in warn_msgs)
+        assert any(
+            r.levelno == logging.ERROR and "adapter close failed" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_timeout_logs_error(self, monkeypatch, tmp_path, caplog):
+        fake_adapter = _build_fake_adapter(tmp_path, terminal="tmux")
+        monkeypatch.setattr(
+            ow_service,
+            "_get_adapter_path",
+            lambda terminal: fake_adapter if terminal == "tmux" else None,
+        )
+        monkeypatch.setenv("OW_TERMINAL", "tmux")
+
+        def fake_run(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=15)
+
+        monkeypatch.setattr(ow_service.subprocess, "run", fake_run)
+
+        with caplog.at_level(logging.WARNING, logger=OW_SERVICE_LOGGER):
+            result = ow_service.ow_close_worker(term_ref="%99")
+
+        assert result["error"]["code"] == "ADAPTER_CLOSE_TIMEOUT"
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any("close timed out" in m for m in warn_msgs)
+        assert any(
+            r.levelno == logging.ERROR and "close timed out" in r.getMessage()
+            for r in caplog.records
+        )


### PR DESCRIPTION
## Summary

orch から `ow_spawn_worker` 呼び出し時に `manual:true` で返却される事象 (T82) の構造改善 2点:

1. **HTTP server cwd 強制 (案B)** — `src/main.py` の `--transport http` モードで起動された MCP server プロセスの cwd を `os.chdir(project_root)` で強制固定する。`uv run python -m src.main --transport http` を worktree 内などから直接起動すると HTTP server プロセスが当該 cwd に張り付くため、その worktree が `git worktree remove` されると subprocess 呼び出しや相対パス操作の挙動が破綻する。launcher 経由ではすでに `cwd=_PROJECT_ROOT` を指定済 (test_launcher.py で固定済) だが、CLAUDE.local.md の運用手順は `src.main` を直接起動するため bypass される。`src.main` 自身に防御線を入れる。

2. **manual fallback observability (案C)** — `ow_spawn_worker` / `ow_close_worker` が `manual:true` で返却するすべての分岐に `adapter_error` フィールドを必ず付与し、関連 `logger.warning` を `logger.error` に格上げ。adapter_path is None 分岐は従来 `adapter_error` 欠落で原因不明になっていたため、期待 adapter path と OW_TERMINAL 値を含むメッセージを付ける。

## Background

設計議論および採用判断は M#375 (T82 manual:true bug 調査結果と設計選択肢 v0) + orch との合意 (msg#773)。

manual:true 観測時 (T82 起票時) は採用案 A (retry) 案 D (close) を不採用とし、本 PR の案 B + 案 C を採用 (msg#773):
> 採択: B+C (HTTP server cwd 強制 + manual fallback に adapter_error 必須・logger.error 格上げ)。理由: (1) cwd固定は独立した構造リスク、fix valuable。(2) manual:true 再現不能但手動 spawn bypass でセッション継続可能、今必要なのは observability。

調査時 (M#375 §2) では仮説 b/c/d いずれもコード再現できず、実投入 (alias=w-debug-tp1) も `spawning:ok` 返却。orch 観測時点での **一時失敗** だった可能性が高く、本 PR は再発時の追跡可能性と構造的予防を目的とする。

## Changes

- `src/main.py`: トップレベルに `os` / `pathlib.Path` import 追加。`_ensure_project_root_cwd()` 関数を新設し、`if args.transport == "http":` ブロック先頭で呼ぶ。
- `src/services/ow_service.py`:
  - `ow_spawn_worker` の3つの manual fallback 分岐 (`adapter_path is None` / `TimeoutExpired` / `CalledProcessError`) で `adapter_error` を必ず添える + `logger.error` 格上げ。
  - `ow_close_worker` の `adapter_path is None` 分岐に `adapter_error` 追加。`TimeoutExpired` / `CalledProcessError` も `logger.error` 格上げ。
- `tests/unit/test_main_http_cwd.py` (new): `_ensure_project_root_cwd` の動作テスト 3件。
- `tests/unit/test_ow_spawn_manual_fallback_observability.py` (new): manual fallback 各分岐の `adapter_error` 必須化と `logger.error` 格上げを検証する 8件。

## Test plan

- [x] 新規 unit test 11件 pass (`uv run pytest tests/unit/test_main_http_cwd.py tests/unit/test_ow_spawn_manual_fallback_observability.py`)
- [x] 関連既存テスト (test_ow_queue / test_ow_spawn_alias_and_settings / test_launcher / test_pretooluse_ow_spawn_worker) 204件 pass — 回帰なし
- [ ] CI 緑確認
- [ ] マージ後の HTTP server 再起動でリポジトリ root を cwd として起動するパスを再確認 (CLAUDE.local.md 手順とのすり合わせ)

## Related

- topic 454 (ow 実装)
- activity 949 ([作業] orch起動時 TMUX_PANE 自動取得→ow_spawn_worker自動付与の実装)
- 設計材料 M#375 (調査結果 + 設計選択肢 v0)
- 関連 M#350 (TMUX_PANE 自動付与側 v0、PR #396 で実装済)
- 関連 PR: #396 (PreToolUse hook で tmux_target_pane 自動注入), #397 (recv/heartbeat 親監視)

🤖 Generated with [Claude Code](https://claude.com/claude-code)