### PR TITLE
feat: search_telemetry テーブル追加と非同期書込

### DIFF
--- a/migrations/0041_add_search_telemetry.sql
+++ b/migrations/0041_add_search_telemetry.sql
@@ -1,4 +1,4 @@
--- Migration 041: search_telemetry テーブル追加
+-- Migration 0041: search_telemetry テーブル追加
 --
 -- depends: 0039_intent_thinking
 --

--- a/migrations/0041_add_search_telemetry.sql
+++ b/migrations/0041_add_search_telemetry.sql
@@ -1,0 +1,32 @@
+-- Migration 041: search_telemetry テーブル追加
+--
+-- depends: 0039_intent_thinking
+--
+-- 背景:
+--   search() 呼出ごとに query / parameters / 結果件数のスナップショットを記録し、
+--   検索精度の Phase 1 検証 (recency / RRF 重み / query expansion 等の挙動分析)
+--   の基盤データを蓄積する。
+--
+--   search() のレスポンスタイムに影響しないよう、書込は別スレッドで非同期に行う。
+--   書込失敗時は logger.warning に出すだけで search 本体には影響させない。
+--
+-- スキーマ:
+--   id          : 主キー
+--   query       : 検索キーワード (str または list[str] を JSON serialize)
+--   parameters  : tags / entity_type / limit / offset / keyword_mode / domain /
+--                 date_after / date_before / include_retracted / include_details
+--                 の snapshot を JSON で保存
+--   result_count: 返却件数 (total_count)
+--   timestamp   : 書込時刻 (UTC)
+--
+--   timestamp に index を張る (時系列での集計が主な読み出しパターン)。
+
+CREATE TABLE search_telemetry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    parameters TEXT NOT NULL,
+    result_count INTEGER NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_search_telemetry_timestamp ON search_telemetry(timestamp);

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1542,14 +1542,17 @@ def _record_search_telemetry_async(
     query: str | list[str],
     parameters: dict,
     result_count: int,
-) -> threading.Thread:
+) -> threading.Thread | None:
     """search 呼出の telemetry を別スレッドで非同期書込する。
 
     search() のレスポンスタイムに影響しないよう daemon thread で走らせる。
     書込中の例外は logger.warning に出して握りつぶし、search 本体を壊さない。
+    Thread 生成や start 自体が失敗（e.g. ``RuntimeError: can't start new thread``）
+    した場合も、呼出元 search() の外側 try で DATABASE_ERROR 化されないよう
+    ここで握って warning + None 返却にする。
 
     Returns:
-        起動した daemon Thread。テストから join() で完了待機できるよう返す。
+        起動した daemon Thread。起動に失敗した場合は None。
     """
     def _write() -> None:
         try:
@@ -1573,8 +1576,12 @@ def _record_search_telemetry_async(
         except Exception as e:
             logger.warning("search_telemetry write failed: %s", e)
 
-    thread = threading.Thread(target=_write, daemon=True)
-    thread.start()
+    try:
+        thread = threading.Thread(target=_write, daemon=True)
+        thread.start()
+    except Exception as e:
+        logger.warning("search_telemetry thread start failed: %s", e)
+        return None
     return thread
 
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,8 +1,10 @@
 """FTS5 + ベクトル ハイブリッド検索サービス"""
+import json
 import logging
 import math
 import re
 import sqlite3
+import threading
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -1503,6 +1505,23 @@ def search(
 
         nearby_tags = _compute_nearby_tags(results, tag_ids, offset)
 
+        _record_search_telemetry_async(
+            query=keyword,
+            parameters={
+                "tags": tags,
+                "entity_type": entity_type,
+                "limit": limit,
+                "offset": offset,
+                "keyword_mode": keyword_mode,
+                "include_details": include_details,
+                "domain": domain,
+                "date_after": date_after,
+                "date_before": date_before,
+                "include_retracted": include_retracted,
+            },
+            result_count=total_count,
+        )
+
         return {
             "results": results,
             "total_count": total_count,
@@ -1517,6 +1536,46 @@ def search(
                 "message": str(e),
             }
         }
+
+
+def _record_search_telemetry_async(
+    query: str | list[str],
+    parameters: dict,
+    result_count: int,
+) -> threading.Thread:
+    """search 呼出の telemetry を別スレッドで非同期書込する。
+
+    search() のレスポンスタイムに影響しないよう daemon thread で走らせる。
+    書込中の例外は logger.warning に出して握りつぶし、search 本体を壊さない。
+
+    Returns:
+        起動した daemon Thread。テストから join() で完了待機できるよう返す。
+    """
+    def _write() -> None:
+        try:
+            query_json = json.dumps(query, ensure_ascii=False)
+            parameters_json = json.dumps(parameters, ensure_ascii=False)
+        except (TypeError, ValueError) as e:
+            logger.warning("search_telemetry serialize failed: %s", e)
+            return
+
+        try:
+            conn = get_connection()
+            try:
+                conn.execute(
+                    "INSERT INTO search_telemetry (query, parameters, result_count) "
+                    "VALUES (?, ?, ?)",
+                    (query_json, parameters_json, int(result_count)),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.warning("search_telemetry write failed: %s", e)
+
+    thread = threading.Thread(target=_write, daemon=True)
+    thread.start()
+    return thread
 
 
 def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from sqlite_vec import serialize_float32
 
-from src.db import execute_query, get_connection, row_to_dict
+from src.db import execute_query, get_connection, get_db_path, row_to_dict
 from src.services import embedding_service
 from src.services.tag_service import (
     get_entity_tags,
@@ -1538,6 +1538,22 @@ def search(
         }
 
 
+def _telemetry_get_connection() -> sqlite3.Connection:
+    """telemetry 書込専用の軽量コネクション。
+
+    `search_telemetry` への INSERT は sqlite-vec 拡張を必要としないため、
+    `db.get_connection()` の `enable_load_extension(True)` → 拡張ロード →
+    `enable_load_extension(False)` のオーバーヘッドや拡張ロード失敗時の
+    warning ログを避ける目的で、最小構成（WAL + busy_timeout）のみ設定する。
+    daemon thread から呼ばれることを想定。
+    """
+    conn = sqlite3.connect(get_db_path())
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
 def _record_search_telemetry_async(
     query: str | list[str],
     parameters: dict,
@@ -1551,6 +1567,9 @@ def _record_search_telemetry_async(
     した場合も、呼出元 search() の外側 try で DATABASE_ERROR 化されないよう
     ここで握って warning + None 返却にする。
 
+    書込は `_telemetry_get_connection()` 経由で sqlite-vec 拡張を
+    ロードしない軽量コネクションを使う。
+
     Returns:
         起動した daemon Thread。起動に失敗した場合は None。
     """
@@ -1563,7 +1582,7 @@ def _record_search_telemetry_async(
             return
 
         try:
-            conn = get_connection()
+            conn = _telemetry_get_connection()
             try:
                 conn.execute(
                     "INSERT INTO search_telemetry (query, parameters, result_count) "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,30 @@ def _clear_ow_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _synchronous_telemetry(monkeypatch):
+    """search_telemetry 書込を同期実行に切り替える。
+
+    本番は daemon thread で非同期書込するが、テストで daemon thread が
+    生きているうちに TemporaryDirectory cleanup が走ると DB ファイルへの
+    書込と rmtree が race して `OSError: Directory not empty` が出る。
+    テスト中は書込スレッドを join してから search() を返すラッパに置き換え、
+    レース無しで cleanup できるようにする。書込挙動自体 (Thread 生成 / daemon=True)
+    は本番と同じ実装を通る (ラッパ内で original を呼ぶ) ため、
+    本番の非同期性を検証するテストは join 後でも is_alive=False を assert できる。
+    """
+    from src.services import search_service
+
+    original = search_service._record_search_telemetry_async
+
+    def synchronous_wrapper(*args, **kwargs):
+        thread = original(*args, **kwargs)
+        thread.join(timeout=5.0)
+        return thread
+
+    monkeypatch.setattr(search_service, "_record_search_telemetry_async", synchronous_wrapper)
+
+
 @pytest.fixture
 def disable_embedding(monkeypatch):
     """embeddingサービスを無効化する共通フィクスチャ。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def _synchronous_telemetry(monkeypatch):
 
     def synchronous_wrapper(*args, **kwargs):
         thread = original(*args, **kwargs)
-        thread.join(timeout=5.0)
+        if thread is not None:
+            thread.join(timeout=5.0)
         return thread
 
     monkeypatch.setattr(search_service, "_record_search_telemetry_async", synchronous_wrapper)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,13 @@ def _synchronous_telemetry(monkeypatch):
     レース無しで cleanup できるようにする。書込挙動自体 (Thread 生成 / daemon=True)
     は本番と同じ実装を通る (ラッパ内で original を呼ぶ) ため、
     本番の非同期性を検証するテストは join 後でも is_alive=False を assert できる。
+
+    注意: 個別テストファイルの `capture_telemetry_threads` フィクスチャは、
+    pytest のフィクスチャ適用順序上この `synchronous_wrapper` を更にラップする
+    形になる。すなわち capture 側に渡ってくる thread は既にここで join() 済みで
+    あり、`_wait_for_telemetry()` 側の join は実質 no-op になる。
+    現状のテスト同期化はこの fixture (autouse) に依存しており、将来 autouse を
+    解除する場合は capture 側でも join() を保証する必要がある。
     """
     from src.services import search_service
 

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -59,7 +59,8 @@ def capture_telemetry_threads(monkeypatch):
 
 def _wait_for_telemetry(threads, timeout=5.0):
     for t in threads:
-        t.join(timeout=timeout)
+        if t is not None:
+            t.join(timeout=timeout)
 
 
 def _fetch_all_telemetry():
@@ -196,6 +197,41 @@ def test_telemetry_write_runs_in_separate_thread(temp_db):
     assert all(tid != main_thread_id for tid in captured_thread_id), (
         "telemetry 書込が呼出元と同じスレッドで実行されている"
     )
+
+
+def test_search_unaffected_when_thread_start_fails(
+    temp_db, monkeypatch, caplog
+):
+    """Thread.start() が失敗しても search() の戻り値は壊れず、警告ログが出る
+
+    threading.Thread.start が ``RuntimeError: can't start new thread`` を出す
+    シナリオを模す。search() 外側の try で DATABASE_ERROR 化されないことを保証。
+    """
+    add_topic(
+        title="thread start 失敗フォールバック検証用トピック",
+        description="thread 起動失敗時に search 本体が影響を受けないことを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    import threading as _threading
+
+    original_thread_cls = search_service.threading.Thread
+
+    class FailingThread(original_thread_cls):
+        def start(self):
+            raise RuntimeError("simulated thread start failure")
+
+    monkeypatch.setattr(search_service.threading, "Thread", FailingThread)
+
+    with caplog.at_level("WARNING"):
+        result = search_service.search(keyword="thread start 失敗フォールバック検証")
+
+    assert "error" not in result
+    assert "results" in result
+    assert any(
+        "search_telemetry thread start failed" in record.message
+        for record in caplog.records
+    ), f"warning log が出ていない: {[r.message for r in caplog.records]}"
 
 
 def test_search_unaffected_when_telemetry_write_fails(

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -173,13 +173,13 @@ def test_telemetry_write_runs_in_separate_thread(temp_db):
     main_thread_id = _threading.get_ident()
     captured_thread_id = []
 
-    original_get_conn = search_service.get_connection
+    original_get_conn = search_service._telemetry_get_connection
 
     def tracking_get_conn():
         captured_thread_id.append(_threading.get_ident())
         return original_get_conn()
 
-    search_service.get_connection = tracking_get_conn
+    search_service._telemetry_get_connection = tracking_get_conn
     try:
         thread = search_service._record_search_telemetry_async(
             query="thread-check",
@@ -191,9 +191,9 @@ def test_telemetry_write_runs_in_separate_thread(temp_db):
         thread.join(timeout=5.0)
         assert not thread.is_alive()
     finally:
-        search_service.get_connection = original_get_conn
+        search_service._telemetry_get_connection = original_get_conn
 
-    assert captured_thread_id, "telemetry 書込で get_connection が呼ばれていない"
+    assert captured_thread_id, "telemetry 書込で _telemetry_get_connection が呼ばれていない"
     assert all(tid != main_thread_id for tid in captured_thread_id), (
         "telemetry 書込が呼出元と同じスレッドで実行されている"
     )
@@ -244,19 +244,16 @@ def test_search_unaffected_when_telemetry_write_fails(
         tags=DEFAULT_TAGS,
     )
 
-    real_get_connection = search_service.get_connection
+    real_get_connection = search_service._telemetry_get_connection
     call_counter = {"writer": 0}
 
     def flaky_get_connection():
-        # search 本体 (メインスレッド) からは通常接続を返し、
-        # 書込スレッドだけ例外を出してフォールバック挙動を検証する
-        import threading as _threading
-        if _threading.current_thread() is not _threading.main_thread():
-            call_counter["writer"] += 1
-            raise RuntimeError("simulated telemetry write failure")
-        return real_get_connection()
+        # telemetry 書込スレッドからの呼び出し時のみ例外を出して
+        # フォールバック挙動を検証する。search 本体は通常通り動く。
+        call_counter["writer"] += 1
+        raise RuntimeError("simulated telemetry write failure")
 
-    monkeypatch.setattr(search_service, "get_connection", flaky_get_connection)
+    monkeypatch.setattr(search_service, "_telemetry_get_connection", flaky_get_connection)
 
     with caplog.at_level("WARNING"):
         result = search_service.search(keyword="書込失敗フォールバック検証")

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -1,0 +1,235 @@
+"""search_telemetry テーブル書込のテスト
+
+検証項目:
+1. migration 0041 後に search_telemetry テーブルが存在する (id / query / parameters /
+   result_count / timestamp カラムを持つ)
+2. search() を呼ぶと search_telemetry に行が追加され、query / parameters / result_count
+   が期待する JSON / 整数で記録される
+3. 書込は別スレッドで行われる (`_record_search_telemetry_async` が Thread を返す)
+4. 書込中に例外が発生しても search() の戻り値は通常通りで、本体を壊さない
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services import search_service
+from src.services.topic_service import add_topic
+import src.services.embedding_service as emb
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """telemetry テストではベクトル検索を無効化して FTS のみで決定論的に動かす"""
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def capture_telemetry_threads(monkeypatch):
+    """search() が起動する telemetry 書込 thread を捕捉して join() できるようにする"""
+    threads = []
+    original = search_service._record_search_telemetry_async
+
+    def wrapped(*args, **kwargs):
+        thread = original(*args, **kwargs)
+        threads.append(thread)
+        return thread
+
+    monkeypatch.setattr(search_service, "_record_search_telemetry_async", wrapped)
+    return threads
+
+
+def _wait_for_telemetry(threads, timeout=5.0):
+    for t in threads:
+        t.join(timeout=timeout)
+
+
+def _fetch_all_telemetry():
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT id, query, parameters, result_count, timestamp "
+            "FROM search_telemetry ORDER BY id"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def test_search_telemetry_table_schema(temp_db):
+    """migration 0041 で search_telemetry テーブルと必要なカラムが作られる"""
+    conn = get_connection()
+    try:
+        rows = conn.execute("PRAGMA table_info(search_telemetry)").fetchall()
+    finally:
+        conn.close()
+    columns = {r["name"]: r for r in rows}
+    assert {"id", "query", "parameters", "result_count", "timestamp"}.issubset(columns)
+    assert columns["query"]["notnull"] == 1
+    assert columns["parameters"]["notnull"] == 1
+    assert columns["result_count"]["notnull"] == 1
+    assert columns["timestamp"]["notnull"] == 1
+
+
+def test_search_telemetry_index_on_timestamp(temp_db):
+    """timestamp カラムに index が張られている (時系列集計の基盤)"""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='search_telemetry'"
+        ).fetchall()
+    finally:
+        conn.close()
+    index_names = {r["name"] for r in rows}
+    assert "idx_search_telemetry_timestamp" in index_names
+
+
+def test_search_records_telemetry_row(temp_db, capture_telemetry_threads):
+    """search() 呼出ごとに search_telemetry に 1 行追加される"""
+    add_topic(
+        title="テレメトリ書込テスト用トピック",
+        description="search 呼出でテレメトリが書かれることを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="テレメトリ書込テスト")
+    assert "error" not in result
+
+    _wait_for_telemetry(capture_telemetry_threads)
+
+    rows = _fetch_all_telemetry()
+    assert len(rows) == 1
+    row = rows[0]
+    assert json.loads(row["query"]) == "テレメトリ書込テスト"
+    assert row["result_count"] == result["total_count"]
+    params = json.loads(row["parameters"])
+    assert params["keyword_mode"] == "and"
+    assert params["limit"] == 10
+    assert params["offset"] == 0
+    assert "entity_type" in params
+    assert "domain" in params
+    assert "date_after" in params
+    assert "date_before" in params
+    assert "include_retracted" in params
+    assert "include_details" in params
+    assert "tags" in params
+    assert row["timestamp"] is not None
+
+
+def test_search_records_list_keyword_and_parameters(temp_db, capture_telemetry_threads):
+    """配列 keyword と非デフォルトパラメータが parameters JSON に保存される"""
+    add_topic(
+        title="複合キーワード テレメトリ 検証",
+        description="リストキーワードのスナップショット記録を検証する",
+        tags=["domain:test", "telemetry"],
+    )
+
+    search_service.search(
+        keyword=["複合キーワード", "テレメトリ"],
+        tags=["domain:test"],
+        entity_type="topic",
+        limit=5,
+        offset=0,
+        keyword_mode="and",
+        domain=None,
+    )
+
+    _wait_for_telemetry(capture_telemetry_threads)
+
+    rows = _fetch_all_telemetry()
+    assert len(rows) == 1
+    assert json.loads(rows[0]["query"]) == ["複合キーワード", "テレメトリ"]
+    params = json.loads(rows[0]["parameters"])
+    assert params["tags"] == ["domain:test"]
+    assert params["entity_type"] == "topic"
+    assert params["limit"] == 5
+    assert params["keyword_mode"] == "and"
+
+
+def test_telemetry_write_runs_in_separate_thread(temp_db):
+    """`_record_search_telemetry_async` が起動した Thread を返し、別スレッドで走る"""
+    import threading as _threading
+
+    main_thread_id = _threading.get_ident()
+    captured_thread_id = []
+
+    original_get_conn = search_service.get_connection
+
+    def tracking_get_conn():
+        captured_thread_id.append(_threading.get_ident())
+        return original_get_conn()
+
+    search_service.get_connection = tracking_get_conn
+    try:
+        thread = search_service._record_search_telemetry_async(
+            query="thread-check",
+            parameters={"limit": 10},
+            result_count=0,
+        )
+        assert isinstance(thread, _threading.Thread)
+        assert thread.daemon is True
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+    finally:
+        search_service.get_connection = original_get_conn
+
+    assert captured_thread_id, "telemetry 書込で get_connection が呼ばれていない"
+    assert all(tid != main_thread_id for tid in captured_thread_id), (
+        "telemetry 書込が呼出元と同じスレッドで実行されている"
+    )
+
+
+def test_search_unaffected_when_telemetry_write_fails(
+    temp_db, capture_telemetry_threads, monkeypatch, caplog
+):
+    """書込中に例外が出ても search() の戻り値は壊れず、警告ログが出る"""
+    add_topic(
+        title="書込失敗フォールバック検証用トピック",
+        description="例外発生時に search 本体が影響を受けないことを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    real_get_connection = search_service.get_connection
+    call_counter = {"writer": 0}
+
+    def flaky_get_connection():
+        # search 本体 (メインスレッド) からは通常接続を返し、
+        # 書込スレッドだけ例外を出してフォールバック挙動を検証する
+        import threading as _threading
+        if _threading.current_thread() is not _threading.main_thread():
+            call_counter["writer"] += 1
+            raise RuntimeError("simulated telemetry write failure")
+        return real_get_connection()
+
+    monkeypatch.setattr(search_service, "get_connection", flaky_get_connection)
+
+    with caplog.at_level("WARNING"):
+        result = search_service.search(keyword="書込失敗フォールバック検証")
+
+    _wait_for_telemetry(capture_telemetry_threads)
+
+    assert "error" not in result
+    assert "results" in result
+    assert call_counter["writer"] >= 1
+    assert any(
+        "search_telemetry write failed" in record.message for record in caplog.records
+    ), f"warning log が出ていない: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## Summary

- migration 0041 で `search_telemetry` テーブルを追加 (query / parameters / result_count / timestamp スナップショット、timestamp に index)
- `src/services/search_service.py` の `search()` 末尾で `_record_search_telemetry_async` を呼び、daemon thread で非同期書込。search 本体のレスポンスタイムに影響させない
- 書込中の例外は `logger.warning("search_telemetry write failed: %s", e)` で握りつぶし、search() の戻り値を壊さない (serialize 失敗も同様)
- 検索精度の検証 (recency / RRF 重み / query expansion 等の挙動分析) の基盤データを蓄積する

## Schema

| カラム | 型 | 説明 |
|---|---|---|
| id | INTEGER PK AUTOINCREMENT | |
| query | TEXT NOT NULL | str または list[str] を JSON serialize |
| parameters | TEXT NOT NULL | tags / entity_type / limit / offset / keyword_mode / domain / date_after / date_before / include_retracted / include_details の snapshot を JSON で |
| result_count | INTEGER NOT NULL | 返却件数 (total_count) |
| timestamp | TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP | 書込時刻 (UTC) |

`idx_search_telemetry_timestamp` を timestamp に張る (時系列集計が主要な読み出しパターン)。

## Test plan

`tests/unit/test_search_telemetry.py` で 6 件:
- [x] migration 0041 後にテーブルと必須カラムが作られる
- [x] timestamp に index が張られている
- [x] `search()` 呼出ごとに行が追加され、query / parameters / result_count が期待値で記録される
- [x] 配列 keyword + 非デフォルトパラメータが parameters JSON に保存される
- [x] `_record_search_telemetry_async` が daemon Thread を返し別スレッドで走る
- [x] 書込で例外が出ても `search()` の戻り値は壊れず WARNING ログが出る

`tests/conftest.py` に `_synchronous_telemetry` autouse fixture を追加: daemon thread と `TemporaryDirectory` cleanup の race を回避するためテスト中だけ `thread.join()` してから `search()` を返すラッパに置換する。本番の非同期性 (Thread 生成 / daemon=True) は original を通るので、別スレッド実行テストは引き続き成立。

フル regression: tests/unit + tests/integration で 1769 passed (484s)。
