### PR TITLE
feat: ow projector 経路追加 (A#911 SP-2 PR-α)

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1863,8 +1863,11 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
         channel: relay channel コード。OwState.channel に格納する。
 
     Returns:
-        構築・保存できた :class:`OwState`。relay HTTP エラー等で full pull
-        に失敗した場合は ``None`` (cache ファイルは触らない)。
+        構築・保存できた :class:`OwState`。以下のいずれかで ``None`` を返す
+        (cache ファイルは触らない):
+
+          - relay HTTP エラー等で full pull に失敗した場合
+          - cache ファイル書き出し (:func:`save_state`) が OSError で失敗した場合
     """
     history_limit = 10000
     history = ow_history(channel, since=0, limit=history_limit)
@@ -1967,7 +1970,18 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
         "presence": sorted(presence),
         "updated_at": now.isoformat(),
     }
-    save_state(topic_id, state)
+    try:
+        save_state(topic_id, state)
+    except OSError as e:
+        # ファイルシステムエラー (ディスク満杯、権限不足、I/O エラー等) を
+        # 呼び出し側 (ow_status 等) に伝播させない。docstring の契約通り None を返す。
+        logger.warning(
+            "ow projector: save_state failed for topic=%s channel=%r: %s",
+            topic_id,
+            channel,
+            e,
+        )
+        return None
     return state
 
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1934,6 +1934,11 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
                     "created_at": msg.get("created_at", ""),
                 }
 
+    # 内部集計用の latest_msg_id を cache JSON に含めないよう取り除く
+    # (state event 新旧判定の実装詳細であり OwState.workers の公開スキーマには含めない)
+    for entry in workers.values():
+        entry.pop("latest_msg_id", None)
+
     identities = {h: e["data"] for h, e in identity_by_handle.items()}
 
     # presence: heartbeat 時刻ベースの online 判定 (ow_get_presence と同ロジック)

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1866,11 +1866,23 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
         構築・保存できた :class:`OwState`。relay HTTP エラー等で full pull
         に失敗した場合は ``None`` (cache ファイルは触らない)。
     """
-    history = ow_history(channel, since=0, limit=10000)
+    history_limit = 10000
+    history = ow_history(channel, since=0, limit=history_limit)
     if "error" in history:
         return None
 
     messages = history.get("messages", [])
+    # limit に達した場合は古い state declarations が欠落して
+    # cache が不完全になる可能性がある (reconstruct_state_from_relay と同様
+    # の警告)。状態の無音欠損リスクを少なくとも logger.warning で可視化する。
+    if len(messages) >= history_limit:
+        logger.warning(
+            "ow projector: relay history truncated at limit=%d for channel=%r topic=%s; "
+            "oldest state declarations may be missing and cache may be incomplete",
+            history_limit,
+            channel,
+            topic_id,
+        )
 
     workers: dict[str, dict] = {}
     identity_by_handle: dict[str, dict] = {}

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -28,6 +28,12 @@ from pathlib import Path
 import yaml
 
 from src.relay import PROTOCOL_VERSION
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    OwState,
+    load_state,
+    save_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1826,6 +1832,145 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
             entry["latest_at"] = msg.get("created_at", "")
 
     return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id, "truncated": truncated}
