### PR TITLE
feat: Read系7ツールの docstring 冒頭に「Choose:」テンプレ統一形を追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -295,7 +295,7 @@ def get_logs(
     include_retracted: bool = False,
 ) -> dict:
     """
-    Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map。
+    Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in。
 
     指定エンティティの議論ログを取得する。
 
@@ -327,7 +327,7 @@ def get_decisions(
     include_retracted: bool = False,
 ) -> dict:
     """
-    Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map。
+    Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in。
 
     指定エンティティに関連する決定事項を取得する。
 
@@ -721,7 +721,7 @@ def get_material(
     material_id: int,
 ) -> dict:
     """
-    Choose: material_id 既知で資材の全文だけ取得したいとき。複数種別を一括なら get_by_ids、activity 配下の関連 material カタログなら check_in、起点からの関連グラフ走査なら get_map。
+    Choose: material_id 既知で資材の全文だけ取得したいとき。複数種別を一括なら get_by_ids、起点からの関連グラフ走査なら get_map、log/decision/material の混合時系列なら get_timeline。
 
     資材の全文を取得する。
 

--- a/src/main.py
+++ b/src/main.py
@@ -295,7 +295,7 @@ def get_logs(
     include_retracted: bool = False,
 ) -> dict:
     """
-    Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in。
+    Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
 
     指定エンティティの議論ログを取得する。
 
@@ -327,7 +327,7 @@ def get_decisions(
     include_retracted: bool = False,
 ) -> dict:
     """
-    Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in。
+    Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
 
     指定エンティティに関連する決定事項を取得する。
 
@@ -836,7 +836,7 @@ def get_map(
     max_depth: int = 2,
 ) -> dict:
     """
-    Choose: 起点エンティティから relation を辿って到達可能な topic/activity/material のカタログが欲しいとき。log/decision/material の時系列なら get_timeline、特定 activity の文脈集約なら check_in、log/decision の本文一覧なら get_logs / get_decisions。
+    Choose: 起点エンティティから relation を辿って到達可能な topic/activity/material のカタログが欲しいとき。log/decision/material の時系列なら get_timeline、特定 activity の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）、log/decision の本文一覧なら get_logs / get_decisions。
 
     リレーショングラフを走査し、到達可能エンティティのカタログを返す。
 
@@ -977,7 +977,7 @@ def get_timeline(
     order: str = "desc",
 ) -> dict:
     """
-    Choose: topic/activity に紐づく decision/log/material を時系列順に並べたいとき。log だけなら get_logs、decision だけなら get_decisions、関連グラフ走査なら get_map、activity の文脈集約なら check_in。
+    Choose: topic/activity に紐づく decision/log/material を時系列順に並べたいとき。log だけなら get_logs、decision だけなら get_decisions、関連グラフ走査なら get_map、activity の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
 
     トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
 

--- a/src/main.py
+++ b/src/main.py
@@ -295,6 +295,8 @@ def get_logs(
     include_retracted: bool = False,
 ) -> dict:
     """
+    Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map。
+
     指定エンティティの議論ログを取得する。
 
     Args:
@@ -325,6 +327,8 @@ def get_decisions(
     include_retracted: bool = False,
 ) -> dict:
     """
+    Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map。
+
     指定エンティティに関連する決定事項を取得する。
 
     Args:
@@ -405,6 +409,8 @@ def get_by_ids(
     items: list[dict],
 ) -> dict:
     """
+    Choose: search 結果の type+id ペアを本文付きで一括取得したいとき（複数種別 OK）。material 単独なら get_material、topic/activity 起点の log/decision 集約なら get_logs / get_decisions、関連グラフ走査なら get_map。
+
     search結果の詳細情報を取得する。
 
     searchツールで得られたtype + idペアを指定して、
@@ -715,6 +721,8 @@ def get_material(
     material_id: int,
 ) -> dict:
     """
+    Choose: material_id 既知で資材の全文だけ取得したいとき。複数種別を一括なら get_by_ids、activity 配下の関連 material カタログなら check_in、起点からの関連グラフ走査なら get_map。
+
     資材の全文を取得する。
 
     get_by_idsで取得したmaterial概要の詳細を取得する際に使う（2段階リードの後半）。
@@ -733,6 +741,8 @@ def check_in(
     activity_id: int,
 ) -> dict:
     """
