### PR TITLE
feat: get_by_ids(material) に content/source 同梱

### DIFF
--- a/docs/architecture/sequences/check-in.md
+++ b/docs/architecture/sequences/check-in.md
@@ -179,7 +179,7 @@ sequenceDiagram
 5次元統合レポートT2（Read Path分析）で次の課題が指摘されている。
 
 - **coverage の materials 分母が pin注入分を含まない**（P9）。`coverage.materials` は `relations(source=activity)` の件数しか分母に含まないため、pinで寄せた重要materialを「カバーし切ったか」の判断指標として片手落ちになる。Pr9で `pinned_materials: "K"` をcoverageに足す案あり。
-- **coverageを先頭キーに置く設計は強み**（S6）の一方で、coverageが「3呼び」（search → get_by_ids → get_material）のループを誘発する一因になっているという指摘がP4にある。
+- **coverageを先頭キーに置く設計は強み**（S6）の一方で、coverageが「3呼び」（search → get_by_ids → get_material）のループを誘発する一因になっているという指摘がP4にあった。P0-6 で `get_by_ids` の material レスポンスに `content` / `source` を同梱し、2呼びに短縮済み。
 - **hint生成が二重実装**（P8）。`_get_recompose_hints`（tag単位、増分30/初回15）と `harness_service.get_recommendations`（topic単位）が並走しており、エージェントから見ると2系統の `hints` がどちらも `result["hints"]` に乗り得る。Pr10でHintService統一を提案している。
 - **update_activityが別コネクション**で独立コミットされる（既存APIの制約）。check_inのトランザクションとは独立しており、片方だけ成功するケースがあり得る。
 - **SessionStartのトピック別グルーピング合意（D#2464-2466）と現状実装の乖離**（P7）。check-in skillのactivity選択UI体験に直接影響する。

--- a/docs/architecture/sequences/check-in.md
+++ b/docs/architecture/sequences/check-in.md
@@ -179,7 +179,7 @@ sequenceDiagram
 5次元統合レポートT2（Read Path分析）で次の課題が指摘されている。
 
 - **coverage の materials 分母が pin注入分を含まない**（P9）。`coverage.materials` は `relations(source=activity)` の件数しか分母に含まないため、pinで寄せた重要materialを「カバーし切ったか」の判断指標として片手落ちになる。Pr9で `pinned_materials: "K"` をcoverageに足す案あり。
-- **coverageを先頭キーに置く設計は強み**（S6）の一方で、coverageが「3呼び」（search → get_by_ids → get_material）のループを誘発する一因になっているという指摘がP4にあった。P0-6 で `get_by_ids` の material レスポンスに `content` / `source` を同梱し、2呼びに短縮済み。
+- **coverageを先頭キーに置く設計は強み**（S6）の一方で、coverageが「3呼び」（search → get_by_ids → get_material）のループを誘発する一因になっているという指摘がP4にあった。本変更で `get_by_ids` の material レスポンスに `content` / `source` を同梱し、2呼びに短縮済み。
 - **hint生成が二重実装**（P8）。`_get_recompose_hints`（tag単位、増分30/初回15）と `harness_service.get_recommendations`（topic単位）が並走しており、エージェントから見ると2系統の `hints` がどちらも `result["hints"]` に乗り得る。Pr10でHintService統一を提案している。
 - **update_activityが別コネクション**で独立コミットされる（既存APIの制約）。check_inのトランザクションとは独立しており、片方だけ成功するケースがあり得る。
 - **SessionStartのトピック別グルーピング合意（D#2464-2466）と現状実装の乖離**（P7）。check-in skillのactivity選択UI体験に直接影響する。

