### PR TITLE
feat: ow reducer の cache fastpath 化と relay full pull 撤去

### DIFF
--- a/src/services/ow/__init__.py
+++ b/src/services/ow/__init__.py
@@ -1,4 +1,4 @@
-"""ow runtime state cache layer (C-2案 / A#911, D#2654-2657).
+"""ow runtime state cache layer.
 
 真実源は relay events。本パッケージが管理する JSON ファイルキャッシュは
 relay から再生成可能な派生データに過ぎず、破損・schema mismatch時には

--- a/src/services/ow/__init__.py
+++ b/src/services/ow/__init__.py
@@ -8,6 +8,7 @@ relay から再生成可能な派生データに過ぎず、破損・schema mism
 from src.services.ow.cache import (
     CURRENT_SCHEMA_VERSION,
     OwState,
+    find_topic_id_by_channel,
     load_state,
     save_state,
 )
@@ -15,6 +16,7 @@ from src.services.ow.cache import (
 __all__ = [
     "CURRENT_SCHEMA_VERSION",
     "OwState",
+    "find_topic_id_by_channel",
     "load_state",
     "save_state",
 ]

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -1,18 +1,18 @@
-"""ow runtime state ファイルキャッシュ (C-2案, A#911 SP-1, D#2654-2657).
+"""ow runtime state ファイルキャッシュ。
 
 真実源は relay events (`ow_history`)。本モジュールが書き出す JSON ファイルは
 relay から再生成可能な派生キャッシュであり、破損・schema mismatch・channel
 mismatch を検出した場合は即削除して None を返す (cache は再生成可能なので
-backup は取らない、裁定 L3)。
+backup は取らない)。
 
 配置:
     $OW_STATE_DIR (未設定時は ~/.cc-memory/ow/cache/)
 
 ファイル名:
