### PR TITLE
feat: heartbeat に session_id 同梱、session_start_hook で自セッションフィルタ

### DIFF
--- a/hooks/heartbeat.py
+++ b/hooks/heartbeat.py
@@ -2,13 +2,21 @@
 from src.db import get_connection
 
 
-def update_heartbeat(activity_id: int) -> None:
-    """last_heartbeat_at を現在時刻に更新する"""
+def update_heartbeat(activity_id: int, session_id: str | None = None) -> None:
+    """last_heartbeat_at と last_heartbeat_session_id を現在のセッションで更新する。
+
+    session_id を同梱することで、session_start_hook が「自セッション自身の
+    heartbeat を別セッション扱いする」誤表示を回避できる。session_id が None
+    の場合（テストフィクスチャ等）は NULL のまま書き込み、既存挙動を保つ。
+    """
     conn = get_connection()
     try:
         conn.execute(
-            "UPDATE activities SET last_heartbeat_at = datetime('now') WHERE id = ?",
-            (activity_id,),
+            "UPDATE activities "
+            "SET last_heartbeat_at = datetime('now'), "
+            "    last_heartbeat_session_id = ? "
+            "WHERE id = ?",
+            (session_id, activity_id),
         )
         conn.commit()
     finally:

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -135,10 +135,12 @@ def _shorten_topic_title(title: str) -> str:
     return title
 
 
-def _build_activities_section(conn) -> str:
+def _build_activities_section(conn, session_id: str | None = None) -> str:
     """アクティビティ一覧を組み立てる。
 
     - heartbeat 中のアクティビティは「## 作業中（別セッション）」セクションで提示（D#2466 据え置き）
+      - ただし last_heartbeat_session_id が自セッション (引数 session_id) と一致するものは
+        「別セッション」ではないので通常側へ回す（P1-7: 3軸モデル「所在」軸の可観測化）
     - それ以外は topic 別グルーピング (D#2464-2466)
       - 各アクティビティは関連 topic_id 最小を primary topic として 1 グループに配置
       - 関連 topic 無しは「その他」セクション
@@ -174,7 +176,14 @@ def _build_activities_section(conn) -> str:
             if a["id"] in seen_ids:
                 continue
             seen_ids.add(a["id"])
-            if a.get("is_heartbeat_active"):
+            # 自セッションの heartbeat は「別セッション」扱いしない (P1-7)。
+            # session_id が None（hook stdin に未同梱）の場合は照合不能なため、
+            # 従来通り heartbeat_active なら別セッションとして表示する。
+            is_own_session = (
+                session_id is not None
+                and a.get("last_heartbeat_session_id") == session_id
+            )
+            if a.get("is_heartbeat_active") and not is_own_session:
                 heartbeat_activities.append(a)
             else:
                 normal_activities.append(a)
@@ -295,7 +304,7 @@ def _build_activities_section(conn) -> str:
     return "\n".join(parts) + "\n"
 
 
-def _build_habits_section(conn) -> str:
+def _build_habits_section(conn, session_id: str | None = None) -> str:
     """振る舞い一覧を組み立てる。"""
     contents = get_active_habit_contents_with_conn(conn)
 
@@ -309,14 +318,14 @@ def _build_habits_section(conn) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _build_sync_policy_section(conn) -> str:  # conn: buildersループの統一シグネチャ
+def _build_sync_policy_section(conn, session_id: str | None = None) -> str:  # conn: buildersループの統一シグネチャ
     """sync_policyが設定されていれば注入する。未設定時はコンテキスト消費ゼロ。"""
     if not config.SYNC_POLICY:
         return ""
     return f"# sync_policy\n{config.SYNC_POLICY}\n"
 
 
-def _build_snapshot_section(conn) -> str:
+def _build_snapshot_section(conn, session_id: str | None = None) -> str:
     """スナップショット取得＋ヘルスチェック。異常検知時のみ警告を返す。
 
     connは引数として受け取るが、snapshot.pyはdb_pathベースで動作するため
@@ -379,8 +388,11 @@ _CONTEXT_FLOW_GUIDE = """\
 """
 
 
