### PR TITLE
feat: ow worker lifecycle hygiene 改善統合

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -165,11 +165,18 @@ case "$ACTION" in
     fi
     tmux kill-pane -t "$TERM_REF" 2>/dev/null || true
 
-    # 6. 最終確認。pane が消えていれば killed、残っていれば failed。
-    if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
-      echo "killed"
-      exit 0
-    fi
+    # 6. 最終確認。SIGKILL 直後に tmux 内部の pane 消滅処理が完了するまで
+    # 短時間リトライ (default: 0.5s × 2 = 最大 1s)。step 4 と同パラメータ。
+    j=0
+    final_iter=2
+    while [[ $j -lt $final_iter ]]; do
+      if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+        echo "killed"
+        exit 0
+      fi
+      sleep "$FALLBACK_INTERVAL"
+      j=$((j + 1))
+    done
 
     echo "failed" >&2
     echo "failed"

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -126,8 +126,54 @@ case "$ACTION" in
       exit 1
     fi
     TERM_REF="$2"
-    # pane IDでpaneをkill (存在しない場合はエラーを無視)
+    # close 契約: stdout に "closed" / "killed" / "failed" を 1 行返す。
+    # ow_close_worker (src/services/ow_service.py) はこの最終行を読んで
+    # closed/killed bool を組み立てる。
+    #
+    # 環境変数で fallback 待機を調整可能 (テスト・運用調整用):
+    #   OW_CLOSE_FALLBACK_ITER     pane 不在確認のリトライ回数 (default: 6)
+    #   OW_CLOSE_FALLBACK_INTERVAL リトライ間隔の秒数 (default: 0.5)
+    FALLBACK_ITER="${OW_CLOSE_FALLBACK_ITER:-6}"
+    FALLBACK_INTERVAL="${OW_CLOSE_FALLBACK_INTERVAL:-0.5}"
+
+    # 1. pane の生存確認。既に不在ならそのまま closed 扱い。
+    if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+      echo "closed"
+      exit 0
+    fi
+
+    # 2. pane 内 claude の PID を取得 (SIGKILL fallback 用に先に押さえる)。
+    PANE_PID="$(tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null || true)"
+
+    # 3. tmux kill-pane で SIGHUP 経由の正常 close を試みる。
     tmux kill-pane -t "$TERM_REF" 2>/dev/null || true
+
+    # 4. pane 不在になるまで短時間リトライ (default: 0.5s × 6 = 最大 3s)。
+    i=0
+    while [[ $i -lt $FALLBACK_ITER ]]; do
+      if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+        echo "closed"
+        exit 0
+      fi
+      sleep "$FALLBACK_INTERVAL"
+      i=$((i + 1))
+    done
+
+    # 5. SIGKILL fallback: pane 内 PID に直接 SIGKILL を送って再度 kill-pane。
+    if [[ -n "$PANE_PID" ]]; then
+      kill -KILL "$PANE_PID" 2>/dev/null || true
+    fi
+    tmux kill-pane -t "$TERM_REF" 2>/dev/null || true
+
+    # 6. 最終確認。pane が消えていれば killed、残っていれば failed。
+    if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+      echo "killed"
+      exit 0
+    fi
+
+    echo "failed" >&2
+    echo "failed"
+    exit 1
     ;;
 
   *)

--- a/scripts/ow/recv.sh
+++ b/scripts/ow/recv.sh
@@ -43,8 +43,8 @@ cleanup() {
     if [ -n "${CURL_PID:-}" ]; then
         kill "$CURL_PID" 2>/dev/null || true
     fi
-    if [ -n "${FIFO:-}" ] && [ -e "$FIFO" ]; then
-        rm -f "$FIFO"
+    if [ -n "${FIFO_DIR:-}" ] && [ -d "$FIFO_DIR" ]; then
+        rm -rf "$FIFO_DIR"
     fi
     exit 0
 }
@@ -63,8 +63,18 @@ while parent_alive; do
     # SSE は long-poll で意図的に hang させるため curl 自体には max-time を付けない。
     # mkfifo 経由で curl の stdout を python3 の stdin に繋ぐことで、両プロセスを
     # 別々の bg job として起動できる (= 個別 PID を `$!` で取得可能)。
-    FIFO="$(mktemp -u -t ow_recv.XXXXXX)"
-    mkfifo "$FIFO"
+    #
+    # `mktemp -d` で専用ディレクトリを作り、その下に FIFO を mkfifo する。
+    # `mktemp -u` (パス名のみ生成) は TOCTOU 競合があり deprecated 的な用法。
+    # -d はディレクトリ自体を atomic に作成するため安全。
+    FIFO_DIR="$(mktemp -d -t ow_recv.XXXXXX)"
+    FIFO="$FIFO_DIR/fifo"
+    if ! mkfifo "$FIFO" 2>/dev/null; then
+        rm -rf "$FIFO_DIR"
+        unset FIFO_DIR FIFO
+        sleep 1
+        continue
+    fi
 
     curl -sN --get \
         --data-urlencode "channel=${CHANNEL}" \
@@ -94,8 +104,8 @@ while parent_alive; do
     wait "$CURL_PID" 2>/dev/null || true
     unset PIPE_PID CURL_PID
 
-    rm -f "$FIFO"
-    unset FIFO
+    rm -rf "$FIFO_DIR"
+    unset FIFO_DIR FIFO
 
     # SSE 切断後は1秒待ってから再接続を試みる。親死亡なら次の while 条件で抜ける。
     sleep 1

--- a/scripts/ow/recv.sh
+++ b/scripts/ow/recv.sh
@@ -16,8 +16,6 @@
 # (≒ watchdog 機能を壊す)、heartbeat.sh のような「1ショット send + sleep」の
 # 構造とは要件が異なる。pipefail も同様に pipeline 中の curl 失敗を errno 化して
 # しまうため未設定。未定義参照は `${VAR:-}` で個別に防御している。
-# (判断保留: 将来 set -u だけ局所的に有効化する余地はあるが、現状の `${PIPE_PID:-}`
-#  パターンで実害なし。)
 
 RELAY_URL="${RELAY_URL:-http://127.0.0.1:8765}"
 CHANNEL="$1"
@@ -30,22 +28,23 @@ if [ -z "$CHANNEL" ] || [ -z "$HANDLE" ]; then
     exit 1
 fi
 
-# B案: trap でシグナル受信時に pipeline 末尾プロセスを殺してから exit。
-# bg化された後の親 SIGHUP は macOS デフォルトで届かないため A案(PPID watchdog)
-# の補助にすぎないが、claude が正常 exit する SIGTERM 経路には反応する。
+# curl と python3 を mkfifo 経由で個別の bg job として起動することで、
+# curl と python3 双方の PID を `$!` で個別に取得できる。pipeline
+# `curl | python3` だと `$!` は末尾の python3 PID しか取れず、SSE 無音時に
+# curl が SIGPIPE 連鎖死しないケースで孤児として残るリスクが残る (M#412 §B-3)。
 #
