### PR TITLE
feat: search結果にscore_breakdownとfinal_scoreを別フィールド化

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1162,13 +1162,24 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
     """RRFスコアにrecency boost（指数減衰）を適用する（in-place）。
 
     recency_factor = max(exp(-age_days * RECENCY_DECAY_RATE), RECENCY_DECAY_FLOOR)
-    をスコアに乗算し、スコア降順で再ソートする。
+    を score_breakdown.rrf_normalized に乗算して final_score を確定する。
+    各結果に以下を付与する:
+    - score_breakdown.recency_factor: 適用された減衰係数（created_at取得不可時は1.0）
+    - final_score: rrf_normalized * recency_factor
+    - score: final_score と同値（互換のため残置。Phase Bで削除予定）
+
+    確定後、final_score 降順で再ソートする。
     """
     if not results:
         return
 
     if now is None:
         now = datetime.now(timezone.utc)
+
+    # 初期値: recency_factor=1.0 (created_at取得不可時のデフォルト)
+    for item in results:
+        item.setdefault("score_breakdown", {"fts": 0.0, "vec": 0.0, "tag": 0.0, "rrf_normalized": item.get("score", 0.0)})
+        item["score_breakdown"].setdefault("recency_factor", 1.0)
 
     # typeごとにcreated_atをバッチ取得
     by_type: dict[str, list[dict]] = {}
@@ -1192,10 +1203,18 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
                 created = datetime.fromisoformat(created_str).replace(tzinfo=timezone.utc)
                 age_days = max(0, (now - created).days)
                 recency_factor = max(math.exp(-age_days * RECENCY_DECAY_RATE), RECENCY_DECAY_FLOOR)
-                item["score"] *= recency_factor
+                item["score_breakdown"]["recency_factor"] = recency_factor
 
-    # スコア降順で再ソート
-    results.sort(key=lambda x: x["score"], reverse=True)
+    # final_score = rrf_normalized * recency_factor を確定
+    # TODO(Phase B): 既存 score フィールドは廃止し final_score のみに統一する。
+    for item in results:
+        bd = item["score_breakdown"]
+        final_score = bd["rrf_normalized"] * bd["recency_factor"]
+        item["final_score"] = final_score
+        item["score"] = final_score
+
+    # final_score 降順で再ソート
+    results.sort(key=lambda x: x["final_score"], reverse=True)
 
 
 def _compute_adaptive_weights(fts_count: int, vec_count: int) -> tuple[float, float]:
@@ -1223,58 +1242,65 @@ def _rrf_merge(
     limit: int,
     tag_results: Optional[list[dict]] = None,
 ) -> list[dict]:
-    """RRF（Reciprocal Rank Fusion）でFTS5・ベクトル・タグLIKE結果を統合する。"""
+    """RRF（Reciprocal Rank Fusion）でFTS5・ベクトル・タグLIKE結果を統合する。
+
+    各結果に以下のスコア内訳フィールドを付与する:
+    - score_breakdown.fts: FTS5由来のRRF寄与（生値、正規化前）
+    - score_breakdown.vec: ベクトル由来のRRF寄与（生値、正規化前）
+    - score_breakdown.tag: タグLIKE由来のRRF寄与（生値、正規化前）
+    - score_breakdown.rrf_normalized: 3寄与の合計を理論最大値で割った正規化済みスコア（0〜1）
+
+    recency_factor / final_score は後段の `_apply_recency_boost` で付与される。
+    既存 score フィールドは互換のため最終的な final_score と同値で残置する。
+    """
     scores: dict[tuple, dict] = {}  # key: (type, id)
 
     # Adaptive RRF: ヒット数比率に応じてFTS/ベクトルの重みを動的調整
     w_fts, w_vec = _compute_adaptive_weights(len(fts_results), len(vec_results))
 
-    # FTS5結果にRRFスコアを付与（1始まりランク）
-    for rank, item in enumerate(fts_results, start=1):
+    def _ensure_entry(item: dict) -> dict:
         key = (item["type"], item["id"])
