### PR TITLE
feat: retract時にsearch_index/FTS5/vec_indexから物理削除

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -444,7 +444,6 @@ def search(
     domain: Optional[str] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
-    include_retracted: bool = False,
     flavor: _FlavorArg = "internal",
 ) -> dict:
     """
@@ -471,7 +470,6 @@ def search(
         domain: ドメインフィルタ。内部でtags=["domain:{domain}"]にマージされる
         date_after: 日付フィルタ（以降）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
         date_before: 日付フィルタ（以前）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
-        include_retracted: Trueのとき取り消し済みのdecision/logも含める（デフォルトFalse）
 
     Returns:
         検索結果一覧（type, id, title, score, snippet, tags）
@@ -480,9 +478,13 @@ def search(
         snippetは各typeの対応するソースカラムの先頭200文字（materialはtitle優先表示）。
         tagsはエンティティに紐づくタグ文字列のリスト。
         include_details=Trueの場合、上位10件にdetailsが追加される。
+
+        取り消し済み（retracted）のdecision/logはretract時に物理削除されているため、
+        検索結果には現れない。直接取得したい場合はget_decisions/get_logsで
+        include_retracted=Trueを指定する。
     """
     flavor = _normalize_flavor(flavor)
-    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before, include_retracted=include_retracted)
+    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before)
     if "error" not in result:
         _apply_flavor_to_snippets(result.get("results", []), flavor)
     if "error" not in result and tags:

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -260,6 +260,15 @@ def update_embedding(search_index_id: int, embedding: list[float]) -> None:
         conn.close()
 
 