+    Choose: アクティビティに着手するときに関連情報を一括取得したいとき（status を in_progress に自動更新）。関連グラフだけ俯瞰したいなら get_map、log/decision/material の時系列なら get_timeline、log だけなら get_logs。
+
     アクティビティにcheck-inする。関連情報を集約取得しsummaryを返す。
 
     既存アクティビティに関連する作業を始めるときに呼ぶ。
@@ -826,6 +836,8 @@ def get_map(
     max_depth: int = 2,
 ) -> dict:
     """
+    Choose: 起点エンティティから relation を辿って到達可能な topic/activity/material のカタログが欲しいとき。log/decision/material の時系列なら get_timeline、特定 activity の文脈集約なら check_in、log/decision の本文一覧なら get_logs / get_decisions。
+
     リレーショングラフを走査し、到達可能エンティティのカタログを返す。
 
     再帰的にリレーションを辿り、指定深度範囲のエンティティをカタログ形式で返す。
@@ -964,7 +976,10 @@ def get_timeline(
     limit: int = 50,
     order: str = "desc",
 ) -> dict:
-    """トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
+    """
+    Choose: topic/activity に紐づく decision/log/material を時系列順に並べたいとき。log だけなら get_logs、decision だけなら get_decisions、関連グラフ走査なら get_map、activity の文脈集約なら check_in。
+
+    トピックまたはアクティビティに紐づくdecision・log・materialを時系列で返す。
 
     Args:
         topic_id: トピックID（activity_idと排他）


### PR DESCRIPTION
## Summary

- Read 系 7 ツール (`get_by_ids` / `get_material` / `get_logs` / `get_decisions` / `get_timeline` / `get_map` / `check_in`) の docstring 冒頭に「Choose:」テンプレ統一形を追加
- 「Choose: \<このツールが向く用途\>。\<別用途A\>なら \<toolA\>、\<別用途B\>なら \<toolB\>。」のフォーマットで他リードツールとの差異を1文表現
- 全 7 ツール共通の書き出し・同じ位置 (docstring の最初の段落) に配置

## Why

- リファインメント設計議論で挙がっていた Read Path 改善とツール記述インターフェース改善の実装
- RULES や MCP instructions はツール選択前に必ず注入される保証がないため、ツール選択時点で読まれる docstring に配置するのが効きやすい
- 「`get_decisions` と `get_timeline(entity_types=['decision'])` の区別が docstring 上だけでは付かない」等のラウンドトリップ要因を解消

## 適用したテンプレ内容

| tool | Choose 行 (要旨) |
|------|------------------|
| `get_logs` | log 一覧 → これ。decision なら `get_decisions`、混合時系列なら `get_timeline`、関連グラフなら `get_map` |
| `get_decisions` | decision 一覧 → これ。log なら `get_logs`、混合時系列なら `get_timeline`、関連グラフなら `get_map` |
| `get_by_ids` | search ヒットの type+id ペア本文 → これ。material 単独なら `get_material`、topic/activity 起点の集約なら `get_logs` / `get_decisions` |
| `get_material` | material_id 既知の全文 → これ。複数種別一括なら `get_by_ids`、activity 配下カタログなら `check_in` |
| `check_in` | activity 着手時の文脈一括取得 → これ (status 自動更新)。関連グラフなら `get_map`、時系列なら `get_timeline`、log だけなら `get_logs` |
| `get_map` | 起点からの relation グラフ走査 → これ。時系列なら `get_timeline`、特定 activity 集約なら `check_in` |
| `get_timeline` | decision/log/material の時系列 → これ。log だけなら `get_logs`、decision だけなら `get_decisions`、関連グラフなら `get_map` |

## Test plan

- [x] ローカル full pytest 1934 passed (8m36s)
- [x] `python -c "from src import main"` OK (docstring 構文エラー無)
- [ ] CI 全緑
- [ ] claude-review bot 指摘対応