-        scores[key] = {
-            "type": item["type"],
-            "id": item["id"],
-            "title": item["title"],
-            "score": w_fts / (RRF_K + rank),
-        }
-
-    # ベクトル結果のRRFスコアを加算（1始まりランク）
-    for rank, item in enumerate(vec_results, start=1):
-        key = (item["type"], item["id"])
-        vec_score = w_vec / (RRF_K + rank)
-        if key in scores:
-            scores[key]["score"] += vec_score
-        else:
+        if key not in scores:
             scores[key] = {
                 "type": item["type"],
                 "id": item["id"],
                 "title": item["title"],
-                "score": vec_score,
+                "score_breakdown": {"fts": 0.0, "vec": 0.0, "tag": 0.0},
             }
+        return scores[key]
+
+    # FTS5結果にRRFスコアを付与（1始まりランク）
+    for rank, item in enumerate(fts_results, start=1):
+        entry = _ensure_entry(item)
+        entry["score_breakdown"]["fts"] += w_fts / (RRF_K + rank)
+
+    # ベクトル結果のRRFスコアを加算（1始まりランク）
+    for rank, item in enumerate(vec_results, start=1):
+        entry = _ensure_entry(item)
+        entry["score_breakdown"]["vec"] += w_vec / (RRF_K + rank)
 
     # タグLIKE結果のRRFスコアを加算（1始まりランク）
     if tag_results:
         for rank, item in enumerate(tag_results, start=1):
-            key = (item["type"], item["id"])
-            tag_score = RRF_W_TAG / (RRF_K + rank)
-            if key in scores:
-                scores[key]["score"] += tag_score
-            else:
-                scores[key] = {
-                    "type": item["type"],
-                    "id": item["id"],
-                    "title": item["title"],
-                    "score": tag_score,
-                }
+            entry = _ensure_entry(item)
+            entry["score_breakdown"]["tag"] += RRF_W_TAG / (RRF_K + rank)
 
     # 理論最大値で正規化（全ソース1位の場合のスコア）
     max_score = (w_fts + w_vec) / (RRF_K + 1)
     if tag_results:
         max_score += RRF_W_TAG / (RRF_K + 1)
-    if max_score > 0:
-        for item in scores.values():
-            item["score"] = round(item["score"] / max_score, 4)
+    for entry in scores.values():
+        bd = entry["score_breakdown"]
+        raw_sum = bd["fts"] + bd["vec"] + bd["tag"]
+        rrf_normalized = round(raw_sum / max_score, 4) if max_score > 0 else 0.0
+        bd["fts"] = round(bd["fts"], 6)
+        bd["vec"] = round(bd["vec"], 6)
+        bd["tag"] = round(bd["tag"], 6)
+        bd["rrf_normalized"] = rrf_normalized
+        # recency boost 前のスコアを score にセット。
+        # _apply_recency_boost で recency_factor 乗算後に final_score を確定する。
+        # TODO(Phase B): 既存 score フィールドは廃止し final_score のみに統一する。
+        entry["score"] = rrf_normalized
 
     # RRFスコア降順でソートし、上位limit件を返す
     merged = sorted(scores.values(), key=lambda x: x["score"], reverse=True)
