### PR TITLE
docs: PRマージ後の反映手順に main ブランチ確認ステップを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,11 @@ Conventional Commits形式（scopeなし）。typeは英語、subjectは日本�
 
 cc-memoryはローカルディレクトリをmarketplaceとして登録しており、mainブランチからプラグインキャッシュが生成される。PRマージ後は以下を実行する:
 
+0. **メインディレクトリが main ブランチをホールドしていることを確認**: `cd ~/workspace/cc-memory && git branch --show-current` で `main` を返すこと。別ブランチに居る・別 worktree が main を握っている場合は以下で復旧してから手順 1 へ:
+   - 未コミット変更があれば `git stash push -u -m "wip"` で退避
+   - 別 worktree が main を握っていれば `git worktree remove <path>` で開放
+   - その上で `git checkout main`
+   - 理由: 手順 6 のサーバー起動は cwd 配下のコードで動くため、メインディレクトリが main 以外だとプラグインキャッシュ（main 由来）とサーバー本体（別ブランチ由来）のミスマッチで動作不整合が起きる
 1. `git pull origin main`
 2. マージ済みworktreeを削除: `git worktree remove .trees/<name>`
 3. ローカルブランチを削除: `git branch -D <branch>`


### PR DESCRIPTION
## Summary

PR マージ後の反映手順 (CLAUDE.md / CLAUDE.local.md) に **step 0**「メインディレクトリが main ブランチをホールドしていることを確認」を追加する。

## なぜ要るか

手順 6 のサーバー起動は cwd 配下のコードで動く (`uv run python -m src.main` または `src.launcher`)。メインディレクトリが main 以外のブランチに居る状態で再起動すると、

- **プラグインキャッシュ** (`~/.claude/plugins/cache/claude-code-memory-marketplace/`) は main の SKILL.md / playbook で再生成される
- **MCP サーバー本体** (cwd の Python コード) は別ブランチの ow_service / launcher で動く

両者がミスマッチを起こし、たとえば SKILL.md は queue 脱却後の新真実源モデルなのにサーバー側は queue 運用版のまま、というような不整合が発生する。実際に本日 (2026-06-21) orch t454 セッションで「orch SKILL.md が古い queue 運用版でロードされる」事象がユーザー指摘で発覚した経緯から本修正。

## 復旧手順

step 0 として以下を明示:

- 未コミット変更があれば `git stash push -u -m "wip"` で退避
- 別 worktree が main を握っていれば `git worktree remove <path>` で開放
- その上で `git checkout main`

## Test plan

- [ ] CLAUDE.md / CLAUDE.local.md の step 0 文言を目視確認
- [ ] 次回 PR マージ後の反映手順で step 0 から実行できることを確認