--- a/docs/architecture/sequences/search.md
+++ b/docs/architecture/sequences/search.md
@@ -182,6 +182,6 @@ sequenceDiagram
 - **検索効果測定の仕組みが皆無**（P6）。`QE_DISTANCE_THRESHOLD=0.3` / `W_VEC=1.0` / `RECENCY_DECAY_RATE` などのパラメータを実データで再評価する経路がなく、調整が「感覚」になっている。Pr7で `search_telemetry` テーブル導入を提案している。
 - **QE が「素タグ前提」**（P13）。`QE_EXCLUDE_NAMESPACES=True` のため `domain:*` / `intent:*` は除外され、素タグの少ないドメインでは QE がほぼ無効化される。
 - **tag_like AND の意味論が不揃い**（P14）。「全キーワードを1つのタグ名が含む」セマンティクスはFTS/ベクトルのAND（複数語が文書内で共起）とずれる。Pr14で「タグ集合のAND」セマンティクスへの変更を提案している。
-- **3呼びラウンドトリップ**（P4）：〔解消済〕P0-6 で `get_by_ids` の material レスポンスに `content` / `source` を同梱したため、`search → get_by_ids` の2呼びで material 全文取得が完結する。`get_material` は material_id 単発取得用として残存。
+- **3呼びラウンドトリップ**（P4）：〔解消済〕`get_by_ids` の material レスポンスに `content` / `source` を同梱したため、`search → get_by_ids` の2呼びで material 全文取得が完結する。`get_material` は material_id 単発取得用として残存。
 
 未確認: `embedding_service.encode_query` / `search_similar_tags` の内部実装（モデル呼び出し経路）は今回のスコープ外で深く読んでいない。本書では「テキストからembeddingを取る」「tag_vecをKNNする」抽象レベルにとどめている。

--- a/docs/architecture/sequences/search.md
+++ b/docs/architecture/sequences/search.md
@@ -182,6 +182,6 @@ sequenceDiagram
 - **検索効果測定の仕組みが皆無**（P6）。`QE_DISTANCE_THRESHOLD=0.3` / `W_VEC=1.0` / `RECENCY_DECAY_RATE` などのパラメータを実データで再評価する経路がなく、調整が「感覚」になっている。Pr7で `search_telemetry` テーブル導入を提案している。
 - **QE が「素タグ前提」**（P13）。`QE_EXCLUDE_NAMESPACES=True` のため `domain:*` / `intent:*` は除外され、素タグの少ないドメインでは QE がほぼ無効化される。
 - **tag_like AND の意味論が不揃い**（P14）。「全キーワードを1つのタグ名が含む」セマンティクスはFTS/ベクトルのAND（複数語が文書内で共起）とずれる。Pr14で「タグ集合のAND」セマンティクスへの変更を提案している。
-- **3呼びラウンドトリップ**（P4）。`search → get_by_ids（materialはcontent欠落）→ get_material` の3呼出しが必要になるケースがある。Pr6で `get_by_ids(material)` に content/source 同梱を提案している。
+- **3呼びラウンドトリップ**（P4）：〔解消済〕P0-6 で `get_by_ids` の material レスポンスに `content` / `source` を同梱したため、`search → get_by_ids` の2呼びで material 全文取得が完結する。`get_material` は material_id 単発取得用として残存。
 
 未確認: `embedding_service.encode_query` / `search_similar_tags` の内部実装（モデル呼び出し経路）は今回のスコープ外で深く読んでいない。本書では「テキストからembeddingを取る」「tag_vecをKNNする」抽象レベルにとどめている。

--- a/docs/spec-v0.md
+++ b/docs/spec-v0.md
@@ -197,14 +197,14 @@ cc-memoryに関する議論を始めるとき、「これはどの層の話か�
 
 #### Read系ツールの選び方
 
-- get_by_ids: search結果のチェリーピック / ID指定の確認
-- get_material: materialの全文（searchはsnippet止まり）
+- get_by_ids: search結果のチェリーピック / ID指定の確認（materialの場合はcontent/sourceも含まれる）
+- get_material: material_idだけ手元にあり概要も含めて取りたい単発ケース
 - get_logs / get_decisions: エンティティ深掘り
 - get_timeline: 時系列変遷
 - get_map: 関連構造の俯瞰
 - check_in: 作業開始時の文脈ロード
 