@@ -1320,8 +1346,13 @@ def search(
         date_before: 日付フィルタ（以前）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
 
     Returns:
-        検索結果一覧（type, id, title, score, snippet, tags）
-        scoreは0〜1に正規化された関連度スコア（RRF理論最大値基準）。
+        検索結果一覧（type, id, title, score, final_score, score_breakdown, snippet, tags）。
+        final_score は 0〜1 に正規化された関連度スコア（RRF理論最大値基準 × recency減衰）。
+        score_breakdown は以下のサブフィールドを持つ:
+          - fts / vec / tag: 各ソースのRRF生寄与（正規化前、recency適用前）
+          - rrf_normalized: 3寄与の合計を理論最大値で割った正規化済み値（0〜1、recency適用前）
+          - recency_factor: created_atに基づく指数減衰係数（0〜1）
+        既存 score フィールドは互換のため final_score と同値で残置されている（Phase Bで廃止予定）。
         snippetは各typeの対応するソースカラムの先頭200文字（materialはtitle優先表示）。
         tagsはエンティティに紐づくタグ文字列のリスト。
         include_details=Trueの場合、上位DETAILS_MAX_RESULTS件にdetailsが追加される。

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1176,10 +1176,16 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
     if now is None:
         now = datetime.now(timezone.utc)
 
-    # 初期値: recency_factor=1.0 (created_at取得不可時のデフォルト)
+    # 初期値: score_breakdown が無い場合は score を rrf_normalized 相当として扱い、
+    # recency_factor=1.0 で初期化。score_breakdown はあるが個別キーが欠ける場合も
+    # 各キーを setdefault で補完する（_rrf_merge 経由なら既に全キー揃っている）。
     for item in results:
-        item.setdefault("score_breakdown", {"fts": 0.0, "vec": 0.0, "tag": 0.0, "rrf_normalized": item.get("score", 0.0)})
-        item["score_breakdown"].setdefault("recency_factor", 1.0)
+        bd = item.setdefault("score_breakdown", {})
+        bd.setdefault("fts", 0.0)
+        bd.setdefault("vec", 0.0)
+        bd.setdefault("tag", 0.0)
+        bd.setdefault("rrf_normalized", item.get("score", 0.0))
+        bd.setdefault("recency_factor", 1.0)
 
     # typeごとにcreated_atをバッチ取得
     by_type: dict[str, list[dict]] = {}
@@ -1245,13 +1251,21 @@ def _rrf_merge(
     """RRF（Reciprocal Rank Fusion）でFTS5・ベクトル・タグLIKE結果を統合する。
 
     各結果に以下のスコア内訳フィールドを付与する:
-    - score_breakdown.fts: FTS5由来のRRF寄与（生値、正規化前）
-    - score_breakdown.vec: ベクトル由来のRRF寄与（生値、正規化前）
-    - score_breakdown.tag: タグLIKE由来のRRF寄与（生値、正規化前）
+    - score_breakdown.fts: FTS5由来のRRF寄与（Adaptive RRF重み w_fts 適用後、理論最大値による正規化前）
+    - score_breakdown.vec: ベクトル由来のRRF寄与（Adaptive RRF重み w_vec 適用後、理論最大値による正規化前）
+    - score_breakdown.tag: タグLIKE由来のRRF寄与（RRF_W_TAG 適用後、理論最大値による正規化前）
     - score_breakdown.rrf_normalized: 3寄与の合計を理論最大値で割った正規化済みスコア（0〜1）
+
+    重要: fts/vec の重みは `_compute_adaptive_weights` がヒット数比率で動的に決めるため、
+    同一ランクでも検索ごとに値の絶対値が異なりうる。クロス検索での絶対比較には向かない。
 
     recency_factor / final_score は後段の `_apply_recency_boost` で付与される。
     既存 score フィールドは互換のため最終的な final_score と同値で残置する。
+
+    前提: 各ソース (fts_results / vec_results / tag_results) 内に同一 (type, id) の重複は無い
+    ことを呼出元が保証する。重複があると `+=` により寄与が二重に加算され rrf_normalized が
+    1.0 を超える可能性がある。現状の `_fts_search` / `_vector_search` / `_tag_like_search` は
+    重複を返さない実装になっている。
     """
     scores: dict[tuple, dict] = {}  # key: (type, id)
 
@@ -1291,6 +1305,9 @@ def _rrf_merge(
         max_score += RRF_W_TAG / (RRF_K + 1)
     for entry in scores.values():
         bd = entry["score_breakdown"]
+        # 注: rrf_normalized は丸め前の生 raw_sum から算出する。
+        # 公開フィールド fts/vec/tag は表示用に round(.,6) するため、
+        # それらを足して max_score で割っても rrf_normalized と微小（≤1e-6 程度）にずれる。
         raw_sum = bd["fts"] + bd["vec"] + bd["tag"]
         rrf_normalized = round(raw_sum / max_score, 4) if max_score > 0 else 0.0
         bd["fts"] = round(bd["fts"], 6)

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -599,6 +599,176 @@ def test_recency_boost_cross_type(temp_db):
 
 
 # ========================================
+# score_breakdown / final_score テスト
+# ========================================
+
+
+def test_rrf_merge_attaches_score_breakdown_fields():
+    """_rrf_merge は各結果に score_breakdown を fts/vec/tag/rrf_normalized 付きで付与する"""
+    fts = [{"type": "topic", "id": 1, "title": "A"}]
+    vec = [{"type": "topic", "id": 1, "title": "A"}]
+    tag = [{"type": "topic", "id": 1, "title": "A"}]
+
+    results = _rrf_merge(fts, vec, limit=10, tag_results=tag)
+
+    assert len(results) == 1
+    item = results[0]
+    assert "score_breakdown" in item
+    bd = item["score_breakdown"]
+    assert set(bd.keys()) == {"fts", "vec", "tag", "rrf_normalized"}
+    # 各ソース 1 位ヒットなので寄与値は w_src / (k+1)
+    assert bd["fts"] == pytest.approx(RRF_W_FTS / (RRF_K + 1), abs=1e-6)
+    assert bd["vec"] == pytest.approx(RRF_W_VEC / (RRF_K + 1), abs=1e-6)
+    assert bd["tag"] == pytest.approx(RRF_W_TAG / (RRF_K + 1), abs=1e-6)
+    # 3ソース全1位ヒット → rrf_normalized は 1.0
+    assert bd["rrf_normalized"] == pytest.approx(1.0)
+    # score は recency 未適用時点で rrf_normalized と一致
+    assert item["score"] == pytest.approx(bd["rrf_normalized"])
+
+
+def test_rrf_merge_score_breakdown_fts_only_zero_for_vec_tag():
+    """FTS のみヒット時、vec/tag は 0、fts は正値"""
+    fts = [{"type": "topic", "id": 1, "title": "A"}]
+
+    results = _rrf_merge(fts, [], limit=10)
+
+    bd = results[0]["score_breakdown"]
+    assert bd["fts"] > 0
+    assert bd["vec"] == 0.0
+    assert bd["tag"] == 0.0
+    assert bd["rrf_normalized"] > 0
+
+
+def test_rrf_merge_score_breakdown_sums_to_normalized():
+    """score_breakdown の fts+vec+tag を理論最大値で割ると rrf_normalized になる"""
+    fts = [
+        {"type": "topic", "id": 1, "title": "A"},
+        {"type": "topic", "id": 2, "title": "B"},
+    ]
+    vec = [
+        {"type": "topic", "id": 2, "title": "B"},
+        {"type": "topic", "id": 1, "title": "A"},
+    ]
+
+    results = _rrf_merge(fts, vec, limit=10)
+
+    max_score = (RRF_W_FTS + RRF_W_VEC) / (RRF_K + 1)
+    for item in results:
+        bd = item["score_breakdown"]
+        raw_sum = bd["fts"] + bd["vec"] + bd["tag"]
+        assert bd["rrf_normalized"] == pytest.approx(round(raw_sum / max_score, 4), abs=1e-4)
+
+
+def test_apply_recency_boost_attaches_recency_factor_and_final_score(temp_db):
+    """_apply_recency_boost は score_breakdown.recency_factor と final_score を付与する"""
+    t = add_topic(title="breakdown 検証用", description="テスト", tags=DEFAULT_TAGS)
+
+    # rrf_normalized 0.5 相当の score_breakdown 付き入力
+    results = [
+        {
+            "type": "topic",
+            "id": t["topic_id"],
+            "title": "breakdown 検証用",
+            "score": 0.5,
+            "score_breakdown": {"fts": 0.1, "vec": 0.2, "tag": 0.0, "rrf_normalized": 0.5},
+        }
+    ]
+
+    _apply_recency_boost(results)
+
+    item = results[0]
+    bd = item["score_breakdown"]
+    assert "recency_factor" in bd
+    assert 0 < bd["recency_factor"] <= 1.0
+    assert "final_score" in item
+    assert item["final_score"] == pytest.approx(bd["rrf_normalized"] * bd["recency_factor"])
+    # 互換: score も final_score と同値
+    assert item["score"] == pytest.approx(item["final_score"])
+
+
+def test_apply_recency_boost_recency_factor_floor(temp_db):
+    """非常に古いアイテムの recency_factor は FLOOR で打ち止め"""
+    t = add_topic(title="floor breakdown 検証", description="テスト", tags=DEFAULT_TAGS)
+
+    created_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    now = datetime(2025, 12, 31, 0, 0, 0, tzinfo=timezone.utc)  # 730日後
+    conn = get_connection()
+    conn.execute(
+        "UPDATE discussion_topics SET created_at = ? WHERE id = ?",
+        (created_at.strftime("%Y-%m-%d %H:%M:%S"), t["topic_id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    results = [
+        {
+            "type": "topic",
+            "id": t["topic_id"],
+            "title": "floor breakdown 検証",
+            "score": 1.0,
+            "score_breakdown": {"fts": 1.0, "vec": 0.0, "tag": 0.0, "rrf_normalized": 1.0},
+        }
+    ]
+
+    _apply_recency_boost(results, now=now)
+
+    bd = results[0]["score_breakdown"]
+    assert bd["recency_factor"] == pytest.approx(RECENCY_DECAY_FLOOR)
+    assert results[0]["final_score"] == pytest.approx(1.0 * RECENCY_DECAY_FLOOR)
+
+
+def test_search_returns_score_breakdown_and_final_score(temp_db, mock_embedding_model):
+    """search の各結果に score_breakdown と final_score が含まれる"""
+    add_topic(
+        title="ブレークダウン検索テスト用トピック",
+        description="score_breakdown 検証データ",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="ブレークダウン検索テスト")
+
+    assert "error" not in result
+    assert len(result["results"]) >= 1
+    item = result["results"][0]
+    # 必須フィールド
+    assert "score_breakdown" in item
+    assert "final_score" in item
+    assert "score" in item
+    bd = item["score_breakdown"]
+    for key in ("fts", "vec", "tag", "rrf_normalized", "recency_factor"):
+        assert key in bd, f"score_breakdown に {key} が欠けている"
+    # final_score == rrf_normalized * recency_factor
+    assert item["final_score"] == pytest.approx(bd["rrf_normalized"] * bd["recency_factor"])
+    # 互換: 既存 score フィールドは final_score と同値
+    assert item["score"] == pytest.approx(item["final_score"])
+
+
+def test_search_score_breakdown_values_in_range(temp_db, mock_embedding_model):
+    """score_breakdown の各サブフィールドが妥当な値域に収まる"""
+    add_topic(
+        title="ブレークダウン値域テスト用トピック",
+        description="score_breakdown 値域確認データ",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="ブレークダウン値域テスト")
+
+    assert "error" not in result
+    for item in result["results"]:
+        bd = item["score_breakdown"]
+        # 各ソース寄与は非負
+        assert bd["fts"] >= 0
+        assert bd["vec"] >= 0
+        assert bd["tag"] >= 0
+        # 正規化後は 0〜1
+        assert 0 <= bd["rrf_normalized"] <= 1.0
+        # recency_factor は FLOOR〜1.0
+        assert RECENCY_DECAY_FLOOR <= bd["recency_factor"] <= 1.0
+        # final_score は 0〜1（rrf_normalized * recency_factor、両者とも 0〜1 なので）
+        assert 0 <= item["final_score"] <= 1.0
+
+
+# ========================================
 # recency boost 統合テスト
 # ========================================
 

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -659,6 +659,41 @@ def test_rrf_merge_score_breakdown_sums_to_normalized():
         assert bd["rrf_normalized"] == pytest.approx(round(raw_sum / max_score, 4), abs=1e-4)
 
 
+def test_rrf_merge_score_breakdown_under_adaptive_weights():
+    """Adaptive RRF重み適用ケース (w_fts != w_vec) でも fts/vec/rrf_normalized が整合する"""
+    # fts_count / vec_count = 1/5 = 0.2 → ratio<0.2 ではないが ratio<0.5 なので w=(0.8, 1.2)
+    # ratio<0.2 を狙うため fts=1, vec=10 にする
+    fts = [{"type": "topic", "id": 100, "title": "F"}]
+    vec = [{"type": "topic", "id": i, "title": f"V{i}"} for i in range(1, 11)]
+
+    results = _rrf_merge(fts, vec, limit=20)
+
+    w_fts, w_vec = _compute_adaptive_weights(len(fts), len(vec))
+    # ratio = 0.1 < 0.2 → w_fts=0.5, w_vec=1.5
+    assert (w_fts, w_vec) == (0.5, 1.5)
+    max_score = (w_fts + w_vec) / (RRF_K + 1)
+
+    # id=100 は FTS のみヒット (vec にはなし)、id=1 は vec ランク1のみヒット
+    fts_only = next(r for r in results if r["id"] == 100)
+    vec_top = next(r for r in results if r["id"] == 1)
+
+    bd_f = fts_only["score_breakdown"]
+    bd_v = vec_top["score_breakdown"]
+
+    # 各寄与は Adaptive 重み適用後の値
+    assert bd_f["fts"] == pytest.approx(w_fts / (RRF_K + 1), abs=1e-6)
+    assert bd_f["vec"] == 0.0
+    assert bd_v["fts"] == 0.0
+    assert bd_v["vec"] == pytest.approx(w_vec / (RRF_K + 1), abs=1e-6)
+
+    # rrf_normalized: 各 raw_sum を max_score で割る
+    assert bd_f["rrf_normalized"] == pytest.approx(round((w_fts / (RRF_K + 1)) / max_score, 4), abs=1e-4)
+    assert bd_v["rrf_normalized"] == pytest.approx(round((w_vec / (RRF_K + 1)) / max_score, 4), abs=1e-4)
+
+    # vec_top のほうが上位 (w_vec が大きいため)
+    assert vec_top["score"] > fts_only["score"]
+
+
 def test_apply_recency_boost_attaches_recency_factor_and_final_score(temp_db):
     """_apply_recency_boost は score_breakdown.recency_factor と final_score を付与する"""
     t = add_topic(title="breakdown 検証用", description="テスト", tags=DEFAULT_TAGS)
@@ -684,6 +719,33 @@ def test_apply_recency_boost_attaches_recency_factor_and_final_score(temp_db):
     assert item["final_score"] == pytest.approx(bd["rrf_normalized"] * bd["recency_factor"])
     # 互換: score も final_score と同値
     assert item["score"] == pytest.approx(item["final_score"])
+
+
+def test_apply_recency_boost_fills_missing_score_breakdown_keys(temp_db):
+    """score_breakdown が空dict / 部分dict で渡されても rrf_normalized 等を補完する"""
+    t = add_topic(title="部分breakdown 検証", description="テスト", tags=DEFAULT_TAGS)
+
+    # score_breakdown は空dict（rrf_normalized も欠落）。score=0.3 をフォールバックに使う
+    results = [
+        {
+            "type": "topic",
+            "id": t["topic_id"],
+            "title": "部分breakdown 検証",
+            "score": 0.3,
+            "score_breakdown": {},
+        }
+    ]
+
+    _apply_recency_boost(results)
+
+    bd = results[0]["score_breakdown"]
+    # 欠落キーが全て補完されている
+    assert bd["fts"] == 0.0
+    assert bd["vec"] == 0.0
+    assert bd["tag"] == 0.0
+    assert bd["rrf_normalized"] == pytest.approx(0.3)
+    assert 0 < bd["recency_factor"] <= 1.0
+    assert results[0]["final_score"] == pytest.approx(0.3 * bd["recency_factor"])
 
 
 def test_apply_recency_boost_recency_factor_floor(temp_db):


### PR DESCRIPTION
## 変更内容

検索結果の各エントリに以下のフィールドを追加した。

- `score_breakdown.fts` / `vec` / `tag`: 各ソースのRRF生寄与（正規化前、recency適用前）
- `score_breakdown.rrf_normalized`: 3寄与合計を理論最大値で正規化した0〜1スコア
- `score_breakdown.recency_factor`: 指数減衰係数（古いほど小、FLOORで打ち止め）
- `final_score`: `rrf_normalized × recency_factor`

呼出側がRRFスコア統合の内訳と最終スコアを別々に観測できる。

## 互換性

既存 `score` フィールドは `final_score` と同値で残置している。将来削除する旨を `_rrf_merge` / `_apply_recency_boost` 双方の実装にTODOコメントで残した。

## テスト

`tests/unit/test_hybrid_search.py` に以下を追加。

- `_rrf_merge` が `score_breakdown` を fts/vec/tag/rrf_normalized 付きで付与する
- FTSのみ/3ソース全ヒット/寄与合計が正規化値に一致
- `_apply_recency_boost` が `recency_factor` と `final_score` を付与する
- recency FLOOR が効いている
- `search()` の結果に `score_breakdown` と `final_score` が含まれ値域が妥当

全unit/integrationテスト pass (1573 passed, 1 skipped)。