+def delete_embedding_with_conn(conn, search_index_id: int) -> None:
+    """vec_indexから1行削除する（コミットは呼び出し側の責任）。
+
+    vec0仮想テーブルは外部キー制約を持てないため、search_indexのレコード削除と
+    同じトランザクション内でこの関数を呼び、孤児レコードを残さないようにする。
+    """
+    conn.execute("DELETE FROM vec_index WHERE rowid = ?", (search_index_id,))
+
+
 _ENTITY_TEXT_QUERIES = {
     "topic": (
         "SELECT title, description FROM discussion_topics WHERE id = ?",

--- a/src/services/retract_service.py
+++ b/src/services/retract_service.py
@@ -19,12 +19,23 @@ _SEARCH_INDEX_SOURCE_TYPE = {
     "log": "log",
 }
 
+# FTS5 contentless 'delete' コマンドはインサート時と同じtitle/body値を要求するため、
+# 元テーブルからbodyカラム相当を取り直すクエリ（INSERTトリガーと整合させる必要あり）。
+# - decision: trg_search_decisions_insert → VALUES (last_insert_rowid(), NEW.decision, NEW.reason)
+# - log:      trg_search_logs_insert      → VALUES (last_insert_rowid(), NEW.title, NEW.content)
+_FTS_BODY_QUERY = {
+    "decision": "SELECT reason FROM decisions WHERE id = ?",
+    "log": "SELECT content FROM discussion_logs WHERE id = ?",
+}
+
 
 def _delete_search_index_entry(conn, source_type: str, source_id: int) -> None:
     """search_index / search_index_fts / vec_index から該当エントリを物理削除する。
 
     contentless FTS5は通常のDELETE FROM search_index_fts WHERE ... ができないため、
-    'delete'コマンドINSERTでマーカー消去する必要がある。
+    'delete'コマンドINSERTでマーカー消去する。SQLite公式仕様により、'delete'コマンドには
+    インサート時と同じtitle/body値を渡す必要がある（異なる値を渡すとインデックスが
+    unknown stateになり肥大化・BM25スコア歪みの原因となる）。
 
     エントリが存在しない場合は何もしない（冪等）。
     呼び出し側がトランザクション/SAVEPOINTを管理する。
@@ -39,9 +50,16 @@ def _delete_search_index_entry(conn, source_type: str, source_id: int) -> None:
     search_index_id = row["id"]
     title = row["title"] or ""
 
+    body = ""
+    body_query = _FTS_BODY_QUERY.get(source_type)
+    if body_query:
+        body_row = conn.execute(body_query, (source_id,)).fetchone()
+        if body_row is not None:
+            body = body_row[0] or ""
+
     conn.execute(
-        "INSERT INTO search_index_fts (search_index_fts, rowid, title, body) VALUES ('delete', ?, ?, '')",
-        (search_index_id, title),
+        "INSERT INTO search_index_fts (search_index_fts, rowid, title, body) VALUES ('delete', ?, ?, ?)",
+        (search_index_id, title, body),
     )
     embedding_service.delete_embedding_with_conn(conn, search_index_id)
     conn.execute("DELETE FROM search_index WHERE id = ?", (search_index_id,))

--- a/src/services/retract_service.py
+++ b/src/services/retract_service.py
@@ -4,6 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 
 from src.db import get_connection
+from src.services import embedding_service
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,39 @@ ENTITY_TABLE_MAP = {
     "log": "discussion_logs",
 }
 
+# search_indexのsource_typeとENTITY_TABLE_MAPの対応
+_SEARCH_INDEX_SOURCE_TYPE = {
+    "decision": "decision",
+    "log": "log",
+}
+
+
+def _delete_search_index_entry(conn, source_type: str, source_id: int) -> None:
+    """search_index / search_index_fts / vec_index から該当エントリを物理削除する。
+
+    contentless FTS5は通常のDELETE FROM search_index_fts WHERE ... ができないため、
+    'delete'コマンドINSERTでマーカー消去する必要がある。
+
+    エントリが存在しない場合は何もしない（冪等）。
+    呼び出し側がトランザクション/SAVEPOINTを管理する。
+    """
+    row = conn.execute(
+        "SELECT id, title FROM search_index WHERE source_type = ? AND source_id = ?",
+        (source_type, source_id),
+    ).fetchone()
+    if not row:
+        return
+
+    search_index_id = row["id"]
+    title = row["title"] or ""
+
+    conn.execute(
+        "INSERT INTO search_index_fts (search_index_fts, rowid, title, body) VALUES ('delete', ?, ?, '')",
+        (search_index_id, title),
+    )
+    embedding_service.delete_embedding_with_conn(conn, search_index_id)
+    conn.execute("DELETE FROM search_index WHERE id = ?", (search_index_id,))
+
 
 def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
     """エンティティを取り消し（retract）またはun-retractする。
@@ -19,6 +53,14 @@ def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
     SAVEPOINT方式で各IDを個別処理し、部分成功を許容する。
     冪等: 既にretracted状態でretractしても成功扱い、
     既に非retracted状態でun-retractしても成功扱い。
+
+    retract時はretracted_atをUPDATEした直後に、search_index / search_index_fts /
+    vec_index からも物理削除する（同じSAVEPOINT内）。これによりsearch経路の
+    NOT EXISTS二段フィルタが不要になり、KNNの実効recall劣化も解消する。
+
+    undo時はretracted_atをNULLに戻すのみで、search経路への再登録は行わない。
+    物理削除は不可逆として扱う。un-retractしたエンティティを再び検索可能にしたい
+    場合は、別途add_decisions/add_logsで新規追加する。
 
     Args:
         entity_type: エンティティ種別 ("decision" | "log")
@@ -73,12 +115,15 @@ def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
                             (entity_id,),
                         )
                 else:
-                    # retract: retracted_at IS NULLの場合のみ更新
+                    # retract: retracted_at IS NULLの場合のみ更新 + search index物理削除
                     if row["retracted_at"] is None:
                         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
                         conn.execute(
                             f"UPDATE {table} SET retracted_at = ? WHERE id = ?",
                             (now, entity_id),
+                        )
+                        _delete_search_index_entry(
+                            conn, _SEARCH_INDEX_SOURCE_TYPE[entity_type], entity_id
                         )
 
                 conn.execute(f"RELEASE SAVEPOINT retract_{i}")

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -53,18 +53,6 @@ TAG_LIKE_MAX_TAG_IDS = 100
 # details付与パラメータ
 DETAILS_MAX_RESULTS = 10
 
-# retracted除外フィルタ: search_indexのsource_type='decision'/'log'のみ対象
-# decision/logはretracted_atカラムを持つが、topic/activity/materialは持たない
-RETRACT_FILTER_SQL = """
-  AND NOT EXISTS (
-    SELECT 1 FROM decisions d
-    WHERE d.id = si.source_id AND si.source_type = 'decision' AND d.retracted_at IS NOT NULL
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM discussion_logs dl
-    WHERE dl.id = si.source_id AND si.source_type = 'log' AND dl.retracted_at IS NOT NULL
-  )
-"""
 DETAILS_DESCRIPTION_MAX = 500
 # RRFパラメータ
 RRF_K = 60
@@ -576,14 +564,15 @@ def _fts_search(
     original_keyword_count: Optional[int] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
-    include_retracted: bool = False,
 ) -> list[dict]:
     """FTS5検索。結果はBM25ランク順のリスト。
+
+    retract時にsearch_index/search_index_fts/vec_indexから物理削除されるため、
+    取り消し済みエンティティは検索対象に現れない。
 
     Args:
         keywords: 検索キーワードリスト（QE拡張分を含む場合がある）
         tag_ids: タグフィルタ用のtag_idリスト
-        entity_type: 検索対象の絞り込み
         entity_type: 検索対象の絞り込み
         limit: 取得件数上限
         keyword_mode: キーワード結合モード（"and" / "or"）
@@ -591,7 +580,6 @@ def _fts_search(
             残りをOR追加する（Query Expansion用）。未指定時は従来通り。
         date_after: 日付フィルタ（以降）
         date_before: 日付フィルタ（以前）
-        include_retracted: Trueのとき取り消し済みdecision/logも含める
     """
     # OR時: 3文字以上のキーワードだけでFTS5クエリを組む（2文字はフィルタ除外）
     if keyword_mode == "or":
@@ -623,7 +611,6 @@ def _fts_search(
         date_clauses.append("AND si.created_at <= ?")
         date_params.append(date_before)
     date_sql = "\n          ".join(date_clauses)
-    retract_sql = "" if include_retracted else RETRACT_FILTER_SQL
 
     if tag_ids:
         cte_sql, cte_params = _build_tag_filter_cte(tag_ids)
@@ -639,7 +626,6 @@ def _fts_search(
         WHERE search_index_fts MATCH ?
           AND (? IS NULL OR si.source_type = ?)
           {date_sql}
-          {retract_sql}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -655,7 +641,6 @@ def _fts_search(
         WHERE search_index_fts MATCH ?
           AND (? IS NULL OR si.source_type = ?)
           {date_sql}
-          {retract_sql}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -681,24 +666,13 @@ def _vector_search(
     keyword_mode: str = "and",
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
-    include_retracted: bool = False,
 ) -> Optional[list[dict]]:
-    """ベクトル検索。ベクトル検索無効時はNoneを返す。"""
-    try:
-        # retractフィルタ（search_indexのsiエイリアスを使う版）
-        # _vector_searchではsearch_indexにsiエイリアスがないクエリがあるため、
-        # search_index直接参照版を使う
-        retract_sql_direct = "" if include_retracted else """
-  AND NOT EXISTS (
-    SELECT 1 FROM decisions d
-    WHERE d.id = search_index.source_id AND search_index.source_type = 'decision' AND d.retracted_at IS NOT NULL
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM discussion_logs dl
-    WHERE dl.id = search_index.source_id AND search_index.source_type = 'log' AND dl.retracted_at IS NOT NULL
-  )
-"""
+    """ベクトル検索。ベクトル検索無効時はNoneを返す。
 
+    retract時にvec_indexから物理削除されるため、取り消し済みエンティティは
+    KNNの候補スロットを食わない（KNN実効recall改善）。
+    """
+    try:
         # 日付フィルタの動的WHERE句構築
         date_clauses = []
         date_params_list: list = []
@@ -748,7 +722,6 @@ def _vector_search(
                           AND tf.source_id = search_index.source_id
                       )
                       {date_sql}
-                      {retract_sql_direct}
                     """
                     params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
                 else:
@@ -758,7 +731,6 @@ def _vector_search(
                     WHERE id IN ({rowid_placeholders})
                       AND (? IS NULL OR source_type = ?)
                       {date_sql}
-                      {retract_sql_direct}
                     """
                     params = (*rowids, entity_type, entity_type, *date_params_list)
 
@@ -821,7 +793,6 @@ def _vector_search(
                       AND tf.source_id = search_index.source_id
                   )
                   {date_sql}
-                  {retract_sql_direct}
                 """
                 params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
             else:
@@ -831,7 +802,6 @@ def _vector_search(
                 WHERE id IN ({rowid_placeholders})
                   AND (? IS NULL OR source_type = ?)
                   {date_sql}
-                  {retract_sql_direct}
                 """
                 params = (*rowids, entity_type, entity_type, *date_params_list)
 
@@ -1020,7 +990,6 @@ def _tag_like_search(
     keyword_mode: str = "and",
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
-    include_retracted: bool = False,
 ) -> list[dict]:
     """タグ名のLIKE検索。キーワードにマッチするタグを持つエンティティを返す。
 
@@ -1086,7 +1055,6 @@ def _tag_like_search(
         date_clauses.append("AND si.created_at <= ?")
         date_params_tl.append(date_before)
     date_sql = "\n      ".join(date_clauses)
-    retract_sql = "" if include_retracted else RETRACT_FILTER_SQL
 
     # 各中間テーブルからエンティティを収集（UNION ALL）
     query = f"""
@@ -1095,7 +1063,6 @@ def _tag_like_search(
     WHERE
       (? IS NULL OR si.source_type = ?)
       {date_sql}
-      {retract_sql}
       AND (
         EXISTS (
             SELECT 1 FROM topic_tags tt
@@ -1292,7 +1259,6 @@ def search(
     domain: Optional[str] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
-    include_retracted: bool = False,
 ) -> dict:
     """
     キーワードで横断検索する。
@@ -1453,22 +1419,22 @@ def search(
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before, include_retracted=include_retracted)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
             # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
             if min_len >= 3:
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before, include_retracted=include_retracted)
+                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before)
                 methods_used.append("fts5")
 
         # ベクトル検索（元のキーワードのまま、拡張なし）
-        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted=include_retracted)
+        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
         if vec_results is not None:
             methods_used.append("vector")
 
         # タグLIKE検索（キーワード長の制限なし）
-        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before, include_retracted=include_retracted)
+        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
         if tag_like_results:
             methods_used.append("tag_like")
 
@@ -1523,7 +1489,6 @@ def search(
                 "domain": domain,
                 "date_after": date_after,
                 "date_before": date_before,
-                "include_retracted": include_retracted,
             },
             result_count=total_count,
         )

--- a/tests/unit/test_retract_filter.py
+++ b/tests/unit/test_retract_filter.py
@@ -264,8 +264,8 @@ class TestSearchFilter:
         ids = [(r["type"], r["id_raw"]) for r in search_result.get("results", [])]
         assert ("log", retracted_id) not in ids
 
-    def test_retracted_included_with_flag(self, topic):
-        """include_retracted=Trueでretractされたエンティティが検索結果に含まれる"""
+    def test_retracted_physically_removed_from_search_index(self, topic):
+        """retract時にsearch_index/search_index_fts/vec_indexから物理削除される"""
         from src.services.search_service import search
 
         tid = topic["topic_id"]
@@ -274,8 +274,118 @@ class TestSearchFilter:
         ])
         retracted_id = result["created"][0]["decision_id"]
 
+        # retract前: search_indexにエントリが存在することを確認
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = ?",
+                (retracted_id,),
+            ).fetchone()
+            assert row is not None
+            search_index_id = row["id"]
+        finally:
+            conn.close()
+
         retract("decision", [retracted_id])
 
-        search_result = search("撤回テスト用ユニーク決定DEF", include_retracted=True)
+        # retract後: search_index / search_index_fts / vec_index 全てから消えている
+        conn = get_connection()
+        try:
+            si_row = conn.execute(
+                "SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = ?",
+                (retracted_id,),
+            ).fetchone()
+            assert si_row is None
+
+            vec_row = conn.execute(
+                "SELECT rowid FROM vec_index WHERE rowid = ?",
+                (search_index_id,),
+            ).fetchone()
+            assert vec_row is None
+        finally:
+            conn.close()
+
+        # search経由でもヒットしない（include_retracted は search から撤去済み）
+        search_result = search("撤回テスト用ユニーク決定DEF")
         ids = [(r["type"], r["id_raw"]) for r in search_result.get("results", [])]
-        assert ("decision", retracted_id) in ids
+        assert ("decision", retracted_id) not in ids
+
+    def test_retracted_log_physically_removed_from_search_index(self, topic):
+        """logもretract時にsearch_index/FTS/vec_indexから物理削除される"""
+        from src.services.search_service import search
+
+        tid = topic["topic_id"]
+        result = add_logs([
+            {"topic_id": tid, "content": "物理削除テスト用ユニークログGHI", "title": "物理削除テストGHI"},
+        ])
+        retracted_id = result["created"][0]["log_id"]
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id FROM search_index WHERE source_type = 'log' AND source_id = ?",
+                (retracted_id,),
+            ).fetchone()
+            assert row is not None
+            search_index_id = row["id"]
+        finally:
+            conn.close()
+
+        retract("log", [retracted_id])
+
+        conn = get_connection()
+        try:
+            si_row = conn.execute(
+                "SELECT id FROM search_index WHERE source_type = 'log' AND source_id = ?",
+                (retracted_id,),
+            ).fetchone()
+            assert si_row is None
+
+            vec_row = conn.execute(
+                "SELECT rowid FROM vec_index WHERE rowid = ?",
+                (search_index_id,),
+            ).fetchone()
+            assert vec_row is None
+        finally:
+            conn.close()
+
+        search_result = search("物理削除テストGHI")
+        ids = [(r["type"], r["id_raw"]) for r in search_result.get("results", [])]
+        assert ("log", retracted_id) not in ids
+
+    def test_undo_does_not_reindex(self, topic):
+        """un-retractはretracted_atをNULLに戻すのみで、search経路への再登録は行わない"""
+        from src.services.search_service import search
+
+        tid = topic["topic_id"]
+        result = add_decisions([
+            {"topic_id": tid, "decision": "アンリトラクトテスト用JKL", "reason": "理由"},
+        ])
+        decision_id = result["created"][0]["decision_id"]
+
+        # retract → un-retract
+        retract("decision", [decision_id])
+        retract("decision", [decision_id], undo=True)
+
+        # un-retract後: retracted_at は NULL に戻る
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT retracted_at FROM decisions WHERE id = ?",
+                (decision_id,),
+            ).fetchone()
+            assert row["retracted_at"] is None
+
+            # しかしsearch_indexエントリは復活していない（物理削除は不可逆）
+            si_row = conn.execute(
+                "SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = ?",
+                (decision_id,),
+            ).fetchone()
+            assert si_row is None
+        finally:
+            conn.close()
+
+        # search経由でもヒットしない
+        search_result = search("アンリトラクトテストJKL")
+        ids = [(r["type"], r["id_raw"]) for r in search_result.get("results", [])]
+        assert ("decision", decision_id) not in ids

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -130,7 +130,6 @@ def test_search_records_telemetry_row(temp_db, capture_telemetry_threads):
     assert "domain" in params
     assert "date_after" in params
     assert "date_before" in params
-    assert "include_retracted" in params
     assert "include_details" in params
     assert "tags" in params
     assert row["timestamp"] is not None


### PR DESCRIPTION
## Summary

- retract時に retracted_at UPDATE と同じ SAVEPOINT 内で search_index / search_index_fts / vec_index から物理削除
- search経路の NOT EXISTS 二段フィルタ撤去、include_retracted パラメータも search から撤去
- KNN の実効 recall 劣化を解消（取り消し済みエントリが候補スロットを食わなくなる）

## 変更内容

- `embedding_service.delete_embedding_with_conn(conn, search_index_id)` 追加
- `retract_service._delete_search_index_entry` helper + `retract()` 内で呼出
- `search_service`: `RETRACT_FILTER_SQL` 定数 + `_fts_search` / `_vector_search` / `_tag_like_search` 内の retract_sql / include_retracted パラメータを撤去
- `main.py search()`: include_retracted パラメータ撤去
- 既存 retract テストに物理削除確認 + un-retract再登録なし確認を追加

## 設計判断

物理削除は不可逆として扱う:
- un-retract は retracted_at を NULL に戻すのみで search 経路への再登録は行わない
- get_decisions / get_logs / check_in 等の直接テーブル参照系は include_retracted=True で従来通り取り消し済みを取得可能
- search ツールから include_retracted を撤去（取り消し済みは物理削除されているため意味を持たなくなる）

## Test plan

- [x] unit: tests/unit/test_retract_service.py 12件 + tests/unit/test_retract_filter.py 14件 すべて pass
- [x] フル regression: 1924 passed / 1 skipped
- [ ] CI 緑化確認
- [ ] bot レビュー対応
- [ ] 人間 approve