### PR TITLE
feat: orch が auto 遷移すべき state で詰まった worker を検出する仕組みを追加

### DIFF
--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""ow stagnation detector — Phase A (案B: orch 側 watcher)。
+
+relay の /history を polling し、worker の state 遷移を追跡する。
+auto 遷移すべき state で閾値を超えた場合 ``ow_sentinel`` handle で
+stagnation event を relay に append する。
+
+- 監視対象: state=ready (60秒で working/terminated に遷移すべき),
+  state=draining (90秒で terminated に遷移すべき)
+- loading→ready は対象外 (heartbeat 継続中の長時間 loading は許容、
+  巨大 context warm-up を誤検知するため)
+- 既存 watchdog (heartbeat 途絶検知) とは責務分離して併走する
+  (watchdog=死活、stagnation=詰まり)
+
+D#2752 / M#388 の仕様に基づく Phase A 実装。Phase B (ow_service
+projector への push hook 統合) で本ファイルは廃止予定。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+SENTINEL_HANDLE = "ow_sentinel"
+
+# state -> 閾値秒。loading は意図的に含めない (D#2752 仕様)。
+DEFAULT_THRESHOLDS: dict[str, int] = {
+    "ready": 60,
+    "draining": 90,
+}
+
+DEFAULT_POLL_INTERVAL_SEC = 5
+DEFAULT_RELAY_URL = "http://127.0.0.1:8765"
+
+
+@dataclass
+class WatchEntry:
+    """1 worker handle の現在 watch 中 state エントリ。"""
+
+    handle: str
+    state: str
+    transitioned_at: float
+    task: Optional[str] = None
+    emitted: bool = False
+
+
+class SentinelState:
+    """state 遷移追跡と stagnation 判定の純粋ロジック。
+
+    relay event を observe_event で 1件ずつ取り込み、scan(now) で
+    閾値超え未通知の watch entry から stagnation envelope を生成する。
+    HTTP 副作用を含まないため、deterministic に unit test できる。
+    """
+
+    def __init__(self, thresholds: Optional[dict[str, int]] = None) -> None:
+        self.thresholds = dict(thresholds) if thresholds else dict(DEFAULT_THRESHOLDS)
+        self.watches: dict[str, WatchEntry] = {}
+
+    def observe_event(self, message: dict, now: float) -> None:
+        """relay message 1件を観測し watch entry を更新する。
+
+        body の data.type に応じて分岐する:
+        - state: 監視対象 state なら entry を新規作成 (再武装も兼ねる)、
+          それ以外の state なら entry を削除する
+        - identity: terminated_at が入っていれば entry を削除する
+        """
+        body = message.get("body")
+        if not isinstance(body, dict):
+            return
+        data = body.get("data") or {}
+        etype = data.get("type")
+        handle = body.get("from") or message.get("handle")
+        if not handle:
+            return
+
+        if etype == "state":
+            state = data.get("state")
+            if state in self.thresholds:
+                self.watches[handle] = WatchEntry(
+                    handle=handle,
+                    state=state,
+                    transitioned_at=now,
+                    task=body.get("task"),
+                )
+            else:
+                self.watches.pop(handle, None)
+        elif etype == "identity":
+            if data.get("terminated_at"):
+                self.watches.pop(handle, None)
+
+    def scan(self, now: float) -> list[dict]:
+        """全 watch entry をスキャンし、閾値超え未通知の entry から envelope を返す。
+
+        発火した entry には emitted=True をセットして同一 state 内での
+        重複通知を抑止する。state 遷移時に observe_event 側で entry が
+        差し替えられた瞬間 emitted は自動的にリセットされる (再武装)。
+        """
+        envelopes: list[dict] = []
+        for handle, entry in self.watches.items():
+            if entry.emitted:
+                continue
+            threshold = self.thresholds[entry.state]
+            elapsed = now - entry.transitioned_at
+            if elapsed < threshold:
+                continue
+            envelope: dict = {
+                "v": 1,
+                "kind": "event",
+                "from": SENTINEL_HANDLE,
+                "to": "orch",
+                "data": {
+                    "type": "stagnation",
+                    "target_handle": handle,
+                    "target_state": entry.state,
+                    "elapsed_sec": int(elapsed),
+                    "threshold_sec": threshold,
+                },
+            }
+            if entry.task is not None:
+                envelope["task"] = entry.task
+            envelopes.append(envelope)
+            entry.emitted = True
+        return envelopes
+
+
+class RelayClient:
+    """relay HTTP API への薄い wrapper (history pull / send)。"""
+
+    def __init__(self, relay_url: str = DEFAULT_RELAY_URL, timeout: float = 10.0) -> None:
+        self.relay_url = relay_url.rstrip("/")
+        self.timeout = timeout
+
+    def fetch_history(self, channel: str, since: int) -> list[dict]:
+        url = f"{self.relay_url}/history?channel={channel}&since={since}"
+        with urllib.request.urlopen(url, timeout=self.timeout) as resp:
+            payload = json.load(resp)
+        return list(payload.get("messages") or [])
+
+    def send_event(self, channel: str, envelope: dict) -> None:
+        body = json.dumps(
+            {
+                "channel": channel,
+                "handle": SENTINEL_HANDLE,
+                "body": envelope,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.relay_url}/send",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            resp.read()
+
+
+def _coerce_message_body(message: dict) -> dict:
+    """body が JSON 文字列で返ってきた場合に dict に正規化する。"""
+    body = message.get("body")
+    if isinstance(body, str):
+        try:
+            message = dict(message)
+            message["body"] = json.loads(body)
+        except json.JSONDecodeError:
+            return message
+    return message
+
+
+def run(
+    channel: str,
+    relay_url: str = DEFAULT_RELAY_URL,
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SEC,
+    thresholds: Optional[dict[str, int]] = None,
+) -> None:
+    state = SentinelState(thresholds=thresholds)
+    client = RelayClient(relay_url=relay_url)
+    last_msg_id = 0
+    print(
+        f"[ow_sentinel] start channel={channel} relay={relay_url} "
+        f"poll={poll_interval}s thresholds={state.thresholds}",
+        file=sys.stderr,
+        flush=True,
+    )
+    while True:
+        now = time.time()
+        try:
+            messages = client.fetch_history(channel, last_msg_id)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            print(f"[ow_sentinel] fetch_history error: {exc}", file=sys.stderr, flush=True)
+            messages = []
+        for raw in messages:
+            msg = _coerce_message_body(raw)
+            state.observe_event(msg, time.time())
+            msg_id = msg.get("msg_id")
+            if isinstance(msg_id, int) and msg_id > last_msg_id:
+                last_msg_id = msg_id
+
+        for envelope in state.scan(time.time()):
+            try:
+                client.send_event(channel, envelope)
+                print(
+                    f"[ow_sentinel] sent stagnation handle={envelope['data']['target_handle']} "
+                    f"state={envelope['data']['target_state']} "
+                    f"elapsed={envelope['data']['elapsed_sec']}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            except (urllib.error.URLError, TimeoutError) as exc:
+                print(f"[ow_sentinel] send_event error: {exc}", file=sys.stderr, flush=True)
+
+        time.sleep(poll_interval)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) < 1:
+        print(
+            "Usage: sentinel.py <channel_code> [poll_interval_sec]",
+            file=sys.stderr,
+        )
+        return 2
+    channel = args[0]
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SEC
+    if len(args) >= 2:
+        try:
+            poll_interval = float(args[1])
+        except ValueError:
+            print(f"invalid poll_interval: {args[1]}", file=sys.stderr)
+            return 2
+    relay_url = os.environ.get("RELAY_URL", DEFAULT_RELAY_URL)
+    try:
+        run(channel, relay_url=relay_url, poll_interval=poll_interval)
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -98,9 +98,10 @@ class SentinelState:
     def scan(self, now: float) -> list[dict]:
         """全 watch entry をスキャンし、閾値超え未通知の entry から envelope を返す。
 
-        発火した entry には emitted=True をセットして同一 state 内での
-        重複通知を抑止する。state 遷移時に observe_event 側で entry が
-        差し替えられた瞬間 emitted は自動的にリセットされる (再武装)。
+        この関数は副作用なしで pending envelope を返すだけ。発火を確定
+        させるには呼び出し側で送信成功を確認後 mark_emitted(handle, state)
+        を呼ぶ。送信に失敗した場合 mark しなければ次の scan で再度返り、
+        retry になる (stagnation が永続的に失われない)。
         """
         envelopes: list[dict] = []
         for handle, entry in self.watches.items():
@@ -126,8 +127,19 @@ class SentinelState:
             if entry.task is not None:
                 envelope["task"] = entry.task
             envelopes.append(envelope)
-            entry.emitted = True
         return envelopes
+
+    def mark_emitted(self, handle: str, state: str) -> None:
+        """送信成功した stagnation を確定して同一 state 内重複発火を抑止する。
+
+        scan で返した envelope を呼び出し側が relay に送信成功した直後に
+        呼ぶ。entry が既に別 state に差し替わっていた場合 (再武装) は
+        何もしない (古い state の mark は新しい watch entry に影響させない)。
+        """
+        entry = self.watches.get(handle)
+        if entry is None or entry.state != state:
+            return
+        entry.emitted = True
 
 
 class RelayClient:
@@ -204,17 +216,23 @@ def run(
                 last_msg_id = msg_id
 
         for envelope in state.scan(now):
+            target_handle = envelope["data"]["target_handle"]
+            target_state = envelope["data"]["target_state"]
             try:
                 client.send_event(channel, envelope)
-                print(
-                    f"[ow_sentinel] sent stagnation handle={envelope['data']['target_handle']} "
-                    f"state={envelope['data']['target_state']} "
-                    f"elapsed={envelope['data']['elapsed_sec']}s",
-                    file=sys.stderr,
-                    flush=True,
-                )
             except (urllib.error.URLError, TimeoutError) as exc:
+                # 送信失敗時は mark_emitted を呼ばないので次の scan で
+                # 再度同じ envelope が返り retry される (stagnation を失わない)
                 print(f"[ow_sentinel] send_event error: {exc}", file=sys.stderr, flush=True)
+                continue
+            state.mark_emitted(target_handle, target_state)
+            print(
+                f"[ow_sentinel] sent stagnation handle={target_handle} "
+                f"state={target_state} "
+                f"elapsed={envelope['data']['elapsed_sec']}s",
+                file=sys.stderr,
+                flush=True,
+            )
 
         time.sleep(poll_interval)
 

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -198,12 +198,12 @@ def run(
             messages = []
         for raw in messages:
             msg = _coerce_message_body(raw)
-            state.observe_event(msg, time.time())
+            state.observe_event(msg, now)
             msg_id = msg.get("msg_id")
             if isinstance(msg_id, int) and msg_id > last_msg_id:
                 last_msg_id = msg_id
 
-        for envelope in state.scan(time.time()):
+        for envelope in state.scan(now):
             try:
                 client.send_event(channel, envelope)
                 print(

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -198,10 +198,16 @@ def run(
 ) -> None:
     state = SentinelState(thresholds=thresholds)
     client = RelayClient(relay_url=relay_url)
+    # 既知トレードオフ (Phase A): last_msg_id=0 で起動するため、初回 fetch
+    # で history 全件 (=過去の state 遷移) をリプレイする。古い transitioned_at
+    # は再生時刻 (now) で上書きされるので、再起動直後 60〜90 秒は誤検知より
+    # 誤抑止寄りの挙動になる (古い遷移を「いま起きた」と見なす)。
+    # Phase B (ow_service projector hook 統合) で本ファイル廃止と同時に解消予定。
     last_msg_id = 0
     print(
         f"[ow_sentinel] start channel={channel} relay={relay_url} "
-        f"poll={poll_interval}s thresholds={state.thresholds}",
+        f"poll={poll_interval}s thresholds={state.thresholds} "
+        f"(Phase A: replay all history from msg_id=0)",
         file=sys.stderr,
         flush=True,
     )

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -23,6 +23,7 @@ import os
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Optional
@@ -137,7 +138,8 @@ class RelayClient:
         self.timeout = timeout
 
     def fetch_history(self, channel: str, since: int) -> list[dict]:
-        url = f"{self.relay_url}/history?channel={channel}&since={since}"
+        query = urllib.parse.urlencode({"channel": channel, "since": since})
+        url = f"{self.relay_url}/history?{query}"
         with urllib.request.urlopen(url, timeout=self.timeout) as resp:
             payload = json.load(resp)
         return list(payload.get("messages") or [])

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -70,7 +70,11 @@ class SentinelState:
         - state: 監視対象 state なら entry を新規作成 (再武装も兼ねる)、
           それ以外の state なら entry を削除する
         - identity: terminated_at が入っていれば entry を削除する
+
+        body が JSON 文字列のまま渡された場合は内部で dict に正規化する
+        (呼び出し側で _coerce_message_body を事前に呼ぶ必要はない)。
         """
+        message = _coerce_message_body(message)
         body = message.get("body")
         if not isinstance(body, dict):
             return
@@ -208,8 +212,8 @@ def run(
         except (urllib.error.URLError, TimeoutError) as exc:
             print(f"[ow_sentinel] fetch_history error: {exc}", file=sys.stderr, flush=True)
             messages = []
-        for raw in messages:
-            msg = _coerce_message_body(raw)
+        for msg in messages:
+            # body 文字列 → dict 正規化は observe_event 内部で行われる
             state.observe_event(msg, now)
             msg_id = msg.get("msg_id")
             if isinstance(msg_id, int) and msg_id > last_msg_id:

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -354,6 +354,44 @@ orchは `ow_get_workload_state(channel, handle)` で現在のstateを参照し�
 
 **spawning（ready前）タイムアウト**: spawning は orch 側 queue の状態。worker が `event:identity` または `event:state(loading)` を送る前に timeout_min 経過した場合は、spawn失敗の可能性が高い（cwd不在・aliasぶつかり・relay疎通断等）。`ow_recover` で pending_spawn として検出される。
 
+## stagnation detector (Phase A: ow_sentinel)
+
+watchdog が「死活 (heartbeat 途絶)」を見るのに対し、stagnation detector は「詰まり (heartbeat 継続中に state 遷移が起きない)」を見る。両者は責務分離・併走であり、stagnation が watchdog の前段に位置する fallback 仕組み (M#388 / D#2752)。
+
+**監視対象 state と閾値**:
+
+| 観測 state | 期待される遷移 | 閾値 | 検出する詰まり |
+|---|---|---|---|
+| `ready` | `working` (auto-assign 成功) | **60秒** | auto-assign 不発 |
+| `draining` | `terminated` | **90秒** | close ハンドシェイク失敗 / worker-sync 詰まり |
+
+`loading` / `working` / `blocked` / `escalated` は対象外 (`loading` は巨大 context warm-up を許容、他は heartbeat watchdog または人間判断側でカバー)。
+
+**Phase A 実装**: `scripts/ow/sentinel.py` を別 process として orch と並走起動する (薄実装、Phase B = ow_service projector への push hook 統合で廃止予定)。
+
+```bash
+RELAY_URL=http://127.0.0.1:8765 python3 scripts/ow/sentinel.py <channel_code> &
+```
+
+sentinel は relay `/history` を 5秒間隔で polling し、state event / identity event から各 handle の現在 state を追跡する。閾値超え時に handle=`ow_sentinel` で stagnation event を append する。
+
+**sentinel envelope 形式**:
+
+```json
+{"v":1, "kind":"event", "from":"ow_sentinel", "to":"orch", "task":"T<n>",
+ "data":{"type":"stagnation", "target_handle":"<alias>",
+         "target_state":"ready|draining", "elapsed_sec":<int>, "threshold_sec":<int>}}
+```
+
+**orch 側受信時の対処**: 既存 Monitor SSE 経路 (`recv_filter.py` は `to:"orch"` を通す) で受信される。`data.type=="stagnation"` を見たら以下を判断する:
+
+- `target_state="ready"` → auto-assign 不発の疑い。`command:assign` を明示送信、または worker 側 SKILL 不発の調査
+- `target_state="draining"` → close ハンドシェイク失敗の疑い。`command:close` 再送、または `ow_recover` で stalled_close 候補を確認
+
+**重複抑止**: 同一 `(target_handle, target_state)` の閾値超過中は 1回だけ通知される。worker が次の state に遷移する (またはterminated になる) と sentinel 側で watch entry が解除され、再度 ready / draining に入った場合は新規 entry として再武装される。
+
+**watchdog との発火順序**: 典型的には ready 滞留時 → 60秒 で stagnation 先行発火 → orch が対処判断 → 解決すれば watchdog 不要。orch 対処後も worker が動かず heartbeat も止まる場合は、別途 watchdog (90秒) が crash 推論する。
+
 ## モデル選択 (プロトコル制約のみ)
 
 `command:assign` envelope では `model` が必須フィールド。値の選び方は合算版 playbook の §モデル選択 セクションに従う (一般版・特化版で上書きされうる)。

--- a/tests/unit/test_ow_sentinel.py
+++ b/tests/unit/test_ow_sentinel.py
@@ -263,10 +263,24 @@ def test_observe_event_ignores_non_state_non_identity_types():
 
 def test_observe_event_skips_messages_without_dict_body():
     s = SentinelState()
-    # body が文字列のまま渡されるケース (parse 失敗想定) は無視される
+    # body が parse 不能な文字列のケースは無視される
     s.observe_event({"msg_id": 1, "handle": "w-a", "body": "not a dict"}, now=0.0)
     s.observe_event({"msg_id": 2, "handle": "w-a"}, now=0.0)
     assert s.watches == {}
+
+
+def test_observe_event_coerces_json_string_body_internally():
+    """body が JSON 文字列で渡されても observe_event 内部で dict 化される。"""
+    s = SentinelState()
+    s.observe_event(
+        {
+            "msg_id": 1,
+            "handle": "w-a",
+            "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"ready"}}',
+        },
+        now=0.0,
+    )
+    assert "w-a" in s.watches
 
 
 def test_observe_event_uses_handle_fallback_when_from_missing():

--- a/tests/unit/test_ow_sentinel.py
+++ b/tests/unit/test_ow_sentinel.py
@@ -1,0 +1,289 @@
+"""scripts/ow/sentinel.py の純粋ロジックを検証する unit test。
+
+ow stagnation detector Phase A (案B orch 側 watcher) の SentinelState が
+M#388 + D#2752 の仕様通りに動作することを確認する:
+
+- ready→working は 60秒、draining→terminated は 90秒で stagnation 発火
+- 同一 (handle, state) は 1回だけ通知 (重複抑止)
+- state 遷移 (entry 差し替え) で再武装、二度目以降の ready 滞留でも再発火
+- identity (terminated_at) で watch 解除
+- loading は監視対象外
+- 複数 handle は独立して追跡される
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.ow.sentinel import (  # noqa: E402
+    SENTINEL_HANDLE,
+    SentinelState,
+    _coerce_message_body,
+)
+
+
+def _state_msg(handle: str, state: str, task: str | None = None) -> dict:
+    body: dict = {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "orch",
+        "data": {"type": "state", "state": state},
+    }
+    if task is not None:
+        body["task"] = task
+    return {"msg_id": 1, "handle": handle, "body": body}
+
+
+def _identity_msg(handle: str, *, terminated_at: str | None = None) -> dict:
+    data: dict = {"type": "identity", "handle": handle}
+    if terminated_at is not None:
+        data["terminated_at"] = terminated_at
+    return {
+        "msg_id": 1,
+        "handle": handle,
+        "body": {
+            "v": 1,
+            "kind": "event",
+            "from": handle,
+            "to": "*",
+            "data": data,
+        },
+    }
+
+
+def test_ready_60sec_triggers_stagnation():
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready", task="T1"), now=0.0)
+
+    assert s.scan(59.0) == []
+
+    envelopes = s.scan(60.0)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env["from"] == SENTINEL_HANDLE
+    assert env["to"] == "orch"
+    assert env["kind"] == "event"
+    assert env["v"] == 1
+    assert env["task"] == "T1"
+    data = env["data"]
+    assert data == {
+        "type": "stagnation",
+        "target_handle": "w-a",
+        "target_state": "ready",
+        "elapsed_sec": 60,
+        "threshold_sec": 60,
+    }
+
+
+def test_draining_90sec_triggers_stagnation():
+    s = SentinelState()
+    s.observe_event(_state_msg("w-b", "draining"), now=0.0)
+
+    assert s.scan(89.0) == []
+
+    envelopes = s.scan(90.0)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env["data"]["target_state"] == "draining"
+    assert env["data"]["threshold_sec"] == 90
+    assert env["data"]["target_handle"] == "w-b"
+    # task が未指定なら envelope に task キーは含まれない
+    assert "task" not in env
+
+
+def test_duplicate_suppression_for_same_state():
+    """同一 (handle, state) の閾値超過中は scan を何度呼んでも 1回しか発火しない。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+
+    first = s.scan(60.0)
+    assert len(first) == 1
+
+    # さらに時間が経っても再発火しない
+    assert s.scan(120.0) == []
+    assert s.scan(600.0) == []
+
+
+def test_rearm_after_state_transition_back_to_ready():
+    """ready→working で watch 解除、再度 ready に戻ったら 60秒で再発火する。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    assert len(s.scan(60.0)) == 1
+
+    # ready → working: 監視対象外なので watch 解除
+    s.observe_event(_state_msg("w-a", "working"), now=70.0)
+    assert s.scan(200.0) == []
+
+    # working → ready: 新規 watch entry (emitted=False)
+    s.observe_event(_state_msg("w-a", "ready"), now=300.0)
+    assert s.scan(359.0) == []
+
+    envelopes = s.scan(360.0)
+    assert len(envelopes) == 1
+    assert envelopes[0]["data"]["target_state"] == "ready"
+    assert envelopes[0]["data"]["target_handle"] == "w-a"
+
+
+def test_terminated_identity_clears_watch():
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
+    s.observe_event(_identity_msg("w-a", terminated_at="2026-06-19T17:00:00Z"), now=30.0)
+
+    # 監視解除済みなので閾値を超えても発火しない
+    assert s.scan(120.0) == []
+
+
+def test_identity_without_terminated_does_not_clear_watch():
+    """spawn 時の identity (terminated_at 無し) は watch を解除しない。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_identity_msg("w-a"), now=10.0)
+
+    envelopes = s.scan(60.0)
+    assert len(envelopes) == 1
+
+
+def test_loading_state_is_not_monitored():
+    """loading→ready は仕様により監視対象外 (D#2752)。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "loading"), now=0.0)
+
+    assert s.scan(120.0) == []
+    # 内部状態にも entry が積まれない
+    assert "w-a" not in s.watches
+
+
+def test_blocked_and_escalated_states_are_not_monitored():
+    """blocked / escalated はそれぞれ orch 回答待ち・人間対話中なので対象外。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "blocked"), now=0.0)
+    s.observe_event(_state_msg("w-b", "escalated"), now=0.0)
+
+    assert s.scan(600.0) == []
+
+
+def test_multiple_handles_tracked_independently():
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-b", "draining"), now=10.0)
+
+    # t=70: w-a だけ閾値到達 (60秒経過)、w-b はまだ 60秒
+    envelopes_70 = s.scan(70.0)
+    assert len(envelopes_70) == 1
+    assert envelopes_70[0]["data"]["target_handle"] == "w-a"
+
+    # t=100: w-b も 90秒経過で発火
+    envelopes_100 = s.scan(100.0)
+    assert len(envelopes_100) == 1
+    assert envelopes_100[0]["data"]["target_handle"] == "w-b"
+    assert envelopes_100[0]["data"]["target_state"] == "draining"
+
+
+def test_working_event_after_ready_within_threshold_clears_watch():
+    """ready 受信後すぐ working が来た正常ケースは発火しない。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "working"), now=5.0)
+
+    assert s.scan(60.0) == []
+    assert s.scan(120.0) == []
+
+
+def test_observe_event_ignores_non_state_non_identity_types():
+    """heartbeat 等は watch に影響しない。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    # heartbeat はスキップ
+    s.observe_event(
+        {
+            "msg_id": 1,
+            "handle": "w-a",
+            "body": {
+                "v": 1,
+                "kind": "event",
+                "from": "w-a",
+                "to": "*",
+                "data": {"type": "heartbeat", "phase": "ready"},
+            },
+        },
+        now=30.0,
+    )
+
+    envelopes = s.scan(60.0)
+    assert len(envelopes) == 1
+
+
+def test_observe_event_skips_messages_without_dict_body():
+    s = SentinelState()
+    # body が文字列のまま渡されるケース (parse 失敗想定) は無視される
+    s.observe_event({"msg_id": 1, "handle": "w-a", "body": "not a dict"}, now=0.0)
+    s.observe_event({"msg_id": 2, "handle": "w-a"}, now=0.0)
+    assert s.watches == {}
+
+
+def test_observe_event_uses_handle_fallback_when_from_missing():
+    """body.from が無い場合は message.handle で識別する。"""
+    s = SentinelState()
+    s.observe_event(
+        {
+            "msg_id": 1,
+            "handle": "w-a",
+            "body": {
+                "v": 1,
+                "kind": "event",
+                "to": "orch",
+                "data": {"type": "state", "state": "ready"},
+            },
+        },
+        now=0.0,
+    )
+    assert "w-a" in s.watches
+
+
+def test_custom_thresholds_override_defaults():
+    s = SentinelState(thresholds={"ready": 10, "draining": 20})
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-b", "draining"), now=0.0)
+
+    envelopes = s.scan(10.0)
+    handles = {e["data"]["target_handle"] for e in envelopes}
+    assert handles == {"w-a"}
+
+    envelopes2 = s.scan(20.0)
+    handles2 = {e["data"]["target_handle"] for e in envelopes2}
+    assert handles2 == {"w-b"}
+
+
+def test_coerce_message_body_parses_json_string():
+    raw = {
+        "msg_id": 1,
+        "handle": "w-a",
+        "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"ready"}}',
+    }
+    coerced = _coerce_message_body(raw)
+    assert isinstance(coerced["body"], dict)
+    assert coerced["body"]["data"]["state"] == "ready"
+    # 元 dict は破壊しない
+    assert isinstance(raw["body"], str)
+
+
+def test_coerce_message_body_passes_through_dict_body():
+    raw = {
+        "msg_id": 1,
+        "handle": "w-a",
+        "body": {"v": 1, "from": "w-a", "data": {"type": "state", "state": "ready"}},
+    }
+    coerced = _coerce_message_body(raw)
+    assert coerced is raw or coerced["body"] is raw["body"]
+
+
+def test_coerce_message_body_returns_original_on_invalid_json():
+    raw = {"msg_id": 1, "handle": "w-a", "body": "not-json"}
+    coerced = _coerce_message_body(raw)
+    assert coerced["body"] == "not-json"

--- a/tests/unit/test_ow_sentinel.py
+++ b/tests/unit/test_ow_sentinel.py
@@ -98,16 +98,56 @@ def test_draining_90sec_triggers_stagnation():
 
 
 def test_duplicate_suppression_for_same_state():
-    """同一 (handle, state) の閾値超過中は scan を何度呼んでも 1回しか発火しない。"""
+    """同一 (handle, state) で mark_emitted 後は scan を何度呼んでも返らない。"""
     s = SentinelState()
     s.observe_event(_state_msg("w-a", "ready"), now=0.0)
 
     first = s.scan(60.0)
     assert len(first) == 1
+    # 送信成功を mark
+    s.mark_emitted("w-a", "ready")
 
     # さらに時間が経っても再発火しない
     assert s.scan(120.0) == []
     assert s.scan(600.0) == []
+
+
+def test_scan_returns_envelope_again_when_not_marked_emitted():
+    """送信失敗で mark_emitted を呼ばないと次回 scan で再度返る (retry)。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+
+    first = s.scan(60.0)
+    assert len(first) == 1
+    # mark_emitted を呼ばない (= 送信失敗を模擬)
+    second = s.scan(65.0)
+    assert len(second) == 1
+    assert second[0]["data"]["target_handle"] == "w-a"
+
+    # ようやく成功 → 以降は出ない
+    s.mark_emitted("w-a", "ready")
+    assert s.scan(70.0) == []
+
+
+def test_mark_emitted_ignores_state_mismatch_after_rearm():
+    """mark_emitted は古い state の確定が新 watch entry に影響しないこと。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    assert len(s.scan(60.0)) == 1
+    # ready の mark を立てる前に state 遷移して draining に再武装
+    s.observe_event(_state_msg("w-a", "draining"), now=70.0)
+    # 古い state の mark は新 entry に影響しない
+    s.mark_emitted("w-a", "ready")
+    # draining 閾値超過で発火できる
+    envelopes = s.scan(170.0)
+    assert len(envelopes) == 1
+    assert envelopes[0]["data"]["target_state"] == "draining"
+
+
+def test_mark_emitted_for_unknown_handle_is_noop():
+    s = SentinelState()
+    s.mark_emitted("nonexistent", "ready")  # 例外を出さない
+    assert s.watches == {}
 
 
 def test_rearm_after_state_transition_back_to_ready():
@@ -115,6 +155,7 @@ def test_rearm_after_state_transition_back_to_ready():
     s = SentinelState()
     s.observe_event(_state_msg("w-a", "ready"), now=0.0)
     assert len(s.scan(60.0)) == 1
+    s.mark_emitted("w-a", "ready")
 
     # ready → working: 監視対象外なので watch 解除
     s.observe_event(_state_msg("w-a", "working"), now=70.0)
@@ -177,6 +218,7 @@ def test_multiple_handles_tracked_independently():
     envelopes_70 = s.scan(70.0)
     assert len(envelopes_70) == 1
     assert envelopes_70[0]["data"]["target_handle"] == "w-a"
+    s.mark_emitted("w-a", "ready")
 
     # t=100: w-b も 90秒経過で発火
     envelopes_100 = s.scan(100.0)
@@ -254,6 +296,7 @@ def test_custom_thresholds_override_defaults():
     envelopes = s.scan(10.0)
     handles = {e["data"]["target_handle"] for e in envelopes}
     assert handles == {"w-a"}
+    s.mark_emitted("w-a", "ready")
 
     envelopes2 = s.scan(20.0)
     handles2 = {e["data"]["target_handle"] for e in envelopes2}


### PR DESCRIPTION
## Summary

orch が「auto で次の state に遷移すべき worker」が一定時間滞留しているのを検出して、orch に通知するフォールバック機構を追加する。watchdog (heartbeat 死活) とは別軸で、heartbeat が生きているのに state が遷移しないケース (= 詰まり) を捉える。

## 変更内容

- `scripts/ow/sentinel.py`: relay の `/history` を 5 秒間隔で polling し、state event / identity event から各 handle の current state を追跡。`ready → working` 60 秒 / `draining → terminated` 90 秒 の閾値超過で `handle=ow_sentinel` として stagnation event を append する。
- `tests/unit/test_ow_sentinel.py`: `SentinelState` の純粋ロジックを 21 件で検証。
- `skills/orch/SKILL.md`: stagnation detector 節を追記。watchdog (heartbeat 死活) との責務分離・併走・発火順序・受信時の対処 (assign 再送 / `ow_recover`) を明文化。

## sentinel envelope 形式

```json
{"v":1, "kind":"event", "from":"ow_sentinel", "to":"orch", "task":"T<n>",
 "data":{"type":"stagnation", "target_handle":"<alias>",
         "target_state":"ready|draining", "elapsed_sec":<int>, "threshold_sec":<int>}}
```

## 重複抑止と再武装

- 同一 `(target_handle, target_state)` の閾値超過中は 1 回だけ通知する。
- worker が次の state に遷移するか `terminated` になると watch entry が解除され、再び `ready` / `draining` に入った場合は新規 entry として再武装される。

## watchdog との関係

- watchdog (heartbeat 途絶 = 死活) と stagnation (heartbeat 継続中の state 不変 = 詰まり) は責務分離・併走。
- 典型シナリオ: `ready` 滞留 60 秒で stagnation 先行発火 → orch 対処判断 → 解決すれば watchdog 不要。orch 対処後も worker が動かず heartbeat も止まる場合は別途 watchdog (90 秒) が crash 推論する。

## Test plan

- [x] \`uv run pytest tests/unit/test_ow_sentinel.py -v\` で 21 件全 PASS (ローカル)
  - ready 60 秒で発火 / draining 90 秒で発火
  - 重複抑止 (mark_emitted 後の再 scan で発火しない)
  - 送信失敗 retry (mark_emitted を呼ばないと次回 scan で再度返る)
  - state 遷移後の再武装 (ready → working → ready で再度 60 秒経過時に発火)
  - terminated identity で watch 解除
  - loading / blocked / escalated は対象外
  - 複数 handle の独立追跡
  - JSON 文字列 body の coerce / handle fallback / custom thresholds
- [ ] CI 全 pass
- [ ] 実機で sentinel を 1 サイクル動かし、stagnation event が relay に積まれるのを確認