### PR TITLE
docs: PRマージ後反映手順の claude bot レビュー指摘 4 件を反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,15 @@ Conventional Commits形式（scopeなし）。typeは英語、subjectは日本�
 
 cc-memoryはローカルディレクトリをmarketplaceとして登録しており、mainブランチからプラグインキャッシュが生成される。PRマージ後は以下を実行する:
 
-0. **メインディレクトリが main ブランチをホールドしていることを確認**: `cd ~/workspace/cc-memory && git branch --show-current` で `main` を返すこと。別ブランチに居る・別 worktree が main を握っている場合は以下で復旧してから手順 1 へ:
+1. **メインディレクトリが main ブランチをホールドしていることを確認**: プロジェクトルートで `git branch --show-current` が `main` を返すこと。別ブランチに居る・別 worktree が main を握っている場合は以下で復旧してから手順 2 へ:
    - 未コミット変更があれば `git stash push -u -m "wip"` で退避
-   - 別 worktree が main を握っていれば `git worktree remove <path>` で開放
+   - 別 worktree が main を握っていれば `git worktree remove <path>` で開放（対象 worktree に未コミット変更が残っているとコマンドが失敗するため、先に stash / commit してから実行する）
    - その上で `git checkout main`
-   - 理由: 手順 6 のサーバー起動は cwd 配下のコードで動くため、メインディレクトリが main 以外だとプラグインキャッシュ（main 由来）とサーバー本体（別ブランチ由来）のミスマッチで動作不整合が起きる
-1. `git pull origin main`
-2. マージ済みworktreeを削除: `git worktree remove .trees/<name>`
-3. ローカルブランチを削除: `git branch -D <branch>`
-4. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
-5. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
-6. 既存のhttpサーバーを停止・再起動: `lsof -ti :52837 | xargs kill; uv run python -m src.launcher &`
-7. Claude Codeセッションを再起動（個別でOK、全セッション同時に落とす必要なし）
+   - 理由: 手順 7 のサーバー起動は cwd 配下のコードで動くため、メインディレクトリが main 以外だとプラグインキャッシュ（main 由来）とサーバー本体（別ブランチ由来）のミスマッチで動作不整合が起きる
+2. `git pull origin main`
+3. マージ済みworktreeを削除: `git worktree remove .trees/<name>`（対象 worktree に未コミット変更が残っているとコマンドが失敗するため、先に stash / commit してから実行する）
+4. ローカルブランチを削除: `git branch -D <branch>`
+5. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
+6. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
+7. 既存のhttpサーバーを停止・再起動: `lsof -ti :52837 | xargs kill; uv run python -m src.launcher &`
+8. Claude Codeセッションを再起動（個別でOK、全セッション同時に落とす必要なし）


### PR DESCRIPTION
## Summary

PR #416 マージ直後に claude bot から残された 4 件のレビュー指摘を反映する follow-up。CLAUDE.md の「PRマージ後の反映手順」セクションのみを修正する。

## 修正内容

1. **ハードコードパス除去**: `cd ~/workspace/cc-memory && git branch --show-current` を「プロジェクトルートで `git branch --show-current`」に変更。CLAUDE.md はリポジトリにチェックインされる共有ドキュメントなのでマシン固有パスは不適切。
2. **番号付きリスト 0 始まり回避**: 先頭ステップを `0.` から `1.` に変更し、以降の 1〜7 を 2〜8 に繰り上げ。本文中の「手順 6 のサーバー起動」参照も「手順 7」に追従。CommonMark では 0 開始は許容だが GitHub レンダリング差分のリスクを避けるため。
3. **`git worktree remove` 注記追加**: ステップ 1 子要素・ステップ 3 の両出現に「対象 worktree に未コミット変更が残っているとコマンドが失敗するため、先に stash / commit してから実行する」を追記。
4. **CLAUDE.local.md は対象外**: PR #416 説明文 (Test plan) で「CLAUDE.md / CLAUDE.local.md の step 0 文言を目視確認」と記載されていたが、CLAUDE.local.md は `.gitignore` line 60 に列挙されているリポジトリ外ファイル (個別開発者のプライベート設定) のため本 PR の修正対象から除外する。当該 .local 側手順はユーザー側で別途反映する想定。

## Test plan

- [ ] CLAUDE.md の番号付けが 1〜8 で連続することを目視確認
- [ ] ハードコードパス `~/workspace/cc-memory` が CLAUDE.md から消えていることを確認
- [ ] `git worktree remove` の出現 2 箇所いずれにも未コミット変更時の注記が付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)