-**やらないとどうなる:** 同じ情報を別ツールで何度も取って context を圧迫する。「3呼び」（get_by_ids → get_material → さらに get_logs）でラウンドトリップが増える。
+**やらないとどうなる:** 同じ情報を別ツールで何度も取って context を圧迫する。例えばmaterialならsearch→get_by_idsで完結するところを、不要な get_material を続けて呼んでラウンドトリップが増える。
 
 ---
 

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -533,7 +533,7 @@ ow系ツール（特に `ow_spawn_worker` / `ow_close_worker` / `ow_status` / `o
 2. **entity_type が文字列フリー**: `topic` / `activity` / `material` / `decision` / `log` の5値は型としてLiteralやEnumで縛られておらず、ツール間で許容値の差（`add_relation` は全5種、`get_logs` は2種のみ等）が散在している。
 3. **Read系ツール選択基準の不在**: `search` / `get_by_ids` / `get_map` / `get_timeline` / `check_in` の使い分け方針が一元化されていない。エージェントが最適なツールを選びにくい。
 4. **OW_ROLE による直接的なガードの不在**: workerロール時の意図しない高権限操作（spawn_worker / recover 等）を防ぐコードレベルの仕組みが確認できなかった。運用ルールでカバーする現状は脆い。
-5. **2段階リード（search → get_by_ids → get_material）の冗長性**: 〔解消済〕`get_by_ids`の`material`レスポンスに`content`/`source`を同梱したため、`search → get_by_ids` の2ステップで全文取得が完結する（P0-6）。`get_material`はmaterial_id単発取得用として残存。
+5. **2段階リード（search → get_by_ids → get_material）の冗長性**: 〔解消済〕`get_by_ids`の`material`レスポンスに`content`/`source`を同梱したため、`search → get_by_ids` の2ステップで全文取得が完結する。`get_material`はmaterial_id単発取得用として残存。
 6. **`propagate_to` の二重記録経路**: `add_decisions(propagate_to=...)` で habit / tag_note を派生生成できるが、直接 `add_habit` や `update_tag(notes=)` を呼ぶ経路と並存している。どちらを使うべきかが明確でない。
 7. **`related_decisions` の embedding 依存**: embedding サーバー未起動時は空配列を返すが、それを呼び出し側が判別する手段がレスポンスにない。
 8. **タグnamespaceのリテラル化**: `domain:` / `intent:` / 素タグの3区分は文字列パースに依存しており、型安全ではない。

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -184,7 +184,7 @@
 | --- | --- | --- | --- | --- |
 | items | list[{type, id}] | yes | - | 最大20件 |
 
-**返り値**: `{results: [{type, id, data}, ...]}`。2段階リード（searchで概要→get_by_idsで全文）の後半に位置する。
+**返り値**: `{results: [{type, id, data}, ...]}`。2段階リード（searchで概要→get_by_idsで全文）の後半に位置する。materialは`data`に`content`/`source`が含まれ、追加で`get_material`を呼ぶ必要はない。
 
 ### 2.8 search_tags
 
@@ -533,7 +533,7 @@ ow系ツール（特に `ow_spawn_worker` / `ow_close_worker` / `ow_status` / `o
 2. **entity_type が文字列フリー**: `topic` / `activity` / `material` / `decision` / `log` の5値は型としてLiteralやEnumで縛られておらず、ツール間で許容値の差（`add_relation` は全5種、`get_logs` は2種のみ等）が散在している。
 3. **Read系ツール選択基準の不在**: `search` / `get_by_ids` / `get_map` / `get_timeline` / `check_in` の使い分け方針が一元化されていない。エージェントが最適なツールを選びにくい。
 4. **OW_ROLE による直接的なガードの不在**: workerロール時の意図しない高権限操作（spawn_worker / recover 等）を防ぐコードレベルの仕組みが確認できなかった。運用ルールでカバーする現状は脆い。
