### PR TITLE
feat: 本文の {{cite:X#NNN}} を構造化保存し flavor で展開を切替

### DIFF
--- a/migrations/0042_citations_table.sql
+++ b/migrations/0042_citations_table.sql
@@ -1,0 +1,72 @@
+-- Migration 0042: citations テーブル追加
+--
+-- depends: 0040_add_heartbeat_session_id 0041_add_search_telemetry
+--
+-- 背景:
+--   本文中の `{{cite:X#NNN}}` テンプレ参照を構造化テーブルに保存する。
+--   X は M/D/L/A/T の 5 種で、それぞれ material/decision/log/activity/topic に対応する。
+--   読み出し時に flavor 引数で展開形式 (raw/internal/readable) を切り替える前提の参照基盤。
+--
+-- スキーマ:
+--   id          : 主キー
+--   owner_type  : 参照を含む本文を持つエンティティの種別
+--   owner_id    : 同上 ID
+--   target_type : 参照先エンティティの種別
+--   target_id   : 同上 ID
+--   occurrence  : owner 本文中の出現順 (1 始まり連番、文字オフセットは保持しない)
+--   created_at  : INSERT 時刻
+--
+-- ライフサイクル:
+--   - owner 削除: 該当 owner の citations 行はトリガーで cascade 削除
+--   - target retract / 物理削除: citations 行は残置 (監査トレース要件)
+--     展開時に dangling 判定を動的に行い `[deleted X#NNN]` / `[retracted X#NNN]` 表現にする
+
+CREATE TABLE citations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_type TEXT NOT NULL CHECK(owner_type IN ('material', 'decision', 'log', 'activity', 'topic')),
+    owner_id INTEGER NOT NULL,
+    target_type TEXT NOT NULL CHECK(target_type IN ('material', 'decision', 'log', 'activity', 'topic')),
+    target_id INTEGER NOT NULL,
+    occurrence INTEGER NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(owner_type, owner_id, occurrence)
+);
+
+CREATE INDEX idx_citations_target ON citations(target_type, target_id);
+CREATE INDEX idx_citations_owner ON citations(owner_type, owner_id);
+
+-- owner 側 cascade delete トリガー (5 種)
+CREATE TRIGGER trg_citations_cascade_delete_material
+AFTER DELETE ON materials
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'material' AND owner_id = OLD.id;
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_decision
+AFTER DELETE ON decisions
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'decision' AND owner_id = OLD.id;
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_log
+AFTER DELETE ON discussion_logs
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'log' AND owner_id = OLD.id;
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_activity
+AFTER DELETE ON activities
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'activity' AND owner_id = OLD.id;
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_topic
+AFTER DELETE ON discussion_topics
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'topic' AND owner_id = OLD.id;
+END;

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from src.services import (
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
 from src.services.tag_analysis_service import analyze_tags as _analyze_tags
+from src.services import citation_renderer
 from src.db import get_connection
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -156,6 +157,78 @@ def _collect_result_tags(items: list[dict]) -> list[str]:
     return sorted(tags)
 
 
+_FlavorArg = Literal["raw", "internal", "readable"]
+_VALID_FLAVORS = ("raw", "internal", "readable")
+
+
+def _normalize_flavor(flavor: str | None) -> str:
+    """flavor 引数を検証し、未指定 (None) の場合は既定値 "internal" を返す。"""
+    if flavor is None:
+        return citation_renderer.DEFAULT_FLAVOR
+    if flavor not in _VALID_FLAVORS:
+        raise ValueError(
+            f"Invalid flavor {flavor!r}; must be one of {_VALID_FLAVORS}"
+        )
+    return flavor
+
+
+def _apply_flavor_to_items(
+    items: list[dict],
+    entity_type: str,
+    flavor: str,
+    id_key: str = "id",
+    attach_citations: bool = True,
+) -> None:
+    """同種エンティティのリストに対し flavor 展開 + citations_in/out 付与 (in-place)。"""
+    if not items:
+        return
+    conn = get_connection()
+    try:
+        for item in items:
+            citation_renderer.apply_flavor_to_entity_dict(
+                item, entity_type, flavor, conn,
+                id_key=id_key, attach_citations=attach_citations,
+            )
+    finally:
+        conn.close()
+
+
+def _apply_flavor_to_single(
+    item: dict,
+    entity_type: str,
+    flavor: str,
+    id_key: str = "id",
+    attach_citations: bool = True,
+) -> None:
+    """単一エンティティ dict に flavor 展開 + citations_in/out 付与 (in-place)。"""
+    if not item:
+        return
+    conn = get_connection()
+    try:
+        citation_renderer.apply_flavor_to_entity_dict(
+            item, entity_type, flavor, conn,
+            id_key=id_key, attach_citations=attach_citations,
+        )
+    finally:
+        conn.close()
+
+
+def _apply_flavor_to_snippets(items: list[dict], flavor: str) -> None:
+    """検索結果 snippet 群に raw 境界調整 → flavor 展開を適用 (in-place)。"""
+    if not items or flavor == "raw":
+        return
+    conn = get_connection()
+    try:
+        for item in items:
+            snippet = item.get("snippet")
+            if isinstance(snippet, str) and snippet:
+                item["snippet"] = citation_renderer.apply_flavor_to_snippet(
+                    snippet, flavor, conn
+                )
+    finally:
+        conn.close()
+
+
 # MCPサーバーを作成
 mcp = FastMCP("cc-memory", instructions=build_instructions())
 
@@ -271,6 +344,7 @@ def get_topics(
     offset: int = 0,
     since: str | None = None,
     until: str | None = None,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """トピックを新しい順に取得する（ページネーション付き）。
 
@@ -278,8 +352,10 @@ def get_topics(
     since: ISO日付文字列（例: "2026-03-10"）。この日付以降に作成されたトピックのみ返す
     until: ISO日付文字列。この日付以前に作成されたトピックのみ返す
     """
+    flavor = _normalize_flavor(flavor)
     result = topic_service.get_topics(tags, limit, offset, since, until)
     if "error" not in result:
+        _apply_flavor_to_items(result.get("topics", []), "topic", flavor)
         all_tags = _collect_result_tags(result.get("topics", []))
         if all_tags:
             _maybe_inject_tag_notes(result, all_tags, mark=False)
@@ -293,6 +369,7 @@ def get_logs(
     start_id: Optional[int] = None,
     limit: int = 30,
     include_retracted: bool = False,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: topic/activity に紐づく log 一覧が欲しいとき。決定事項一覧なら get_decisions、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
@@ -310,8 +387,10 @@ def get_logs(
         議論ログ一覧（各logにtags付き）
         entity_type == "activity" の場合はrelated topics経由でlogs集約
     """
+    flavor = _normalize_flavor(flavor)
     result = discussion_log_service.get_logs(entity_type, entity_id, start_id, limit, include_retracted=include_retracted)
     if "error" not in result:
+        _apply_flavor_to_items(result.get("logs", []), "log", flavor)
         all_tags = _collect_result_tags(result.get("logs", []))
         if all_tags:
             _maybe_inject_tag_notes(result, all_tags, mark=False)
@@ -325,6 +404,7 @@ def get_decisions(
     start_id: Optional[int] = None,
     limit: int = 30,
     include_retracted: bool = False,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: topic/activity に紐づく decision 一覧が欲しいとき。議論経緯の log なら get_logs、log/decision/material の混合時系列なら get_timeline、起点からの関連グラフ走査なら get_map、activity 着手時の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
@@ -342,8 +422,10 @@ def get_decisions(
         決定事項一覧（各decisionにtags付き）
         entity_type == "activity" の場合はrelated topics経由でdecisions集約
     """
+    flavor = _normalize_flavor(flavor)
     result = decision_service.get_decisions(entity_type, entity_id, start_id, limit, include_retracted=include_retracted)
     if "error" not in result:
+        _apply_flavor_to_items(result.get("decisions", []), "decision", flavor)
         all_tags = _collect_result_tags(result.get("decisions", []))
         if all_tags:
             _maybe_inject_tag_notes(result, all_tags, mark=False)
@@ -363,6 +445,7 @@ def search(
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
     include_retracted: bool = False,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     キーワードで横断検索する。
@@ -398,7 +481,10 @@ def search(
         tagsはエンティティに紐づくタグ文字列のリスト。
         include_details=Trueの場合、上位10件にdetailsが追加される。
     """
+    flavor = _normalize_flavor(flavor)
     result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before, include_retracted=include_retracted)
+    if "error" not in result:
+        _apply_flavor_to_snippets(result.get("results", []), flavor)
     if "error" not in result and tags:
         _maybe_inject_tag_notes(result, tags)
     return result
@@ -407,6 +493,7 @@ def search(
 @mcp.tool()
 def get_by_ids(
     items: list[dict],
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: search 結果の type+id ペアを本文付きで一括取得したいとき（複数種別 OK）。material 単独なら get_material、topic/activity 起点の log/decision 集約なら get_logs / get_decisions、関連グラフ走査なら get_map。
@@ -424,8 +511,22 @@ def get_by_ids(
     Returns:
         取得結果（各アイテムの詳細情報）
     """
+    flavor = _normalize_flavor(flavor)
     result = search_service.get_by_ids(items)
     if "error" not in result:
+        conn = get_connection()
+        try:
+            for entry in result.get("results", []):
+                data = entry.get("data")
+                if not isinstance(data, dict):
+                    continue
+                etype = entry.get("type")
+                if etype in citation_renderer.RESPONSE_TEXT_FIELDS:
+                    citation_renderer.apply_flavor_to_entity_dict(
+                        data, etype, flavor, conn,
+                    )
+        finally:
+            conn.close()
         all_tags = []
         for item in result.get("results", []):
             if "data" in item:
@@ -575,6 +676,7 @@ def get_activities(
     limit: int = 5,
     since: str | None = None,
     until: str | None = None,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     アクティビティ一覧を取得する（tagsでフィルタリング、statusでフィルタリング可能）。
@@ -599,8 +701,10 @@ def get_activities(
     Returns:
         アクティビティ一覧（total_countで該当ステータスの全件数を確認可能）
     """
+    flavor = _normalize_flavor(flavor)
     result = activity_service.get_activities(tags, status, limit, since, until)
     if "error" not in result:
+        _apply_flavor_to_items(result.get("activities", []), "activity", flavor)
         all_tags = _collect_result_tags(result.get("activities", []))
         if all_tags:
             _maybe_inject_tag_notes(result, all_tags, mark=False)
@@ -719,6 +823,7 @@ def update_material(
 @mcp.tool()
 def get_material(
     material_id: int,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: material_id 既知で資材の全文だけ取得したいとき。複数種別を一括なら get_by_ids、起点からの関連グラフ走査なら get_map、log/decision/material の混合時系列なら get_timeline。
@@ -734,12 +839,17 @@ def get_material(
     Returns:
         資材の全文情報（material_id, title, content, source, tags, created_at）
     """
-    return material_service.get_material(material_id)
+    flavor = _normalize_flavor(flavor)
+    result = material_service.get_material(material_id)
+    if "error" not in result:
+        _apply_flavor_to_single(result, "material", flavor, id_key="material_id")
+    return result
 
 
 @mcp.tool()
 def check_in(
     activity_id: int,
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: アクティビティに着手するときに関連情報を一括取得したいとき（status を in_progress に自動更新）。関連グラフだけ俯瞰したいなら get_map、log/decision/material の時系列なら get_timeline、log だけなら get_logs。
@@ -758,12 +868,71 @@ def check_in(
     Returns:
         check-in結果（coverage, activity, related_topics, related_activities, pinned, tag_notes, materials, recent_decisions, latest_log, logs, catalog, summary）
     """
+    flavor = _normalize_flavor(flavor)
     try:
         ctx = get_context()
         session_id = ctx.session_id
     except RuntimeError:
         session_id = None
-    return _check_in(activity_id, session_id=session_id)
+    result = _check_in(activity_id, session_id=session_id)
+    if "error" not in result and flavor != "raw":
+        _apply_flavor_to_check_in_result(result, flavor)
+    return result
+
+
+def _apply_flavor_to_check_in_result(result: dict, flavor: str) -> None:
+    """check_in レスポンスの各セクションに flavor 展開を適用する (in-place)。
+
+    check_in は activity / related_topics / related_activities / materials /
+    recent_decisions / latest_log / logs / catalog の各セクションを持つ。
+    各 snippet には raw 境界調整 → flavor 展開、entity 詳細は dict 単位で展開。
+    """
+    conn = get_connection()
+    try:
+        activity = result.get("activity")
+        if isinstance(activity, dict):
+            citation_renderer.apply_flavor_to_entity_dict(
+                activity, "activity", flavor, conn, attach_citations=True
+            )
+        for key, etype in (
+            ("related_topics", "topic"),
+            ("related_activities", "activity"),
+        ):
+            for item in result.get(key, []) or []:
+                if isinstance(item, dict):
+                    citation_renderer.apply_flavor_to_entity_dict(
+                        item, etype, flavor, conn, attach_citations=False
+                    )
+        # snippet 系: materials / latest_log / logs / catalog
+        for item in result.get("materials", []) or []:
+            _flavor_snippet(item, flavor, conn)
+        for item in result.get("logs", []) or []:
+            _flavor_snippet(item, flavor, conn)
+        for item in result.get("catalog", []) or []:
+            _flavor_snippet(item, flavor, conn)
+        latest = result.get("latest_log")
+        if isinstance(latest, dict):
+            _flavor_snippet(latest, flavor, conn)
+            if isinstance(latest.get("content"), str):
+                latest["content"] = citation_renderer.expand(
+                    latest["content"], flavor, conn
+                )
+        for item in result.get("recent_decisions", []) or []:
+            _flavor_snippet(item, flavor, conn)
+    finally:
+        conn.close()
+
+
+def _flavor_snippet(item: dict, flavor: str, conn) -> None:
+    """item dict 内の snippet / title フィールドに flavor を適用する (in-place)。"""
+    if not isinstance(item, dict) or flavor == "raw":
+        return
+    if isinstance(item.get("snippet"), str):
+        item["snippet"] = citation_renderer.apply_flavor_to_snippet(
+            item["snippet"], flavor, conn
+        )
+    if isinstance(item.get("title"), str):
+        item["title"] = citation_renderer.expand(item["title"], flavor, conn)
 
 
 
@@ -976,6 +1145,7 @@ def get_timeline(
     before: str | None = None,
     limit: int = 50,
     order: str = "desc",
+    flavor: _FlavorArg = "internal",
 ) -> dict:
     """
     Choose: topic/activity に紐づく decision/log/material を時系列順に並べたいとき。log だけなら get_logs、decision だけなら get_decisions、関連グラフ走査なら get_map、activity の文脈集約なら check_in（status を in_progress に自動更新する副作用あり、着手時のみ）。
@@ -990,11 +1160,20 @@ def get_timeline(
         limit: 取得件数上限（デフォルト50、最大100）
         order: ソート方向（"desc"または"asc"、デフォルト"desc"）
     """
-    return timeline_service.get_timeline(
+    flavor = _normalize_flavor(flavor)
+    result = timeline_service.get_timeline(
         topic_id=topic_id, activity_id=activity_id,
         entity_types=entity_types, before=before,
         limit=limit, order=order,
     )
+    if "error" not in result and flavor != "raw":
+        conn = get_connection()
+        try:
+            for item in result.get("items", []) or []:
+                _flavor_snippet(item, flavor, conn)
+        finally:
+            conn.close()
+    return result
 
 
 @mcp.tool()

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -5,6 +5,7 @@ import sqlite3
 from typing import Optional
 
 from src.db import get_connection, row_to_dict
+from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
@@ -166,6 +167,11 @@ def add_activity(
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "activity", activity_id, related)
+
+        # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+        upsert_citations_for_owner_with_conn(
+            conn, "activity", activity_id, title=title, description=description
+        )
 
         conn.commit()
 
@@ -570,6 +576,14 @@ def update_activity(
         conn.execute(
             f"UPDATE activities SET {set_clause} WHERE id = ?",
             tuple(values),
+        )
+
+        # citations 全削除→再投入 (本文無変更でも実施)
+        new_title = title if title is not None else row["title"]
+        new_description = description if description is not None else row["description"]
+        upsert_citations_for_owner_with_conn(
+            conn, "activity", activity_id,
+            title=new_title, description=new_description,
         )
 
         conn.commit()

--- a/src/services/citation_renderer.py
+++ b/src/services/citation_renderer.py
@@ -38,9 +38,12 @@ RESPONSE_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
 
 
 def expand(content: str, flavor: Flavor, conn: sqlite3.Connection) -> str:
-    """本文中の `{{cite:X#NNN}}` テンプレを flavor に応じて展開する。"""
+    """本文中の `{{cite:X#NNN}}` テンプレを flavor に応じて展開する。
+
+    None 入力時は空文字を返す (戻り値型 `str` 契約を維持するため)。
+    """
     if content is None:
-        return content
+        return ""
     if flavor == "raw":
         return content
     if flavor not in VALID_FLAVORS:
@@ -200,9 +203,12 @@ def _extract_entity_id(d: dict, entity_type: str, id_key: str) -> int | None:
 def apply_flavor_to_snippet(
     snippet: str, flavor: Flavor, conn: sqlite3.Connection
 ) -> str:
-    """snippet 文字列に raw 境界調整 → flavor 展開を適用する (D#2726)。"""
+    """snippet 文字列に raw 境界調整 → flavor 展開を適用する。
+
+    None 入力時は空文字を返す (戻り値型 `str` 契約を維持するため)。
+    """
     if snippet is None:
-        return snippet
+        return ""
     if flavor == "raw":
         return snippet
     adjusted = adjust_snippet_boundary(snippet)

--- a/src/services/citation_renderer.py
+++ b/src/services/citation_renderer.py
@@ -1,0 +1,237 @@
+"""citation テンプレ (`{{cite:X#NNN}}`) を flavor に応じて展開する。
+
+3 flavor:
+- raw      : 本文無加工 (テンプレも deleted/retracted 加工もしない)
+- internal : `<title> (X#NNN)` 形式 (AI エージェント向け、ID 保持)
+- readable : `<title>` 形式 (人間向け、ID 出力なし)
+
+target が物理削除 / retracted (decision/log) の場合:
+- internal : `[deleted X#NNN]` / `[retracted X#NNN]`
+- readable : `[deleted item]` / `[retracted item]`
+
+コードブロック内 / `\\{{cite:...}}` エスケープはどの flavor でも無加工で残す。
+"""
+import re
+import sqlite3
+from typing import Literal
+
+from src.services.citations_service import (
+    TYPE_CODE_TO_NAME,
+    TYPE_NAME_TO_CODE,
+    _CITE_PATTERN,
+    _get_in_out_with_conn,
+    _resolve_targets,
+)
+
+Flavor = Literal["raw", "internal", "readable"]
+VALID_FLAVORS = ("raw", "internal", "readable")
+DEFAULT_FLAVOR: Flavor = "internal"
+
+# read response 内で展開を試みるフィールド名 (DB カラム名と一致するキーのみ対象)
+RESPONSE_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
+    "material": ("title", "content"),
+    "decision": ("title", "decision", "reason"),
+    "log": ("title", "content"),
+    "activity": ("title", "description"),
+    "topic": ("title", "description"),
+}
+
+
+def expand(content: str, flavor: Flavor, conn: sqlite3.Connection) -> str:
+    """本文中の `{{cite:X#NNN}}` テンプレを flavor に応じて展開する。"""
+    if content is None:
+        return content
+    if flavor == "raw":
+        return content
+    if flavor not in VALID_FLAVORS:
+        raise ValueError(f"Invalid flavor {flavor!r}; must be one of {VALID_FLAVORS}")
+
+    spans = _collect_spans(content)
+    if not spans:
+        return content
+    pairs = list({(target_type, target_id) for _, _, target_type, target_id in spans})
+    resolved = _resolve_targets(conn, pairs)
+    # 逆順で置換 (オフセットがズレないように)
+    parts: list[str] = []
+    cursor = 0
+    for start, end, target_type, target_id in spans:
+        parts.append(content[cursor:start])
+        meta = resolved.get((target_type, target_id))
+        parts.append(_render_one(flavor, target_type, target_id, meta))
+        cursor = end
+    parts.append(content[cursor:])
+    return "".join(parts)
+
+
+def _render_one(flavor: Flavor, target_type: str, target_id: int, meta: dict | None) -> str:
+    code = TYPE_NAME_TO_CODE[target_type]
+    full_id = f"{code}#{target_id}"
+    deleted = bool(meta and meta.get("deleted"))
+    retracted = bool(meta and meta.get("retracted"))
+    if deleted:
+        if flavor == "internal":
+            return f"[deleted {full_id}]"
+        return "[deleted item]"
+    if retracted:
+        if flavor == "internal":
+            return f"[retracted {full_id}]"
+        return "[retracted item]"
+    title = (meta or {}).get("title") or full_id
+    if flavor == "internal":
+        return f"{title} ({full_id})"
+    return title
+
+
+def _collect_spans(content: str) -> list[tuple[int, int, str, int]]:
+    """本文中の有効な citation テンプレ位置を出現順に集める。
+
+    コードブロック / エスケープ / 不正形式はスキップ。
+
+    Returns:
+        [(start, end, target_type, target_id), ...]
+    """
+    spans: list[tuple[int, int, str, int]] = []
+    lines = content.split("\n")
+    line_offset = 0  # content[line_offset:line_offset+len(line)] が現在行
+    in_fence = False
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            line_offset += len(line) + 1
+            continue
+        if in_fence:
+            line_offset += len(line) + 1
+            continue
+        spans.extend(_scan_line_for_spans(line, line_offset))
+        line_offset += len(line) + 1
+    return spans
+
+
+def _scan_line_for_spans(line: str, base: int) -> list[tuple[int, int, str, int]]:
+    out: list[tuple[int, int, str, int]] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "`":
+            close = line.find("`", i + 1)
+            if close == -1:
+                break
+            i = close + 1
+            continue
+        if ch == "\\" and line[i + 1 : i + 3] == "{{":
+            end = line.find("}}", i + 1)
+            if end == -1:
+                i += 1
+                continue
+            i = end + 2
+            continue
+        m = _CITE_PATTERN.match(line, i)
+        if m:
+            code = m.group(1)
+            target_type = TYPE_CODE_TO_NAME.get(code)
+            if target_type:
+                try:
+                    target_id = int(m.group(2))
+                    out.append((base + m.start(), base + m.end(), target_type, target_id))
+                except ValueError:
+                    pass
+            i = m.end()
+            continue
+        i += 1
+    return out
+
+
+def apply_flavor_to_entity_dict(
+    d: dict,
+    entity_type: str,
+    flavor: Flavor,
+    conn: sqlite3.Connection,
+    id_key: str = "id",
+    attach_citations: bool = True,
+) -> dict:
+    """read response の単一エンティティ dict に対し flavor 展開 + citations_in/out を貼る。
+
+    Args:
+        d: 改変対象 dict (in-place 改変)
+        entity_type: "material" / "decision" / "log" / "activity" / "topic"
+        flavor: 展開フォーマット
+        conn: DB 接続
+        id_key: dict 内の ID キー名 (デフォルト "id"。material_id 等の場合は上書き)
+        attach_citations: True のとき citations_in/citations_out を追加
+
+    Returns:
+        改変済み dict (同オブジェクト)
+    """
+    if not isinstance(d, dict) or entity_type not in RESPONSE_TEXT_FIELDS:
+        return d
+    if flavor != "raw":
+        for field in RESPONSE_TEXT_FIELDS[entity_type]:
+            if field in d and isinstance(d[field], str) and d[field]:
+                d[field] = expand(d[field], flavor, conn)
+    if attach_citations:
+        entity_id = _extract_entity_id(d, entity_type, id_key)
+        if entity_id is not None:
+            io = _get_in_out_with_conn(conn, entity_type, entity_id)
+            d["citations_out"] = io["out"]
+            d["citations_in"] = io["in"]
+    return d
+
+
+def _extract_entity_id(d: dict, entity_type: str, id_key: str) -> int | None:
+    """response dict から整数 ID を取り出す。
+
+    apply_readable_id_inplace で `id` / `<entity>_id` が文字列化されている場合に
+    備えて `<key>_raw` フィールドにフォールバックする。"""
+    for key in (
+        id_key,
+        f"{entity_type}_id",
+        f"{id_key}_raw",
+        f"{entity_type}_id_raw",
+        "id_raw",
+    ):
+        v = d.get(key)
+        if isinstance(v, int):
+            return v
+    return None
+
+
+def apply_flavor_to_snippet(
+    snippet: str, flavor: Flavor, conn: sqlite3.Connection
+) -> str:
+    """snippet 文字列に raw 境界調整 → flavor 展開を適用する (D#2726)。"""
+    if snippet is None:
+        return snippet
+    if flavor == "raw":
+        return snippet
+    adjusted = adjust_snippet_boundary(snippet)
+    return expand(adjusted, flavor, conn)
+
+
+def adjust_snippet_boundary(snippet: str) -> str:
+    """snippet 文字列が境界で `{{cite:...}}` テンプレを半端に切ったとき、
+    テンプレ全体を含めるか除外するかで境界を調整する。
+
+    snippet は raw 段階で受け取り、調整後に flavor 展開する想定。
+
+    調整方針:
+    - 先頭: `}}` で閉じる前にテンプレ開始が来ていれば、その先頭まで切り詰める
+    - 末尾: `{{cite:` の途中で切れていれば、その手前で切る
+    """
+    if not snippet:
+        return snippet
+    adjusted = snippet
+    # 末尾側: 末尾近くで `{{cite:...` が始まったが `}}` で閉じていないケース
+    last_open = adjusted.rfind("{{cite:")
+    if last_open != -1:
+        close_after = adjusted.find("}}", last_open)
+        if close_after == -1:
+            adjusted = adjusted[:last_open]
+    # 先頭側: 先頭近くで `...}}` で閉じているが対応する `{{cite:` が無いケース
+    first_close = adjusted.find("}}")
+    if first_close != -1:
+        open_before = adjusted.rfind("{{cite:", 0, first_close)
+        if open_before == -1:
+            adjusted = adjusted[first_close + 2 :]
+    return adjusted

--- a/src/services/citations_service.py
+++ b/src/services/citations_service.py
@@ -1,0 +1,319 @@
+"""citation 参照テンプレ (`{{cite:X#NNN}}`) の抽出・保存・引き当てを行うサービス。
+
+本文中の `{{cite:X#NNN}}` テンプレを `citations` テーブルに保存し、
+read 経路では `flavor` で展開形式を切り替える前提の参照基盤を提供する。
+
+X は M/D/L/A/T のいずれかで、それぞれ material/decision/log/activity/topic に対応する。
+"""
+import logging
+import re
+import sqlite3
+from typing import Literal
+
+from src.db import get_connection
+
+logger = logging.getLogger(__name__)
+
+VALID_OWNER_TYPES = ("material", "decision", "log", "activity", "topic")
+VALID_TARGET_TYPES = VALID_OWNER_TYPES
+
+TYPE_CODE_TO_NAME: dict[str, str] = {
+    "M": "material",
+    "D": "decision",
+    "L": "log",
+    "A": "activity",
+    "T": "topic",
+}
+TYPE_NAME_TO_CODE: dict[str, str] = {v: k for k, v in TYPE_CODE_TO_NAME.items()}
+
+TYPE_TO_TABLE: dict[str, str] = {
+    "material": "materials",
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "activity": "activities",
+    "topic": "discussion_topics",
+}
+
+# 各 entity 種別の表示タイトル取得式 (SELECT 内で使用)。
+# decision は title が NULL のとき decision 本文へ fall back する。
+TYPE_TO_TITLE_EXPR: dict[str, str] = {
+    "material": "title",
+    "decision": "COALESCE(NULLIF(TRIM(title), ''), substr(decision, 1, 80))",
+    "log": "COALESCE(NULLIF(TRIM(title), ''), substr(content, 1, 30))",
+    "activity": "title",
+    "topic": "title",
+}
+
+# retract カラムを持つ entity 種別
+TYPES_WITH_RETRACT = {"decision", "log"}
+
+# owner 種別ごとに、本文中の citation 抽出対象となるテキストフィールド
+# (DB カラム名そのまま、結合順は occurrence の決定要因)
+OWNER_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
+    "material": ("title", "content"),
+    "decision": ("decision", "reason"),
+    "log": ("content",),
+    "activity": ("title", "description"),
+    "topic": ("title", "description"),
+}
+
+_CITE_PATTERN = re.compile(r"\{\{cite:([MDLAT])#(\d+)\}\}")
+_CITE_LIKE_PATTERN = re.compile(r"\{\{cite:[^}]*\}\}")
+
+
+def extract_citations(content: str) -> list[tuple[str, int]]:
+    """本文から citation 参照を出現順に抽出する。
+
+    コードブロック (フェンス ``` / ~~~ と インラインバッククォート) 内の
+    テンプレはスキップする。`\\{{cite:...}}` のエスケープもスキップする。
+    不正形式 (`{{cite:Z#1}}`, `{{cite:foo}}` 等) は警告ログを出して無視する。
+
+    Returns:
+        [(target_type, target_id), ...] の出現順リスト。occurrence は 1 始まりで連番。
+    """
+    results: list[tuple[str, int]] = []
+    in_fence = False
+    for raw_line in content.split("\n"):
+        stripped = raw_line.lstrip()
+        # フェンス境界 (```/~~~ で始まる行) でトグル
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        results.extend(_scan_line(raw_line))
+    return results
+
+
+def _scan_line(line: str) -> list[tuple[str, int]]:
+    """1 行内の citation を走査。インラインバッククォート / エスケープをスキップ。"""
+    out: list[tuple[str, int]] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "`":
+            # 対応する閉じバッククォートまでスキップ
+            close = line.find("`", i + 1)
+            if close == -1:
+                # 未閉じインラインコード: 行末まで保守的にスキップ
+                break
+            i = close + 1
+            continue
+        if ch == "\\" and line[i + 1 : i + 3] == "{{":
+            # エスケープ `\{{cite:...}}` 全体をスキップ
+            end = line.find("}}", i + 1)
+            if end == -1:
+                i += 1
+                continue
+            i = end + 2
+            continue
+        m = _CITE_PATTERN.match(line, i)
+        if m:
+            code = m.group(1)
+            target_id_str = m.group(2)
+            target_type = TYPE_CODE_TO_NAME.get(code)
+            if target_type is None:
+                logger.warning("citation parser: unknown type code %r", code)
+                i = m.end()
+                continue
+            try:
+                target_id = int(target_id_str)
+            except ValueError:
+                logger.warning("citation parser: invalid id %r", target_id_str)
+                i = m.end()
+                continue
+            out.append((target_type, target_id))
+            i = m.end()
+            continue
+        # 不正形式テンプレ (`{{cite:foo}}` 等) は警告
+        like = _CITE_LIKE_PATTERN.match(line, i)
+        if like:
+            logger.warning("citation parser: malformed template skipped: %r", like.group(0))
+            i = like.end()
+            continue
+        i += 1
+    return out
+
+
+def _validate_owner_type(owner_type: str) -> None:
+    if owner_type not in VALID_OWNER_TYPES:
+        raise ValueError(
+            f"Invalid owner_type {owner_type!r}; must be one of {VALID_OWNER_TYPES}"
+        )
+
+
+def extract_and_insert(owner_type: str, owner_id: int, content: str) -> int:
+    """owner 本文をパースして citations へ INSERT する公開関数。
+
+    既存 citations は削除しない (新規 INSERT のみ)。update 経路では replace_all を使うこと。
+
+    Returns:
+        INSERT 件数
+    """
+    _validate_owner_type(owner_type)
+    with get_connection() as conn:
+        with conn:
+            return _extract_and_insert_with_conn(conn, owner_type, owner_id, content)
+
+
+def _extract_and_insert_with_conn(
+    conn: sqlite3.Connection, owner_type: str, owner_id: int, content: str
+) -> int:
+    citations = extract_citations(content or "")
+    if not citations:
+        return 0
+    rows = [
+        (owner_type, owner_id, target_type, target_id, occurrence)
+        for occurrence, (target_type, target_id) in enumerate(citations, start=1)
+    ]
+    conn.executemany(
+        "INSERT INTO citations (owner_type, owner_id, target_type, target_id, occurrence) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    return len(rows)
+
+
+def replace_all(owner_type: str, owner_id: int, content: str) -> int:
+    """既存 citations 全削除 → 新本文をパース → 再投入 (update 経路用)。"""
+    _validate_owner_type(owner_type)
+    with get_connection() as conn:
+        with conn:
+            return _replace_all_with_conn(conn, owner_type, owner_id, content)
+
+
+def _replace_all_with_conn(
+    conn: sqlite3.Connection, owner_type: str, owner_id: int, content: str
+) -> int:
+    conn.execute(
+        "DELETE FROM citations WHERE owner_type = ? AND owner_id = ?",
+        (owner_type, owner_id),
+    )
+    return _extract_and_insert_with_conn(conn, owner_type, owner_id, content)
+
+
+def delete_all_for_owner(owner_type: str, owner_id: int) -> int:
+    """owner 自身が削除されたとき呼ぶ手動 cascade (DB トリガーで自動削除されるが
+    トリガー経由しない経路の互換用)。"""
+    _validate_owner_type(owner_type)
+    with get_connection() as conn:
+        with conn:
+            return _delete_all_for_owner_with_conn(conn, owner_type, owner_id)
+
+
+def _delete_all_for_owner_with_conn(
+    conn: sqlite3.Connection, owner_type: str, owner_id: int
+) -> int:
+    cur = conn.execute(
+        "DELETE FROM citations WHERE owner_type = ? AND owner_id = ?",
+        (owner_type, owner_id),
+    )
+    return cur.rowcount
+
+
+def _combine_owner_text(owner_type: str, fields: dict) -> str:
+    """owner の本文を occurrence 計算用に決定的順序で結合する。"""
+    cols = OWNER_TEXT_FIELDS[owner_type]
+    return "\n".join(fields.get(c) or "" for c in cols)
+
+
+def upsert_citations_for_owner_with_conn(
+    conn: sqlite3.Connection, owner_type: str, owner_id: int, **fields
+) -> int:
+    """add/update 共通: 既存 citations を全削除 → 本文結合 → 再投入。
+
+    本文無変更でも呼ぶことで occurrence の一貫性が保たれる (M#373 §3.4.4)。
+    fields は OWNER_TEXT_FIELDS で定義された名前の部分集合を渡す
+    (未指定キーは空文字扱い)。
+    """
+    _validate_owner_type(owner_type)
+    if owner_type not in OWNER_TEXT_FIELDS:
+        return 0
+    text = _combine_owner_text(owner_type, fields)
+    return _replace_all_with_conn(conn, owner_type, owner_id, text)
+
+
+def _resolve_targets(
+    conn: sqlite3.Connection, pairs: list[tuple[str, int]]
+) -> dict[tuple[str, int], dict]:
+    """(type, id) の集合に対し、現在の DB から title / deleted / retracted を取得する。
+
+    Returns:
+        {(type, id): {"title": str|None, "deleted": bool, "retracted": bool}}
+    """
+    if not pairs:
+        return {}
+    by_type: dict[str, set[int]] = {}
+    for t, i in pairs:
+        by_type.setdefault(t, set()).add(i)
+    out: dict[tuple[str, int], dict] = {}
+    for t, ids in by_type.items():
+        table = TYPE_TO_TABLE[t]
+        title_expr = TYPE_TO_TITLE_EXPR[t]
+        placeholders = ",".join(["?"] * len(ids))
+        has_retract = t in TYPES_WITH_RETRACT
+        retract_expr = "retracted_at" if has_retract else "NULL"
+        query = (
+            f"SELECT id, {title_expr} AS title, {retract_expr} AS retracted_at "
+            f"FROM {table} WHERE id IN ({placeholders})"
+        )
+        found_ids: set[int] = set()
+        for row in conn.execute(query, tuple(ids)):
+            found_ids.add(row["id"])
+            out[(t, row["id"])] = {
+                "title": row["title"],
+                "deleted": False,
+                "retracted": bool(row["retracted_at"]) if has_retract else False,
+            }
+        # 未発見 = 物理削除済
+        for missing in ids - found_ids:
+            out[(t, missing)] = {"title": None, "deleted": True, "retracted": False}
+    return out
+
+
+def get_in_out(owner_type: str, owner_id: int) -> dict:
+    """owner の citations_in / citations_out を DISTINCT で取得する。"""
+    _validate_owner_type(owner_type)
+    with get_connection() as conn:
+        return _get_in_out_with_conn(conn, owner_type, owner_id)
+
+
+def _get_in_out_with_conn(
+    conn: sqlite3.Connection, owner_type: str, owner_id: int
+) -> dict:
+    out_pairs: list[tuple[str, int]] = []
+    for row in conn.execute(
+        "SELECT DISTINCT target_type, target_id FROM citations "
+        "WHERE owner_type = ? AND owner_id = ? "
+        "ORDER BY target_type, target_id",
+        (owner_type, owner_id),
+    ):
+        out_pairs.append((row["target_type"], row["target_id"]))
+    in_pairs: list[tuple[str, int]] = []
+    for row in conn.execute(
+        "SELECT DISTINCT owner_type, owner_id FROM citations "
+        "WHERE target_type = ? AND target_id = ? "
+        "ORDER BY owner_type, owner_id",
+        (owner_type, owner_id),
+    ):
+        in_pairs.append((row["owner_type"], row["owner_id"]))
+    resolved_out = _resolve_targets(conn, out_pairs)
+    resolved_in = _resolve_targets(conn, in_pairs)
+    return {
+        "out": [_format_in_out_entry(t, i, resolved_out[(t, i)]) for t, i in out_pairs],
+        "in": [_format_in_out_entry(t, i, resolved_in[(t, i)]) for t, i in in_pairs],
+    }
+
+
+def _format_in_out_entry(entity_type: str, entity_id: int, meta: dict) -> dict:
+    entry: dict = {
+        "type": entity_type,
+        "id": entity_id,
+        "title": meta["title"],
+    }
+    if meta["deleted"]:
+        entry["deleted"] = True
+    if meta["retracted"]:
+        entry["retracted"] = True
+    return entry

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -2,6 +2,7 @@
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
+from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.tag_service import (
@@ -87,6 +88,11 @@ def add_decisions(items: list[dict]) -> dict:
                 if parsed_tags:
                     tag_ids = ensure_tag_ids(conn, parsed_tags)
                     link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
+
+                # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+                upsert_citations_for_owner_with_conn(
+                    conn, "decision", decision_id, decision=decision, reason=reason
+                )
 
                 # propagate_to 処理
                 propagate_to = item.get("propagate_to")

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -3,6 +3,7 @@ import re
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
+from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.tag_service import (
@@ -91,6 +92,11 @@ def add_logs(items: list[dict]) -> dict:
                 if parsed_tags:
                     tag_ids = ensure_tag_ids(conn, parsed_tags)
                     link_tags(conn, "log_tags", "log_id", log_id, tag_ids)
+
+                # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+                upsert_citations_for_owner_with_conn(
+                    conn, "log", log_id, content=content
+                )
 
                 conn.execute(f"RELEASE SAVEPOINT item_{i}")
                 created.append({

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -6,6 +6,7 @@ from typing import Literal
 from src.db import get_connection, row_to_dict
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
+from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -105,6 +106,11 @@ def add_material(title: str, content: str, tags: list[str], source: str, related
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "material", material_id, related)
+
+        # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+        upsert_citations_for_owner_with_conn(
+            conn, "material", material_id, title=title, content=content
+        )
 
         # タグを取得（commit前）
         tag_strings = get_entity_tags(conn, "material_tags", "material_id", material_id)
@@ -305,6 +311,13 @@ def update_material(
             conn.execute("DELETE FROM material_tags WHERE material_id = ?", (material_id,))
             tag_ids = ensure_tag_ids(conn, parsed_tags)
             link_tags(conn, "material_tags", "material_id", material_id, tag_ids)
+
+        # citations 全削除→再投入 (本文無変更でも実施)
+        new_title = title if title is not None else row["title"]
+        new_content = effective_content if content is not None else row["content"]
+        upsert_citations_for_owner_with_conn(
+            conn, "material", material_id, title=new_title, content=new_content
+        )
 
         conn.commit()
 

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -3,6 +3,7 @@ import re
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
+from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
@@ -179,6 +180,11 @@ def add_topic(
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "topic", topic_id, related)
+
+        # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+        upsert_citations_for_owner_with_conn(
+            conn, "topic", topic_id, title=title, description=description
+        )
 
         conn.commit()
 

--- a/tests/integration/test_citations_service.py
+++ b/tests/integration/test_citations_service.py
@@ -1,0 +1,312 @@
+"""citations_service / citation_renderer の統合テスト
+
+write hook (add_*/update_*) と read tool (get_*) を通した実 DB シナリオ。
+"""
+import os
+import tempfile
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.activity_service import add_activity, update_activity
+from src.services.material_service import add_material, get_material, update_material
+from src.services.decision_service import add_decisions
+from src.services.discussion_log_service import add_logs
+from src.services.topic_service import add_topic
+from src.services.retract_service import retract
+from src.services import citation_renderer
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic_id(temp_db):
+    return add_topic(
+        title="Topic", description="desc", tags=DEFAULT_TAGS,
+    )["topic_id"]
+
+
+@pytest.fixture
+def activity_id(temp_db):
+    return add_activity(
+        title="Test Activity", description="for tests", tags=DEFAULT_TAGS,
+        check_in=False,
+    )["activity_id"]
+
+
+def _citations_rows(owner_type: str, owner_id: int) -> list:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT target_type, target_id, occurrence FROM citations "
+            "WHERE owner_type = ? AND owner_id = ? ORDER BY occurrence",
+            (owner_type, owner_id),
+        ).fetchall()
+        return [tuple(r) for r in rows]
+    finally:
+        conn.close()
+
+
+class TestAddMaterialCitations:
+    def test_add_material_inserts_citation_rows(self, temp_db, activity_id):
+        # target material を1個先に作る
+        target = add_material(
+            title="target", content="body", tags=DEFAULT_TAGS, source="t",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )
+        target_id = target["material_id"]
+        # 本文に cite を含む material を作る
+        m = add_material(
+            title="owner", content=f"see {{{{cite:M#{target_id}}}}} please",
+            tags=DEFAULT_TAGS, source="t",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )
+        owner_id = m["material_id"]
+        assert _citations_rows("material", owner_id) == [("material", target_id, 1)]
+
+    def test_no_cite_no_rows(self, temp_db, activity_id):
+        m = add_material(
+            title="t", content="no cite here", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )
+        assert _citations_rows("material", m["material_id"]) == []
+
+
+class TestUpdateMaterialCitations:
+    def test_update_material_replaces_citations(self, temp_db, activity_id):
+        t1 = add_material(
+            title="t1", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        t2 = add_material(
+            title="t2", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="owner", content=f"cite {{{{cite:M#{t1}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        assert _citations_rows("material", owner) == [("material", t1, 1)]
+        # 本文書き換えで t2 を参照に変更
+        update_material(owner, content=f"now {{{{cite:M#{t2}}}}}")
+        assert _citations_rows("material", owner) == [("material", t2, 1)]
+
+    def test_update_material_title_only_replays(self, temp_db, activity_id):
+        t1 = add_material(
+            title="t1", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="owner", content=f"cite {{{{cite:M#{t1}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        before = _citations_rows("material", owner)
+        update_material(owner, title="new title")
+        after = _citations_rows("material", owner)
+        # 本文無変更でも再投入が走り、参照リストは同等
+        assert before == after
+
+
+class TestUpdateActivityCitations:
+    def test_update_activity_replaces_citations(self, temp_db, activity_id):
+        t1 = add_material(
+            title="t1", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        update_activity(
+            activity_id, description=f"now refer {{{{cite:M#{t1}}}}}",
+        )
+        assert _citations_rows("activity", activity_id) == [("material", t1, 1)]
+
+
+class TestAddDecisionsCitations:
+    def test_decision_cite_inserted(self, temp_db, topic_id, activity_id):
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        res = add_decisions([{
+            "topic_id": topic_id,
+            "decision": f"adopt {{{{cite:M#{t}}}}}",
+            "reason": "based on findings",
+        }])
+        decision_id = res["created"][0]["decision_id"]
+        assert _citations_rows("decision", decision_id) == [("material", t, 1)]
+
+
+class TestAddLogsCitations:
+    def test_log_cite_inserted(self, temp_db, topic_id, activity_id):
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        res = add_logs([{
+            "topic_id": topic_id,
+            "title": "L",
+            "content": f"discussion of {{{{cite:M#{t}}}}}",
+        }])
+        log_id = res["created"][0]["log_id"]
+        assert _citations_rows("log", log_id) == [("material", t, 1)]
+
+
+class TestAddTopicCitations:
+    def test_topic_cite_inserted(self, temp_db, activity_id):
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        new_topic = add_topic(
+            title=f"refer {{{{cite:M#{t}}}}}",
+            description="topic desc",
+            tags=DEFAULT_TAGS,
+        )
+        topic_id = new_topic["topic_id"]
+        assert _citations_rows("topic", topic_id) == [("material", t, 1)]
+
+
+class TestOwnerCascade:
+    def test_owner_delete_cascades_citations(self, temp_db, activity_id):
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="owner", content=f"see {{{{cite:M#{t}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        assert _citations_rows("material", owner) == [("material", t, 1)]
+        # owner を物理削除 → trigger でカスケード削除
+        conn = get_connection()
+        with conn:
+            conn.execute("DELETE FROM materials WHERE id = ?", (owner,))
+        conn.close()
+        assert _citations_rows("material", owner) == []
+
+
+class TestTargetRetractStaysButRendersDangling:
+    def test_target_retract_leaves_citations_row(self, temp_db, topic_id, activity_id):
+        # decision を作って citation の target にする
+        target_dec = add_decisions([{
+            "topic_id": topic_id,
+            "decision": "to be retracted",
+            "reason": "x",
+            "title": "target dec",
+        }])["created"][0]["decision_id"]
+        owner = add_material(
+            title="owner",
+            content=f"adopt {{{{cite:D#{target_dec}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        # target を retract
+        retract("decision", [target_dec])
+        # citations 行は残る
+        assert _citations_rows("material", owner) == [("decision", target_dec, 1)]
+        # renderer で [retracted] 表示
+        from src.services.citation_renderer import expand
+        conn = get_connection()
+        try:
+            out = expand(f"see {{{{cite:D#{target_dec}}}}}", "internal", conn)
+            assert f"[retracted D#{target_dec}]" in out
+        finally:
+            conn.close()
+
+
+class TestGetMaterialFlavor:
+    def test_get_material_internal_default(self, temp_db, activity_id):
+        from src.main import get_material as tool_get_material
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="o", content=f"see {{{{cite:M#{t}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        out = tool_get_material(owner)
+        assert "(M#" + str(t) + ")" in out["content"]
+        assert "citations_in" in out
+        assert "citations_out" in out
+        assert out["citations_out"] == [{"type": "material", "id": t, "title": "t"}]
+
+    def test_get_material_raw(self, temp_db, activity_id):
+        from src.main import get_material as tool_get_material
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="o", content=f"see {{{{cite:M#{t}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        out = tool_get_material(owner, flavor="raw")
+        # raw は無加工
+        assert f"{{{{cite:M#{t}}}}}" in out["content"]
+
+    def test_get_material_readable(self, temp_db, activity_id):
+        from src.main import get_material as tool_get_material
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="o", content=f"see {{{{cite:M#{t}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        out = tool_get_material(owner, flavor="readable")
+        assert "(M#" + str(t) + ")" not in out["content"]
+        assert " t" in out["content"]  # title だけ展開
+
+
+class TestCitationsInOut:
+    def test_distinct_dedupes_multiple_occurrences(self, temp_db, activity_id):
+        t = add_material(
+            title="t", content="b", tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        owner = add_material(
+            title="o",
+            content=f"first {{{{cite:M#{t}}}}} second {{{{cite:M#{t}}}}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        from src.services.citations_service import _get_in_out_with_conn
+        conn = get_connection()
+        try:
+            io = _get_in_out_with_conn(conn, "material", owner)
+        finally:
+            conn.close()
+        # owner 側 citations_out は DISTINCT で 1 件
+        assert io["out"] == [{"type": "material", "id": t, "title": "t"}]
+
+    def test_deleted_target_meta(self, temp_db, activity_id):
+        owner = add_material(
+            title="o", content="see {{cite:M#9999}}",
+            tags=DEFAULT_TAGS, source="x",
+            related=[{"type": "activity", "ids": [activity_id]}],
+        )["material_id"]
+        from src.services.citations_service import _get_in_out_with_conn
+        conn = get_connection()
+        try:
+            io = _get_in_out_with_conn(conn, "material", owner)
+        finally:
+            conn.close()
+        assert io["out"] == [
+            {"type": "material", "id": 9999, "title": None, "deleted": True}
+        ]

--- a/tests/unit/test_citation_renderer.py
+++ b/tests/unit/test_citation_renderer.py
@@ -1,0 +1,135 @@
+"""citation_renderer.expand / adjust_snippet_boundary の単体テスト"""
+import sqlite3
+import pytest
+
+from src.services.citation_renderer import (
+    adjust_snippet_boundary,
+    apply_flavor_to_snippet,
+    expand,
+)
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript(
+        """
+        CREATE TABLE materials (id INTEGER PRIMARY KEY, title TEXT, content TEXT);
+        CREATE TABLE decisions (id INTEGER PRIMARY KEY, decision TEXT, reason TEXT, title TEXT, retracted_at TEXT);
+        CREATE TABLE discussion_logs (id INTEGER PRIMARY KEY, title TEXT, content TEXT, retracted_at TEXT);
+        CREATE TABLE activities (id INTEGER PRIMARY KEY, title TEXT, description TEXT);
+        CREATE TABLE discussion_topics (id INTEGER PRIMARY KEY, title TEXT, description TEXT);
+        CREATE TABLE citations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner_type TEXT, owner_id INTEGER,
+            target_type TEXT, target_id INTEGER,
+            occurrence INTEGER,
+            UNIQUE(owner_type, owner_id, occurrence)
+        );
+        INSERT INTO materials VALUES (1, 'Design v3', 'body');
+        INSERT INTO decisions VALUES (10, 'use SQLite', 'simplicity', NULL, NULL);
+        INSERT INTO decisions VALUES (11, 'old choice', 'reason', NULL, '2026-01-01');
+        INSERT INTO discussion_logs VALUES (100, 'kickoff', 'content here', NULL);
+        INSERT INTO activities VALUES (50, 'sprint plan', 'goals');
+        INSERT INTO discussion_topics VALUES (200, 'main topic', 'description');
+        """
+    )
+    yield c
+    c.close()
+
+
+class TestFlavorExpand:
+    def test_raw_unchanged(self, conn):
+        text = "See {{cite:M#1}} and {{cite:D#10}}."
+        assert expand(text, "raw", conn) == text
+
+    def test_internal_with_id(self, conn):
+        text = "See {{cite:M#1}} and {{cite:D#10}}."
+        out = expand(text, "internal", conn)
+        assert "Design v3 (M#1)" in out
+        assert "use SQLite (D#10)" in out
+
+    def test_readable_no_id(self, conn):
+        text = "See {{cite:M#1}} and {{cite:D#10}}."
+        out = expand(text, "readable", conn)
+        assert "Design v3" in out
+        assert "(M#1)" not in out
+        assert "(D#10)" not in out
+
+    def test_deleted_target_internal(self, conn):
+        out = expand("missing {{cite:M#999}} here", "internal", conn)
+        assert "[deleted M#999]" in out
+
+    def test_deleted_target_readable(self, conn):
+        out = expand("missing {{cite:M#999}} here", "readable", conn)
+        assert "[deleted item]" in out
+
+    def test_retracted_target_internal(self, conn):
+        out = expand("see {{cite:D#11}}.", "internal", conn)
+        assert "[retracted D#11]" in out
+
+    def test_retracted_target_readable(self, conn):
+        out = expand("see {{cite:D#11}}.", "readable", conn)
+        assert "[retracted item]" in out
+
+    def test_un_retract_dynamic(self, conn):
+        # retract → un-retract で通常表示に戻る
+        out1 = expand("{{cite:D#11}}", "internal", conn)
+        assert "[retracted" in out1
+        conn.execute("UPDATE decisions SET retracted_at = NULL WHERE id = 11")
+        out2 = expand("{{cite:D#11}}", "internal", conn)
+        assert "[retracted" not in out2
+        assert "old choice" in out2
+
+    def test_code_block_not_expanded(self, conn):
+        text = "before {{cite:M#1}}\n```\n{{cite:M#1}}\n```\nafter {{cite:M#1}}"
+        out = expand(text, "internal", conn)
+        # 3 つ中、code block 内の 1 つだけ無加工
+        assert out.count("Design v3 (M#1)") == 2
+        assert "{{cite:M#1}}" in out  # 元のまま残る
+
+    def test_escape_not_expanded(self, conn):
+        text = r"escape \{{cite:M#1}} only"
+        out = expand(text, "internal", conn)
+        assert out == text  # 展開しない
+
+    def test_inline_backtick_not_expanded(self, conn):
+        text = "raw `{{cite:M#1}}` and live {{cite:M#1}}"
+        out = expand(text, "internal", conn)
+        assert "`{{cite:M#1}}`" in out
+        assert "Design v3 (M#1)" in out
+
+
+class TestSnippetBoundary:
+    def test_truncated_open_template_at_end(self):
+        s = "before {{cite:M#"
+        assert adjust_snippet_boundary(s) == "before "
+
+    def test_full_template_preserved(self):
+        s = "before {{cite:M#1}} after"
+        assert adjust_snippet_boundary(s) == s
+
+    def test_truncated_close_at_start(self):
+        s = "M#1}} after"
+        assert adjust_snippet_boundary(s) == " after"
+
+    def test_no_templates_unchanged(self):
+        s = "just plain text"
+        assert adjust_snippet_boundary(s) == s
+
+
+class TestApplyFlavorToSnippet:
+    def test_raw_no_change(self, conn):
+        s = "See {{cite:M#1}} ext"
+        assert apply_flavor_to_snippet(s, "raw", conn) == s
+
+    def test_internal_adjusts_and_expands(self, conn):
+        s = "See {{cite:M#1}} ext"
+        out = apply_flavor_to_snippet(s, "internal", conn)
+        assert "Design v3 (M#1)" in out
+
+    def test_truncated_template_dropped(self, conn):
+        s = "See {{cite:M#"
+        out = apply_flavor_to_snippet(s, "internal", conn)
+        assert out == "See "

--- a/tests/unit/test_citation_renderer.py
+++ b/tests/unit/test_citation_renderer.py
@@ -100,6 +100,11 @@ class TestFlavorExpand:
         assert "`{{cite:M#1}}`" in out
         assert "Design v3 (M#1)" in out
 
+    def test_none_input_returns_empty_string(self, conn):
+        assert expand(None, "internal", conn) == ""
+        assert expand(None, "readable", conn) == ""
+        assert expand(None, "raw", conn) == ""
+
 
 class TestSnippetBoundary:
     def test_truncated_open_template_at_end(self):
@@ -133,3 +138,8 @@ class TestApplyFlavorToSnippet:
         s = "See {{cite:M#"
         out = apply_flavor_to_snippet(s, "internal", conn)
         assert out == "See "
+
+    def test_none_input_returns_empty_string(self, conn):
+        assert apply_flavor_to_snippet(None, "internal", conn) == ""
+        assert apply_flavor_to_snippet(None, "readable", conn) == ""
+        assert apply_flavor_to_snippet(None, "raw", conn) == ""

--- a/tests/unit/test_citations_parser.py
+++ b/tests/unit/test_citations_parser.py
@@ -1,0 +1,85 @@
+"""citations_service.extract_citations のパーサ単体テスト"""
+import pytest
+
+from src.services.citations_service import extract_citations
+
+
+class TestBasicParse:
+    def test_single_material_cite(self):
+        assert extract_citations("See {{cite:M#239}}.") == [("material", 239)]
+
+    def test_all_five_type_codes(self):
+        text = "{{cite:M#1}} {{cite:D#2}} {{cite:L#3}} {{cite:A#4}} {{cite:T#5}}"
+        assert extract_citations(text) == [
+            ("material", 1),
+            ("decision", 2),
+            ("log", 3),
+            ("activity", 4),
+            ("topic", 5),
+        ]
+
+    def test_occurrence_preserved_in_order(self):
+        text = "{{cite:M#1}} ... {{cite:D#2}} ... {{cite:M#1}}"
+        assert extract_citations(text) == [
+            ("material", 1),
+            ("decision", 2),
+            ("material", 1),
+        ]
+
+    def test_no_citations(self):
+        assert extract_citations("plain text without cites") == []
+
+    def test_empty_string(self):
+        assert extract_citations("") == []
+
+
+class TestInvalidForms:
+    def test_unknown_type_code_skipped(self, caplog):
+        # `Z` は invalid type code: 正規表現にマッチしないため警告は malformed として記録される
+        result = extract_citations("{{cite:Z#1}}")
+        assert result == []
+
+    def test_missing_id_skipped(self, caplog):
+        result = extract_citations("{{cite:M#}}")
+        assert result == []
+
+    def test_random_garbage_skipped(self, caplog):
+        result = extract_citations("{{cite:foo}}")
+        assert result == []
+
+    def test_valid_cite_after_invalid_still_parsed(self):
+        result = extract_citations("{{cite:foo}} then {{cite:M#5}}")
+        assert result == [("material", 5)]
+
+
+class TestEscapeAndCode:
+    def test_backslash_escape_skips(self):
+        assert extract_citations(r"\{{cite:M#1}}") == []
+
+    def test_inline_backtick_skips(self):
+        assert extract_citations("see `{{cite:M#1}}` raw") == []
+
+    def test_inline_backtick_does_not_swallow_after_close(self):
+        assert extract_citations("see `inline` then {{cite:M#1}}") == [("material", 1)]
+
+    def test_fenced_code_block_skips(self):
+        text = "intro\n```\n{{cite:M#99}}\n```\nafter {{cite:D#1}}"
+        assert extract_citations(text) == [("decision", 1)]
+
+    def test_tilde_fence_skips(self):
+        text = "intro\n~~~\n{{cite:M#99}}\n~~~\nafter"
+        assert extract_citations(text) == []
+
+
+class TestEdgeCases:
+    def test_same_target_twice_two_occurrences(self):
+        text = "{{cite:M#7}} and again {{cite:M#7}}"
+        assert extract_citations(text) == [("material", 7), ("material", 7)]
+
+    def test_large_id_allowed(self):
+        assert extract_citations("{{cite:M#9999999}}") == [("material", 9999999)]
+
+    def test_no_whitespace_in_template(self):
+        # 仕様: 空白を含めない厳密マッチング (M#348 §3.1)
+        assert extract_citations("{{cite: M#1}}") == []
+        assert extract_citations("{{ cite:M#1}}") == []


### PR DESCRIPTION
## Summary

- 本文中の `{{cite:X#NNN}}` (X = M/D/L/A/T) を `citations` テーブルに owner→target 構造で保存する。書き込み (`add_*` / `update_*`) は本文 UPDATE と同一 tx 内に DELETE→INSERT する。
- 全 read tool に `flavor: Literal["raw","internal","readable"] = "internal"` を追加し、`raw` は無加工、`internal` は `<title> (X#NNN)`、`readable` は `<title>` 形式で展開する。物理削除は `[deleted ...]`、retract は `[retracted ...]` で表現する。
- `get_by_ids` / `get_material` 等のレスポンスに `citations_in` / `citations_out` を DISTINCT で添える。dangling target は `deleted: true` / `retracted: true` メタフィールドで識別可能。
- `search` / `check_in` / `get_timeline` の snippet は、raw 段階でテンプレ境界を調整してから flavor 展開する順序にする。

## 何が変わるか

- 本文に `{{cite:M#239}}` と書くと、`get_material(...)` で既定 `internal` 経路では `Design v3 (M#239)` のように展開された文字列が返る。AI エージェントは展開後の文字列を見るだけで、ID も追従もできる。
- 削除されたり取り消されたりした参照先は `[deleted ...]` / `[retracted ...]` に置換されるため、本文中で生 ID をハードコードする場合と違って、参照先の状態に追従できる。
- これまで `get_material(...)` の `content` フィールドは生本文だったが、本変更後は `flavor=raw` を明示しない限り展開後の文字列になる。バックワード互換が必要な経路は `flavor="raw"` を指定する。

## 既存 caller への影響

`{{cite:...}}` 構文は今回新規。過去資産の生 `M#NNN` リテラルは本変更ではパースしないため、既存テスト・ドキュメントの記述には影響しない。読み出し系の関数シグネチャは `flavor` パラメータが optional default で追加されたのみ。

## Test plan

- [x] 全 read tool に `flavor` 引数追加、既定 `internal` で既存テスト 2018 件 green
- [x] `raw` / `internal` / `readable` の展開フォーマット (タイトル形式 / `[deleted]` / `[retracted]`) を unit test で検証
- [x] パーサのコードブロック / `\\{{...}}` エスケープ / 不正形式 warning 動作を unit test で検証
- [x] `add_material` / `update_material` / `add_decisions` / `add_logs` / `add_activity` / `update_activity` / `add_topic` の write 経路で citations が連番 INSERT される integration test
- [x] update 時に既存 citations が同一 tx 内で全削除→再投入される integration test (本文無変更ケース含む)
- [x] target retract 後 `[retracted ...]` で展開され、un-retract で通常表示に戻る (動的計算)
- [x] target 物理削除で citations 行残置、owner 物理削除で DB トリガーが cascade 削除
- [x] `get_material` レスポンスに `citations_in` / `citations_out` が DISTINCT で付与され dangling メタが反映される
- [x] snippet で境界に半端に切れたテンプレが安全に除外される

🤖 Generated with [Claude Code](https://claude.com/claude-code)