-def _build_session_context() -> str:
+def _build_session_context(session_id: str | None = None) -> str:
     """サービス層経由でセッション開始時のコンテキストを組み立てる。
+
+    session_id は session_start_hook の stdin payload に含まれる Claude Code 提供の
+    識別子。アクティビティ一覧の「自セッション heartbeat」照合に使う (P1-7)。
 
     各セクションは独立してtry/exceptで保護し、
     一部のセクションが失敗しても残りは返す。
@@ -396,7 +408,7 @@ def _build_session_context() -> str:
         ]
         for builder in builders:
             try:
-                result = builder(conn)
+                result = builder(conn, session_id)
                 if result:
                     sections.append(result)
             except Exception:
@@ -415,9 +427,20 @@ def _build_session_context() -> str:
 
 def main() -> None:
     try:
-        sys.stdin.read()  # stdinを消費（session_id等が渡されるが今は不使用）
+        raw = sys.stdin.read()
+        session_id: str | None = None
+        if raw:
+            try:
+                payload = json.loads(raw)
+                if isinstance(payload, dict):
+                    sid = payload.get("session_id")
+                    if isinstance(sid, str) and sid:
+                        session_id = sid
+            except json.JSONDecodeError:
+                # session_id 取得失敗時は従来挙動（self 照合なし）にフォールバック
+                session_id = None
 
-        context = _build_session_context()
+        context = _build_session_context(session_id)
 
         output = {
             "hookSpecificOutput": {

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -304,7 +304,7 @@ def _build_activities_section(conn, session_id: str | None = None) -> str:
     return "\n".join(parts) + "\n"
 
 
-def _build_habits_section(conn, session_id: str | None = None) -> str:
+def _build_habits_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
     """振る舞い一覧を組み立てる。"""
     contents = get_active_habit_contents_with_conn(conn)
 
@@ -318,14 +318,14 @@ def _build_habits_section(conn, session_id: str | None = None) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _build_sync_policy_section(conn, session_id: str | None = None) -> str:  # conn: buildersループの統一シグネチャ
+def _build_sync_policy_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
     """sync_policyが設定されていれば注入する。未設定時はコンテキスト消費ゼロ。"""
     if not config.SYNC_POLICY:
         return ""
     return f"# sync_policy\n{config.SYNC_POLICY}\n"
 
 
-def _build_snapshot_section(conn, session_id: str | None = None) -> str:
+def _build_snapshot_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
     """スナップショット取得＋ヘルスチェック。異常検知時のみ警告を返す。
 
     connは引数として受け取るが、snapshot.pyはdb_pathベースで動作するため
@@ -438,7 +438,8 @@ def main() -> None:
                         session_id = sid
             except json.JSONDecodeError:
                 # session_id 取得失敗時は従来挙動（self 照合なし）にフォールバック
-                session_id = None
+                # 初期値 None のまま継続するため再代入不要
+                pass
 
         context = _build_session_context(session_id)
 

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -120,7 +120,7 @@ def main() -> None:
         if in_skill_span:
             state.reset_block_count()
             _output("approve", "Skill Span中のためチェックをスキップします。")
-            _safe_post_approve(state, all_events, transcript_path)
+            _safe_post_approve(state, all_events, transcript_path, session_id=session_id)
             return
 
         # 6. check-in判定
@@ -156,6 +156,7 @@ def main() -> None:
         _safe_post_approve(
             state, all_events, transcript_path, current_turn,
             run_nudges=not suppress_personal_flow,
+            session_id=session_id,
         )
 
     except Exception as e:
@@ -217,13 +218,14 @@ def _safe_post_approve(
     current_turn: int = 0,
     *,
     run_nudges: bool = False,
+    session_id: str | None = None,
 ) -> None:
     """approve出力後の状態更新。例外はstderrログのみ（double-output防止）。
 
     各処理は独立したtryブロックで囲み、一方の失敗が他方を阻害しないようにする。
     """
     try:
-        _update_state_on_approve(state, events, transcript_path)
+        _update_state_on_approve(state, events, transcript_path, session_id=session_id)
     except Exception as e:
         print(
             f"stop_hook.py post-approve error (state): {e}\n{traceback.format_exc()}",
@@ -240,13 +242,15 @@ def _safe_post_approve(
 
 
 def _update_state_on_approve(
-    state: HookState, events: list[dict], transcript_path: str
+    state: HookState, events: list[dict], transcript_path: str,
+    *,
+    session_id: str | None = None,
 ) -> None:
     """approve時の状態更新（heartbeat）"""
     # heartbeat更新
     activity_id = state.get_checked_in_activity()
     if activity_id is not None:
-        update_heartbeat(activity_id)
+        update_heartbeat(activity_id, session_id)
 
 
 def _handle_nudges(state: HookState, events: list[dict], current_turn: int) -> None:

--- a/migrations/0040_add_heartbeat_session_id.sql
+++ b/migrations/0040_add_heartbeat_session_id.sql
@@ -1,0 +1,17 @@
+-- Migration 0040: heartbeat に session_id 同梱
+--
+-- depends: 0039_extend_tag_namespace
+--
+-- 背景:
+--   activities.last_heartbeat_at と組で書き込む last_heartbeat_session_id を導入する。
+--   session_start_hook の「## 作業中（別セッション）」セクションが、自セッション自身の
+--   heartbeat を「別セッション扱い」と誤表示していた問題を解消するため、書込元の
+--   セッションを記録する。
+--
+-- 設計:
+--   - 既存 last_heartbeat_at と同じ activities テーブルに同居（書込が同一トランザクション
+--     で完結し、片方だけ更新される状態を生まない）。
+--   - nullable: 過去 heartbeat（カラム導入前）や session_id 未知のテストフィクスチャでは
+--     NULL のまま。NULL は「未知 → 別セッション扱い」として既存挙動を保つ。
+
+ALTER TABLE activities ADD COLUMN last_heartbeat_session_id TEXT;

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -420,13 +420,17 @@ def get_active_domains() -> list[dict]:
 def get_active_activities_by_tag_with_conn(conn, tag_id: int) -> list[dict]:
     """domain:タグに紐づくホットアクティビティを取得する（conn共有版）。
 
+    last_heartbeat_session_id は呼び出し側（session_start_hook）が自セッション
+    照合に使うため一緒に返す。
+
     Returns:
-        [{"id": int, "title": str, "status": str, "updated_at": str, "is_heartbeat_active": bool}, ...]
+        [{"id": int, "title": str, "status": str, "updated_at": str,
+          "last_heartbeat_session_id": str | None, "is_heartbeat_active": bool}, ...]
         （in_progress優先、updated_at降順）
     """
     rows = conn.execute(
         """
-        SELECT a.id, a.title, a.status, a.updated_at,
+        SELECT a.id, a.title, a.status, a.updated_at, a.last_heartbeat_session_id,
                CASE WHEN a.last_heartbeat_at > datetime('now', '-' || ? || ' minutes') THEN 1 ELSE 0 END AS is_heartbeat_active
         FROM activities a
         JOIN activity_tags at ON a.id = at.activity_id

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -37,8 +37,13 @@ def _run_session_start_hook(
     db_path: str,
     extra_env: dict | None = None,
     env_remove: list[str] | None = None,
+    stdin_payload: dict | None = None,
 ) -> dict:
-    """session_start_hook.pyを実行してJSON出力を返す"""
+    """session_start_hook.pyを実行してJSON出力を返す。
+
+    stdin_payload を指定すると {session_id: ...} などを stdin に流し込める
+    (P1-7 の自セッション照合テスト用)。
+    """
     env = {**os.environ, "DISCUSSION_DB_PATH": db_path}
     # runnerのOW_ROLEを継承しない（テストの決定性確保。worker抑制テストはextra_envで明示設定する）
     env.pop("OW_ROLE", None)
@@ -48,9 +53,10 @@ def _run_session_start_hook(
         for key in env_remove:
             env.pop(key, None)
 
+    payload_str = "{}" if stdin_payload is None else json.dumps(stdin_payload)
     result = subprocess.run(
         [sys.executable, "hooks/session_start_hook.py"],
-        input="{}",
+        input=payload_str,
         capture_output=True,
         text=True,
         cwd=str(PROJECT_ROOT),
@@ -626,3 +632,87 @@ class TestSessionStartHookTopicGrouping:
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "# スコアリング指示" in context
+
+
+def _set_heartbeat(activity_id: int, session_id: str | None) -> None:
+    """activity の heartbeat を「今」に更新し session_id を同梱する"""
+    from datetime import datetime, timezone
+
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE activities SET last_heartbeat_at = ?, last_heartbeat_session_id = ? WHERE id = ?",
+            (now_iso, session_id, activity_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestSessionStartHookSelfSessionHeartbeat:
+    """P1-7: 自セッション自身の heartbeat を「別セッション扱い」しない"""
+
+    def test_self_session_heartbeat_not_in_other_session_block(self, temp_db):
+        """stdin session_id と一致する heartbeat は「## 作業中（別セッション）」に出ない"""
+        activity_id = _seed_activity("[作業] 自セッション中", status="in_progress")
+        _set_heartbeat(activity_id, session_id="sess-self")
+
+        result = _run_session_start_hook(
+            temp_db, stdin_payload={"session_id": "sess-self"}
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        # 「別セッション」ブロック自体が出ないか、出ても対象 activity が含まれない
+        if "## 作業中（別セッション）" in context:
+            other_block_start = context.index("## 作業中（別セッション）")
+            # 直後セクションまでで切り出す
+            tail = context[other_block_start:]
+            next_section = tail.find("\n## ", 1)
+            other_block = tail if next_section == -1 else tail[:next_section]
+            assert f"[{activity_id}]" not in other_block, (
+                "自セッションの heartbeat が「作業中（別セッション）」に出てしまっている"
+            )
+
+    def test_other_session_heartbeat_in_other_session_block(self, temp_db):
+        """別 session_id の heartbeat は引き続き「## 作業中（別セッション）」に出る"""
+        activity_id = _seed_activity("[作業] 別セッション中", status="in_progress")
+        _set_heartbeat(activity_id, session_id="sess-other")
+
+        result = _run_session_start_hook(
+            temp_db, stdin_payload={"session_id": "sess-self"}
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "## 作業中（別セッション）" in context
+        heartbeat_idx = context.index("## 作業中（別セッション）")
+        assert f"[{activity_id}]" in context[heartbeat_idx:], (
+            "他セッション heartbeat が「作業中（別セッション）」に出ていない"
+        )
+
+    def test_null_session_id_falls_back_to_other_session(self, temp_db):
+        """last_heartbeat_session_id=NULL（カラム導入前データ）は従来通り別セッション扱い"""
+        activity_id = _seed_activity("[作業] 旧データ", status="in_progress")
+        _set_heartbeat(activity_id, session_id=None)
+
+        result = _run_session_start_hook(
+            temp_db, stdin_payload={"session_id": "sess-self"}
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "## 作業中（別セッション）" in context
+        heartbeat_idx = context.index("## 作業中（別セッション）")
+        assert f"[{activity_id}]" in context[heartbeat_idx:]
+
+    def test_no_stdin_session_id_keeps_other_session_block(self, temp_db):
+        """stdin に session_id が無い場合は照合不能 → 従来通り別セッション扱い"""
+        activity_id = _seed_activity("[作業] sid不明", status="in_progress")
+        _set_heartbeat(activity_id, session_id="sess-anything")
+
+        # 引数省略で stdin_payload=None → {}
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "## 作業中（別セッション）" in context
+        heartbeat_idx = context.index("## 作業中（別セッション）")
+        assert f"[{activity_id}]" in context[heartbeat_idx:]

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -636,8 +637,6 @@ class TestSessionStartHookTopicGrouping:
 
 def _set_heartbeat(activity_id: int, session_id: str | None) -> None:
     """activity の heartbeat を「今」に更新し session_id を同梱する"""
-    from datetime import datetime, timezone
-
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     conn = get_connection()
     try:

--- a/tests/test_migrations/test_0040_add_heartbeat_session_id.py
+++ b/tests/test_migrations/test_0040_add_heartbeat_session_id.py
@@ -1,0 +1,172 @@
+"""migration 0040_add_heartbeat_session_id のテスト
+
+0040適用後に activities テーブルへ last_heartbeat_session_id 列が追加され、
+既存行のデータ・他カラムが保持されることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0040含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0040():
+    """0040より前のmigrationを適用したDBを提供する。0040の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0040 = MigrationList([m for m in all_migs if m.id < "0040"])
+        with backend.lock():
+            backend.apply_migrations(pre_0040)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0040(db_path: str) -> None:
+    """db_pathに対してmigration 0040のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0040 = MigrationList([m for m in all_migs if m.id.startswith("0040")])
+    with backend.lock():
+        backend.apply_migrations(only_0040)
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    """指定テーブルのカラム名セットを返す。"""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+class TestSessionIdColumnAdded:
+    """0040適用後に last_heartbeat_session_id 列が追加されていることの確認"""
+
+    def test_activities_has_session_id_column_after_0040(self, migrated_db):
+        """migration 0040適用後、activities に last_heartbeat_session_id 列が存在する"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "activities")
+            assert "last_heartbeat_session_id" in column_names, (
+                "activities.last_heartbeat_session_id が0040適用後に存在しない"
+            )
+        finally:
+            conn.close()
+
+    def test_activities_has_no_session_id_column_before_0040(self, db_before_0040):
+        """0040適用前は activities に last_heartbeat_session_id 列が存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            assert "last_heartbeat_session_id" not in _get_column_names(
+                conn, "activities"
+            ), "0040適用前に既に last_heartbeat_session_id 列が存在している"
+        finally:
+            conn.close()
+
+    def test_other_columns_intact_after_0040(self, migrated_db):
+        """0040適用後、activities の主要カラム（id/title/description/status/last_heartbeat_at）が保持される"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "activities")
+            for col in [
+                "id",
+                "title",
+                "description",
+                "status",
+                "created_at",
+                "updated_at",
+                "last_heartbeat_at",
+            ]:
+                assert col in column_names, (
+                    f"activities.{col} が0040適用後に消えている"
+                )
+        finally:
+            conn.close()
+
+
+class TestExistingRowsPreserved:
+    """0040適用時に既存行が破壊されないことの確認"""
+
+    def test_existing_rows_preserved_with_null_session_id(self, db_before_0040):
+        """0040適用前の activities 行は、適用後に last_heartbeat_session_id が NULL のまま既存データを保持する"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO activities (title, description, status, last_heartbeat_at) "
+                "VALUES (?, ?, ?, ?)",
+                ("既存タスク", "desc", "in_progress", "2026-01-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0040(db_before_0040)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT title, status, last_heartbeat_at, last_heartbeat_session_id "
+                "FROM activities WHERE title=?",
+                ("既存タスク",),
+            ).fetchone()
+            assert row is not None
+            assert row["status"] == "in_progress"
+            assert row["last_heartbeat_at"] == "2026-01-01 00:00:00"
+            assert row["last_heartbeat_session_id"] is None, (
+                "既存行の last_heartbeat_session_id は NULL であるべき"
+            )
+        finally:
+            conn.close()
+
+    def test_insert_with_session_id_after_0040(self, migrated_db):
+        """0040適用後、activities に last_heartbeat_session_id を指定してINSERT/UPDATEできる"""
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                ("新規タスク", "desc", "pending"),
+            )
+            activity_id = cursor.lastrowid
+            conn.execute(
+                "UPDATE activities "
+                "SET last_heartbeat_at = ?, last_heartbeat_session_id = ? "
+                "WHERE id = ?",
+                ("2026-06-19 00:00:00", "sess-xyz", activity_id),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT last_heartbeat_session_id FROM activities WHERE id=?",
+                (activity_id,),
+            ).fetchone()
+            assert row is not None
+            assert row["last_heartbeat_session_id"] == "sess-xyz"
+        finally:
+            conn.close()

--- a/tests/unit/test_heartbeat.py
+++ b/tests/unit/test_heartbeat.py
@@ -400,3 +400,80 @@ class TestUpdateHeartbeat:
 
         # 2回目のheartbeatは1回目以降（同一秒の可能性があるので>=）
         assert row2["last_heartbeat_at"] >= row1["last_heartbeat_at"]
+
+    def test_writes_session_id_when_provided(self, temp_db):
+        """update_heartbeat に session_id を渡すと last_heartbeat_session_id に保存される"""
+        from src.services.activity_service import add_activity
+        from hooks.heartbeat import update_heartbeat
+
+        result = add_activity(
+            title="Heartbeat session_id Test",
+            description="Desc",
+            tags=["domain:test"],
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+
+        update_heartbeat(activity_id, session_id="sess-abc-123")
+
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT last_heartbeat_at, last_heartbeat_session_id "
+            "FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["last_heartbeat_at"] is not None
+        assert row["last_heartbeat_session_id"] == "sess-abc-123"
+
+    def test_session_id_defaults_to_null(self, temp_db):
+        """session_id を渡さない場合 last_heartbeat_session_id は NULL のまま"""
+        from src.services.activity_service import add_activity
+        from hooks.heartbeat import update_heartbeat
+
+        result = add_activity(
+            title="Heartbeat no-session_id Test",
+            description="Desc",
+            tags=["domain:test"],
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+
+        update_heartbeat(activity_id)
+
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT last_heartbeat_at, last_heartbeat_session_id "
+            "FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["last_heartbeat_at"] is not None
+        assert row["last_heartbeat_session_id"] is None
+
+    def test_session_id_updated_on_subsequent_heartbeat(self, temp_db):
+        """別 session_id で再度 update_heartbeat すると上書きされる"""
+        from src.services.activity_service import add_activity
+        from hooks.heartbeat import update_heartbeat
+
+        result = add_activity(
+            title="Heartbeat session_id Overwrite Test",
+            description="Desc",
+            tags=["domain:test"],
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+
+        update_heartbeat(activity_id, session_id="sess-old")
+        update_heartbeat(activity_id, session_id="sess-new")
+
+        conn = get_connection()
+        row = conn.execute(
+            "SELECT last_heartbeat_session_id FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["last_heartbeat_session_id"] == "sess-new"


### PR DESCRIPTION
## Summary

- `activities.last_heartbeat_session_id` (TEXT, nullable) を `migration 0040` で追加
- `hooks/heartbeat.update_heartbeat(activity_id, session_id=None)` が書込元セッションを同梱
- `hooks/stop_hook` から stdin payload の `session_id` をスレッドして渡す
- `hooks/session_start_hook` が stdin の `session_id` を読み、`last_heartbeat_session_id` と一致する activity を「## 作業中（別セッション）」セクションから除外（自セッション自身を別セッション扱いしない）
- `src/services/activity_service.get_active_activities_by_tag_with_conn` が `last_heartbeat_session_id` を返却

## 動機

3軸モデル「所在」軸の可観測化。自分のセッション自身がheartbeatを打ったactivityが「別セッション作業中」と出てしまう誤表示を解消する。

## 互換性

- 列は nullable。既存行は `NULL` のまま据え置き
- `update_heartbeat` の `session_id` 引数はデフォルト `None` で後方互換
- stdin に `session_id` が無い、または `last_heartbeat_session_id` が NULL の場合は従来通り「別セッション」扱い（フェイルセーフ）

## Test plan

- [x] migration 0040: 列追加・既存行保持・前後カラム健全性（`tests/test_migrations/test_0040_add_heartbeat_session_id.py`）
- [x] `update_heartbeat` が `session_id` を書き込む / `None` で NULL 維持 / 再書込で上書き（`tests/unit/test_heartbeat.py`）
- [x] session_start_hook フィルタ: 自セッション heartbeat → 通常側に / 他セッション heartbeat → 別セッション側に / NULL→別セッション側に / stdin に session_id なし→従来挙動（`tests/e2e/test_session_start_hook.py`）
- [x] フルテストスイート 1879 件 pass（ローカル）