-# PIPE_PID は `curl ... | python3 ... &` で取得した `$!` の値で、これは
-# パイプライン末尾の python3 の PID。これを kill すると python3 が死に、
-# 上流の curl は stdout への書き込み時 SIGPIPE で連鎖死する。
-# (TODO: SSE 無音時など stdout に書き込みが起きない状況では curl が孤児として
-#  生き残るリスクがある。根本対策は別 issue 扱い。)
-#
-# exit 0 は HUP/INT/TERM 経由で呼ばれた際の終了コードを明示するためのもの。
-# EXIT 経由では冗長だが、シグナル経路で「子の状態に引きずられない 0 終了」を
-# 確定させる目的で残している。
+# cleanup trap は PIPE_PID (python3) と CURL_PID (curl) の両方を明示 kill し、
+# 名前付きパイプ (FIFO) も削除する。EXIT/HUP/INT/TERM のいずれで起こされても
+# 同じ後始末経路に流れる。
 cleanup() {
     if [ -n "${PIPE_PID:-}" ]; then
         kill "$PIPE_PID" 2>/dev/null || true
+    fi
+    if [ -n "${CURL_PID:-}" ]; then
+        kill "$CURL_PID" 2>/dev/null || true
+    fi
+    if [ -n "${FIFO:-}" ] && [ -e "$FIFO" ]; then
+        rm -f "$FIFO"
     fi
     exit 0
 }