-5. **2段階リード（search → get_by_ids → get_material）の冗長性**: materialは検索でsnippetが出るがget_by_idsでもcontent全文が返らず、`get_material` を別途叩く必要がある。3ステップは多い。
+5. **2段階リード（search → get_by_ids → get_material）の冗長性**: 〔解消済〕`get_by_ids`の`material`レスポンスに`content`/`source`を同梱したため、`search → get_by_ids` の2ステップで全文取得が完結する（P0-6）。`get_material`はmaterial_id単発取得用として残存。
 6. **`propagate_to` の二重記録経路**: `add_decisions(propagate_to=...)` で habit / tag_note を派生生成できるが、直接 `add_habit` や `update_tag(notes=)` を呼ぶ経路と並存している。どちらを使うべきかが明確でない。
 7. **`related_decisions` の embedding 依存**: embedding サーバー未起動時は空配列を返すが、それを呼び出し側が判別する手段がレスポンスにない。
 8. **タグnamespaceのリテラル化**: `domain:` / `intent:` / 素タグの3区分は文字列パースに依存しており、型安全ではない。

--- a/src/main.py
+++ b/src/main.py
@@ -717,8 +717,8 @@ def get_material(
     """
     資材の全文を取得する。
 
-    通常はsearch/check_in/get_by_idsの応答にmaterialのcontent/sourceが同梱されるため呼ぶ必要はない。
-    material_idだけが手元にあり概要も含めて取得したい単発ケースで使う。
+    通常はcheck_in/get_by_idsの応答にmaterialのcontent/sourceが同梱されるため呼ぶ必要はない
+    （searchはsnippet止まり）。material_idだけが手元にあり概要も含めて取得したい単発ケースで使う。
 
     Args:
         material_id: 資材のID

--- a/src/main.py
+++ b/src/main.py
@@ -648,7 +648,7 @@ def add_material(
     資材を追加する。独立エンティティとしてタグ付きで保存される。
 
     資材はセッション中の成果物・ドキュメントをDB保存する仕組み。
-    search(entity_type="material")で検索でき、全文はget_materialで取得する2段階リード設計。
+    search(entity_type="material")で概要を検索し、get_by_idsまたはget_materialで全文を取得する。
     決定事項と違って「双方の合意」が不要。成果物が出た時点でユーザーに確認せず呼ぶ。
 
     典型的な使い方:
@@ -717,7 +717,8 @@ def get_material(
     """
     資材の全文を取得する。
 
-    get_by_idsで取得したmaterial概要の詳細を取得する際に使う（2段階リードの後半）。
+    通常はsearch/check_in/get_by_idsの応答にmaterialのcontent/sourceが同梱されるため呼ぶ必要はない。
+    material_idだけが手元にあり概要も含めて取得したい単発ケースで使う。
 
     Args:
         material_id: 資材のID

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1575,6 +1575,7 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
             "source": data["source"],
             "tags": tags,
             "created_at": data["created_at"],
+            "hint": "contentの先頭1-2文は内容の説明・要約にしてください（check-in時にsnippetとして表示されます）",
         }
     return data
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1571,6 +1571,8 @@ def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
         return {
             "material_id": data["id"],
             "title": data["title"],
+            "content": data["content"],
+            "source": data["source"],
             "tags": tags,
             "created_at": data["created_at"],
         }

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -238,7 +238,7 @@ class TestGetByIdMaterial:
     """get_by_id / get_by_ids でmaterialを取得するテスト"""
 
     def test_get_by_id_material(self, temp_db):