-    topic-<id>.json  (1 topic = 1 file、最小粒度開始 / D#2655)
+    topic-<id>.json  (1 topic = 1 file)
 
 JSON 構造:
-    schema_version をJSON先頭フィールドに置き (裁定 L4)、cat 観測で即座に
+    schema_version をJSON先頭フィールドに置き、cat 観測で即座に
     schema 世代が分かる形にする。schema 変更時は CURRENT_SCHEMA_VERSION を
     bump → mismatch fallback で自動再構築する forward-only 戦略。
 """
@@ -35,10 +35,6 @@ CURRENT_SCHEMA_VERSION = 2
 class OwState(TypedDict):
     """topic 単位の ow ランタイム状態キャッシュ。
 
-    schema_version=2 で reducer fastpath 用フィールド ``identity_events`` / ``states`` /
-    ``heartbeats`` を追加した (A#911 SP-2 PR-β)。1 → 2 の自動再構築は load_state の
-    version mismatch fallback でハンドリングされる (forward-only)。
-
     EventEntry: ``{"msg_id": int, "data": dict, "created_at": str}``
 
     必須フィールド (projector が常に書き出すもの):
@@ -46,11 +42,11 @@ class OwState(TypedDict):
         channel: relay channel コード
         last_msg_id: projector が走査した最大 msg_id
         workers: handle → workload 軽量サマリ {task, state, latest_msg_id, latest_at}
-        identities: handle → identity event の raw data dict (PR-α 形式、後方互換)
+        identities: handle → identity event の raw data dict
         presence: projection 時点の online handle (静的スナップショット)
         updated_at: projection を実行した UTC ISO8601
 
-    optional フィールド (PR-β 追加、reducer fastpath 用、既存 cache との後方互換のため NotRequired):
+    optional フィールド (reducer fastpath 用、既存 cache との後方互換のため NotRequired):
         identity_events: handle → identity EventEntry
         states: handle → 最新 state EventEntry
         heartbeats: handle → 最新 heartbeat EventEntry
@@ -72,7 +68,7 @@ def _get_state_dir() -> Path:
     """cache ディレクトリのパスを返す。
 
     OW_STATE_DIR 環境変数が設定されていればそのパスを使用する。
-    未設定の場合は ~/.cc-memory/ow/cache/ をデフォルトとして返す (裁定 L5)。
+    未設定の場合は ~/.cc-memory/ow/cache/ をデフォルトとして返す。
     """
     env = os.environ.get("OW_STATE_DIR", "")
     if env:
@@ -93,7 +89,7 @@ def find_topic_id_by_channel(channel: str) -> int | None:
     reducer 4関数 (``ow_get_identity`` 等) は ``channel`` のみを受け取り
     ``topic_id`` を知らないため、cache fastpath で load_state を呼ぶには
     channel → topic_id の解決が必要。本ヘルパーは cache 物理ファイルの
-    ``channel`` フィールドで線形検索する (A#911 SP-2 PR-β)。
+    ``channel`` フィールドで線形検索する。
 
     破損ファイル / version mismatch は **削除しない** (load_state 経路でない
     走査時の副作用を避ける)。schema_version も検証しない (channel フィールド
@@ -174,7 +170,7 @@ def save_state(topic_id: int, state: OwState) -> None:
     """state を JSON として書き出す。
 
     schema_version は呼び出し側の値より CURRENT_SCHEMA_VERSION を優先し、
-    JSON 先頭フィールドに配置する (裁定 L4)。updated_at が未設定の場合は
+    JSON 先頭フィールドに配置する。updated_at が未設定の場合は
     現在時刻 (UTC ISO8601) を埋める。
 
     書き込みは temp file + rename によるアトミック書き換え。

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -25,14 +25,14 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 logger = logging.getLogger(__name__)
 
 CURRENT_SCHEMA_VERSION = 2
 
 
-class OwState(TypedDict, total=False):
+class OwState(TypedDict):
     """topic 単位の ow ランタイム状態キャッシュ。
 
     schema_version=2 で reducer fastpath 用フィールド ``identity_events`` / ``states`` /
@@ -41,17 +41,19 @@ class OwState(TypedDict, total=False):
 
     EventEntry: ``{"msg_id": int, "data": dict, "created_at": str}``
 
-    フィールド:
+    必須フィールド (projector が常に書き出すもの):
         schema_version: 現スキーマ世代 (CURRENT_SCHEMA_VERSION と等しい)
         channel: relay channel コード
         last_msg_id: projector が走査した最大 msg_id
         workers: handle → workload 軽量サマリ {task, state, latest_msg_id, latest_at}
         identities: handle → identity event の raw data dict (PR-α 形式、後方互換)
-        identity_events: handle → identity EventEntry (PR-β 追加, reducer fastpath 用)
-        states: handle → 最新 state EventEntry (PR-β 追加)
-        heartbeats: handle → 最新 heartbeat EventEntry (PR-β 追加)
         presence: projection 時点の online handle (静的スナップショット)
         updated_at: projection を実行した UTC ISO8601
+
+    optional フィールド (PR-β 追加、reducer fastpath 用、既存 cache との後方互換のため NotRequired):
+        identity_events: handle → identity EventEntry
+        states: handle → 最新 state EventEntry
+        heartbeats: handle → 最新 heartbeat EventEntry
     """
 
     schema_version: int
@@ -59,11 +61,11 @@ class OwState(TypedDict, total=False):
     last_msg_id: int
     workers: dict[str, Any]
     identities: dict[str, Any]
-    identity_events: dict[str, Any]
-    states: dict[str, Any]
-    heartbeats: dict[str, Any]
     presence: list[str]
     updated_at: str
+    identity_events: NotRequired[dict[str, Any]]
+    states: NotRequired[dict[str, Any]]
+    heartbeats: NotRequired[dict[str, Any]]
 
 
 def _get_state_dir() -> Path:

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -22,23 +22,46 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
 logger = logging.getLogger(__name__)
 
-CURRENT_SCHEMA_VERSION = 1
+CURRENT_SCHEMA_VERSION = 2
 
 
-class OwState(TypedDict):
-    """topic 単位の ow ランタイム状態キャッシュ。"""
+class OwState(TypedDict, total=False):
+    """topic 単位の ow ランタイム状態キャッシュ。
+
+    schema_version=2 で reducer fastpath 用フィールド ``identity_events`` / ``states`` /
+    ``heartbeats`` を追加した (A#911 SP-2 PR-β)。1 → 2 の自動再構築は load_state の
+    version mismatch fallback でハンドリングされる (forward-only)。
+
+    EventEntry: ``{"msg_id": int, "data": dict, "created_at": str}``
+
+    フィールド:
+        schema_version: 現スキーマ世代 (CURRENT_SCHEMA_VERSION と等しい)
+        channel: relay channel コード
+        last_msg_id: projector が走査した最大 msg_id
+        workers: handle → workload 軽量サマリ {task, state, latest_msg_id, latest_at}
+        identities: handle → identity event の raw data dict (PR-α 形式、後方互換)
+        identity_events: handle → identity EventEntry (PR-β 追加, reducer fastpath 用)
+        states: handle → 最新 state EventEntry (PR-β 追加)
+        heartbeats: handle → 最新 heartbeat EventEntry (PR-β 追加)
+        presence: projection 時点の online handle (静的スナップショット)
+        updated_at: projection を実行した UTC ISO8601
+    """
 
     schema_version: int
     channel: str
     last_msg_id: int
     workers: dict[str, Any]
     identities: dict[str, Any]
+    identity_events: dict[str, Any]
+    states: dict[str, Any]
+    heartbeats: dict[str, Any]
     presence: list[str]
     updated_at: str
 
@@ -57,6 +80,41 @@ def _get_state_dir() -> Path:
 
 def _state_file_path(topic_id: int) -> Path:
     return _get_state_dir() / f"topic-{topic_id}.json"
+
+
+_TOPIC_FILE_RE = re.compile(r"^topic-(\d+)\.json$")
+
+
+def find_topic_id_by_channel(channel: str) -> int | None:
+    """cache ディレクトリを走査し、引数 channel と一致する OwState の topic_id を返す。
+
+    reducer 4関数 (``ow_get_identity`` 等) は ``channel`` のみを受け取り
+    ``topic_id`` を知らないため、cache fastpath で load_state を呼ぶには
+    channel → topic_id の解決が必要。本ヘルパーは cache 物理ファイルの
+    ``channel`` フィールドで線形検索する (A#911 SP-2 PR-β)。
+
+    破損ファイル / version mismatch は **削除しない** (load_state 経路でない
+    走査時の副作用を避ける)。schema_version も検証しない (channel フィールド
+    の存在のみ確認)。
+
+    Returns:
+        最初に一致した topic_id、見つからなければ None。
+    """
+    state_dir = _get_state_dir()
+    if not state_dir.exists():
+        return None
+    for path in state_dir.iterdir():
+        m = _TOPIC_FILE_RE.match(path.name)
+        if m is None:
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict) and data.get("channel") == channel:
+            return int(m.group(1))
+    return None
 
 
 def load_state(topic_id: int, channel: str | None = None) -> OwState | None:
@@ -123,7 +181,17 @@ def save_state(topic_id: int, state: OwState) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
     ordered: dict = {"schema_version": CURRENT_SCHEMA_VERSION}
-    for key in ("channel", "last_msg_id", "workers", "identities", "presence", "updated_at"):
+    for key in (
+        "channel",
+        "last_msg_id",
+        "workers",
+        "identities",
+        "identity_events",
+        "states",
+        "heartbeats",
+        "presence",
+        "updated_at",
+    ):
         if key in state:
             ordered[key] = state[key]
     if "updated_at" not in ordered:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -2637,6 +2637,13 @@ def _load_state_by_channel(channel: str) -> OwState | None:
     cache ディレクトリを ``find_topic_id_by_channel`` で走査して topic_id を
     特定し、``load_state(topic_id, channel=channel)`` で読み出す。topic_id が
     見つからない、または cache が無効なら ``None`` を返す (relay を叩かない)。
+
+    TODO(perf): 現状 ``find_topic_id_by_channel`` と ``load_state`` で同一の
+    cache JSON を二重に読んでいる (検索フェーズと検証フェーズ)。reducer の
+    ホットパスで効くため、将来的に find_topic_id_by_channel が (topic_id, data)
+    のタプルを返すよう拡張するか、_load_state_by_channel 内で iterdir を直接
+    走査して 1 read で済ませるリファクタが望ましい。本 PR では PR スコープを
+    広げないため対応せず、観測 (cache hit 数 / file read 回数) を取ってから判断する。
     """
     topic_id = find_topic_id_by_channel(channel)
     if topic_id is None:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -28,6 +28,12 @@ from pathlib import Path
 import yaml
 
 from src.relay import PROTOCOL_VERSION
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    OwState,
+    load_state,
+    save_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1826,6 +1832,145 @@ def reconstruct_state_from_relay(channel: str, limit: int = 10000) -> dict:
             entry["latest_at"] = msg.get("created_at", "")
 
     return {"by_worker_task": by_worker_task, "max_msg_id": max_msg_id, "truncated": truncated}
+
+
+# ----------------------------
+# projector: relay → OwState → save_state (A#911 SP-2 PR-α)
+# ----------------------------
+#
+# C-2案 (D#2654-2657) の projector 経路。relay events を真実源とし
+# (D#2751)、cache JSON を派生キャッシュとして保つ。PR-α 時点では既存
+# queue write は触らず並走 (shadow write) し、consumer (ow_status 等) の
+# 挙動は不変。reducer 系の cache fastpath 化は PR-β、queue write 撤去は
+# PR-γ で行う (M#386 §6 / T94 v0)。
+#
+# orch concern 原則 (D#2749): orch は project_state_to_cache を直接呼ばず、
+# ow_status 等の状態取得 API 越しに結果を読む。本関数は ow_service 内部の
+# 隠蔽境界の中に閉じる。
+
+
+def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
+    """relay full pull → OwState 構築 → save_state を呼ぶ projector 経路。
+
+    1回の ``ow_history(since=0)`` 全件取得から、handle 単位の最新 state /
+    identity / heartbeat を集計して :class:`OwState` を組み立て、
+    :func:`save_state` でファイル先 (cache JSON) に書き出す (D#2750 ファイル先)。
+
+    既存 queue write 経路は触らない (shadow 並走、consumer 不変)。
+
+    Args:
+        topic_id: cache ファイル ``topic-<id>.json`` を決めるための topic 識別子。
+        channel: relay channel コード。OwState.channel に格納する。
+
+    Returns:
+        構築・保存できた :class:`OwState`。relay HTTP エラー等で full pull
+        に失敗した場合は ``None`` (cache ファイルは触らない)。
+    """
+    history = ow_history(channel, since=0, limit=10000)
+    if "error" in history:
+        return None
+
+    messages = history.get("messages", [])
+
+    workers: dict[str, dict] = {}
+    identity_by_handle: dict[str, dict] = {}
+    heartbeat_by_handle: dict[str, dict] = {}
+    max_msg_id = 0
+
+    for msg in messages:
+        msg_id = msg.get("msg_id", 0)
+        if isinstance(msg_id, int) and msg_id > max_msg_id:
+            max_msg_id = msg_id
+        body = msg.get("body", {})
+        if not isinstance(body, dict):
+            continue
+        if body.get("kind") != "event":
+            continue
+        data = body.get("data") or {}
+        t = data.get("type")
+        handle = body.get("from") or ""
+        if not handle:
+            continue
+
+        if t == "state":
+            state_val = data.get("state") or ""
+            if not state_val:
+                continue
+            task = body.get("task") or ""
+            entry = workers.get(handle)
+            if entry is None or msg_id >= entry.get("latest_msg_id", 0):
+                workers[handle] = {
+                    "task": task,
+                    "state": state_val,
+                    "latest_msg_id": msg_id,
+                    "latest_at": msg.get("created_at", ""),
+                }
+        elif t == "identity":
+            current = identity_by_handle.get(handle)
+            if current is None or msg_id > current["msg_id"]:
+                identity_by_handle[handle] = {
+                    "msg_id": msg_id,
+                    "data": dict(data),
+                    "created_at": msg.get("created_at", ""),
+                }
+        elif t == "heartbeat":
+            current = heartbeat_by_handle.get(handle)
+            if current is None or msg_id > current["msg_id"]:
+                heartbeat_by_handle[handle] = {
+                    "msg_id": msg_id,
+                    "phase": data.get("phase"),
+                    "created_at": msg.get("created_at", ""),
+                }
+
+    identities = {h: e["data"] for h, e in identity_by_handle.items()}
+
+    # presence: heartbeat 時刻ベースの online 判定 (ow_get_presence と同ロジック)
+    now = datetime.now(timezone.utc)
+    presence: list[str] = []
+    for handle, hb in heartbeat_by_handle.items():
+        phase = hb.get("phase") or ""
+        timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase, _HEARTBEAT_TIMEOUT_DEFAULT)
+        created_at = hb.get("created_at") or ""
+        try:
+            hb_time = datetime.fromisoformat(created_at)
+            if hb_time.tzinfo is None:
+                hb_time = hb_time.replace(tzinfo=timezone.utc)
+            elapsed = (now - hb_time).total_seconds()
+        except (ValueError, TypeError):
+            continue
+        if elapsed < timeout:
+            presence.append(handle)
+
+    state: OwState = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "channel": channel,
+        "last_msg_id": max_msg_id,
+        "workers": workers,
+        "identities": identities,
+        "presence": sorted(presence),
+        "updated_at": now.isoformat(),
+    }
+    save_state(topic_id, state)
+    return state
+
+
+def get_or_rebuild_state(topic_id: int, channel: str) -> OwState | None:
+    """cache から load_state、None なら projector で再構築する自動 fallback ヘルパー。
+
+    :func:`src.services.ow.cache.load_state` が以下のいずれかで ``None`` を返した
+    場合に :func:`project_state_to_cache` を呼んで cache を再生成する:
+
+      1. cache ファイル不存在 (cache miss)
+      2. JSON corruption — ``load_state`` が削除して ``None``
+      3. ``schema_version`` mismatch — 同上
+      4. ``channel`` mismatch — 同上 (引数 ``channel`` を ``load_state`` に渡す)
+
+    relay full pull に失敗した場合は ``None`` (cache は書き換えない)。
+    """
+    state = load_state(topic_id, channel=channel)
+    if state is not None:
+        return state
+    return project_state_to_cache(topic_id, channel)
 
 
 def _parse_spawning_at(value: str | None) -> datetime | None:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -31,6 +31,7 @@ from src.relay import PROTOCOL_VERSION
 from src.services.ow.cache import (
     CURRENT_SCHEMA_VERSION,
     OwState,
+    find_topic_id_by_channel,
     load_state,
     save_state,
 )
@@ -1874,6 +1875,7 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
 
     workers: dict[str, dict] = {}
     identity_by_handle: dict[str, dict] = {}
+    state_by_handle: dict[str, dict] = {}
     heartbeat_by_handle: dict[str, dict] = {}
     max_msg_id = 0
 
@@ -1892,6 +1894,8 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
         if not handle:
             continue
 
+        created_at = msg.get("created_at", "")
+
         if t == "state":
             state_val = data.get("state") or ""
             if not state_val:
@@ -1903,7 +1907,14 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
                     "task": task,
                     "state": state_val,
                     "latest_msg_id": msg_id,
-                    "latest_at": msg.get("created_at", ""),
+                    "latest_at": created_at,
+                }
+            current_state = state_by_handle.get(handle)
+            if current_state is None or msg_id > current_state["msg_id"]:
+                state_by_handle[handle] = {
+                    "msg_id": msg_id,
+                    "data": dict(data),
+                    "created_at": created_at,
                 }
         elif t == "identity":
             current = identity_by_handle.get(handle)
@@ -1911,24 +1922,22 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
                 identity_by_handle[handle] = {
                     "msg_id": msg_id,
                     "data": dict(data),
-                    "created_at": msg.get("created_at", ""),
+                    "created_at": created_at,
                 }
         elif t == "heartbeat":
             current = heartbeat_by_handle.get(handle)
             if current is None or msg_id > current["msg_id"]:
                 heartbeat_by_handle[handle] = {
                     "msg_id": msg_id,
-                    "phase": data.get("phase"),
-                    "created_at": msg.get("created_at", ""),
+                    "data": dict(data),
+                    "created_at": created_at,
                 }
-
-    identities = {h: e["data"] for h, e in identity_by_handle.items()}
 
     # presence: heartbeat 時刻ベースの online 判定 (ow_get_presence と同ロジック)
     now = datetime.now(timezone.utc)
     presence: list[str] = []
     for handle, hb in heartbeat_by_handle.items():
-        phase = hb.get("phase") or ""
+        phase = (hb["data"].get("phase") if isinstance(hb.get("data"), dict) else None) or ""
         timeout = _HEARTBEAT_TIMEOUT_SECS.get(phase, _HEARTBEAT_TIMEOUT_DEFAULT)
         created_at = hb.get("created_at") or ""
         try:
@@ -1941,12 +1950,21 @@ def project_state_to_cache(topic_id: int, channel: str) -> OwState | None:
         if elapsed < timeout:
             presence.append(handle)
 
+    # ``identities`` は PR-α 互換の raw data 形式 (handle → data dict)。
+    # reducer fastpath 用には EventEntry 形式の ``identity_events`` を別途持つ
+    # (msg_id / created_at が必要なため)。冗長だが PR-α テストとの後方互換を
+    # 優先した (cache スキーマは forward-only な fallback を備える)。
+    identities_raw = {h: e["data"] for h, e in identity_by_handle.items()}
+
     state: OwState = {
         "schema_version": CURRENT_SCHEMA_VERSION,
         "channel": channel,
         "last_msg_id": max_msg_id,
         "workers": workers,
-        "identities": identities,
+        "identities": identities_raw,
+        "identity_events": identity_by_handle,
+        "states": state_by_handle,
+        "heartbeats": heartbeat_by_handle,
         "presence": sorted(presence),
         "updated_at": now.isoformat(),
     }
@@ -2588,37 +2606,103 @@ def _parse_ow_event(msg: dict) -> dict | None:
     }
 
 
+# ----------------------------
+# reducer cache fastpath (A#911 SP-2 PR-β/γ, M#386 §6)
+# ----------------------------
+#
+# `_query_latest_event` / `_latest_events_by_type` は、PR-α で導入した projector
+# (`project_state_to_cache`) が書き出した OwState を読むだけのキャッシュ参照に
+# 切り替えた (PR-γ で relay full pull コードは削除)。
+#
+# キャッシュは orch tick で `project_state_to_cache` 経由 (D#2750 push型projector)
+# に更新される前提。reducer 自身は relay を直接叩かない (D#2749 orch concern原則:
+# reducer は読むだけ、書き手は orch)。
+#
+# 対象 data_type: "identity" / "state" / "heartbeat" の3種。
+# それ以外の data_type で呼ばれた場合は ``None`` / ``{}`` を返す
+# (現状の呼び出し元はすべて上記3種、`_query_events_since` は対象外で従来通り)。
+
+
+_CACHE_EVENT_FIELDS = ("identity_events", "states", "heartbeats")
+_DATA_TYPE_TO_CACHE_FIELD: dict[str, str] = {
+    "identity": "identity_events",
+    "state": "states",
+    "heartbeat": "heartbeats",
+}
+
+
+def _load_state_by_channel(channel: str) -> OwState | None:
+    """channel から OwState をキャッシュ越しに読み出す。
+
+    cache ディレクトリを ``find_topic_id_by_channel`` で走査して topic_id を
+    特定し、``load_state(topic_id, channel=channel)`` で読み出す。topic_id が
+    見つからない、または cache が無効なら ``None`` を返す (relay を叩かない)。
+    """
+    topic_id = find_topic_id_by_channel(channel)
+    if topic_id is None:
+        return None
+    return load_state(topic_id, channel=channel)
+
+
+def _entry_to_parsed_event(entry: dict, handle: str, data_type: str) -> dict:
+    """OwState の EventEntry を `_query_*` 戻り値形式 (parsed event) に組み立てる。
+
+    既存呼び出し元 (ow_get_identity / ow_get_presence / ow_get_workload_state) の
+    parsed event 取り扱いと互換にするため、kind=event / from=handle / data 同梱の
+    envelope に組み戻す。
+    """
+    data = dict(entry.get("data") or {})
+    if data.get("type") is None:
+        data["type"] = data_type
+    return {
+        "msg_id": entry.get("msg_id", 0),
+        "handle": handle,
+        "body": {
+            "v": 1,
+            "kind": "event",
+            "from": handle,
+            "data": data,
+        },
+        "created_at": entry.get("created_at", ""),
+    }
+
+
 def _query_latest_event(
     channel: str, handle: str | None, data_type: str, since: int = 0
 ) -> dict | None:
-    """指定 channel/handle/data_type の最新 event を返す（kind=event のみ対象）。
+    """指定 channel/handle/data_type の最新 event をキャッシュから返す。
 
     Args:
         channel: channelコード
         handle: workerハンドル（Noneなら全handle対象）
-        data_type: eventのdata.type（例: "identity", "state", "heartbeat"）
+        data_type: eventのdata.type（"identity" / "state" / "heartbeat"）
         since: このmsg_idより大きいものを返す（0=全件）
 
     Returns:
-        最新のparsed event dict または None
+        最新の parsed event dict（OwState の EventEntry から再構築）
+        キャッシュ無し / 未サポート type / 該当 entry 無しなら None
     """
-    history = ow_history(channel, since=since, limit=10000)
-    if "error" in history:
+    field = _DATA_TYPE_TO_CACHE_FIELD.get(data_type)
+    if field is None:
         return None
-    result = None
-    for msg in history.get("messages", []):
-        if handle is not None and msg.get("handle") != handle:
+    state = _load_state_by_channel(channel)
+    if state is None:
+        return None
+    events_map = state.get(field) or {}
+    best: dict | None = None
+    for h, entry in events_map.items():
+        if not isinstance(entry, dict):
             continue
-        parsed = _parse_ow_event(msg)
-        if parsed is None:
+        if handle is not None and h != handle:
             continue
-        if parsed["body"].get("kind") != "event":
+        msg_id = entry.get("msg_id", 0)
+        if not isinstance(msg_id, int):
             continue
-        if parsed["body"].get("data", {}).get("type") != data_type:
+        if since and msg_id <= since:
             continue
-        if result is None or parsed["msg_id"] > result["msg_id"]:
-            result = parsed
-    return result
+        if best is None or msg_id > best["msg_id"]:
+            best = _entry_to_parsed_event(entry, h, data_type)
+    return best
 
 
 def _query_events_since(
@@ -2697,34 +2781,39 @@ def _infer_crash_cause(
 def _latest_events_by_type(
     channel: str, handle: str | None, data_types: tuple[str, ...]
 ) -> dict[str, dict]:
-    """指定 handle の各 data_type について最新 event を1回の ow_history で取得する。
+    """指定 handle の各 data_type について最新 event をキャッシュから返す。
 
     Args:
         channel: channelコード
         handle: workerハンドル（Noneなら全handle対象）
         data_types: 対象とする event の data.type タプル
+            ("identity" / "state" / "heartbeat" のみ対応、それ以外はキー欠落)
 
     Returns:
         {data_type: latest_event_dict} — 該当 event が無い type はキー欠落
     """
-    history = ow_history(channel, since=0, limit=10000)
-    if "error" in history:
+    state = _load_state_by_channel(channel)
+    if state is None:
         return {}
     latest: dict[str, dict] = {}
-    for msg in history.get("messages", []):
-        if handle is not None and msg.get("handle") != handle:
+    for data_type in data_types:
+        field = _DATA_TYPE_TO_CACHE_FIELD.get(data_type)
+        if field is None:
             continue
-        parsed = _parse_ow_event(msg)
-        if parsed is None:
-            continue
-        if parsed["body"].get("kind") != "event":
-            continue
-        t = parsed["body"].get("data", {}).get("type")
-        if t not in data_types:
-            continue
-        current = latest.get(t)
-        if current is None or parsed["msg_id"] > current["msg_id"]:
-            latest[t] = parsed
+        events_map = state.get(field) or {}
+        best: dict | None = None
+        for h, entry in events_map.items():
+            if not isinstance(entry, dict):
+                continue
+            if handle is not None and h != handle:
+                continue
+            msg_id = entry.get("msg_id", 0)
+            if not isinstance(msg_id, int):
+                continue
+            if best is None or msg_id > best["msg_id"]:
+                best = _entry_to_parsed_event(entry, h, data_type)
+        if best is not None:
+            latest[data_type] = best
     return latest
 
 
@@ -2766,63 +2855,49 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
 
 
 def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
-    """channel 上の全 handle の identity リスト。
+    """channel 上の全 handle の identity リスト（A#911 SP-2 PR-β/γ: cache fastpath 化）。
 
     alive_only=True の場合:
     - identity bundle に terminated_at / cause(closed/cancelled/dead) を持つ entry を除外
     - 加えて、ow_get_identity と同様の crash 推論（state が non-terminal + heartbeat 途絶）
       で inferred_cause が付与される entry も除外する
-    handle フィールドが欠落した event は集約キーが None になるためスキップする。
 
     term_ref 透過保持: ow_get_identity と同様、entry = dict(data) により term_ref も
                       そのまま保持される。
+
+    実装: relay full pull は撤去し、``project_state_to_cache`` が書き出した
+    OwState (``identity_events`` / ``states`` / ``heartbeats``) を読むだけ。
+    キャッシュ未生成なら空リストを返す (orch 側で project_state_to_cache 必須)。
     """
-    history = ow_history(channel, since=0, limit=10000)
-    if "error" in history:
+    state = _load_state_by_channel(channel)
+    if state is None:
         return []
 
-    # handle別に identity / state / heartbeat の最新msgを収集
-    identity_by_handle: dict[str, dict] = {}
-    state_by_handle: dict[str, dict] = {}
-    heartbeat_by_handle: dict[str, dict] = {}
-    for msg in history.get("messages", []):
-        parsed = _parse_ow_event(msg)
-        if parsed is None:
-            continue
-        h = parsed["handle"]
-        if h is None:
-            continue
-        if parsed["body"].get("kind") != "event":
-            continue
-        t = parsed["body"].get("data", {}).get("type")
-        if t == "identity":
-            current = identity_by_handle.get(h)
-            if current is None or parsed["msg_id"] > current["msg_id"]:
-                identity_by_handle[h] = parsed
-        elif t == "state":
-            current = state_by_handle.get(h)
-            if current is None or parsed["msg_id"] > current["msg_id"]:
-                state_by_handle[h] = parsed
-        elif t == "heartbeat":
-            current = heartbeat_by_handle.get(h)
-            if current is None or parsed["msg_id"] > current["msg_id"]:
-                heartbeat_by_handle[h] = parsed
+    identity_by_handle: dict[str, dict] = state.get("identity_events") or {}
+    state_by_handle: dict[str, dict] = state.get("states") or {}
+    heartbeat_by_handle: dict[str, dict] = state.get("heartbeats") or {}
 
     entries = []
-    for h, parsed in identity_by_handle.items():
-        data = parsed["body"].get("data", {})
+    for h, identity_entry in identity_by_handle.items():
+        if not isinstance(identity_entry, dict):
+            continue
+        data = identity_entry.get("data") or {}
         entry = dict(data)
-        entry["msg_id"] = parsed["msg_id"]
-        entry["identity_at"] = parsed["created_at"]
+        entry["msg_id"] = identity_entry.get("msg_id", 0)
+        entry["identity_at"] = identity_entry.get("created_at", "")
 
-        state_msg = state_by_handle.get(h)
+        state_entry = state_by_handle.get(h)
         workload_state = (
-            state_msg["body"].get("data", {}).get("state")
-            if state_msg is not None
+            (state_entry.get("data") or {}).get("state")
+            if isinstance(state_entry, dict)
             else None
         )
-        hb_msg = heartbeat_by_handle.get(h)
-        last_heartbeat_at = hb_msg["created_at"] if hb_msg is not None else None
+        hb_entry = heartbeat_by_handle.get(h)
+        last_heartbeat_at = (
+            hb_entry.get("created_at")
+            if isinstance(hb_entry, dict)
+            else None
+        )
         inferred_cause = _infer_crash_cause(workload_state, last_heartbeat_at)
         if inferred_cause is not None:
             entry["inferred_cause"] = inferred_cause

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -113,7 +113,7 @@ def _normalize_and_validate_model(model: str) -> tuple[str, str | None]:
 THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathink"})
 
 # orch 側コード/skill/ドキュメントから sentinel 綴り `ultratink` を渡せるよう、最大段の
-# alias を1つ受け付ける (D#2600)。orch セッションが MCP 呼び出し時に正規綴り
+# alias を1つ受け付ける。orch セッションが MCP 呼び出し時に正規綴り
 # `ultrathink` を入力すると orch 自身の extended thinking モードが暴発するため、
 # orch は sentinel `ultratink` を使い、ow_service 側で正規綴りに畳む。
 _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
@@ -563,13 +563,13 @@ def ensure_channel(channel_code: str) -> bool:
 
 
 def _maybe_inject_term_ref(body: dict) -> dict:
-    """identity event の term_ref をファイルキャッシュから補完する（B案 D#2720）。
+    """identity event の term_ref をファイルキャッシュから補完する。
 
     SessionStart hook (hooks/term_ref_cache.py) が worker shell の env を
     `~/.cc-memory/ow/term_refs/<session_id>.json` に書き出している前提。
     body が identity event で term_ref 未設定なら session_id でキャッシュを引いて補完する。
 
-    lookup 失敗時は body をそのまま返す（D#2720: 補完失敗時は素通し）。
+    lookup 失敗時は body をそのまま返す（補完失敗時は素通し）。
     元の body / data dict は破壊せず、補完時のみ shallow copy で新 dict を返す。
     """
     if not isinstance(body, dict) or body.get("kind") != "event":
@@ -1328,7 +1328,7 @@ def ow_spawn_worker(
 
     # アダプタ呼び出し — stdoutから安定IDを取得する
     # tmux アダプタは positional 引数 `[target_pane] [is_thinking]` を受ける:
-    #   - is_thinking=1 のとき split-pane ではなく `tmux new-window` で別タブ起動 (D#2601)
+    #   - is_thinking=1 のとき split-pane ではなく `tmux new-window` で別タブ起動
     #   - target_pane が無い思考worker のときは空文字列をプレースホルダにして is_thinking のみ届ける
     adapter_args = ["bash", str(adapter_path), "spawn", cwd, worker_cmd]
     if terminal == "tmux":
@@ -2547,12 +2547,6 @@ def ow_recover(
 #   - tmux:    "%N"                  例: "%5", "%123"     (tmux pane_id 規約)
 #   - iterm2:  RFC4122 UUID 表記      例: "12345678-1234-...-123456789ABC"
 #   - manual:  "manual:host:pid"      例: "manual:mac-mini:12345"
-#
-# 段階① のスコープ:
-#   - reducer が term_ref を破棄しないことを担保するテストを追加（test_ow_reducer）
-#   - is_valid_term_ref() / classify_term_ref() を診断ヘルパーとして提供
-#
-# 段階②③（relay-side ow_recover での term_ref キー再リンク等）は D#2608 によりスコープ外。
 
 _TERM_REF_PATTERNS: dict[str, re.Pattern[str]] = {
     "tmux": re.compile(r"^%\d+$"),
@@ -2621,16 +2615,13 @@ def _parse_ow_event(msg: dict) -> dict | None:
 
 
 # ----------------------------
-# reducer cache fastpath (A#911 SP-2 PR-β/γ, M#386 §6)
+# reducer cache fastpath
 # ----------------------------
 #
-# `_query_latest_event` / `_latest_events_by_type` は、PR-α で導入した projector
-# (`project_state_to_cache`) が書き出した OwState を読むだけのキャッシュ参照に
-# 切り替えた (PR-γ で relay full pull コードは削除)。
-#
-# キャッシュは orch tick で `project_state_to_cache` 経由 (D#2750 push型projector)
-# に更新される前提。reducer 自身は relay を直接叩かない (D#2749 orch concern原則:
-# reducer は読むだけ、書き手は orch)。
+# `_query_latest_event` / `_latest_events_by_type` は projector
+# (`project_state_to_cache`) が書き出した OwState を読むだけのキャッシュ参照。
+# キャッシュは orch tick で `project_state_to_cache` 経由に更新される前提で、
+# reducer 自身は relay を直接叩かない (reducer は読むだけ、書き手は orch)。
 #
 # 対象 data_type: "identity" / "state" / "heartbeat" の3種。
 # それ以外の data_type で呼ばれた場合は ``None`` / ``{}`` を返す
@@ -2656,8 +2647,7 @@ def _load_state_by_channel(channel: str) -> OwState | None:
     cache JSON を二重に読んでいる (検索フェーズと検証フェーズ)。reducer の
     ホットパスで効くため、将来的に find_topic_id_by_channel が (topic_id, data)
     のタプルを返すよう拡張するか、_load_state_by_channel 内で iterdir を直接
-    走査して 1 read で済ませるリファクタが望ましい。本 PR では PR スコープを
-    広げないため対応せず、観測 (cache hit 数 / file read 回数) を取ってから判断する。
+    走査して 1 read で済ませるリファクタが望ましい。
     """
     topic_id = find_topic_id_by_channel(channel)
     if topic_id is None:
@@ -2876,7 +2866,7 @@ def ow_get_identity(channel: str, handle: str) -> dict | None:
 
 
 def ow_list_identities(channel: str, alive_only: bool = False) -> list[dict]:
-    """channel 上の全 handle の identity リスト（A#911 SP-2 PR-β/γ: cache fastpath 化）。
+    """channel 上の全 handle の identity リスト。
 
     alive_only=True の場合:
     - identity bundle に terminated_at / cause(closed/cancelled/dead) を持つ entry を除外

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-"""Integration test 共通ヘルパー / fixture (A#911 SP-2 PR-α/β/γ)。
+"""Integration test 共通ヘルパー / fixture。
 
 `test_ow_projector.py` と `test_ow_reducer_cache_fastpath.py` で重複していた
 `_free_port` / `_wait_until_healthy` / `_send_*` / `live_relay` fixture を統合。

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,142 @@
+"""Integration test 共通ヘルパー / fixture (A#911 SP-2 PR-α/β/γ)。
+
+`test_ow_projector.py` と `test_ow_reducer_cache_fastpath.py` で重複していた
+`_free_port` / `_wait_until_healthy` / `_send_*` / `live_relay` fixture を統合。
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+
+def _free_port() -> int:
+    """空いている TCP ポートを返す。
+
+    NOTE(TOCTOU): bind→close 直後に同ポートが他プロセスに奪われる可能性が
+    ある (TOCTOU race)。relay 起動側で SO_REUSEADDR / fail-fast 検出を持つ
+    ため実害は小さいが、CI で連続失敗するようなら ``SO_REUSEPORT`` の活用
+    や retry loop を検討する。
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
+    """``GET {url}/health`` が 200 を返すまでポーリングして待つ。"""
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"{url}/health", method="GET")
+            with urllib.request.urlopen(req, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "relay.db"
+
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
+        f"from src.relay import server; server.PORT = {port}; "
+        f"server.main({repr(str(db_path))})"
+    )
+
+    env = os.environ.copy()
+    env["RELAY_DB"] = str(db_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        if not _wait_until_healthy(base_url, timeout_sec=10.0):
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"relay did not become healthy on port {port}. "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+
+        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
+        # OW_STATE_DIR を tmp_path 配下に向けて cache JSON を隔離
+        state_dir = tmp_path / "cache"
+        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
+
+        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _send_identity(channel: str, alias: str, activity_id: int) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": alias,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_state(channel: str, alias: str, task: str, state: str) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]

--- a/tests/integration/test_ow_projector.py
+++ b/tests/integration/test_ow_projector.py
@@ -1,4 +1,4 @@
-"""ow projector 経路 (A#911 SP-2 PR-α) の integration test。
+"""ow projector 経路の integration test。
 
 実 relay サーバープロセスを起動して identity / state / heartbeat envelope を
 ow_send で投入し、project_state_to_cache → cache JSON → load_state の round-trip と

--- a/tests/integration/test_ow_projector.py
+++ b/tests/integration/test_ow_projector.py
@@ -1,0 +1,282 @@
+"""ow projector 経路 (A#911 SP-2 PR-α) の integration test。
+
+実 relay サーバープロセスを起動して identity / state / heartbeat envelope を
+ow_send で投入し、project_state_to_cache → cache JSON → load_state の round-trip と
+自動 fallback (cache miss / corruption / channel mismatch) を実 I/O 経由で検証する。
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import CURRENT_SCHEMA_VERSION, load_state
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"{url}/health", method="GET")
+            with urllib.request.urlopen(req, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "relay.db"
+
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
+        f"from src.relay import server; server.PORT = {port}; "
+        f"server.main({repr(str(db_path))})"
+    )
+
+    env = os.environ.copy()
+    env["RELAY_DB"] = str(db_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        if not _wait_until_healthy(base_url, timeout_sec=10.0):
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"relay did not become healthy on port {port}. "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+
+        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
+        # OW_STATE_DIR を tmp_path 配下に向けて cache JSON を隔離
+        state_dir = tmp_path / "cache"
+        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
+
+        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _send_state(channel: str, alias: str, task: str, state: str) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_identity(channel: str, alias: str, activity_id: int) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": alias,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+class TestProjectorRoundTrip:
+    """relay events を ow_send で投入 → project_state_to_cache → load_state で round-trip。"""
+
+    def test_relay_to_cache_to_load_round_trip(self, live_relay):
+        """実 relay に投入した identity/state/heartbeat が cache → load_state まで一貫して保持される。"""
+        channel = "TestProjA"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-a", activity_id=911)
+        _send_state(channel, "w-a", "T97", "ready")
+        last_hb = _send_heartbeat(channel, "w-a", "ready")
+
+        result = ow_service.project_state_to_cache(topic_id=4001, channel=channel)
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == channel
+        assert result["last_msg_id"] == last_hb
+        assert result["workers"]["w-a"]["state"] == "ready"
+        assert result["workers"]["w-a"]["task"] == "T97"
+        assert result["identities"]["w-a"]["alias"] == "w-a"
+        # heartbeat 直後なので presence に乗る
+        assert "w-a" in result["presence"]
+
+        # cache JSON ファイルが書き出されている
+        cache_path = live_relay["state_dir"] / "topic-4001.json"
+        assert cache_path.exists()
+        on_disk = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert on_disk["channel"] == channel
+        assert on_disk["last_msg_id"] == last_hb
+
+        # load_state で読み戻すと OwState が一致する
+        loaded = load_state(topic_id=4001, channel=channel)
+        assert loaded is not None
+        assert loaded["channel"] == channel
+        assert loaded["last_msg_id"] == last_hb
+        assert loaded["workers"]["w-a"]["state"] == "ready"
+
+    def test_multiple_workers_state_aggregated(self, live_relay):
+        """複数 worker / 複数 state 遷移が handle 単位で最新値に集約される。"""
+        channel = "TestProjB"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-x", activity_id=1)
+        _send_state(channel, "w-x", "T1", "ready")
+        _send_state(channel, "w-x", "T1", "working")
+        last_x = _send_heartbeat(channel, "w-x", "ready")
+
+        _send_identity(channel, "w-y", activity_id=2)
+        _send_state(channel, "w-y", "T2", "ready")
+        _send_state(channel, "w-y", "T2", "working")
+        _send_state(channel, "w-y", "T2", "done")
+        _send_heartbeat(channel, "w-y", "ready")
+
+        result = ow_service.project_state_to_cache(topic_id=4002, channel=channel)
+
+        assert result is not None
+        assert result["workers"]["w-x"]["state"] == "working"
+        assert result["workers"]["w-y"]["state"] == "done"
+        assert "w-x" in result["identities"]
+        assert "w-y" in result["identities"]
+
+
+class TestGetOrRebuildStateIntegration:
+    """get_or_rebuild_state の自動 fallback を実 relay 経由で検証。"""
+
+    def test_fallback_when_cache_missing(self, live_relay):
+        """cache 未生成の状態で get_or_rebuild_state を呼ぶと relay full pull で再構築される。"""
+        channel = "TestProjC"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-m", activity_id=3)
+        _send_state(channel, "w-m", "T3", "working")
+        _send_heartbeat(channel, "w-m", "ready")
+
+        cache_path = live_relay["state_dir"] / "topic-4003.json"
+        assert not cache_path.exists()
+
+        result = ow_service.get_or_rebuild_state(4003, channel)
+
+        assert result is not None
+        assert result["channel"] == channel
+        assert result["workers"]["w-m"]["state"] == "working"
+        assert cache_path.exists()
+
+    def test_fallback_when_cache_corrupt(self, live_relay):
+        """壊れた cache JSON を置いた状態で呼ぶと、load_state が削除 → projector で再構築される。"""
+        channel = "TestProjD"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-n", activity_id=4)
+        _send_state(channel, "w-n", "T4", "done")
+        _send_heartbeat(channel, "w-n", "ready")
+
+        state_dir = live_relay["state_dir"]
+        state_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = state_dir / "topic-4004.json"
+        cache_path.write_text("{not valid json", encoding="utf-8")
+
+        result = ow_service.get_or_rebuild_state(4004, channel)
+
+        assert result is not None
+        assert result["channel"] == channel
+        # 再構築後の cache JSON が読める
+        on_disk = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert on_disk["channel"] == channel
+        assert on_disk["workers"]["w-n"]["state"] == "done"
+
+    def test_fallback_when_channel_mismatches(self, live_relay):
+        """異なる channel の cache が残っている場合、load_state が削除 → 新 channel で再構築される。"""
+        from src.services.ow.cache import save_state
+
+        channel_new = "TestProjE-new"
+        ow_service.ensure_channel(channel_new)
+
+        _send_identity(channel_new, "w-p", activity_id=5)
+        _send_state(channel_new, "w-p", "T5", "ready")
+        _send_heartbeat(channel_new, "w-p", "ready")
+
+        state_dir = live_relay["state_dir"]
+        state_dir.mkdir(parents=True, exist_ok=True)
+        save_state(
+            topic_id=4005,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "TestProjE-old",
+                "last_msg_id": 1,
+                "workers": {"w-stale": {"state": "ready", "task": "T0"}},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        result = ow_service.get_or_rebuild_state(4005, channel_new)
+
+        assert result is not None
+        assert result["channel"] == channel_new
+        # 旧 channel の workers エントリが消えて新 channel の events に差し替わる
+        assert "w-stale" not in result["workers"]
+        assert "w-p" in result["workers"]
+        assert result["workers"]["w-p"]["state"] == "ready"

--- a/tests/integration/test_ow_projector.py
+++ b/tests/integration/test_ow_projector.py
@@ -7,135 +7,17 @@ ow_send で投入し、project_state_to_cache → cache JSON → load_state の 
 from __future__ import annotations
 
 import json
-import os
-import socket
-import subprocess
-import sys
-import time
-import urllib.request
-from datetime import datetime, timezone
-from pathlib import Path
-
-import pytest
 
 from src.services import ow_service
 from src.services.ow.cache import CURRENT_SCHEMA_VERSION, load_state
 
-
-def _free_port() -> int:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
-def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
-    deadline = time.monotonic() + timeout_sec
-    while time.monotonic() < deadline:
-        try:
-            req = urllib.request.Request(f"{url}/health", method="GET")
-            with urllib.request.urlopen(req, timeout=1) as resp:
-                if resp.status == 200:
-                    return True
-        except Exception:
-            pass
-        time.sleep(0.1)
-    return False
-
-
-@pytest.fixture
-def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
-    repo_root = Path(__file__).resolve().parents[2]
-    port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
-    db_path = tmp_path / "relay.db"
-
-    bootstrap = (
-        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
-        f"from src.relay import server; server.PORT = {port}; "
-        f"server.main({repr(str(db_path))})"
-    )
-
-    env = os.environ.copy()
-    env["RELAY_DB"] = str(db_path)
-
-    proc = subprocess.Popen(
-        [sys.executable, "-c", bootstrap],
-        cwd=str(repo_root),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    try:
-        if not _wait_until_healthy(base_url, timeout_sec=10.0):
-            stdout, stderr = proc.communicate(timeout=2)
-            pytest.fail(
-                f"relay did not become healthy on port {port}. "
-                f"stdout={stdout!r} stderr={stderr!r}"
-            )
-
-        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
-        # OW_STATE_DIR を tmp_path 配下に向けて cache JSON を隔離
-        state_dir = tmp_path / "cache"
-        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
-
-        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=2)
-
-
-def _send_state(channel: str, alias: str, task: str, state: str) -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "orch",
-        "task": task,
-        "data": {"type": "state", "state": state},
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
-
-
-def _send_identity(channel: str, alias: str, activity_id: int) -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "*",
-        "data": {
-            "type": "identity",
-            "role": "worker",
-            "handle": alias,
-            "alias": alias,
-            "activity_id": activity_id,
-        },
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
-
-
-def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "*",
-        "data": {"type": "heartbeat", "phase": phase},
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
+# `live_relay` fixture は tests/integration/conftest.py から自動収集される。
+# ヘルパー関数は明示 import する。
+from tests.integration.conftest import (
+    _send_heartbeat,
+    _send_identity,
+    _send_state,
+)
 
 
 class TestProjectorRoundTrip:

--- a/tests/integration/test_ow_reducer_cache_fastpath.py
+++ b/tests/integration/test_ow_reducer_cache_fastpath.py
@@ -1,0 +1,298 @@
+"""ow reducer cache fastpath (A#911 SP-2 PR-β/γ) の integration test。
+
+実 relay にイベントを投入 → project_state_to_cache で cache 生成 → reducer 4関数
+(ow_get_identity / ow_list_identities / ow_get_presence / ow_get_workload_state)
+と内部ヘルパー (_query_latest_event / _latest_events_by_type) を呼び、cache 経由で
+正しく事象が観測されること、および relay 直 pull は走らないことを確認する。
+
+PR-γ で reducer は relay full pull を撤去したため、本テストでは cache 未生成時の
+振る舞い (None / 空) も観測する。
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    find_topic_id_by_channel,
+    load_state,
+)
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(f"{url}/health", method="GET")
+            with urllib.request.urlopen(req, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "relay.db"
+
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
+        f"from src.relay import server; server.PORT = {port}; "
+        f"server.main({repr(str(db_path))})"
+    )
+    env = os.environ.copy()
+    env["RELAY_DB"] = str(db_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        if not _wait_until_healthy(base_url, timeout_sec=10.0):
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"relay did not become healthy on port {port}. "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
+        state_dir = tmp_path / "cache"
+        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
+        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _send_identity(channel: str, alias: str, activity_id: int) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": alias,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_state(channel: str, alias: str, task: str, state: str) -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
+    body = {
+        "v": 1,
+        "kind": "event",
+        "from": alias,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
+    assert "msg_id" in result, f"send failed: {result}"
+    return result["msg_id"]
+
+
+class TestReducerCacheFastpathEndToEnd:
+    """relay → projector → cache → reducer の一貫した経路を実I/O で観測する。"""
+
+    def test_ow_get_identity_via_cache_only(self, live_relay):
+        """identity event を投入 → project_state_to_cache → ow_get_identity が cache 経由で返る。"""
+        channel = "ReducerFastA"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-a", activity_id=911)
+        _send_state(channel, "w-a", "T1", "ready")
+        _send_heartbeat(channel, "w-a", "ready")
+
+        ow_service.project_state_to_cache(topic_id=5001, channel=channel)
+
+        result = ow_service.ow_get_identity(channel, "w-a")
+        assert result is not None
+        assert result["alias"] == "w-a"
+        assert result["activity_id"] == 911
+
+        # cache 経路を通っていることの確認: find_topic_id_by_channel が一致する。
+        assert find_topic_id_by_channel(channel) == 5001
+
+    def test_ow_get_presence_online_via_cache(self, live_relay):
+        """直近 heartbeat → cache → ow_get_presence で online 判定。"""
+        channel = "ReducerFastB"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-b", activity_id=1)
+        _send_state(channel, "w-b", "T1", "working")
+        _send_heartbeat(channel, "w-b", "working")
+
+        ow_service.project_state_to_cache(topic_id=5002, channel=channel)
+
+        result = ow_service.ow_get_presence(channel, "w-b")
+        assert result["handle"] == "w-b"
+        assert result["status"] == "online"
+
+    def test_ow_get_workload_state_via_cache(self, live_relay):
+        """state 遷移を投入 → projector → ow_get_workload_state が最新を返す。"""
+        channel = "ReducerFastC"
+        ow_service.ensure_channel(channel)
+
+        _send_state(channel, "w-c", "T7", "loading")
+        last_state_msg = _send_state(channel, "w-c", "T7", "working")
+        _send_heartbeat(channel, "w-c", "working")
+
+        ow_service.project_state_to_cache(topic_id=5003, channel=channel)
+
+        result = ow_service.ow_get_workload_state(channel, "w-c")
+        assert result is not None
+        assert result["state"] == "working"
+        assert result["msg_id"] == last_state_msg
+
+    def test_ow_list_identities_returns_all_via_cache(self, live_relay):
+        """複数 worker → projector → ow_list_identities が cache 経由で全件返す。"""
+        channel = "ReducerFastD"
+        ow_service.ensure_channel(channel)
+
+        for alias in ("w-x", "w-y", "w-z"):
+            _send_identity(channel, alias, activity_id=hash(alias) & 0xFFFF)
+            _send_state(channel, alias, "T1", "ready")
+            _send_heartbeat(channel, alias, "ready")
+
+        ow_service.project_state_to_cache(topic_id=5004, channel=channel)
+
+        result = ow_service.ow_list_identities(channel)
+        aliases = sorted(e["alias"] for e in result)
+        assert aliases == ["w-x", "w-y", "w-z"]
+
+    def test_reducer_without_cache_returns_empty(self, live_relay):
+        """cache を生成しないまま reducer を呼ぶ → relay は叩かず空/None を返す (PR-γ)。"""
+        channel = "ReducerFastE"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-only", activity_id=42)
+        _send_state(channel, "w-only", "T1", "working")
+        _send_heartbeat(channel, "w-only", "working")
+
+        # ※ project_state_to_cache を意図的に呼ばない
+        assert find_topic_id_by_channel(channel) is None
+
+        assert ow_service.ow_get_identity(channel, "w-only") is None
+        assert ow_service.ow_list_identities(channel) == []
+        assert ow_service.ow_get_workload_state(channel, "w-only") is None
+        presence = ow_service.ow_get_presence(channel, "w-only")
+        assert presence["status"] == "unknown"
+        assert presence["last_heartbeat_at"] is None
+
+
+class TestQueryHelpersCacheFastpath:
+    """_query_latest_event / _latest_events_by_type の cache 直接観測。"""
+
+    def test_query_latest_event_reads_from_cache_for_state(self, live_relay):
+        """projector で書いた cache の states[handle] を _query_latest_event が返す。"""
+        channel = "QueryFastA"
+        ow_service.ensure_channel(channel)
+
+        _send_state(channel, "w-q", "T1", "loading")
+        last_state_msg = _send_state(channel, "w-q", "T1", "working")
+        _send_heartbeat(channel, "w-q", "working")
+
+        ow_service.project_state_to_cache(topic_id=5101, channel=channel)
+
+        result = ow_service._query_latest_event(channel, "w-q", "state")
+        assert result is not None
+        assert result["msg_id"] == last_state_msg
+        assert result["body"]["data"]["state"] == "working"
+
+    def test_query_latest_event_unsupported_type_returns_none(self, live_relay):
+        """対応しない data_type は cache にもなく None を返す (relay 直叩きしない)。"""
+        channel = "QueryFastB"
+        ow_service.ensure_channel(channel)
+
+        # relay には arbitrary な event を投入する
+        body = {
+            "v": 1,
+            "kind": "event",
+            "from": "w-r",
+            "to": "orch",
+            "data": {"type": "custom_type", "payload": "x"},
+        }
+        ow_service.ow_send(channel=channel, handle="w-r", body=body)
+
+        ow_service.project_state_to_cache(topic_id=5102, channel=channel)
+
+        # custom_type は cache 化対象外、reducer は None を返す
+        assert ow_service._query_latest_event(channel, "w-r", "custom_type") is None
+
+    def test_latest_events_by_type_reads_cache(self, live_relay):
+        """_latest_events_by_type が cache の identity/state/heartbeat を一括取得する。"""
+        channel = "QueryFastC"
+        ow_service.ensure_channel(channel)
+
+        _send_identity(channel, "w-c", activity_id=7)
+        _send_state(channel, "w-c", "T1", "ready")
+        _send_heartbeat(channel, "w-c", "ready")
+
+        ow_service.project_state_to_cache(topic_id=5103, channel=channel)
+
+        bundle = ow_service._latest_events_by_type(
+            channel, "w-c", ("identity", "state", "heartbeat")
+        )
+        assert set(bundle.keys()) == {"identity", "state", "heartbeat"}
+        assert bundle["identity"]["body"]["data"]["alias"] == "w-c"
+        assert bundle["state"]["body"]["data"]["state"] == "ready"
+        assert bundle["heartbeat"]["body"]["data"]["phase"] == "ready"
+
+    def test_query_returns_none_when_cache_missing(self, live_relay):
+        """cache が未生成なら _query_latest_event は relay を叩かず None を返す。"""
+        channel = "QueryFastD"
+        ow_service.ensure_channel(channel)
+        _send_state(channel, "w-d", "T1", "working")
+
+        # projector を呼ばない
+        assert ow_service._query_latest_event(channel, "w-d", "state") is None

--- a/tests/integration/test_ow_reducer_cache_fastpath.py
+++ b/tests/integration/test_ow_reducer_cache_fastpath.py
@@ -1,12 +1,12 @@
-"""ow reducer cache fastpath (A#911 SP-2 PR-β/γ) の integration test。
+"""ow reducer cache fastpath の integration test。
 
 実 relay にイベントを投入 → project_state_to_cache で cache 生成 → reducer 4関数
 (ow_get_identity / ow_list_identities / ow_get_presence / ow_get_workload_state)
 と内部ヘルパー (_query_latest_event / _latest_events_by_type) を呼び、cache 経由で
 正しく事象が観測されること、および relay 直 pull は走らないことを確認する。
 
-PR-γ で reducer は relay full pull を撤去したため、本テストでは cache 未生成時の
-振る舞い (None / 空) も観測する。
+reducer は relay full pull を撤去したため、cache 未生成時の振る舞い (None / 空)
+も観測する。
 """
 from __future__ import annotations
 
@@ -96,7 +96,7 @@ class TestReducerCacheFastpathEndToEnd:
         assert aliases == ["w-x", "w-y", "w-z"]
 
     def test_reducer_without_cache_returns_empty(self, live_relay):
-        """cache を生成しないまま reducer を呼ぶ → relay は叩かず空/None を返す (PR-γ)。"""
+        """cache を生成しないまま reducer を呼ぶ → relay は叩かず空/None を返す。"""
         channel = "ReducerFastE"
         ow_service.ensure_channel(channel)
 

--- a/tests/integration/test_ow_reducer_cache_fastpath.py
+++ b/tests/integration/test_ow_reducer_cache_fastpath.py
@@ -10,17 +10,6 @@ PR-γ で reducer は relay full pull を撤去したため、本テストでは
 """
 from __future__ import annotations
 
-import os
-import socket
-import subprocess
-import sys
-import time
-import urllib.request
-from datetime import datetime, timezone
-from pathlib import Path
-
-import pytest
-
 from src.services import ow_service
 from src.services.ow.cache import (
     CURRENT_SCHEMA_VERSION,
@@ -28,117 +17,13 @@ from src.services.ow.cache import (
     load_state,
 )
 
-
-def _free_port() -> int:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
-def _wait_until_healthy(url: str, timeout_sec: float = 10.0) -> bool:
-    deadline = time.monotonic() + timeout_sec
-    while time.monotonic() < deadline:
-        try:
-            req = urllib.request.Request(f"{url}/health", method="GET")
-            with urllib.request.urlopen(req, timeout=1) as resp:
-                if resp.status == 200:
-                    return True
-        except Exception:
-            pass
-        time.sleep(0.1)
-    return False
-
-
-@pytest.fixture
-def live_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """別 port で relay サーバーを起動し、ow_service の RELAY_URL を差し替える。"""
-    repo_root = Path(__file__).resolve().parents[2]
-    port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
-    db_path = tmp_path / "relay.db"
-
-    bootstrap = (
-        f"import sys; sys.path.insert(0, {repr(str(repo_root))}); "
-        f"from src.relay import server; server.PORT = {port}; "
-        f"server.main({repr(str(db_path))})"
-    )
-    env = os.environ.copy()
-    env["RELAY_DB"] = str(db_path)
-
-    proc = subprocess.Popen(
-        [sys.executable, "-c", bootstrap],
-        cwd=str(repo_root),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    try:
-        if not _wait_until_healthy(base_url, timeout_sec=10.0):
-            stdout, stderr = proc.communicate(timeout=2)
-            pytest.fail(
-                f"relay did not become healthy on port {port}. "
-                f"stdout={stdout!r} stderr={stderr!r}"
-            )
-        monkeypatch.setattr(ow_service, "RELAY_URL", base_url)
-        state_dir = tmp_path / "cache"
-        monkeypatch.setenv("OW_STATE_DIR", str(state_dir))
-        yield {"url": base_url, "tmp_path": tmp_path, "state_dir": state_dir}
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=2)
-
-
-def _send_identity(channel: str, alias: str, activity_id: int) -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "*",
-        "data": {
-            "type": "identity",
-            "role": "worker",
-            "handle": alias,
-            "alias": alias,
-            "activity_id": activity_id,
-        },
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
-
-
-def _send_state(channel: str, alias: str, task: str, state: str) -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "orch",
-        "task": task,
-        "data": {"type": "state", "state": state},
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
-
-
-def _send_heartbeat(channel: str, alias: str, phase: str = "ready") -> int:
-    body = {
-        "v": 1,
-        "kind": "event",
-        "from": alias,
-        "to": "*",
-        "data": {"type": "heartbeat", "phase": phase},
-    }
-    result = ow_service.ow_send(channel=channel, handle=alias, body=body)
-    assert "msg_id" in result, f"send failed: {result}"
-    return result["msg_id"]
+# `live_relay` fixture は tests/integration/conftest.py から自動収集される。
+# ヘルパー関数は明示 import する。
+from tests.integration.conftest import (
+    _send_heartbeat,
+    _send_identity,
+    _send_state,
+)
 
 
 class TestReducerCacheFastpathEndToEnd:

--- a/tests/unit/test_ow_cache_lookup.py
+++ b/tests/unit/test_ow_cache_lookup.py
@@ -1,0 +1,118 @@
+"""find_topic_id_by_channel と _load_state_by_channel のユニットテスト
+(A#911 SP-2 PR-β/γ で追加した channel → topic_id 解決ヘルパー)。
+
+reducer は channel しか持たないが cache は topic_id でキーされているため、
+cache ディレクトリ走査で channel → topic_id を逆引きする。本テストはそのスキャン
+振る舞いと、壊れたファイル / 無関係なファイルを安全に無視する不変条件を確認する。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import (
+    CURRENT_SCHEMA_VERSION,
+    find_topic_id_by_channel,
+    save_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _save_cache_file(topic_id: int, channel: str) -> None:
+    save_state(
+        topic_id=topic_id,
+        state={
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "channel": channel,
+            "last_msg_id": 0,
+            "workers": {},
+            "identities": {},
+            "identity_events": {},
+            "states": {},
+            "heartbeats": {},
+            "presence": [],
+            "updated_at": "2026-06-19T17:00:00+00:00",
+        },
+    )
+
+
+class TestFindTopicIdByChannel:
+    def test_returns_none_when_state_dir_missing(self, tmp_path: Path) -> None:
+        """OW_STATE_DIR がそもそも作られていない場合は None。"""
+        # _isolated_state_dir が autouse で OW_STATE_DIR を tmp_path に設定済み。
+        # tmp_path 自体は存在するがファイルは空。
+        assert find_topic_id_by_channel("any") is None
+
+    def test_returns_topic_id_when_match(self, _isolated_state_dir: Path) -> None:
+        """channel フィールドが一致する cache を見つけて topic_id を返す。"""
+        _save_cache_file(454, "P_match")
+        assert find_topic_id_by_channel("P_match") == 454
+
+    def test_returns_none_when_no_match(self, _isolated_state_dir: Path) -> None:
+        """どの cache ファイルも channel が一致しなければ None。"""
+        _save_cache_file(454, "P_a")
+        _save_cache_file(455, "P_b")
+        assert find_topic_id_by_channel("P_z") is None
+
+    def test_picks_first_match_among_multiple(self, _isolated_state_dir: Path) -> None:
+        """同一 channel を含む cache が複数あっても、いずれかの topic_id を返す。"""
+        _save_cache_file(454, "P_dup")
+        _save_cache_file(458, "P_dup")
+        result = find_topic_id_by_channel("P_dup")
+        assert result in (454, 458)
+
+    def test_ignores_unrelated_files(self, _isolated_state_dir: Path) -> None:
+        """topic-<n>.json 以外のファイルがあっても走査が壊れない。"""
+        (_isolated_state_dir / "README.md").write_text("ignored", encoding="utf-8")
+        (_isolated_state_dir / "other.json").write_text("{}", encoding="utf-8")
+        _save_cache_file(456, "P_ok")
+        assert find_topic_id_by_channel("P_ok") == 456
+
+    def test_ignores_corrupt_json(self, _isolated_state_dir: Path) -> None:
+        """壊れた JSON ファイルがあっても削除せず素通りし、他の正常ファイルから検索する。"""
+        bad = _isolated_state_dir / "topic-999.json"
+        bad.write_text("{not valid", encoding="utf-8")
+        _save_cache_file(457, "P_good")
+        # 壊れたファイルは削除されない (load_state 経路ではないため)
+        assert bad.exists()
+        assert find_topic_id_by_channel("P_good") == 457
+
+    def test_ignores_non_topic_filename_pattern(self, _isolated_state_dir: Path) -> None:
+        """topic- prefix が無い JSON は無視される。"""
+        (_isolated_state_dir / "snapshot-123.json").write_text(
+            json.dumps({"channel": "P_skip"}), encoding="utf-8"
+        )
+        assert find_topic_id_by_channel("P_skip") is None
+
+
+class TestLoadStateByChannel:
+    """ow_service._load_state_by_channel: channel → topic_id 解決 → load_state 統合経路。"""
+
+    def test_returns_state_when_cache_present(self, _isolated_state_dir: Path) -> None:
+        _save_cache_file(454, "P_present")
+        result = ow_service._load_state_by_channel("P_present")
+        assert result is not None
+        assert result["channel"] == "P_present"
+
+    def test_returns_none_when_topic_not_found(self, _isolated_state_dir: Path) -> None:
+        result = ow_service._load_state_by_channel("P_missing")
+        assert result is None
+
+    def test_returns_none_when_channel_mismatch_in_cache_file(
+        self, _isolated_state_dir: Path
+    ) -> None:
+        """find_topic_id_by_channel は channel 一致で topic_id を返すが、
+        load_state がさらに channel パラメータで再検証する。一致するので state を返す。
+        """
+        _save_cache_file(454, "P_exact")
+        result = ow_service._load_state_by_channel("P_exact")
+        assert result is not None
+        assert result["channel"] == "P_exact"

--- a/tests/unit/test_ow_cache_lookup.py
+++ b/tests/unit/test_ow_cache_lookup.py
@@ -1,5 +1,4 @@
-"""find_topic_id_by_channel と _load_state_by_channel のユニットテスト
-(A#911 SP-2 PR-β/γ で追加した channel → topic_id 解決ヘルパー)。
+"""find_topic_id_by_channel と _load_state_by_channel のユニットテスト。
 
 reducer は channel しか持たないが cache は topic_id でキーされているため、
 cache ディレクトリ走査で channel → topic_id を逆引きする。本テストはそのスキャン

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -1,4 +1,4 @@
-"""ow_service の projector 経路 (A#911 SP-2 PR-α) のユニットテスト。
+"""ow_service の projector 経路のユニットテスト。
 
 project_state_to_cache / get_or_rebuild_state の挙動を、
 ow_history を monkeypatch したフィクスチャ relay 履歴に対して検証する。

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -1,0 +1,416 @@
+"""ow_service の projector 経路 (A#911 SP-2 PR-α) のユニットテスト。
+
+project_state_to_cache / get_or_rebuild_state の挙動を、
+ow_history を monkeypatch したフィクスチャ relay 履歴に対して検証する。
+cache miss / corruption / schema mismatch / channel mismatch の4条件で
+load_state が None を返し、projector が再構築する自動 fallback も含む。
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+from src.services.ow.cache import CURRENT_SCHEMA_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """各テストで OW_STATE_DIR を tmp_path に向ける (ホーム汚染防止)。"""
+    monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _iso_now_offset(seconds: float = 0.0) -> str:
+    """now - seconds (秒) の UTC ISO8601 を返す。heartbeat の経過時間制御用。"""
+    return (datetime.now(timezone.utc).astimezone(timezone.utc)).isoformat()
+
+
+def _iso_offset_seconds(seconds_ago: float) -> str:
+    from datetime import timedelta
+
+    return (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    ).isoformat()
+
+
+def _make_msg(
+    msg_id: int,
+    handle: str,
+    body: dict,
+    created_at: str | None = None,
+) -> dict:
+    return {
+        "msg_id": msg_id,
+        "handle": handle,
+        "body": body,
+        "created_at": created_at or "2026-06-19T10:00:00+00:00",
+    }
+
+
+def _state_body(handle: str, task: str, state_val: str) -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "orch",
+        "task": task,
+        "data": {"type": "state", "state": state_val},
+    }
+
+
+def _identity_body(handle: str, alias: str, activity_id: int) -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "*",
+        "data": {
+            "type": "identity",
+            "role": "worker",
+            "handle": handle,
+            "alias": alias,
+            "activity_id": activity_id,
+        },
+    }
+
+
+def _heartbeat_body(handle: str, phase: str = "ready") -> dict:
+    return {
+        "v": 1,
+        "kind": "event",
+        "from": handle,
+        "to": "*",
+        "data": {"type": "heartbeat", "phase": phase},
+    }
+
+
+def _patch_history(monkeypatch: pytest.MonkeyPatch, messages: list[dict]) -> None:
+    """ow_history を固定フィクスチャに差し替える。"""
+
+    def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+        return {"messages": list(messages)}
+
+    monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+
+class TestProjectStateToCache:
+    """project_state_to_cache 単体: relay events → OwState 構築 → save_state。"""
+
+    def test_relay_events_produce_cache_json_with_workers_identities_presence(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """state/identity/heartbeat の3種 event から OwState を組み立てて cache JSON を書き出す。"""
+        recent = _iso_offset_seconds(5.0)  # 5秒前 → online (timeout 90s)
+        messages = [
+            _make_msg(10, "w-a", _identity_body("w-a", "w-a", 911), recent),
+            _make_msg(11, "w-a", _state_body("w-a", "T97", "ready"), recent),
+            _make_msg(12, "w-a", _heartbeat_body("w-a", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_test"
+        )
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == "P_test"
+        assert result["last_msg_id"] == 12
+        assert "w-a" in result["workers"]
+        assert result["workers"]["w-a"]["state"] == "ready"
+        assert result["workers"]["w-a"]["task"] == "T97"
+        assert "w-a" in result["identities"]
+        assert result["identities"]["w-a"]["alias"] == "w-a"
+        assert "w-a" in result["presence"]
+
+        cache_path = _isolated_state_dir / "topic-454.json"
+        assert cache_path.exists()
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert data["channel"] == "P_test"
+        assert data["last_msg_id"] == 12
+
+    def test_round_trip_via_load_state(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """projector で書いた cache を load_state で読み戻すと OwState が一致する。"""
+        from src.services.ow.cache import load_state
+
+        recent = _iso_offset_seconds(2.0)
+        messages = [
+            _make_msg(50, "w-b", _identity_body("w-b", "w-b", 912), recent),
+            _make_msg(51, "w-b", _state_body("w-b", "T98", "working"), recent),
+            _make_msg(52, "w-b", _heartbeat_body("w-b", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        projected = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_rt"
+        )
+        loaded = load_state(topic_id=454, channel="P_rt")
+
+        assert projected is not None
+        assert loaded is not None
+        assert loaded["channel"] == projected["channel"]
+        assert loaded["last_msg_id"] == projected["last_msg_id"]
+        assert loaded["workers"] == projected["workers"]
+        assert loaded["identities"] == projected["identities"]
+        assert loaded["presence"] == projected["presence"]
+
+    def test_latest_state_wins_when_multiple_state_events_for_same_handle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """同 handle の state event が複数あるとき、最大 msg_id の state を採用する。"""
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(100, "w-c", _state_body("w-c", "T1", "loading"), recent),
+            _make_msg(101, "w-c", _state_body("w-c", "T1", "ready"), recent),
+            _make_msg(102, "w-c", _state_body("w-c", "T1", "working"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_x"
+        )
+
+        assert result is not None
+        assert result["workers"]["w-c"]["state"] == "working"
+        assert result["workers"]["w-c"]["latest_msg_id"] == 102
+
+    def test_heartbeat_older_than_timeout_excluded_from_presence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """heartbeat が timeout 超過 (>90s) の handle は presence に含めない。"""
+        recent = _iso_offset_seconds(2.0)
+        stale = _iso_offset_seconds(200.0)  # 200秒前 (>= 90s timeout)
+        messages = [
+            _make_msg(200, "w-fresh", _identity_body("w-fresh", "w-fresh", 1), recent),
+            _make_msg(201, "w-fresh", _heartbeat_body("w-fresh", "ready"), recent),
+            _make_msg(202, "w-stale", _identity_body("w-stale", "w-stale", 2), stale),
+            _make_msg(203, "w-stale", _heartbeat_body("w-stale", "ready"), stale),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_pr"
+        )
+
+        assert result is not None
+        assert "w-fresh" in result["presence"]
+        assert "w-stale" not in result["presence"]
+        # identity は presence と独立に維持される
+        assert "w-stale" in result["identities"]
+
+    def test_returns_none_when_relay_history_errors(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """ow_history が error を返すと projector は None を返し cache ファイルも作らない。"""
+
+        def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+            return {"error": {"code": "RELAY_DOWN", "message": "unreachable"}}
+
+        monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_err"
+        )
+
+        assert result is None
+        assert not (_isolated_state_dir / "topic-454.json").exists()
+
+    def test_ignores_non_event_kind_and_missing_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """kind != event や from 欠落 envelope は集計対象外。"""
+        recent = _iso_offset_seconds(1.0)
+        command_body = {
+            "v": 1,
+            "kind": "command",
+            "from": "orch",
+            "to": "w-z",
+            "task": "T1",
+            "data": {"type": "assign"},
+        }
+        no_from_body = {
+            "v": 1,
+            "kind": "event",
+            "from": "",
+            "data": {"type": "state", "state": "ready"},
+        }
+        messages = [
+            _make_msg(300, "orch", command_body, recent),
+            _make_msg(301, "", no_from_body, recent),
+            _make_msg(302, "w-z", _state_body("w-z", "T1", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.project_state_to_cache(
+            topic_id=454, channel="P_ne"
+        )
+
+        assert result is not None
+        assert list(result["workers"].keys()) == ["w-z"]
+        assert result["last_msg_id"] == 302
+
+
+class TestGetOrRebuildState:
+    """get_or_rebuild_state: cache hit 経路と4種類の自動 fallback。"""
+
+    def test_cache_hit_skips_projector(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache が有効なら load_state を返し projector を呼ばない。"""
+        from src.services.ow.cache import save_state
+
+        save_state(
+            topic_id=454,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "P_hit",
+                "last_msg_id": 555,
+                "workers": {"w-x": {"state": "ready", "task": "T1"}},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        called = {"count": 0}
+
+        def _fake_project(topic_id: int, channel: str):
+            called["count"] += 1
+            return None
+
+        monkeypatch.setattr(ow_service, "project_state_to_cache", _fake_project)
+
+        result = ow_service.get_or_rebuild_state(454, "P_hit")
+
+        assert result is not None
+        assert result["channel"] == "P_hit"
+        assert result["last_msg_id"] == 555
+        assert called["count"] == 0
+
+    def test_fallback_when_cache_missing(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache ファイル不存在 → projector が呼ばれて再構築する。"""
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(10, "w-a", _identity_body("w-a", "w-a", 1), recent),
+            _make_msg(11, "w-a", _state_body("w-a", "T1", "ready"), recent),
+            _make_msg(12, "w-a", _heartbeat_body("w-a"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        assert not (_isolated_state_dir / "topic-454.json").exists()
+
+        result = ow_service.get_or_rebuild_state(454, "P_new")
+
+        assert result is not None
+        assert result["channel"] == "P_new"
+        assert (_isolated_state_dir / "topic-454.json").exists()
+
+    def test_fallback_when_cache_corrupt(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """壊れた JSON → load_state がファイル削除 → projector で再構築する。"""
+        corrupt_path = _isolated_state_dir / "topic-454.json"
+        corrupt_path.write_text("not valid json {", encoding="utf-8")
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(20, "w-b", _state_body("w-b", "T2", "working"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_corr")
+
+        assert result is not None
+        assert result["channel"] == "P_corr"
+        # 再生成された cache JSON は有効な構造を持つ
+        data = json.loads(corrupt_path.read_text(encoding="utf-8"))
+        assert data["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert data["channel"] == "P_corr"
+
+    def test_fallback_when_schema_version_mismatches(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """schema_version mismatch → load_state がファイル削除 → projector で再構築する。"""
+        path = _isolated_state_dir / "topic-454.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": CURRENT_SCHEMA_VERSION + 999,
+                    "channel": "P_sv",
+                    "last_msg_id": 1,
+                    "workers": {},
+                    "identities": {},
+                    "presence": [],
+                    "updated_at": "2026-06-19T10:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(30, "w-c", _state_body("w-c", "T3", "ready"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_sv")
+
+        assert result is not None
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert result["channel"] == "P_sv"
+
+    def test_fallback_when_channel_mismatches(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """channel mismatch → load_state がファイル削除 → projector で再構築する。"""
+        from src.services.ow.cache import save_state
+
+        save_state(
+            topic_id=454,
+            state={
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "channel": "P_old",
+                "last_msg_id": 1,
+                "workers": {},
+                "identities": {},
+                "presence": [],
+                "updated_at": "2026-06-19T10:00:00+00:00",
+            },
+        )
+
+        recent = _iso_offset_seconds(1.0)
+        messages = [
+            _make_msg(40, "w-d", _state_body("w-d", "T4", "done"), recent),
+        ]
+        _patch_history(monkeypatch, messages)
+
+        result = ow_service.get_or_rebuild_state(454, "P_new")
+
+        assert result is not None
+        assert result["channel"] == "P_new"
+        # 新 channel の最新 state が反映されている
+        assert "w-d" in result["workers"]
+        assert result["workers"]["w-d"]["state"] == "done"
+
+    def test_fallback_returns_none_when_projector_fails(
+        self, monkeypatch: pytest.MonkeyPatch, _isolated_state_dir: Path
+    ) -> None:
+        """cache miss + relay error → get_or_rebuild_state も None を返す。"""
+
+        def _fake_history(channel: str, since: int = 0, limit: int = 100) -> dict:
+            return {"error": {"code": "X", "message": "x"}}
+
+        monkeypatch.setattr(ow_service, "ow_history", _fake_history)
+
+        result = ow_service.get_or_rebuild_state(454, "P_fail")
+
+        assert result is None
+        assert not (_isolated_state_dir / "topic-454.json").exists()

--- a/tests/unit/test_ow_projector.py
+++ b/tests/unit/test_ow_projector.py
@@ -24,12 +24,8 @@ def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     return tmp_path
 
 
-def _iso_now_offset(seconds: float = 0.0) -> str:
-    """now - seconds (秒) の UTC ISO8601 を返す。heartbeat の経過時間制御用。"""
-    return (datetime.now(timezone.utc).astimezone(timezone.utc)).isoformat()
-
-
 def _iso_offset_seconds(seconds_ago: float) -> str:
+    """now - seconds_ago (秒) の UTC ISO8601 を返す。heartbeat の経過時間制御用。"""
     from datetime import timedelta
 
     return (

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,10 +1,21 @@
-"""ow_service reducer 4関数のユニットテスト。"""
+"""ow_service reducer 4関数のユニットテスト。
+
+A#911 SP-2 PR-β/γ で reducer 系 4関数 (ow_get_identity / ow_list_identities /
+ow_get_presence / ow_get_workload_state) と内部ヘルパー (_query_latest_event /
+_latest_events_by_type) は relay full pull を撤去し、OwState キャッシュを読む
+だけになった。本テストは cache fastpath の振る舞いを検証する (M#386 §6)。
+
+ow_history を mock していた旧 PR-α テストは、tmp 配下に直接 OwState を save_state
+する形式に書き換えた。tmp 隔離は ``_isolated_state_dir`` で OW_STATE_DIR を切り替える。
+"""
 import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
-from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+
 from src.services import ow_service
+from src.services.ow.cache import CURRENT_SCHEMA_VERSION, save_state
 
 
 # ----------------------------
@@ -12,8 +23,17 @@ from src.services import ow_service
 # ----------------------------
 
 
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """OW_STATE_DIR を tmp に閉じて cache 副作用を分離する (PR-β/γ で reducer は
+    relay を叩かず cache のみ参照するため)。
+    """
+    monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
 def _make_msg(msg_id, handle, body, created_at=None):
-    """テスト用リレーメッセージを生成する。"""
+    """テスト用リレーメッセージを生成する (_parse_ow_event の入力形式)。"""
     return {
         "msg_id": msg_id,
         "handle": handle,
@@ -37,13 +57,50 @@ def _make_history(messages):
     return {"messages": messages}
 
 
+def _entry(msg_id: int, data: dict, created_at: str) -> dict:
+    """OwState EventEntry 形式を組み立てる。"""
+    return {"msg_id": msg_id, "data": dict(data), "created_at": created_at}
+
+
+def _save_cache(
+    channel: str,
+    topic_id: int = 454,
+    *,
+    identity_events: dict | None = None,
+    states: dict | None = None,
+    heartbeats: dict | None = None,
+    identities: dict | None = None,
+    workers: dict | None = None,
+    last_msg_id: int = 0,
+    updated_at: str = "2026-06-19T17:00:00+00:00",
+) -> None:
+    """テストで OwState を直接 cache に書き出す。
+
+    reducer が `_load_state_by_channel(channel)` で find_topic_id_by_channel →
+    load_state する経路を通すため、channel フィールドを必ず一致させる。
+    """
+    state = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "channel": channel,
+        "last_msg_id": last_msg_id,
+        "workers": workers or {},
+        "identities": identities or {},
+        "identity_events": identity_events or {},
+        "states": states or {},
+        "heartbeats": heartbeats or {},
+        "presence": [],
+        "updated_at": updated_at,
+    }
+    save_state(topic_id, state)
+
+
 # ----------------------------
 # TestParseOwEvent
 # ----------------------------
 
 
 class TestParseOwEvent:
-    """_parse_ow_event のユニットテスト。"""
+    """_parse_ow_event のユニットテスト (PR-β/γ で振る舞い変化なし)。"""
 
     def test_valid_event_returns_parsed(self):
         """v=1, kind="event" → 正常にparsed dictを返す。"""
@@ -91,71 +148,98 @@ class TestParseOwEvent:
 
 
 # ----------------------------
-# TestQueryLatestEvent
+# TestQueryLatestEvent (cache fastpath)
 # ----------------------------
 
 
 class TestQueryLatestEvent:
-    """_query_latest_event のユニットテスト。"""
+    """_query_latest_event の cache fastpath ユニットテスト。
 
-    def test_returns_latest_by_msg_id(self, monkeypatch):
-        """同じdata_typeが2件 → msg_id大きい方を返す。"""
-        msgs = [
-            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
-            _make_msg(5, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T10:01:00+00:00"),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    PR-γ で relay full pull は撤去された。本関数は OwState の states / heartbeats /
+    identity_events を読むだけ。cache miss = None。
+    """
+
+    def test_returns_event_for_cached_state(self):
+        """cache に states[w-h] がある → parsed event 形式で返る。"""
+        _save_cache(
+            "ch",
+            states={
+                "w-h": _entry(5, {"type": "state", "state": "working"}, "2026-06-14T10:01:00+00:00"),
+            },
+        )
         result = ow_service._query_latest_event("ch", "w-h", "state")
         assert result is not None
         assert result["msg_id"] == 5
+        assert result["handle"] == "w-h"
+        assert result["body"]["kind"] == "event"
+        assert result["body"]["data"]["state"] == "working"
 
-    def test_handle_filter(self, monkeypatch):
-        """複数handleがいる時、指定handleのみ返す。"""
-        msgs = [
-            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
-            _make_msg(2, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_handle_filter(self):
+        """指定 handle のみマッチする (他 handle の entry は無視)。"""
+        _save_cache(
+            "ch",
+            states={
+                "w-a": _entry(1, {"type": "state", "state": "working"}, "2026-06-14T10:00:00+00:00"),
+                "w-b": _entry(2, {"type": "state", "state": "loading"}, "2026-06-14T10:01:00+00:00"),
+            },
+        )
         result = ow_service._query_latest_event("ch", "w-a", "state")
         assert result is not None
         assert result["handle"] == "w-a"
+        assert result["body"]["data"]["state"] == "working"
 
-    def test_handle_none_returns_any_handle(self, monkeypatch):
-        """handle=Noneなら全handleを対象にする。"""
-        msgs = [
-            _make_msg(1, "w-a", _event_body("state", {"state": "working"}, handle="w-a")),
-            _make_msg(3, "w-b", _event_body("state", {"state": "loading"}, handle="w-b")),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_handle_none_returns_max_msg_id(self):
+        """handle=None → states 内の全 handle から最大 msg_id を選ぶ。"""
+        _save_cache(
+            "ch",
+            states={
+                "w-a": _entry(1, {"type": "state", "state": "working"}, "..."),
+                "w-b": _entry(3, {"type": "state", "state": "loading"}, "..."),
+            },
+        )
         result = ow_service._query_latest_event("ch", None, "state")
         assert result is not None
         assert result["msg_id"] == 3
+        assert result["handle"] == "w-b"
 
-    def test_command_kind_skipped(self, monkeypatch):
-        """kind="command" のメッセージはスキップされる。"""
-        body = {"v": 1, "kind": "command", "data": {"type": "state"}}
-        msgs = [_make_msg(1, "w-h", body)]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_cache_miss_returns_none(self):
+        """cache が無い (find_topic_id_by_channel が見つけられない) → None。"""
         result = ow_service._query_latest_event("ch", "w-h", "state")
         assert result is None
 
-    def test_history_error_returns_none(self, monkeypatch):
-        """ow_historyがerrorを返す → None。"""
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: {"error": "conn refused"})
+    def test_cache_for_other_channel_returns_none(self):
+        """cache はあるが channel mismatch → load_state が None → None。"""
+        _save_cache(
+            "another-channel",
+            states={"w-h": _entry(5, {"type": "state", "state": "working"}, "...")},
+        )
         result = ow_service._query_latest_event("ch", "w-h", "state")
         assert result is None
 
-    def test_since_parameter_passed_to_history(self, monkeypatch):
-        """sinceパラメータがow_historyに渡される。"""
-        received = {}
+    def test_since_excludes_entries_with_msg_id_le_since(self):
+        """since パラメータ: msg_id <= since の entry は除外する。"""
+        _save_cache(
+            "ch",
+            states={
+                "w-h": _entry(5, {"type": "state", "state": "working"}, "..."),
+            },
+        )
+        # since=5 → cached msg_id 5 は除外 → None
+        result = ow_service._query_latest_event("ch", "w-h", "state", since=5)
+        assert result is None
+        # since=4 → cached msg_id 5 が残る → 返る
+        result = ow_service._query_latest_event("ch", "w-h", "state", since=4)
+        assert result is not None
+        assert result["msg_id"] == 5
 
-        def fake_history(channel, since=0, limit=100):
-            received["since"] = since
-            return _make_history([])
-
-        monkeypatch.setattr(ow_service, "ow_history", fake_history)
-        ow_service._query_latest_event("ch", "w-h", "state", since=42)
-        assert received["since"] == 42
+    def test_unsupported_data_type_returns_none(self):
+        """対応していない data_type (例: "unknown") は cache に該当領域なし → None。"""
+        _save_cache(
+            "ch",
+            states={"w-h": _entry(5, {"type": "state", "state": "working"}, "...")},
+        )
+        result = ow_service._query_latest_event("ch", "w-h", "unknown_type")
+        assert result is None
 
 
 # ----------------------------
@@ -164,7 +248,10 @@ class TestQueryLatestEvent:
 
 
 class TestQueryEventsSince:
-    """_query_events_since のユニットテスト。"""
+    """_query_events_since のユニットテスト (PR-β/γ では関数自体は変更なし)。
+
+    本関数は cache fastpath の対象外で、引き続き relay full pull を行う。
+    """
 
     def test_returns_all_matching(self, monkeypatch):
         """複数件返す。"""
@@ -199,7 +286,7 @@ class TestQueryEventsSince:
 
 
 class TestInferCrashCause:
-    """_infer_crash_cause のユニットテスト。"""
+    """_infer_crash_cause のユニットテスト (PR-β/γ で振る舞い変化なし)。"""
 
     def _old_hb(self, seconds_ago=200):
         """現在時刻からseconds_ago秒前のISO文字列を返す。"""
@@ -248,42 +335,52 @@ class TestInferCrashCause:
 
 
 class TestOwGetIdentity:
-    """ow_get_identity のユニットテスト。"""
+    """ow_get_identity の cache fastpath テスト。"""
 
-    def _setup_history(self, monkeypatch, messages):
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(messages))
-
-    def test_returns_identity_with_msg_id_and_at(self, monkeypatch):
-        """正常系: identity eventがある → bundle + msg_id + identity_at を返す。"""
-        msgs = [
-            _make_msg(
-                1, "w-h",
-                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
-                "2026-06-14T10:00:00+00:00",
-            ),
-        ]
-        self._setup_history(monkeypatch, msgs)
+    def test_returns_identity_with_msg_id_and_at(self):
+        """正常系: cache に identity_events[handle] があれば bundle + msg_id + identity_at を返す。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-h": _entry(
+                    1,
+                    {"type": "identity", "alias": "worker-1", "channel": "ch"},
+                    "2026-06-14T10:00:00+00:00",
+                ),
+            },
+        )
         result = ow_service.ow_get_identity("ch", "w-h")
         assert result is not None
         assert result["alias"] == "worker-1"
         assert result["msg_id"] == 1
         assert result["identity_at"] == "2026-06-14T10:00:00+00:00"
 
-    def test_returns_none_when_no_identity(self, monkeypatch):
-        """identity eventなし → None。"""
-        self._setup_history(monkeypatch, [])
+    def test_returns_none_when_no_identity(self):
+        """cache に identity_events 未登録 → None。"""
+        _save_cache("ch")  # empty cache
         result = ow_service.ow_get_identity("ch", "w-h")
         assert result is None
 
-    def test_inferred_cause_added_on_crash(self, monkeypatch):
-        """workingで古いheartbeat → inferred_cause付き。"""
+    def test_returns_none_when_cache_missing(self):
+        """cache 自体が未生成 → None (relay は叩かない)。"""
+        result = ow_service.ow_get_identity("ch", "w-h")
+        assert result is None
+
+    def test_inferred_cause_added_on_crash(self):
+        """state=working + 古い heartbeat → inferred_cause 付き。"""
         old_hb = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
-        msgs = [
-            _make_msg(1, "w-h", _event_body("identity", {"alias": "worker-1"}), "2026-06-14T09:00:00+00:00"),
-            _make_msg(2, "w-h", _event_body("state", {"state": "working"}), "2026-06-14T09:01:00+00:00"),
-            _make_msg(3, "w-h", _event_body("heartbeat", {"phase": "working"}), old_hb),
-        ]
-        self._setup_history(monkeypatch, msgs)
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-h": _entry(1, {"type": "identity", "alias": "worker-1"}, "2026-06-14T09:00:00+00:00"),
+            },
+            states={
+                "w-h": _entry(2, {"type": "state", "state": "working"}, "2026-06-14T09:01:00+00:00"),
+            },
+            heartbeats={
+                "w-h": _entry(3, {"type": "heartbeat", "phase": "working"}, old_hb),
+            },
+        )
         result = ow_service.ow_get_identity("ch", "w-h")
         assert result is not None
         assert result.get("inferred_cause") == "crashed (inferred)"
@@ -296,47 +393,39 @@ class TestOwGetIdentity:
             "manual:mac-mini:12345",  # manual fallback
         ],
     )
-    def test_term_ref_round_trip(self, monkeypatch, term_ref_value):
-        """段階①: event:identity の term_ref が ow_get_identity 戻り値にそのまま乗る。
-
-        reducer は dict(data) で透過保持する。tmux %N / iterm2 UUID / manual いずれの
-        形式でも値は加工せず保存される。
-        """
-        msgs = [
-            _make_msg(
-                1, "w-h",
-                _event_body("identity", {"alias": "worker-1", "term_ref": term_ref_value}),
-                "2026-06-14T10:00:00+00:00",
-            ),
-        ]
-        self._setup_history(monkeypatch, msgs)
+    def test_term_ref_round_trip(self, term_ref_value):
+        """段階①: event:identity の term_ref が reducer 戻り値にそのまま乗る。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-h": _entry(
+                    1,
+                    {"type": "identity", "alias": "worker-1", "term_ref": term_ref_value},
+                    "2026-06-14T10:00:00+00:00",
+                ),
+            },
+        )
         result = ow_service.ow_get_identity("ch", "w-h")
         assert result is not None
         assert result.get("term_ref") == term_ref_value
-        # validator が呼び出し側で利用できることを担保（reducer 自体は加工しない）。
         assert ow_service.is_valid_term_ref(term_ref_value) is True
 
-    def test_identity_without_term_ref_works(self, monkeypatch):
-        """後方互換: term_ref フィールドを持たない identity event でも reducer は正常動作する。
-
-        worker が manual モードや term_ref 取得失敗時に term_ref を省略するケースを想定。
-        戻り値には term_ref キーが存在しない（または None）状態となり、他のフィールドは
-        通常通り取り出せる。
-        """
-        msgs = [
-            _make_msg(
-                1, "w-h",
-                _event_body("identity", {"alias": "worker-1", "channel": "ch"}),
-                "2026-06-14T10:00:00+00:00",
-            ),
-        ]
-        self._setup_history(monkeypatch, msgs)
+    def test_identity_without_term_ref_works(self):
+        """後方互換: term_ref キーが無くても他のフィールドは正常取得できる。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-h": _entry(
+                    1,
+                    {"type": "identity", "alias": "worker-1", "channel": "ch"},
+                    "2026-06-14T10:00:00+00:00",
+                ),
+            },
+        )
         result = ow_service.ow_get_identity("ch", "w-h")
         assert result is not None
         assert result["alias"] == "worker-1"
-        # term_ref キーは無いか、あっても None
         assert result.get("term_ref") is None
-        # validator は欠落値を invalid と判定する
         assert ow_service.is_valid_term_ref(result.get("term_ref")) is False
 
 
@@ -346,18 +435,25 @@ class TestOwGetIdentity:
 
 
 class TestOwListIdentities:
-    """ow_list_identities のユニットテスト。"""
+    """ow_list_identities の cache fastpath テスト。"""
 
-    def test_returns_all_handles(self, monkeypatch):
-        """2つのhandleそれぞれのidentityを返す。"""
-        msgs = [
-            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
-            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_returns_all_handles(self):
+        """cache 内の identity_events の全 handle を返す。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-a": _entry(1, {"type": "identity", "alias": "worker-a"}, "..."),
+                "w-b": _entry(2, {"type": "identity", "alias": "worker-b"}, "..."),
+            },
+        )
         result = ow_service.ow_list_identities("ch")
         aliases = {e["alias"] for e in result}
         assert aliases == {"worker-a", "worker-b"}
+
+    def test_returns_empty_when_cache_missing(self):
+        """cache 未生成 → 空リスト (relay は叩かない)。"""
+        result = ow_service.ow_list_identities("ch")
+        assert result == []
 
     @pytest.mark.parametrize(
         "terminated_payload",
@@ -365,62 +461,62 @@ class TestOwListIdentities:
             {"cause": "closed"},
             {"cause": "cancelled"},
             {"cause": "dead"},
-            # terminated_at のみ（cause なし）も除外対象
             {"terminated_at": "2026-06-16T00:00:00Z"},
         ],
     )
-    def test_alive_only_excludes_terminated(self, monkeypatch, terminated_payload):
+    def test_alive_only_excludes_terminated(self, terminated_payload):
         """alive_only=True → cause=closed/cancelled/dead と terminated_at を除外する。"""
-        terminated_identity = {"alias": "worker-b", **terminated_payload}
-        msgs = [
-            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
-            _make_msg(2, "w-b", _event_body("identity", terminated_identity, handle="w-b")),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        terminated_identity = {
+            "type": "identity",
+            "alias": "worker-b",
+            **terminated_payload,
+        }
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-a": _entry(1, {"type": "identity", "alias": "worker-a"}, "..."),
+                "w-b": _entry(2, terminated_identity, "..."),
+            },
+        )
         result = ow_service.ow_list_identities("ch", alive_only=True)
         assert len(result) == 1
         assert result[0]["alias"] == "worker-a"
 
-    def test_term_ref_preserved_per_handle(self, monkeypatch):
-        """段階①: 複数 handle の identity に term_ref が個別に乗る。
-
-        ow_list_identities は handle 単位で最新 identity を集約するが、各 entry の
-        term_ref は元 event のものをそのまま保持し、混線しない。
-        """
-        msgs = [
-            _make_msg(
-                1, "w-a",
-                _event_body("identity", {"alias": "worker-a", "term_ref": "%5"}, handle="w-a"),
-            ),
-            _make_msg(
-                2, "w-b",
-                _event_body(
-                    "identity",
+    def test_term_ref_preserved_per_handle(self):
+        """段階①: 複数 handle の term_ref が個別に保持される。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-a": _entry(
+                    1,
+                    {"type": "identity", "alias": "worker-a", "term_ref": "%5"},
+                    "...",
+                ),
+                "w-b": _entry(
+                    2,
                     {
+                        "type": "identity",
                         "alias": "worker-b",
                         "term_ref": "12345678-1234-1234-1234-123456789ABC",
                     },
-                    handle="w-b",
+                    "...",
                 ),
-            ),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+            },
+        )
         result = ow_service.ow_list_identities("ch")
         by_handle = {e["alias"]: e for e in result}
         assert by_handle["worker-a"]["term_ref"] == "%5"
         assert by_handle["worker-b"]["term_ref"] == "12345678-1234-1234-1234-123456789ABC"
 
-    def test_identities_without_term_ref_work(self, monkeypatch):
-        """後方互換: term_ref を持たない identity event でも ow_list_identities は正常動作する。
-
-        term_ref 省略はあくまで「フィールドが無い」状態であり、reducer は他のフィールドを
-        通常通り集約する。term_ref キーは戻り値に存在しない（None）。
-        """
-        msgs = [
-            _make_msg(1, "w-a", _event_body("identity", {"alias": "worker-a"}, handle="w-a")),
-            _make_msg(2, "w-b", _event_body("identity", {"alias": "worker-b"}, handle="w-b")),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_identities_without_term_ref_work(self):
+        """後方互換: term_ref を持たない identity でも他フィールドは集約される。"""
+        _save_cache(
+            "ch",
+            identity_events={
+                "w-a": _entry(1, {"type": "identity", "alias": "worker-a"}, "..."),
+                "w-b": _entry(2, {"type": "identity", "alias": "worker-b"}, "..."),
+            },
+        )
         result = ow_service.ow_list_identities("ch")
         by_handle = {e["alias"]: e for e in result}
         assert set(by_handle.keys()) == {"worker-a", "worker-b"}
@@ -480,32 +576,42 @@ class TestTermRefValidation:
 
 
 class TestOwGetPresence:
-    """ow_get_presence のユニットテスト。"""
+    """ow_get_presence の cache fastpath テスト。"""
 
-    def test_online_with_recent_heartbeat(self, monkeypatch):
-        """直近heartbeat → online。"""
+    def test_online_with_recent_heartbeat(self):
+        """直近 heartbeat → online。"""
         recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
-        msgs = [
-            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), recent),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        _save_cache(
+            "ch",
+            heartbeats={
+                "w-h": _entry(1, {"type": "heartbeat", "phase": "working"}, recent),
+            },
+        )
         result = ow_service.ow_get_presence("ch", "w-h")
         assert result["status"] == "online"
         assert result["handle"] == "w-h"
 
-    def test_offline_with_old_heartbeat(self, monkeypatch):
-        """古いheartbeat → offline。"""
+    def test_offline_with_old_heartbeat(self):
+        """古い heartbeat → offline。"""
         old = (datetime.now(timezone.utc) - timedelta(seconds=200)).isoformat()
-        msgs = [
-            _make_msg(1, "w-h", _event_body("heartbeat", {"phase": "working"}), old),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+        _save_cache(
+            "ch",
+            heartbeats={
+                "w-h": _entry(1, {"type": "heartbeat", "phase": "working"}, old),
+            },
+        )
         result = ow_service.ow_get_presence("ch", "w-h")
         assert result["status"] == "offline"
 
-    def test_unknown_when_no_heartbeat(self, monkeypatch):
-        """heartbeatなし → unknown。"""
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+    def test_unknown_when_no_heartbeat_in_cache(self):
+        """cache に heartbeats[handle] 無し → unknown / last_heartbeat_at=None。"""
+        _save_cache("ch")
+        result = ow_service.ow_get_presence("ch", "w-h")
+        assert result["status"] == "unknown"
+        assert result["last_heartbeat_at"] is None
+
+    def test_unknown_when_cache_missing(self):
+        """cache 自体が無い → unknown (relay は叩かない)。"""
         result = ow_service.ow_get_presence("ch", "w-h")
         assert result["status"] == "unknown"
         assert result["last_heartbeat_at"] is None
@@ -517,15 +623,20 @@ class TestOwGetPresence:
 
 
 class TestOwGetWorkloadState:
-    """ow_get_workload_state のユニットテスト。"""
+    """ow_get_workload_state の cache fastpath テスト。"""
 
-    def test_returns_latest_state(self, monkeypatch):
-        """最新stateを返す。"""
-        msgs = [
-            _make_msg(1, "w-h", _event_body("state", {"state": "loading"}), "2026-06-14T10:00:00+00:00"),
-            _make_msg(2, "w-h", _event_body("state", {"state": "working", "cause": None}), "2026-06-14T10:01:00+00:00"),
-        ]
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history(msgs))
+    def test_returns_latest_state(self):
+        """cache の states[handle] を parsed event 形式で再構築し API 戻り値に変換する。"""
+        _save_cache(
+            "ch",
+            states={
+                "w-h": _entry(
+                    2,
+                    {"type": "state", "state": "working", "cause": None},
+                    "2026-06-14T10:01:00+00:00",
+                ),
+            },
+        )
         result = ow_service.ow_get_workload_state("ch", "w-h")
         assert result is not None
         assert result["state"] == "working"
@@ -533,8 +644,13 @@ class TestOwGetWorkloadState:
         assert result["msg_id"] == 2
         assert result["state_at"] == "2026-06-14T10:01:00+00:00"
 
-    def test_returns_none_when_no_state(self, monkeypatch):
-        """stateなし → None。"""
-        monkeypatch.setattr(ow_service, "ow_history", lambda *a, **kw: _make_history([]))
+    def test_returns_none_when_no_state_in_cache(self):
+        """cache に states[handle] 無し → None。"""
+        _save_cache("ch")
+        result = ow_service.ow_get_workload_state("ch", "w-h")
+        assert result is None
+
+    def test_returns_none_when_cache_missing(self):
+        """cache 自体が無い → None。"""
         result = ow_service.ow_get_workload_state("ch", "w-h")
         assert result is None

--- a/tests/unit/test_ow_reducer.py
+++ b/tests/unit/test_ow_reducer.py
@@ -1,12 +1,9 @@
 """ow_service reducer 4関数のユニットテスト。
 
-A#911 SP-2 PR-β/γ で reducer 系 4関数 (ow_get_identity / ow_list_identities /
-ow_get_presence / ow_get_workload_state) と内部ヘルパー (_query_latest_event /
-_latest_events_by_type) は relay full pull を撤去し、OwState キャッシュを読む
-だけになった。本テストは cache fastpath の振る舞いを検証する (M#386 §6)。
-
-ow_history を mock していた旧 PR-α テストは、tmp 配下に直接 OwState を save_state
-する形式に書き換えた。tmp 隔離は ``_isolated_state_dir`` で OW_STATE_DIR を切り替える。
+reducer 系 4関数 (ow_get_identity / ow_list_identities / ow_get_presence /
+ow_get_workload_state) と内部ヘルパー (_query_latest_event / _latest_events_by_type)
+は OwState キャッシュを読むだけで relay を直接叩かない。本テストは cache fastpath
+の振る舞いを検証する。tmp 隔離は ``_isolated_state_dir`` で OW_STATE_DIR を切り替える。
 """
 import logging
 from datetime import datetime, timedelta, timezone
@@ -25,9 +22,7 @@ from src.services.ow.cache import CURRENT_SCHEMA_VERSION, save_state
 
 @pytest.fixture(autouse=True)
 def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """OW_STATE_DIR を tmp に閉じて cache 副作用を分離する (PR-β/γ で reducer は
-    relay を叩かず cache のみ参照するため)。
-    """
+    """OW_STATE_DIR を tmp に閉じて cache 副作用を分離する。"""
     monkeypatch.setenv("OW_STATE_DIR", str(tmp_path))
     return tmp_path
 
@@ -100,7 +95,7 @@ def _save_cache(
 
 
 class TestParseOwEvent:
-    """_parse_ow_event のユニットテスト (PR-β/γ で振る舞い変化なし)。"""
+    """_parse_ow_event のユニットテスト。"""
 
     def test_valid_event_returns_parsed(self):
         """v=1, kind="event" → 正常にparsed dictを返す。"""
@@ -155,8 +150,8 @@ class TestParseOwEvent:
 class TestQueryLatestEvent:
     """_query_latest_event の cache fastpath ユニットテスト。
 
-    PR-γ で relay full pull は撤去された。本関数は OwState の states / heartbeats /
-    identity_events を読むだけ。cache miss = None。
+    本関数は OwState の states / heartbeats / identity_events を読むだけで、
+    relay を直接叩かない。cache miss = None。
     """
 
     def test_returns_event_for_cached_state(self):
@@ -248,9 +243,9 @@ class TestQueryLatestEvent:
 
 
 class TestQueryEventsSince:
-    """_query_events_since のユニットテスト (PR-β/γ では関数自体は変更なし)。
+    """_query_events_since のユニットテスト。
 
-    本関数は cache fastpath の対象外で、引き続き relay full pull を行う。
+    本関数は cache fastpath の対象外で、relay full pull を行う。
     """
 
     def test_returns_all_matching(self, monkeypatch):
@@ -286,7 +281,7 @@ class TestQueryEventsSince:
 
 
 class TestInferCrashCause:
-    """_infer_crash_cause のユニットテスト (PR-β/γ で振る舞い変化なし)。"""
+    """_infer_crash_cause のユニットテスト。"""
 
     def _old_hb(self, seconds_ago=200):
         """現在時刻からseconds_ago秒前のISO文字列を返す。"""


### PR DESCRIPTION
## Summary

- `_query_latest_event` / `_latest_events_by_type` に cache fastpath を追加。OwState の `identity_events` / `states` / `heartbeats` から最新 event を引く形に切り替え、relay full pull コードを撤去した。
- `ow_list_identities` も同様に cache 直読みに切替。reducer 4 関数の公開 API は不変。
- OwState スキーマを v2 に拡張: `identity_events` / `states` / `heartbeats` (EventEntry: `{msg_id, data, created_at}`)。`identities` (raw data dict) は後方互換のため残置。schema_version mismatch は `load_state` の forward-only fallback で自動再構築 (cache を削除して projector が relay full pull で再生成)。
- `find_topic_id_by_channel(channel)` を cache.py に追加。reducer は channel しか持たないため cache ディレクトリを走査して topic_id を逆引きする (O(N) で N=cache 化された topic 数、典型は 1-10)。

## Scope (本 PR で触らない)

- `_parse_queue_file` / `_validate_spawn_preconditions` / `ow_recover` / `ow_status` の queue 経路
- OwState への `spawning_at` / `orch_activity_id` / `orch_cwd` 追加
- `_query_events_since` (reducer 4 関数の依存なし、従来通り relay full pull を維持)

## Notes

- 既存 reducer ユニットテストは `ow_history` mock から OwState 直接 save 形式に書き換えた。reducer は relay を叩かなくなったため。
- 既存テスト全件 pass。

## Test plan

- [x] tests/unit/test_ow_reducer.py: cache fastpath fixture で reducer 動作確認
- [x] tests/unit/test_ow_cache_lookup.py: `find_topic_id_by_channel` / `_load_state_by_channel` 単体 (新規)
- [x] tests/integration/test_ow_reducer_cache_fastpath.py: 実 relay → projector → reducer の end-to-end (新規)
- [x] tests/integration/test_ow_projector.py: projector 系の retest
- [x] tests/unit/test_ow_cache.py / test_ow_projector.py: schema v2 への影響無しを確認
- [x] 既存全件 pass