@@ -62,27 +61,41 @@ parent_alive() {
 
 while parent_alive; do
     # SSE は long-poll で意図的に hang させるため curl 自体には max-time を付けない。
-    # 親死亡を素早く検出するために curl を bg で起動し、内側ループで親監視する。
+    # mkfifo 経由で curl の stdout を python3 の stdin に繋ぐことで、両プロセスを
+    # 別々の bg job として起動できる (= 個別 PID を `$!` で取得可能)。
+    FIFO="$(mktemp -u -t ow_recv.XXXXXX)"
+    mkfifo "$FIFO"
+
     curl -sN --get \
         --data-urlencode "channel=${CHANNEL}" \
         --data-urlencode "handle=${HANDLE}" \
         "${RELAY_URL}/stream" \
-        | python3 -u "${SCRIPT_DIR}/recv_filter.py" "${HANDLE}" &
-    # $! はパイプライン末尾 (python3) の PID。これを kill すると python3 が落ち、
-    # 上流の curl は SIGPIPE で連鎖死する想定。変数名 PIPE_PID で意図を明示する。
+        > "$FIFO" &
+    CURL_PID=$!
+
+    python3 -u "${SCRIPT_DIR}/recv_filter.py" "${HANDLE}" < "$FIFO" &
     PIPE_PID=$!
 
     # pipeline 終了 or 親死亡まで待つ。1秒ごとに親監視。
+    # PIPE_PID (python3) 死亡時に CURL_PID も明示的に kill する。
+    # SSE 無音時に curl が SIGPIPE 連鎖死しないケースの保険。
     while kill -0 "$PIPE_PID" 2>/dev/null; do
         if ! parent_alive; then
             kill "$PIPE_PID" 2>/dev/null || true
+            kill "$CURL_PID" 2>/dev/null || true
             wait "$PIPE_PID" 2>/dev/null || true
+            wait "$CURL_PID" 2>/dev/null || true
             exit 0
         fi
         sleep 1
     done
+    kill "$CURL_PID" 2>/dev/null || true
     wait "$PIPE_PID" 2>/dev/null || true
-    unset PIPE_PID
+    wait "$CURL_PID" 2>/dev/null || true
+    unset PIPE_PID CURL_PID
+
+    rm -f "$FIFO"
+    unset FIFO
 
     # SSE 切断後は1秒待ってから再接続を試みる。親死亡なら次の while 条件で抜ける。
     sleep 1

--- a/scripts/ow/recv_filter.py
+++ b/scripts/ow/recv_filter.py
@@ -7,10 +7,40 @@
 
 自分宛（to=自分のhandle）またはbroadcast（to="*"）のメッセージのみ出力する。
 不正なJSON行はスキップ（クラッシュしない）。
+
+envelope schema 検証:
+    - v == 1 必須
+    - kind in ("command", "event") 必須 (旧形式 envelope を drop)
+    - data.type が存在すること
+いずれかを欠く envelope は silent drop する。
+
+task filter (opt-in):
+    環境変数 OW_FILTER_TASK が設定されているとき、`task == OW_FILTER_TASK` を満たす
+    envelope のみ通す。未設定なら無効 (後方互換)。他 task の broadcast event
+    (identity / heartbeat 等) によるコンテキスト汚染を抑止する用途。
+
 python -u + 行ごとflushでMonitorへの遅延なし。
 """
 import json
+import os
 import sys
+
+
+VALID_KINDS = frozenset({"command", "event"})
+
+
+def _is_valid_envelope(body: dict) -> bool:
+    """envelope schema (v / kind / data.type) を検証する。"""
+    if body.get("v") != 1:
+        return False
+    if body.get("kind") not in VALID_KINDS:
+        return False
+    data = body.get("data")
+    if not isinstance(data, dict):
+        return False
+    if not data.get("type"):
+        return False
+    return True
 
 
 def main() -> None:
@@ -19,6 +49,7 @@ def main() -> None:
         sys.exit(1)
 
     my_handle = sys.argv[1]
+    filter_task = os.environ.get("OW_FILTER_TASK") or None
 
     for line in sys.stdin:
         line = line.rstrip("\n")
@@ -28,9 +59,20 @@ def main() -> None:
             msg = json.loads(line[6:])
             body_raw = msg.get("body", "{}")
             body = json.loads(body_raw) if isinstance(body_raw, str) else body_raw
+            if not isinstance(body, dict):
+                continue
+
+            if not _is_valid_envelope(body):
+                continue
+
             to = body.get("to")
-            if to == my_handle or to == "*":
-                print(line, flush=True)
+            if to != my_handle and to != "*":
+                continue
+
+            if filter_task is not None and body.get("task") != filter_task:
+                continue
+
+            print(line, flush=True)
         except (json.JSONDecodeError, TypeError, KeyError):
             continue
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -322,6 +322,42 @@ PHASE_FILEを削除してheartbeatループを終了させる:
 rm /tmp/ow_hb_phase_<alias>
 ```
 
+### Step 6: auto-close（worker 自身による pane/タブ kill）
+
+`event:state(terminated, cause:closed)` または `event:state(terminated, cause:cancelled)` の relay 送信が**完了したあと**、worker は自身の pane/タブを kill して退場する（worker 完結方式）。
+
+kill タイミングは relay POST の**完了後**で固定する。送信前に kill すると process が死んで POST が relay に届かず、orch / dispatcher が `crashed-during-drain` と誤判定するリスクがある。
+
+`cause` 別の対応:
+
+| cause | auto-close 対象 | 理由 |
+|-------|-----------------|------|
+| `closed` | ✅ 対象 | 正常終了（dispatcher の `cmd:close` 受領済み） |
+| `cancelled` | ✅ 対象 | 中断終了（dispatcher の `cmd:cancel` 受領済み） |
+| `dead` | ❌ 対象外 | 起動失敗。人間判断ステージに残す |
+| `crashed` | ❌ 対象外 | reducer 推論のみで本 step を実行する worker は存在しない |
+| `crashed-during-drain` | ❌ 対象外 | 同上 |
+
+起動環境（環境変数）別の経路:
+
+```bash
+if [ -n "${TMUX_PANE:-}" ]; then
+  # 経路 A: tmux pane で起動（通常 worker / 思考 worker tmux new-window 経路）
+  tmux kill-pane -t "$TMUX_PANE"
+elif [ -n "${ITERM_SESSION_ID:-}" ]; then
+  # 経路 B: iTerm2 別タブ（思考 worker iTerm2 経路、暫定）
+  osascript -e 'tell application "iTerm2" to tell current window to close current tab' || true
+else
+  # 経路 C: manual / その他
+  # 環境変数がいずれも未設定なら dispatcher の ow_close_worker による外部 kill にフォールバック
+  :
+fi
+```
+
+注意:
+- 本 step が失敗（pane が消えない）した場合は `ow_close_worker` 側の SIGKILL fallback が二重防御として補完する
+- 経路 B (iTerm2) は思考 worker 別タブ実装方針の確定後に再評価する（tmux 一本化なら削除可）
+
 ## 記録規律（worker専用）
 
 workerは会話相手（ユーザー）がいないため、通常のsync-memoryではなく `worker-sync` スキルの規律に従う:

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -346,7 +346,9 @@ if [ -n "${TMUX_PANE:-}" ]; then
   tmux kill-pane -t "$TMUX_PANE"
 elif [ -n "${ITERM_SESSION_ID:-}" ]; then
   # 経路 B: iTerm2 別タブ（思考 worker iTerm2 経路、暫定）
-  osascript -e 'tell application "iTerm2" to tell current window to close current tab' || true
+  # current tab を狙うとフォアグラウンドが別タブのときに誤って閉じうるため、
+  # ITERM_SESSION_ID で対象タブを特定して閉じる。
+  osascript -e "tell application \"iTerm2\" to tell current window to close (first tab whose current session's unique ID is \"${ITERM_SESSION_ID}\")" || true
 else
   # 経路 C: manual / その他
   # 環境変数がいずれも未設定なら dispatcher の ow_close_worker による外部 kill にフォールバック

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1251,7 +1251,9 @@ def ow_close_worker(term_ref: str) -> dict:
             return {"closed": True, "killed": True, "term_ref": term_ref}
         if last == "closed":
             return {"closed": True, "killed": False, "term_ref": term_ref}
-        return {"closed": True, "term_ref": term_ref}
+        # 旧アダプタ (stdout 空) / manual 経路: killed 不明だが closed 成功扱い。
+        # 呼び出し側が result["killed"] で KeyError にならないよう False を埋める。
+        return {"closed": True, "killed": False, "term_ref": term_ref}
     except subprocess.TimeoutExpired:
         logger.error("ow_close_worker adapter close timed out after 15s")
         return {

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1232,23 +1232,37 @@ def ow_close_worker(term_ref: str) -> dict:
         }
 
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["bash", str(adapter_path), "close", term_ref],
             check=True,
             capture_output=True,
             text=True,
             timeout=15,
         )
+        # tmux.sh は stdout 最終行に "closed" / "killed" のいずれかを返す契約。
+        # 旧アダプタ (stdout 空) や manual 経路は後方互換で closed=True 扱いに倒す。
+        stdout_lines = (result.stdout or "").strip().splitlines()
+        last = stdout_lines[-1] if stdout_lines else ""
+        if last == "killed":
+            logger.warning(
+                "ow_close_worker: pane survived kill-pane, SIGKILL fallback succeeded (term_ref=%s)",
+                term_ref,
+            )
+            return {"closed": True, "killed": True, "term_ref": term_ref}
+        if last == "closed":
+            return {"closed": True, "killed": False, "term_ref": term_ref}
         return {"closed": True, "term_ref": term_ref}
     except subprocess.TimeoutExpired:
         logger.error("ow_close_worker adapter close timed out after 15s")
         return {
+            "closed": False,
             "error": {"code": "ADAPTER_CLOSE_TIMEOUT", "message": "adapter close timed out"},
             "term_ref": term_ref,
         }
     except subprocess.CalledProcessError as e:
         logger.error("ow_close_worker adapter close failed: %s", e.stderr)
         return {
+            "closed": False,
             "error": {"code": "ADAPTER_CLOSE_FAILED", "message": e.stderr},
             "term_ref": term_ref,
         }

--- a/tests/unit/test_ow_recv_filter.py
+++ b/tests/unit/test_ow_recv_filter.py
@@ -5,9 +5,12 @@
 - broadcast（to="*"）→ stdout出力
 - 他者宛 → 出力しない
 - 不正JSON行 → スキップ（クラッシュしない）
+- envelope schema (v / kind / data.type) を欠く → drop
+- OW_FILTER_TASK opt-in: task 不一致 → drop
 """
 import io
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,13 +26,25 @@ def _make_sse_line(body_dict: dict) -> str:
     return f"data: {json.dumps(msg)}"
 
 
-def _run_filter(handle: str, stdin_lines: list[str]) -> list[str]:
+def _valid_envelope(**overrides) -> dict:
+    """envelope schema を満たす最小 body を生成する (v=1 / kind=event / data.type=state)。"""
+    base = {"v": 1, "kind": "event", "to": "orch", "from": "w-a", "data": {"type": "state"}}
+    base.update(overrides)
+    return base
+
+
+def _run_filter(handle: str, stdin_lines: list[str], env: dict | None = None) -> list[str]:
     """recv_filter.pyを実行してstdout行を返す"""
+    run_env = {**os.environ}
+    run_env.pop("OW_FILTER_TASK", None)
+    if env:
+        run_env.update(env)
     result = subprocess.run(
         [sys.executable, str(RECV_FILTER), handle],
         input="\n".join(stdin_lines) + "\n",
         capture_output=True,
         text=True,
+        env=run_env,
     )
     return [line for line in result.stdout.splitlines() if line]
 
@@ -39,20 +54,20 @@ class TestRecvFilterDirect:
 
     def test_outputs_message_addressed_to_me(self):
         """自分宛メッセージ（to=自分のhandle）はstdoutに出力される"""
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"})
+        line = _make_sse_line(_valid_envelope(kind="command", to="orch", data={"type": "assign"}))
         output = _run_filter("orch", [line])
         assert len(output) == 1
         assert "data: " in output[0]
 
     def test_outputs_broadcast_message(self):
         """broadcast（to="*"）はstdoutに出力される"""
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "*", "from": "w-a"})
+        line = _make_sse_line(_valid_envelope(to="*", data={"type": "heartbeat"}))
         output = _run_filter("orch", [line])
         assert len(output) == 1
 
     def test_skips_message_to_others(self):
         """他者宛メッセージはstdoutに出力されない"""
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "w-b", "from": "orch"})
+        line = _make_sse_line(_valid_envelope(to="w-b"))
         output = _run_filter("orch", [line])
         assert len(output) == 0
 