-        """get_by_idでmaterialのカタログ（material_id, title, tags, created_at）を取得できる"""
+        """get_by_idでmaterialの全文（material_id, title, content, source, tags, created_at）を取得できる（P0-6）"""
         created = add_material(
             title="ById Test",
             content="ById content",
@@ -253,7 +253,8 @@ class TestGetByIdMaterial:
         assert result["type"] == "material"
         assert result["data"]["material_id"] == material_id
         assert result["data"]["title"] == "ById Test"
-        assert "content" not in result["data"]  # カタログ形式: 全文なし
+        assert result["data"]["content"] == "ById content"
+        assert result["data"]["source"] == "テスト用データ"
         assert result["data"]["tags"] == ["domain:test"]  # material自身のタグ
         # activity_idが含まれないこと
         assert "activity_id" not in result["data"]

--- a/tests/integration/test_material_service.py
+++ b/tests/integration/test_material_service.py
@@ -238,7 +238,7 @@ class TestGetByIdMaterial:
     """get_by_id / get_by_ids でmaterialを取得するテスト"""
 
     def test_get_by_id_material(self, temp_db):
-        """get_by_idでmaterialの全文（material_id, title, content, source, tags, created_at）を取得できる（P0-6）"""
+        """get_by_idはmaterialのcontent/sourceも返し、get_materialに頼らず全文取得が完結する"""
         created = add_material(
             title="ById Test",
             content="ById content",

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -314,7 +314,7 @@ def test_get_by_ids_single_log(temp_db):
 
 
 def test_get_by_ids_single_material(temp_db):
-    """get_by_ids: materialの詳細取得で content/source が同梱される（P0-6）"""
+    """get_by_ids(material) はsnippetではなくcontent全文とsourceをレスポンスに含む"""
     mat = add_material(
         title="詳細取得テスト素材",
         content="素材本文の全文がレスポンスに含まれることを確認する",
@@ -332,6 +332,8 @@ def test_get_by_ids_single_material(temp_db):
     assert item["data"]["source"] == "単体テスト"
     assert "domain:test" in item["data"]["tags"]
     assert "created_at" in item["data"]
+    # hint も同梱（get_material と整合）
+    assert "hint" in item["data"]
 
 
 def test_get_by_ids_single_not_found(temp_db):

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -313,6 +313,27 @@ def test_get_by_ids_single_log(temp_db):
     assert "domain:test" in item["data"]["tags"]
 
 
+def test_get_by_ids_single_material(temp_db):
+    """get_by_ids: materialの詳細取得で content/source が同梱される（P0-6）"""
+    mat = add_material(
+        title="詳細取得テスト素材",
+        content="素材本文の全文がレスポンスに含まれることを確認する",
+        tags=DEFAULT_TAGS,
+        source="単体テスト",
+    )
+    result = search_service.get_by_ids([{"type": "material", "id": mat["material_id"]}])
+    assert len(result["results"]) == 1
+    item = result["results"][0]
+    assert "error" not in item
+    assert item["type"] == "material"
+    assert item["data"]["material_id"] == mat["material_id"]
+    assert item["data"]["title"] == "詳細取得テスト素材"
+    assert item["data"]["content"] == "素材本文の全文がレスポンスに含まれることを確認する"
+    assert item["data"]["source"] == "単体テスト"
+    assert "domain:test" in item["data"]["tags"]
+    assert "created_at" in item["data"]
+
+
 def test_get_by_ids_single_not_found(temp_db):
     """get_by_ids: 存在しないIDでNOT_FOUNDエラー"""
     result = search_service.get_by_ids([{"type": "topic", "id": 999999}])


### PR DESCRIPTION
## Summary

`get_by_ids` の `material` レスポンスに `content` / `source` を同梱し、3呼びラウンドトリップ (search → get_by_ids → get_material) を 2 呼びに短縮する。

### 変更点

- `src/services/search_service.py` の `_format_row('material')` 分岐で `content` / `source` を含めて返す
- `src/main.py`:
  - `get_material` docstring を「2段階リードの後半」表現から「material_id 単発取得用」へ書き換え
  - `add_material` docstring の「2段階リード設計」表現を「search→get_by_ids または get_material」に修正
- ドキュメント (docs/spec/mcp-tools.md, docs/spec-v0.md, docs/architecture/sequences/search.md, check-in.md) を解消済みステータスで更新
- テスト:
  - `tests/unit/test_fts5_search.py::test_get_by_ids_single_material` 追加（content/source/title/tags/created_at 検証）
  - `tests/integration/test_material_service.py::test_get_by_id_material` を新挙動 (content/source 同梱) に合わせて更新

### スコープ外

- `src/` 配下に `get_by_ids → get_material` を直列呼び出ししているサービス内コードパスは存在せず (`checkin_service` は `get_materials_by_relation_with_conn` で直接取得)、コード上の撤去対象は無し。ドキュメント・docstring 表現の整理のみで対応している
- `get_material` ツール自体は material_id 単発取得用として残置

## Test plan

- [x] `uv run pytest tests/unit/test_fts5_search.py tests/integration/test_material_service.py` (130 passed)
- [x] `uv run pytest` フル regression (1934 passed)
- [ ] CI 全緑
- [ ] claude-review bot 指摘対応