+
+
+# ----------------------------
+# projector: relay → OwState → save_state (A#911 SP-2 PR-α)
+# ----------------------------
+#
+# C-2案 (D#2654-2657) の projector 経路。relay events を真実源とし
+# (D#2751)、cache JSON を派生キャッシュとして保つ。PR-α 時点では既存
+# queue write は触らず並走 (shadow write) し、consumer (ow_status 等) の
+# 挙動は不変。reducer 系の cache fastpath 化は PR-β、queue write 撤去は
+# PR-γ で行う (M#386 §6 / T94 v0)。
+#
+# orch concern 原則 (D#2749): orch は project_state_to_cache を直接呼ばず、
+# ow_status 等の状態取得 API 越しに結果を読む。本関数は ow_service 内部の
+# 隠蔽境界の中に閉じる。
+
+
+def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
+    """relay full pull → OwState 構築 → save_state を呼ぶ projector 経路。
+
+    1回の ``ow_history(since=0)`` 全件取得から、handle 単位の最新 state /
+    identity / heartbeat を集計して :class:`OwState` を組み立て、
+    :func:`save_state` でファイル先 (cache JSON) に書き出す (D#2750 ファイル先)。
+
+    既存 queue write 経路は触らない (shadow 並走、consumer 不変)。
+
+    Args:
+        topic_id: cache ファイル ``topic-<id>.json`` を決めるための topic 識別子。
+        channel: relay channel コード。OwState.channel に格納する。
+
+    Returns:
+        構築・保存できた :class:`OwState`。relay HTTP エラー等で full pull
+        に失敗した場合は ``None`` (cache ファイルは触らない)。
+    """
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return None
+
+    messages = history.get("messages", [])
+
+    workers: dict[str, dict] = {}
+    identity_by_handle: dict[str, dict] = {}
+    heartbeat_by_handle: dict[str, dict] = {}
+    max_msg_id = 0
+
+    for msg in messages:
+        msg_id = msg.get("msg_id", 0)
+        if isinstance(msg_id, int) and msg_id > max_msg_id:
+            max_msg_id = msg_id
+        body = msg.get("body", {})
+        if not isinstance(body, dict):
+            continue
+        if body.get("kind") != "event":
+            continue
+        data = body.get("data") or {}
+        t = data.get("type")
+        handle = body.get("from") or ""
+        if not handle:
+            continue
+
+        if t == "state":
+            state_val = data.get("state") or ""
+            if not state_val:
+                continue
+            task = body.get("task") or ""
+            entry = workers.get(handle)
+            if entry is None or msg_id >= entry.get("latest_msg_id", 0):
+                workers[handle] = {
+                    "task": task,
+                    "state": state_val,
+                    "latest_msg_id": msg_id,
+                    "latest_at": msg.get("created_at", ""),
+                }
+        elif t == "identity":
+            current = identity_by_handle.get(handle)
+            if current is None or msg_id > current["msg_id"]:
+                identity_by_handle[handle] = {
+                    "msg_id": msg_id,
+                    "data": dict(data),
+                    "created_at": msg.get("created_at", ""),
+                }
+        elif t == "heartbeat":
+            current = heartbeat_by_handle.get(handle)
+            if current is None or msg_id > current["msg_id"]:
+                heartbeat_by_handle[handle] = {
+                    "msg_id": msg_id,
+                    "phase": data.get("phase"),
+                    "created_at": msg.get("created_at", ""),
+                }
+
+    identities = {h: e["data"] for h, e in identity_by_handle.items()}
+
+    # presence: heartbeat 時刻ベースの online 判定 (ow_get_presence と同ロジック)
+    now = datetime.now(timezone.utc)
+    presence: list[str] = []
+    for handle, hb in heartbeat_by_handle.items():
+        phase = hb.get("phase") or ""
+        timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase, _HEARTBEAT_TIMEOUT_DEFAULT)
+        created_at = hb.get("created_at") or ""
+        try:
+            hb_time = datetime.fromisoformat(created_at)
+            if hb_time.tzinfo is None:
+                hb_time = hb_time.replace(tzinfo=timezone.utc)
+            elapsed = (now - hb_time).total_seconds()
+        except (ValueError, TypeError):
+            continue
+        if elapsed < timeout:
+            presence.append(handle)
+
+    state: OwState = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "channel": channel,
+        "last_msg_id": max_msg_id,
+        "workers": workers,
+        "identities": identities,
+        "presence": sorted(presence),
+        "updated_at": now.isoformat(),
+    }
+    save_state(topic_id, state)
+    return state
+
+
+def get_or_rebuild_state(topic_id: int, channel: str) -> OwState | None:
+    """cache から load_state、None なら projector で再構築する自動 fallback ヘルパー。
+
+    :func:`src.services.ow.cache.load_state` が以下のいずれかで ``None`` を返した
+    場合に :func:`project_state_to_cache` を呼んで cache を再生成する:
+
+      1. cache ファイル不存在 (cache miss)
+      2. JSON corruption — ``load_state`` が削除して ``None``
+      3. ``schema_version`` mismatch — 同上
+      4. ``channel`` mismatch — 同上 (引数 ``channel`` を ``load_state`` に渡す)
+
+    relay full pull に失敗した場合は ``None`` (cache は書き換えない)。
+    """
+    state = load_state(topic_id, channel=channel)
+    if state is not None:
+        return state
+    return project_state_to_cache(topic_id, channel)
 
 
 def _parse_spawning_at(value: str | None) -> datetime | None:

--- a/tests/integration/test_ow_projector.py
+++ b/tests/integration/test_ow_projector.py
@@ -1,0 +1,282 @@
+"""ow projector 経路 (A#911 SP-2 PR-α) の integration test。
+
+実 relay サーバープロセスを起動して identity / state / heartbeat envelope を
+ow_send で投入し、project_state_to_cache → cache JSON → load_state の round-trip と
+自動 fallback (cache miss / corruption / channel mismatch) を実 I/O 経由で検証する。
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import CURRENT_SCHEMA_VERSION, load_state
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"{url}/health", method="GET")
+            with urllib.request.urlopen(req, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "relay.db"
+
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
+        f"from src.relay import server; server.PORT = {port}; "
+        f"server.main({repr(str(db_path))})"
+    )
+
+    env = os.environ.copy()
+    env["RELAY_DB"] = str(db_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        if not _wait_until_healthy(base_url, timeout_sec=10.0):
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"relay did not become healthy on port {port}. "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+
+        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
+        # OW_STATE_DIR を tmp_path 配下に向けて cache JSON を隔離
+        state_dir = tmp_path / "cache"
+        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
+
+        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _send_state(channel: str, alias: str, task: str, state: str) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_identity(channel: str, alias: str, activity_id: int) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": alias,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+class TestProjectorRoundTrip:
+    """relay events を ow_send で投入 → project_state_to_cache → load_state で round-trip。"""
+
+    def test_relay_to_cache_to_load_round_trip(self, live_relay):
+        """実 relay に投入した identity/state/heartbeat が cache → load_state まで一貫して保持される。"""
+        channel = "TestProjA"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-a", activity_id=911)
+        _send_state(channel, "w-a", "T97", "ready")
+        last_hb = _send_heartbeat(channel, "w-a", "ready")
+
+        result = ow_service.project_state_to_cache(topic_id=4001, channel=channel)
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == channel
+        assert result["last_msg_id"] == last_hb
+        assert result["workers"]["w-a"]["state"] == "ready"
+        assert result["workers"]["w-a"]["task"] == "T97"
+        assert result["identities"]["w-a"]["alias"] == "w-a"
+        # heartbeat 直後なので presence に乗る
+        assert "w-a" in result["presence"]
+
+        # cache JSON ファイルが書き出されている
+        cache_path = live_relay["state_dir"] / "topic-4001.json"
+        assert cache_path.exists()
+        on_disk = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert on_disk["channel"] == channel
+        assert on_disk["last_msg_id"] == last_hb
+
+        # load_state で読み戻すと OwState が一致する
+        loaded = load_state(topic_id=4001, channel=channel)
+        assert loaded is not None
+        assert loaded["channel"] == channel
+        assert loaded["last_msg_id"] == last_hb
+        assert loaded["workers"]["w-a"]["state"] == "ready"
+
+    def test_multiple_workers_state_aggregated(self, live_relay):
+        """複数 worker / 複数 state 遷移が handle 単位で最新値に集約される。"""
+        channel = "TestProjB"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-x", activity_id=1)
+        _send_state(channel, "w-x", "T1", "ready")
+        _send_state(channel, "w-x", "T1", "working")
+        last_x = _send_heartbeat(channel, "w-x", "ready")
+
+        _send_identity(channel, "w-y", activity_id=2)
+        _send_state(channel, "w-y", "T2", "ready")
+        _send_state(channel, "w-y", "T2", "working")
+        _send_state(channel, "w-y", "T2", "done")
+        _send_heartbeat(channel, "w-y", "ready")
+
+        result = ow_service.project_state_to_cache(topic_id=4002, channel=channel)
+
+        assert result is not None
+        assert result["workers"]["w-x"]["state"] == "working"
+        assert result["workers"]["w-y"]["state"] == "done"
+        assert "w-x" in result["identities"]
+        assert "w-y" in result["identities"]
+
+
+class TestGetOrRebuildStateIntegration:
+    """get_or_rebuild_state の自動 fallback を実 relay 経由で検証。"""
+
+    def test_fallback_when_cache_missing(self, live_relay):
+        """cache 未生成の状態で get_or_rebuild_state を呼ぶと relay full pull で再構築される。"""
+        channel = "TestProjC"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-m", activity_id=3)
+        _send_state(channel, "w-m", "T3", "working")
+        _send_heartbeat(channel, "w-m", "ready")
+
+        cache_path = live_relay["state_dir"] / "topic-4003.json"
+        assert not cache_path.exists()
+
+        result = ow_service.get_or_rebuild_state(4003, channel)
+
+        assert result is not None
+        assert result["channel"] == channel
+        assert result["workers"]["w-m"]["state"] == "working"
+        assert cache_path.exists()
+
+    def test_fallback_when_cache_corrupt(self, live_relay):
+        """壊れた cache JSON を置いた状態で呼ぶと、load_state が削除 → projector で再構築される。"""
+        channel = "TestProjD"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-n", activity_id=4)
+        _send_state(channel, "w-n", "T4", "done")
+        _send_heartbeat(channel, "w-n", "ready")
+
+        state_dir = live_relay["state_dir"]
+        state_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = state_dir / "topic-4004.json"
+        cache_path.write_text("{not valid json", encoding="utf-8")
+
+        result = ow_service.get_or_rebuild_state(4004, channel)
+
+        assert result is not None
+        assert result["channel"] == channel
+        # 再構築後の cache JSON が読める
+        on_disk = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert on_disk["channel"] == channel
+        assert on_disk["workers"]["w-n"]["state"] == "done"
+
+    def test_fallback_when_channel_mismatches(self, live_relay):
+        """異なる channel の cache が残っている場合、load_state が削除 → 新 channel で再構築される。"""
+        from src.services.ow.cache import save_state
+
+        channel_new = "TestProjE-new"
+        ow_service.ensure_channel(channel_new)
+
+        _send_identity(channel_new, "w-p", activity_id=5)
+        _send_state(channel_new, "w-p", "T5", "ready")
+        _send_heartbeat(channel_new, "w-p", "ready")
+
+        state_dir = live_relay["state_dir"]
+        state_dir.mkdir(parents=True, exist_ok=True)
+        save_state(
+            topic_id=4005,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "TestProjE-old",
+                "last_msg_id": 1,
+                "workers": {"w-stale": {"state": "ready", "task": "T0"}},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        result = ow_service.get_or_rebuild_state(4005, channel_new)
+
+        assert result is not None
+        assert result["channel"] == channel_new
+        # 旧 channel の workers エントリが消えて新 channel の events に差し替わる
+        assert "w-stale" not in result["workers"]
+        assert "w-p" in result["workers"]
+        assert result["workers"]["w-p"]["state"] == "ready"

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -1,0 +1,416 @@
+"""ow_service の projector 経路 (A#911 SP-2 PR-α) のユニットテスト。
+
+project_state_to_cache / get_or_rebuild_state の挙動を、
+ow_history を monkeypatch したフィクスチャ relay 履歴に対して検証する。
+cache miss / corruption / schema mismatch / channel mismatch の4条件で
+load_state が None を返し、projector が再構築する自動 fallback も含む。
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import CURRENT_SCHEMA_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """各テストで OW_STATE_DIR を tmp_path に向ける (ホーム汚染防止)。"""
+    monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _iso_now_offset(seconds: float = 0.0) -> str:
+    """now - seconds (秒) の UTC ISO8601 を返す。heartbeat の経過時間制御用。"""
+    return (datetime.now(timezone.utc).astimezone(timezone.utc)).isoformat()
+
+
+def _iso_offset_seconds(seconds_ago: float) -> str:
+    from datetime import timedelta
+
+    return (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    ).isoformat()
+
+
+def _make_msg(
+    msg_id: int,
+    handle: str,
+    body: dict,
+    created_at: str | None = None,
+) -> dict:
+    return {
+        "msg_id": msg_id,
+        "handle": handle,
+        "body": body,
+        "created_at": created_at or "2026-06-19T10:00:00+00:00",
+    }
+
+
+def _state_body(handle: str, task: str, state_val: str) -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state_val},
+    }
+
+
+def _identity_body(handle: str, alias: str, activity_id: int) -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": handle,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+
+
+def _heartbeat_body(handle: str, phase: str = "ready") -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+
+
+def _patch_history(monkeypatch: pytest.MonkeyPatch, messages: list[dict]) -> None:
+    """ow_history を固定フィクスチャに差し替える。"""
+
+    def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+        return {"messages": list(messages)}
+
+    monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+
+class TestProjectStateToCache:
+    """project_state_to_cache 単体: relay events → OwState 構築 → save_state。"""
+
+    def test_relay_events_produce_cache_json_with_workers_identities_presence(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """state/identity/heartbeat の3種 event から OwState を組み立てて cache JSON を書き出す。"""
+        recent = _iso_offset_seconds(5.0)  # 5秒前 → online (timeout 90s)
+        messages = [
+            _make_msg(10, "w-a", _identity_body("w-a", "w-a", 911), recent),
+            _make_msg(11, "w-a", _state_body("w-a", "T97", "ready"), recent),
+            _make_msg(12, "w-a", _heartbeat_body("w-a", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_test"
+        )
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == "P_test"
+        assert result["last_msg_id"] == 12
+        assert "w-a" in result["workers"]
+        assert result["workers"]["w-a"]["state"] == "ready"
+        assert result["workers"]["w-a"]["task"] == "T97"
+        assert "w-a" in result["identities"]
+        assert result["identities"]["w-a"]["alias"] == "w-a"
+        assert "w-a" in result["presence"]
+
+        cache_path = _isolated_state_dir / "topic-454.json"
+        assert cache_path.exists()
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert data["channel"] == "P_test"
+        assert data["last_msg_id"] == 12
+
+    def test_round_trip_via_load_state(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """projector で書いた cache を load_state で読み戻すと OwState が一致する。"""
+        from src.services.ow.cache import load_state
+
+        recent = _iso_offset_seconds(2.0)
+        messages = [
+            _make_msg(50, "w-b", _identity_body("w-b", "w-b", 912), recent),
+            _make_msg(51, "w-b", _state_body("w-b", "T98", "working"), recent),
+            _make_msg(52, "w-b", _heartbeat_body("w-b", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        projected = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_rt"
+        )
+        loaded = load_state(topic_id=454, channel="P_rt")
+
+        assert projected is not None
+        assert loaded is not None
+        assert loaded["channel"] == projected["channel"]
+        assert loaded["last_msg_id"] == projected["last_msg_id"]
+        assert loaded["workers"] == projected["workers"]
+        assert loaded["identities"] == projected["identities"]
+        assert loaded["presence"] == projected["presence"]
+
+    def test_latest_state_wins_when_multiple_state_events_for_same_handle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """同 handle の state event が複数あるとき、最大 msg_id の state を採用する。"""
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(100, "w-c", _state_body("w-c", "T1", "loading"), recent),
+            _make_msg(101, "w-c", _state_body("w-c", "T1", "ready"), recent),
+            _make_msg(102, "w-c", _state_body("w-c", "T1", "working"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_x"
+        )
+
+        assert result is not None
+        assert result["workers"]["w-c"]["state"] == "working"
+        assert result["workers"]["w-c"]["latest_msg_id"] == 102
+
+    def test_heartbeat_older_than_timeout_excluded_from_presence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """heartbeat が timeout 超過 (>90s) の handle は presence に含めない。"""
+        recent = _iso_offset_seconds(2.0)
+        stale = _iso_offset_seconds(200.0)  # 200秒前 (>= 90s timeout)
+        messages = [
+            _make_msg(200, "w-fresh", _identity_body("w-fresh", "w-fresh", 1), recent),
+            _make_msg(201, "w-fresh", _heartbeat_body("w-fresh", "ready"), recent),
+            _make_msg(202, "w-stale", _identity_body("w-stale", "w-stale", 2), stale),
+            _make_msg(203, "w-stale", _heartbeat_body("w-stale", "ready"), stale),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_pr"
+        )
+
+        assert result is not None
+        assert "w-fresh" in result["presence"]
+        assert "w-stale" not in result["presence"]
+        # identity は presence と独立に維持される
+        assert "w-stale" in result["identities"]
+
+    def test_returns_none_when_relay_history_errors(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """ow_history が error を返すと projector は None を返し cache ファイルも作らない。"""
+
+        def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+            return {"error": {"code": "RELAY_DOWN", "message": "unreachable"}}
+
+        monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_err"
+        )
+
+        assert result is None
+        assert not (_isolated_state_dir / "topic-454.json").exists()
+
+    def test_ignores_non_event_kind_and_missing_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """kind != event や from 欠落 envelope は集計対象外。"""
+        recent = _iso_offset_seconds(1.0)
+        command_body = {
+            "v": 1,
+            "kind": "command",
+            "from": "orch",
+            "to": "w-z",
+            "task": "T1",
+            "data": {"type": "assign"},
+        }
+        no_from_body = {
+            "v": 1,
+            "kind": "event",
+            "from": "",
+            "data": {"type": "state", "state": "ready"},
+        }
+        messages = [
+            _make_msg(300, "orch", command_body, recent),
+            _make_msg(301, "", no_from_body, recent),
+            _make_msg(302, "w-z", _state_body("w-z", "T1", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_ne"
+        )
+
+        assert result is not None
+        assert list(result["workers"].keys()) == ["w-z"]
+        assert result["last_msg_id"] == 302
+
+
+class TestGetOrRebuildState:
+    """get_or_rebuild_state: cache hit 経路と4種類の自動 fallback。"""
+
+    def test_cache_hit_skips_projector(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache が有効なら load_state を返し projector を呼ばない。"""
+        from src.services.ow.cache import save_state
+
+        save_state(
+            topic_id=454,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "P_hit",
+                "last_msg_id": 555,
+                "workers": {"w-x": {"state": "ready", "task": "T1"}},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        called = {"count": 0}
+
+        def _fake_project(topic_id: int, channel: str):
+            called["count"] += 1
+            return None
+
+        monkeypatch.setattr(ow_service, "project_state_to_cache", _fake_project)
+
+        result = ow_service.get_or_rebuild_state(454, "P_hit")
+
+        assert result is not None
+        assert result["channel"] == "P_hit"
+        assert result["last_msg_id"] == 555
+        assert called["count"] == 0
+
+    def test_fallback_when_cache_missing(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache ファイル不存在 → projector が呼ばれて再構築する。"""
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(10, "w-a", _identity_body("w-a", "w-a", 1), recent),
+            _make_msg(11, "w-a", _state_body("w-a", "T1", "ready"), recent),
+            _make_msg(12, "w-a", _heartbeat_body("w-a"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        assert not (_isolated_state_dir / "topic-454.json").exists()
+
+        result = ow_service.get_or_rebuild_state(454, "P_new")
+
+        assert result is not None
+        assert result["channel"] == "P_new"
+        assert (_isolated_state_dir / "topic-454.json").exists()
+
+    def test_fallback_when_cache_corrupt(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """壊れた JSON → load_state がファイル削除 → projector で再構築する。"""
+        corrupt_path = _isolated_state_dir / "topic-454.json"
+        corrupt_path.write_text("not valid json {", encoding="utf-8")
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(20, "w-b", _state_body("w-b", "T2", "working"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_corr")
+
+        assert result is not None
+        assert result["channel"] == "P_corr"
+        # 再生成された cache JSON は有効な構造を持つ
+        data = json.loads(corrupt_path.read_text(encoding="utf-8"))
+        assert data["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert data["channel"] == "P_corr"
+
+    def test_fallback_when_schema_version_mismatches(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """schema_version mismatch → load_state がファイル削除 → projector で再構築する。"""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": CURRENT_SCHEMA_VERSION + 999,
+                    "channel": "P_sv",
+                    "last_msg_id": 1,
+                    "workers": {},
+                    "identities": {},
+                    "presence": [],
+                    "updated_at": "2026-06-19T10:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(30, "w-c", _state_body("w-c", "T3", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_sv")
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == "P_sv"
+
+    def test_fallback_when_channel_mismatches(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """channel mismatch → load_state がファイル削除 → projector で再構築する。"""
+        from src.services.ow.cache import save_state
+
+        save_state(
+            topic_id=454,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "P_old",
+                "last_msg_id": 1,
+                "workers": {},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(40, "w-d", _state_body("w-d", "T4", "done"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_new")
+
+        assert result is not None
+        assert result["channel"] == "P_new"
+        # 新 channel の最新 state が反映されている
+        assert "w-d" in result["workers"]
+        assert result["workers"]["w-d"]["state"] == "done"
+
+    def test_fallback_returns_none_when_projector_fails(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache miss + relay error → get_or_rebuild_state も None を返す。"""
+
+        def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+            return {"error": {"code": "X", "message": "x"}}
+
+        monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+        result = ow_service.get_or_rebuild_state(454, "P_fail")
+
+        assert result is None
+        assert not (_isolated_state_dir / "topic-454.json").exists()

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -24,11 +24,6 @@ def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     return tmp_path
 
 
-def _iso_now_offset(seconds: float = 0.0) -> str:
-    """now - seconds (秒) の UTC ISO8601 を返す。heartbeat の経過時間制御用。"""
-    return (datetime.now(timezone.utc).astimezone(timezone.utc)).isoformat()
-
-
 def _iso_offset_seconds(seconds_ago: float) -> str:
     from datetime import timedelta
 

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -173,7 +173,10 @@ class TestProjectStateToCache:
 
         assert result is not None
         assert result["workers"]["w-c"]["state"] == "working"
-        assert result["workers"]["w-c"]["latest_msg_id"] == 102
+        # latest_msg_id は内部集計用 (新旧判定) であり cache JSON には含めない
+        assert "latest_msg_id" not in result["workers"]["w-c"]
+        # 全 state event の最大 msg_id は last_msg_id (state 全体) に反映される
+        assert result["last_msg_id"] == 102
 
     def test_heartbeat_older_than_timeout_excluded_from_presence(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

C-2 案 (queue 脱却作戦) の **SP-2 PR-α**。M#386 §6 と D#2750/D#2751 に従い、relay events を真実源とし、ファイルキャッシュ (cache JSON) を派生として保つ **projector 経路** を `reconstruct_state_from_relay` の隣に追加する。

- `project_state_to_cache(topic_id, channel)`: `ow_history(since=0)` で relay を full pull し、handle 単位で state / identity / heartbeat を集計して `OwState` を構築 → `save_state` でファイル先 (cache JSON) に書き出す projector 関数。
- `get_or_rebuild_state(topic_id, channel)`: `load_state` を呼んで `None` なら projector で再構築する自動 fallback ヘルパー。**cache miss / corruption / schema mismatch / channel mismatch** の4条件すべてで再構築が発火する (load_state の既存挙動経由)。
- 既存 queue write 経路 (`_write_queue_spawning` / `_upsert_queue_task` / `_apply_queue_status_update`) は触らず並走 (shadow write、consumer 不変)。reducer 系 (`_query_*`) の cache fastpath 化は PR-β、queue write 撤去は PR-γ で行う。

## 関連 context

- **Activity**: A#911 (C-2 ファイルキャッシュ実装) SP-2 PR-α
- **真実源 / 派生**: D#2751 — relay events = 真実源、cache JSON = projector が自動再生成する派生
- **projector 経路**: D#2750 — push 型 + ファイル先 + コード hardcode マッピング
- **orch concern**: D#2749 — orch は本関数を直接呼ばず ow_status 等の状態取得 API 経由で結果を読む
- **PR分割**: M#386 §6 — PR-α (本PR) / PR-β / PR-γ の3段階

## 変更内容

- `src/services/ow_service.py`: import 追加 + projector 関数 (`project_state_to_cache`, `get_or_rebuild_state`) を `reconstruct_state_from_relay` の直後に追加 (+145行)
- `tests/unit/test_ow_projector.py`: projector / fallback の単体テスト 12件 (新規)
- `tests/integration/test_ow_projector.py`: 実 relay 経由の round-trip / fallback テスト 5件 (新規)

## Test plan

- [x] unit test (`tests/unit/test_ow_projector.py`): 12/12 pass — relay events → OwState 構築、round-trip、latest_msg_id 優先、heartbeat timeout による presence 除外、ow_history error 時の `None`、kind != event の無視、cache hit / cache miss / corruption / schema mismatch / channel mismatch / relay error のすべての fallback 経路。
- [x] integration test (`tests/integration/test_ow_projector.py`): 5/5 pass — 実 relay プロセスを起動し ow_send で投入した envelope が cache JSON に round-trip するか、複数 worker の集約、自動 fallback (cache missing / corruption / channel mismatch)。
- [x] 既存テスト全件 (1974 tests) pass。
- [ ] CI 緑確認。