@@ -61,10 +76,9 @@ class TestRecvFilterDirect:
         lines = [
             "data: not-json-at-all",
             "data: {broken",
-            _make_sse_line({"v": 1, "kind": "state", "to": "orch", "from": "w-a"}),
+            _make_sse_line(_valid_envelope()),
         ]
         output = _run_filter("orch", lines)
-        # 有効な1件のみ出力される
         assert len(output) == 1
 
     def test_skips_non_data_lines(self):
@@ -73,7 +87,7 @@ class TestRecvFilterDirect:
             ": ping",
             "",
             "event: message",
-            _make_sse_line({"v": 1, "kind": "state", "to": "orch", "from": "w-a"}),
+            _make_sse_line(_valid_envelope()),
         ]
         output = _run_filter("orch", lines)
         assert len(output) == 1
@@ -81,18 +95,107 @@ class TestRecvFilterDirect:
     def test_handles_multiple_messages(self):
         """複数行が混在する場合、自分宛のみ出力される"""
         lines = [
-            _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"}),  # 自分宛
-            _make_sse_line({"v": 1, "kind": "state", "to": "w-b", "from": "orch"}),  # 他者宛
-            _make_sse_line({"v": 1, "kind": "state", "to": "*", "from": "w-a"}),  # broadcast
+            _make_sse_line(_valid_envelope(kind="command", to="orch", data={"type": "assign"})),
+            _make_sse_line(_valid_envelope(to="w-b")),
+            _make_sse_line(_valid_envelope(to="*", data={"type": "heartbeat"})),
         ]
         output = _run_filter("orch", lines)
         assert len(output) == 2
 
     def test_skips_message_with_no_to_field(self):
         """toフィールドがない場合はスキップ"""
-        line = _make_sse_line({"v": 1, "kind": "cmd", "from": "w-a"})
+        body = _valid_envelope()
+        body.pop("to")
+        line = _make_sse_line(body)
         output = _run_filter("orch", [line])
         assert len(output) == 0
+
+
+class TestRecvFilterSchemaValidation:
+    """envelope schema 検証 (v / kind / data.type)。"""
+
+    def test_drops_envelope_without_v(self):
+        body = _valid_envelope()
+        body.pop("v")
+        output = _run_filter("orch", [_make_sse_line(body)])
+        assert len(output) == 0
+
+    def test_drops_envelope_with_wrong_v(self):
+        output = _run_filter("orch", [_make_sse_line(_valid_envelope(v=2))])
+        assert len(output) == 0
+
+    def test_drops_envelope_with_old_kind_state(self):
+        """kind: 'state' (旧形式) は drop。"""
+        output = _run_filter("orch", [_make_sse_line(_valid_envelope(kind="state"))])
+        assert len(output) == 0
+
+    def test_drops_envelope_with_old_kind_cmd(self):
+        """kind: 'cmd' (略記) は drop ('command' 必須)。"""
+        output = _run_filter("orch", [_make_sse_line(_valid_envelope(kind="cmd"))])
+        assert len(output) == 0
+
+    def test_drops_envelope_without_data_type(self):
+        output = _run_filter("orch", [_make_sse_line(_valid_envelope(data={}))])
+        assert len(output) == 0
+
+    def test_drops_envelope_without_data(self):
+        body = _valid_envelope()
+        body.pop("data")
+        output = _run_filter("orch", [_make_sse_line(body)])
+        assert len(output) == 0
+
+    def test_drops_envelope_with_non_dict_data(self):
+        output = _run_filter("orch", [_make_sse_line(_valid_envelope(data="not-a-dict"))])
+        assert len(output) == 0
+
+    def test_accepts_valid_v1_command(self):
+        body = _valid_envelope(kind="command", data={"type": "assign"})
+        output = _run_filter("orch", [_make_sse_line(body)])
+        assert len(output) == 1
+
+    def test_accepts_valid_v1_event(self):
+        body = _valid_envelope(kind="event", to="*", data={"type": "heartbeat"})
+        output = _run_filter("orch", [_make_sse_line(body)])
+        assert len(output) == 1
+
+
+class TestRecvFilterTaskFilter:
+    """OW_FILTER_TASK opt-in による task filter。"""
+
+    def test_keeps_matching_task(self):
+        body = _valid_envelope(task="T119")
+        output = _run_filter("orch", [_make_sse_line(body)], env={"OW_FILTER_TASK": "T119"})
+        assert len(output) == 1
+
+    def test_drops_non_matching_task(self):
+        body = _valid_envelope(task="T200")
+        output = _run_filter("orch", [_make_sse_line(body)], env={"OW_FILTER_TASK": "T119"})
+        assert len(output) == 0
+
+    def test_drops_other_task_broadcast(self):
+        """他 task の broadcast event (heartbeat 等) を drop。"""
+        body = _valid_envelope(to="*", task="T200", data={"type": "heartbeat"})
+        output = _run_filter("orch", [_make_sse_line(body)], env={"OW_FILTER_TASK": "T119"})
+        assert len(output) == 0
+
+    def test_drops_envelope_without_task_when_filter_set(self):
+        """task フィールド未設定の envelope も OW_FILTER_TASK 指定時は drop。"""
+        body = _valid_envelope()
+        body.pop("task", None)
+        output = _run_filter("orch", [_make_sse_line(body)], env={"OW_FILTER_TASK": "T119"})
+        assert len(output) == 0
+
+    def test_no_filter_when_env_unset(self):
+        """OW_FILTER_TASK 未設定なら task 検証なし (従来挙動)。"""
+        body = _valid_envelope(to="*", task="T200", data={"type": "heartbeat"})
+        output = _run_filter("orch", [_make_sse_line(body)])
+        assert len(output) == 1
+
+    def test_empty_string_filter_is_inactive(self):
+        """OW_FILTER_TASK が空文字列の場合は未指定と同等扱い。"""
+        body = _valid_envelope(to="*", task="T200", data={"type": "heartbeat"})
+        output = _run_filter("orch", [_make_sse_line(body)], env={"OW_FILTER_TASK": ""})
+        assert len(output) == 1
 
 
 class TestRecvFilterModule:
@@ -130,18 +233,18 @@ class TestRecvFilterModule:
         return captured_output
 
     def test_outputs_addressed_to_me(self):
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "orch", "from": "w-a"})
-        output = self._call_filter("orch", [line])
+        body = _valid_envelope(kind="command", to="orch", data={"type": "assign"})
+        output = self._call_filter("orch", [_make_sse_line(body)])
         assert len(output) == 1
 
     def test_outputs_broadcast(self):
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "*", "from": "w-a"})
-        output = self._call_filter("orch", [line])
+        body = _valid_envelope(to="*", data={"type": "heartbeat"})
+        output = self._call_filter("orch", [_make_sse_line(body)])
         assert len(output) == 1
 
     def test_skips_others(self):
-        line = _make_sse_line({"v": 1, "kind": "cmd", "to": "w-b", "from": "orch"})
-        output = self._call_filter("orch", [line])
+        body = _valid_envelope(to="w-b")
+        output = self._call_filter("orch", [_make_sse_line(body)])
         assert len(output) == 0
 
     def test_skips_invalid_json(self):

--- a/tests/unit/test_ow_service_close_worker.py
+++ b/tests/unit/test_ow_service_close_worker.py
@@ -40,11 +40,11 @@ class TestOwCloseWorkerReturnContract:
             result = ow_service.ow_close_worker(term_ref="%42")
         assert result == {"closed": True, "killed": True, "term_ref": "%42"}
 
-    def test_returns_closed_true_when_stdout_empty_legacy_adapter(self, force_tmux_terminal):
-        """旧アダプタ (stdout 空) は後方互換で closed=True を返す。"""
+    def test_returns_closed_true_killed_false_when_stdout_empty_legacy(self, force_tmux_terminal):
+        """旧アダプタ (stdout 空) は後方互換で closed=True、killed=False (キー欠如しない)。"""
         with patch("src.services.ow_service.subprocess.run", side_effect=_fake_run_factory("")):
             result = ow_service.ow_close_worker(term_ref="%42")
-        assert result == {"closed": True, "term_ref": "%42"}
+        assert result == {"closed": True, "killed": False, "term_ref": "%42"}
 
     def test_returns_closed_false_on_called_process_error(self, force_tmux_terminal):
         """adapter exit 1 (failed) では closed=False と error を返す。"""

--- a/tests/unit/test_ow_service_close_worker.py
+++ b/tests/unit/test_ow_service_close_worker.py
@@ -1,0 +1,79 @@
+"""ow_close_worker の戻り値契約テスト
+
+tmux アダプタが返す stdout (closed / killed / failed) を読み取り、
+戻り値の closed / killed bool を組み立てる契約を回帰テストする。
+"""
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.services import ow_service
+
+
+@pytest.fixture
+def force_tmux_terminal(monkeypatch):
+    """OW_TERMINAL=tmux + 実在するアダプタパスにフォールバックする。"""
+    monkeypatch.setenv("OW_TERMINAL", "tmux")
+    # adapter_path 解決が成功する必要があるが、subprocess.run はモックするので
+    # 実行はされない。実在パスを返せばよい。
+    yield
+
+
+def _fake_run_factory(stdout: str, returncode: int = 0, stderr: str = ""):
+    def _fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0] if args else [], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+    return _fake_run
+
+
+class TestOwCloseWorkerReturnContract:
+    def test_returns_closed_true_killed_false_on_closed_stdout(self, force_tmux_terminal):
+        with patch("src.services.ow_service.subprocess.run", side_effect=_fake_run_factory("closed\n")):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result == {"closed": True, "killed": False, "term_ref": "%42"}
+
+    def test_returns_closed_true_killed_true_on_killed_stdout(self, force_tmux_terminal):
+        with patch("src.services.ow_service.subprocess.run", side_effect=_fake_run_factory("killed\n")):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result == {"closed": True, "killed": True, "term_ref": "%42"}
+
+    def test_returns_closed_true_when_stdout_empty_legacy_adapter(self, force_tmux_terminal):
+        """旧アダプタ (stdout 空) は後方互換で closed=True を返す。"""
+        with patch("src.services.ow_service.subprocess.run", side_effect=_fake_run_factory("")):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result == {"closed": True, "term_ref": "%42"}
+
+    def test_returns_closed_false_on_called_process_error(self, force_tmux_terminal):
+        """adapter exit 1 (failed) では closed=False と error を返す。"""
+        err = subprocess.CalledProcessError(returncode=1, cmd=["bash"], stderr="failed\n")
+
+        def _raise(*args, **kwargs):
+            raise err
+
+        with patch("src.services.ow_service.subprocess.run", side_effect=_raise):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result["closed"] is False
+        assert result["term_ref"] == "%42"
+        assert result["error"]["code"] == "ADAPTER_CLOSE_FAILED"
+
+    def test_returns_closed_false_on_timeout(self, force_tmux_terminal):
+        def _timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["bash"], timeout=15)
+
+        with patch("src.services.ow_service.subprocess.run", side_effect=_timeout):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result["closed"] is False
+        assert result["term_ref"] == "%42"
+        assert result["error"]["code"] == "ADAPTER_CLOSE_TIMEOUT"
+
+    def test_uses_last_stdout_line(self, force_tmux_terminal):
+        """stdout に複数行ある場合は最終行を判定に使う。"""
+        with patch(
+            "src.services.ow_service.subprocess.run",
+            side_effect=_fake_run_factory("warning: something\nkilled\n"),
+        ):
+            result = ow_service.ow_close_worker(term_ref="%42")
+        assert result == {"closed": True, "killed": True, "term_ref": "%42"}

--- a/tests/unit/test_recv_sh.py
+++ b/tests/unit/test_recv_sh.py
@@ -1,7 +1,7 @@
 """recv.sh のユニットテスト
 
 scripts/ow/recv.sh が OW_PARENT_PID 監視で親プロセス死亡時に自動 exit すること、
-trap で curl 子プロセスを掃除すること、構文が正しいことを検証する。
+trap で curl + python3 子プロセスを両方掃除すること、構文が正しいことを検証する。
 """
 
 import os
@@ -16,6 +16,44 @@ import pytest
 SCRIPT_PATH = (
     Path(__file__).parent.parent.parent / "scripts" / "ow" / "recv.sh"
 )
+
+
+def _list_descendants(root_pid: int) -> list[tuple[int, str]]:
+    """root_pid 配下のすべての子孫プロセス (PID, comm) を返す。"""
+    result = subprocess.run(
+        ["ps", "-eo", "pid=,ppid=,comm="],
+        capture_output=True,
+        text=True,
+    )
+    parents: dict[int, list[tuple[int, str]]] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        comm = parts[2]
+        parents.setdefault(ppid, []).append((pid, comm))
+
+    out: list[tuple[int, str]] = []
+    stack = [root_pid]
+    while stack:
+        cur = stack.pop()
+        for child_pid, child_comm in parents.get(cur, []):
+            out.append((child_pid, child_comm))
+            stack.append(child_pid)
+    return out
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
 
 
 class _StreamRelayHandler(BaseHTTPRequestHandler):
@@ -138,11 +176,7 @@ class TestRecvShTrap:
     """B案: trap EXIT で pipeline 子プロセス (python3 + curl) が掃除される"""
 
     def test_pipe_killed_on_sigterm(self, mock_stream_relay):
-        """SIGTERM で recv.sh が exit する (pipeline 末尾 python3 を kill → curl は SIGPIPE 連鎖死)
-
-        TODO: curl 自体のPID追跡アサーションは未実装。SSE 無音時に curl が
-        孤児として残るリスクは別 issue 扱い。
-        """
+        """SIGTERM で recv.sh が exit し、curl と python3 が両方とも消える。"""
         _server, relay_url = mock_stream_relay
 
         env = {
@@ -172,6 +206,110 @@ class TestRecvShTrap:
             exited = False
 
         assert exited, "SIGTERM で recv.sh が exit しなかった"
+
+
+class TestRecvShCurlPid:
+    """curl 子プロセスの個別 PID 追跡 + cleanup 経路で両方 kill される"""
+
+    def _wait_for_children(
+        self, pid: int, expected_names: tuple[str, ...], timeout: float = 3.0
+    ) -> list[tuple[int, str]]:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            children = _list_descendants(pid)
+            if all(
+                any(name in comm for _, comm in children) for name in expected_names
+            ):
+                return children
+            time.sleep(0.1)
+        return _list_descendants(pid)
+
+    def test_curl_and_python_die_on_sigterm(self, mock_stream_relay):
+        """SIGTERM 後、curl と python3 (PIPE_PID) の両方が cleanup trap で kill される。
+
+        旧 pipeline 実装では PIPE_PID = python3 PID のみで curl は SIGPIPE 連鎖死に
+        依存していたが、SSE 無音時には連鎖死しない。mkfifo + 個別 bg job で curl PID
+        を追跡し、cleanup trap で明示 kill する設計の回帰テスト。
+        """
+        _server, relay_url = mock_stream_relay
+
+        env = {**os.environ, "RELAY_URL": relay_url}
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_CURL", "w-curl"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        try:
+            # SSE接続確立 + curl/python3 起動を待つ
+            children = self._wait_for_children(proc.pid, ("curl", "python"))
+            assert proc.poll() is None
+            curl_pids = [pid for pid, comm in children if "curl" in comm]
+            py_pids = [pid for pid, comm in children if "python" in comm]
+            assert curl_pids, (
+                f"curl が子孫プロセスに存在しない (mkfifo 経由 bg 起動の確認)\n"
+                f"children: {children}"
+            )
+            assert py_pids, f"python3 が子孫プロセスに存在しない\nchildren: {children}"
+
+            # SIGTERM → trap cleanup → 両方とも消える
+            proc.terminate()
+            proc.wait(timeout=5)
+
+            time.sleep(0.5)
+            for pid in curl_pids + py_pids:
+                assert not _pid_alive(pid), f"PID {pid} が cleanup 後も残存"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_curl_dies_when_parent_dies(self, mock_stream_relay):
+        """OW_PARENT_PID で指定した親が死ぬと curl も python3 も消える。"""
+        _server, relay_url = mock_stream_relay
+
+        parent = subprocess.Popen(["sleep", "30"])
+        try:
+            env = {
+                **os.environ,
+                "RELAY_URL": relay_url,
+                "OW_PARENT_PID": str(parent.pid),
+            }
+
+            proc = subprocess.Popen(
+                ["bash", str(SCRIPT_PATH), "CH_PWCURL", "w-pwcurl"],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            try:
+                children = self._wait_for_children(proc.pid, ("curl", "python"))
+                assert proc.poll() is None
+                curl_pids = [pid for pid, comm in children if "curl" in comm]
+                py_pids = [pid for pid, comm in children if "python" in comm]
+                assert curl_pids and py_pids
+
+                parent.kill()
+                parent.wait()
+
+                proc.wait(timeout=5)
+
+                time.sleep(0.5)
+                for pid in curl_pids + py_pids:
+                    assert not _pid_alive(pid), (
+                        f"PID {pid} が親死亡後 cleanup で消えていない"
+                    )
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait()
+        finally:
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait()
 
 
 class TestRecvShUsage:

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -18,14 +18,18 @@ def _make_mock_tmux(
     kill_pane_exit: int = 0,
     target_pane_exists: bool = True,
     existing_worker_panes: str = "",
+    display_switch_at_kill: int | None = None,
 ) -> Path:
     """tmuxをモックするシェルスクリプトを作成する。
 
-    spawn時はMOCK_PANE_IDを返す。close時は何も出力しない。
+    spawn時はMOCK_PANE_IDを返す。close時はpane_pid相当のダミー値を返す。
     capture_fileが指定された場合、受け取った引数を追記する。
     kill_pane_exitが1の場合、kill-paneが失敗するモックになる。
 
     target_pane_exists=Falseのとき `tmux display` がexit 1を返す（target_pane不在シミュレーション）。
+    display_switch_at_kill=N のとき、N回目以降の kill-pane 呼び出し後に display が
+    「不在」(exit 1) に切り替わる（SIGKILL fallback シナリオの再現用）。
+
     existing_worker_panesは `tmux list-panes -F "#{pane_id}|#{@ow-worker}"` の擬似出力。
     例: "%5|1\\n%7|" を渡すと既存worker paneが1個ある状態を模擬する（"1"がworkerマーカー、空欄が非worker）。
     """
@@ -35,8 +39,11 @@ def _make_mock_tmux(
 
     has_session_exit = "0" if has_session else "1"
     capture_cmd = f'printf "%s\\n" "$*" >> "{capture_file}"' if capture_file else ""
-    display_exit = "0" if target_pane_exists else "1"
-    display_out = '"@1"' if target_pane_exists else '""'
+    display_state_file = tmp_path / "tmux_display_state"
+    kill_counter_file = tmp_path / "tmux_kill_counter"
+    display_state_file.write_text("1" if target_pane_exists else "0")
+    kill_counter_file.write_text("0")
+    switch_at = "" if display_switch_at_kill is None else str(display_switch_at_kill)
 
     mock.write_text(
         f'#!/usr/bin/env bash\n'
@@ -44,8 +51,22 @@ def _make_mock_tmux(
         f'if [ "$1" = "has-session" ]; then exit {has_session_exit}; fi\n'
         f'if [ "$1" = "new-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
         f'if [ "$1" = "split-window" ]; then echo "{MOCK_PANE_ID}"; fi\n'
-        f'if [ "$1" = "kill-pane" ]; then exit {kill_pane_exit}; fi\n'
-        f'if [ "$1" = "display" ]; then echo {display_out}; exit {display_exit}; fi\n'
+        f'if [ "$1" = "kill-pane" ]; then\n'
+        f'  cnt=$(cat "{kill_counter_file}" 2>/dev/null || echo 0)\n'
+        f'  cnt=$((cnt + 1))\n'
+        f'  echo "$cnt" > "{kill_counter_file}"\n'
+        f'  switch_at="{switch_at}"\n'
+        f'  if [ -n "$switch_at" ] && [ "$cnt" -ge "$switch_at" ]; then\n'
+        f'    echo "0" > "{display_state_file}"\n'
+        f'  fi\n'
+        f'  exit {kill_pane_exit}\n'
+        f'fi\n'
+        f'if [ "$1" = "display" ]; then\n'
+        f'  state=$(cat "{display_state_file}" 2>/dev/null || echo "1")\n'
+        f'  if [ "$state" = "0" ]; then exit 1; fi\n'
+        f'  echo "12345"\n'
+        f'  exit 0\n'
+        f'fi\n'
         f'if [ "$1" = "list-panes" ]; then printf "%b\\n" "{existing_worker_panes}"; fi\n'
         f'exit 0\n'
     )
@@ -53,10 +74,16 @@ def _make_mock_tmux(
     return mock_dir
 
 
-def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple["subprocess.CompletedProcess[str]", str]:
+def _run_adapter(
+    args: list[str],
+    tmp_path: Path,
+    extra_env: dict | None = None,
+    **mock_kwargs,
+) -> tuple["subprocess.CompletedProcess[str]", str]:
     """tmux.shをモックtmux環境で実行し、(result, captured_args)を返す。
 
     mock_kwargsはそのまま_make_mock_tmuxに渡す（has_session, kill_pane_exitなど）。
+    extra_env は追加環境変数（OW_CLOSE_FALLBACK_ITER 等）。
     """
     capture_file = tmp_path / "tmux_args.txt"
     capture_file.write_text("")
@@ -64,6 +91,8 @@ def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple["subpr
 
     env = os.environ.copy()
     env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+    if extra_env:
+        env.update(extra_env)
 
     result = subprocess.run(
         [str(ADAPTER)] + args,
@@ -72,6 +101,10 @@ def _run_adapter(args: list[str], tmp_path: Path, **mock_kwargs) -> tuple["subpr
         env=env,
     )
     return result, capture_file.read_text()
+
+
+# テスト全体で close fallback の sleep を 0 にして高速化
+CLOSE_FAST_ENV = {"OW_CLOSE_FALLBACK_INTERVAL": "0", "OW_CLOSE_FALLBACK_ITER": "2"}
 
 
 class TestTmuxAdapterSpawn:
@@ -128,29 +161,68 @@ class TestTmuxAdapterSpawn:
 
 
 class TestTmuxAdapterClose:
-    def test_close_normal_pane_id(self, tmp_path):
-        """%42形式のpane IDでcloseが正常終了する。"""
-        result, captured = _run_adapter(["close", "%42"], tmp_path)
+    def test_close_already_absent_outputs_closed(self, tmp_path):
+        """既に pane が存在しない term_ref を渡すと stdout に 'closed' を出して exit 0。"""
+        result, captured = _run_adapter(
+            ["close", "%999"], tmp_path, target_pane_exists=False
+        )
         assert result.returncode == 0
+        assert result.stdout.strip().splitlines()[-1] == "closed"
+        # 既に不在のため kill-pane は呼ばれない
+        assert "kill-pane" not in captured
+
+    def test_close_kill_pane_succeeds_outputs_closed(self, tmp_path):
+        """kill-pane 後に pane が消えれば stdout 'closed' を出して exit 0。"""
+        # display_switch_at_kill=1: 1回目の kill-pane 後に display が不在に切り替わる
+        result, captured = _run_adapter(
+            ["close", "%42"],
+            tmp_path,
+            display_switch_at_kill=1,
+            extra_env=CLOSE_FAST_ENV,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip().splitlines()[-1] == "closed"
         assert "kill-pane" in captured
 
-    def test_close_pane_id_passed_to_kill(self, tmp_path):
+    def test_close_passes_pane_id_to_kill(self, tmp_path):
         """closeでtmux kill-paneにpane IDが渡される。"""
-        result, captured = _run_adapter(["close", "%99"], tmp_path)
+        result, captured = _run_adapter(
+            ["close", "%99"],
+            tmp_path,
+            display_switch_at_kill=1,
+            extra_env=CLOSE_FAST_ENV,
+        )
         assert result.returncode == 0
         assert "%99" in captured
 
-    def test_close_nonexistent_pane_exits_zero(self, tmp_path):
-        """存在しないpane IDでもcloseはゼロで終了する（エラーを無視）。"""
-        # kill-paneが失敗しても || true で無視するため、exit 0 を期待
-        result, _ = _run_adapter(["close", "%999"], tmp_path)
-        assert result.returncode == 0
 
-    def test_close_pane_kill_failure_still_exits_zero(self, tmp_path):
-        """kill-paneがexit 1を返しても、|| true によりcloseはゼロで終了する。"""
-        # kill_pane_exit=1でkill-paneが常に失敗するモックを使用
-        result, _ = _run_adapter(["close", "%999"], tmp_path, kill_pane_exit=1)
+class TestTmuxAdapterCloseSigkillFallback:
+    """SIGKILL fallback シナリオ — kill-pane が効かなかったときに 2 回目で消える"""
+
+    def test_close_sigkill_fallback_outputs_killed(self, tmp_path):
+        """1回目の kill-pane 後も残存し、SIGKILL fallback (2回目の kill-pane) で消える → 'killed'。"""
+        result, captured = _run_adapter(
+            ["close", "%42"],
+            tmp_path,
+            display_switch_at_kill=2,
+            extra_env=CLOSE_FAST_ENV,
+        )
         assert result.returncode == 0
+        assert result.stdout.strip().splitlines()[-1] == "killed"
+        # kill-pane が2回呼ばれている（1回目: SIGHUP, 2回目: SIGKILL fallback）
+        assert captured.count("kill-pane") == 2
+
+    def test_close_pane_persists_outputs_failed(self, tmp_path):
+        """SIGKILL fallback 後も pane が残るケースは 'failed' を stdout/stderr に出して exit 1。"""
+        # display_switch_at_kill=None → 常に存在する状態
+        result, _ = _run_adapter(
+            ["close", "%42"],
+            tmp_path,
+            extra_env=CLOSE_FAST_ENV,
+        )
+        assert result.returncode == 1
+        assert result.stdout.strip().splitlines()[-1] == "failed"
+        assert "failed" in result.stderr
 
 
 class TestTmuxAdapterSplit:

--- a/tests/unit/test_worker_skill_md.py
+++ b/tests/unit/test_worker_skill_md.py
@@ -1,0 +1,63 @@
+"""skills/worker/SKILL.md の契約テスト
+
+退場処理 §Step 6 (auto-close) の記述存在と、独自 state "closed" の不在
+(state machine 規約遵守) を assert する。
+"""
+from pathlib import Path
+
+import pytest
+
+SKILL_MD = (
+    Path(__file__).resolve().parent.parent.parent
+    / "skills"
+    / "worker"
+    / "SKILL.md"
+)
+
+
+@pytest.fixture
+def skill_md() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+class TestWorkerSkillAutoClose:
+    def test_step6_section_exists(self, skill_md):
+        assert "### Step 6: auto-close" in skill_md
+
+    def test_step6_documents_tmux_kill_pane(self, skill_md):
+        assert "tmux kill-pane" in skill_md
+        assert "$TMUX_PANE" in skill_md
+
+    def test_step6_documents_iterm_path(self, skill_md):
+        assert "ITERM_SESSION_ID" in skill_md
+        assert "osascript" in skill_md
+
+    def test_step6_documents_target_causes(self, skill_md):
+        # auto-close 対象 cause
+        assert "cancelled" in skill_md
+        # 非対象 cause も記述されている
+        assert "crashed-during-drain" in skill_md
+        assert "dead" in skill_md
+
+    def test_step6_after_step5(self, skill_md):
+        step5_idx = skill_md.find("### Step 5:")
+        step6_idx = skill_md.find("### Step 6:")
+        assert step5_idx > 0 and step6_idx > step5_idx, (
+            "Step 6 が Step 5 より後に配置されていない"
+        )
+
+
+class TestWorkerSkillStateMachineCompliance:
+    def test_no_event_state_closed_as_own_state(self, skill_md):
+        """event:state(closed) の独自 state 送信を残していない (D#2838 規約)。
+
+        cause:closed としての "closed" は許容、独自 state "closed" のみ禁止。
+        """
+        assert '"state":"closed"' not in skill_md
+        assert '"state": "closed"' not in skill_md
+
+    def test_terminated_with_cause_closed_documented(self, skill_md):
+        """退場処理は terminated + cause:closed パターンで記述されている。"""
+        assert "terminated" in skill_md
+        # cause:closed パターン (JSON 内記述)
+        assert '"cause":"closed"' in skill_md or '"cause": "closed"' in skill_md


### PR DESCRIPTION
## 概要

worker / relay の lifecycle hygiene を 3 commit で統合する。orphan 化 / 誤配信 / worker pane 残存 を構造的に防ぐ軽量修正をまとめて積む。

## 変更内容

### 1. recv_filter.py に envelope schema 検証と OW_FILTER_TASK opt-in
- envelope の `v == 1` / `kind in (command, event)` / `data.type` を必須化し、旧形式 envelope を silent drop する
- 環境変数 `OW_FILTER_TASK` 指定時に他 task の broadcast event (heartbeat / identity 等) を drop することで、AI worker のコンテキスト汚染を抑止可能にする (opt-in、未指定時は従来挙動)

### 2. recv.sh に curl PID watchdog + cleanup 明示 kill
- `mkfifo` 経由で curl と python3 を別 bg job として起動し、両プロセスの PID を個別追跡
- `cleanup` trap (EXIT/HUP/INT/TERM) で curl/python3/FIFO の 3 つを後始末する
- SSE 無音時に curl が SIGPIPE 連鎖死しないケースの孤児化を構造的に防ぐ

### 3. ow_close_worker に pane 死亡確認 + SIGKILL fallback + worker auto-close 手順
- `scripts/ow/adapters/tmux.sh` の close action を「pane 不在確認 → kill-pane → 不在再確認ループ → SIGKILL fallback」の多段構造に拡張
- stdout 最終行に `closed` / `killed` / `failed` のいずれかを返す契約を新設
- `ow_close_worker` の戻り値に `closed: bool` と `killed: bool` を追加し、orch 側で実際の close 成否を観測可能に
- `skills/worker/SKILL.md` §退場処理に Step 6 (auto-close) を追加し、`event:state(terminated, ...)` 送信完了後に tmux pane / iTerm2 タブを worker 自身が kill する手順を明文化

## テスト

```
uv run pytest tests/unit/test_ow_recv_filter.py     # 26 passed
uv run pytest tests/unit/test_recv_sh.py            # 8 passed
uv run pytest tests/unit/test_tmux_adapter.py       # 31 passed
uv run pytest tests/unit/test_ow_service_close_worker.py  # 6 passed (new)
uv run pytest tests/unit/test_worker_skill_md.py    # 7 passed (new)
uv run pytest tests/unit/                           # 1455 passed, 1 skipped
```

## post-merge 手順 (user global skill 同期)

`~/.claude/` は git 管理外のため、PR 本体に含めず post-merge で手動同期する:

\`\`\`bash
cp <repo>/skills/worker/SKILL.md ~/.claude/skills/worker/SKILL.md
\`\`\`

これにより従来 `~/.claude/skills/worker/SKILL.md` に残っていた旧 envelope 形式 (`kind:"state"` 直接送信) も Step 6 auto-close 込みの最新 SKILL に同期される。

## レビューポイント

- tmux.sh の SIGKILL fallback タイミング (デフォルト `OW_CLOSE_FALLBACK_ITER=6` × `OW_CLOSE_FALLBACK_INTERVAL=0.5s` = 最大 3 秒) が妥当か
- `mkfifo` 採用根拠: bash 3.2 (macOS デフォルト) で `coproc` / process substitution は curl PID 取得不可のため、`mkfifo` で個別 bg job 化する方式を選択
- recv_filter の `OW_FILTER_TASK` 自動注入は本 PR スコープ外 (worker spawn 経路の修正は別議論)

🤖 Generated with [Claude Code](https://claude.com/claude-code)