### PR TITLE
refactor: citationsのpure関数群を独立モジュールへ切り出し

### DIFF
--- a/src/services/citation_renderer.py
+++ b/src/services/citation_renderer.py
@@ -15,10 +15,12 @@ import re
 import sqlite3
 from typing import Literal
 
-from src.services.citations_service import (
+from src.services.citations_pure import (
     TYPE_CODE_TO_NAME,
     TYPE_NAME_TO_CODE,
     _CITE_PATTERN,
+)
+from src.services.citations_service import (
     _get_in_out_with_conn,
     _resolve_targets,
 )

--- a/src/services/citations_pure.py
+++ b/src/services/citations_pure.py
@@ -1,0 +1,324 @@
+"""citation 参照テンプレ (`{{cite:X#NNN}}`) を扱う pure な層。
+
+- 全 entity 種別の名前/コード/テーブル/タイトル取得式の対応表
+- 本文中の `{{cite:X#NNN}}` 抽出 (コードブロック・エスケープ尊重)
+- 生 `X#NNN` リテラルから `{{cite:X#NNN}}` への変換 (transcript sanitize 用)
+- target 存在チェック (read-only conn 注入)
+
+`from src.db import get_connection` は呼ばない。DB へのアクセスは引数 conn 経由のみ。
+`src.services.citations_service` (write 経路、DB 接続を内部で開く高レベル API) と、
+transcript sanitize hook の両方からこの層を import する。
+"""
+import logging
+import re
+import sqlite3
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+VALID_OWNER_TYPES = ("material", "decision", "log", "activity", "topic")
+VALID_TARGET_TYPES = VALID_OWNER_TYPES
+
+TYPE_CODE_TO_NAME: dict[str, str] = {
+    "M": "material",
+    "D": "decision",
+    "L": "log",
+    "A": "activity",
+    "T": "topic",
+}
+TYPE_NAME_TO_CODE: dict[str, str] = {v: k for k, v in TYPE_CODE_TO_NAME.items()}
+
+TYPE_TO_TABLE: dict[str, str] = {
+    "material": "materials",
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "activity": "activities",
+    "topic": "discussion_topics",
+}
+
+# 各 entity 種別の表示タイトル取得式 (SELECT 内で使用)。
+# decision は title が NULL のとき decision 本文へ fall back する。
+TYPE_TO_TITLE_EXPR: dict[str, str] = {
+    "material": "title",
+    "decision": "COALESCE(NULLIF(TRIM(title), ''), substr(decision, 1, 80))",
+    "log": "COALESCE(NULLIF(TRIM(title), ''), substr(content, 1, 30))",
+    "activity": "title",
+    "topic": "title",
+}
+
+# retract カラムを持つ entity 種別
+TYPES_WITH_RETRACT = {"decision", "log", "material"}
+
+# owner 種別ごとに、本文中の citation 抽出対象となるテキストフィールド
+# (DB カラム名そのまま、結合順は occurrence の決定要因)
+OWNER_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
+    "material": ("title", "content"),
+    "decision": ("decision", "reason"),
+    "log": ("content",),
+    "activity": ("title", "description"),
+    "topic": ("title", "description"),
+}
+
+_CITE_PATTERN = re.compile(r"\{\{cite:([MDLAT])#(\d+)\}\}")
+_CITE_LIKE_PATTERN = re.compile(r"\{\{cite:[^}]*\}\}")
+
+# 生 `X#NNN` 検出パターン。word boundary を lookbehind/lookahead で明示する
+# (前後が英数字/_/ なら識別子の一部とみなして非マッチ)。
+_RAW_CITE_PATTERN = re.compile(r"(?<![A-Za-z0-9_/])([MDLAT])#(\d+)(?![A-Za-z0-9_])")
+
+
+def extract_citations(content: str) -> list[tuple[str, int]]:
+    """本文から citation 参照を出現順に抽出する。
+
+    コードブロック (フェンス ``` / ~~~ と インラインバッククォート) 内の
+    テンプレはスキップする。`\\{{cite:...}}` のエスケープもスキップする。
+    不正形式 (`{{cite:Z#1}}`, `{{cite:foo}}` 等) は警告ログを出して無視する。
+
+    Returns:
+        [(target_type, target_id), ...] の出現順リスト。occurrence は 1 始まりで連番。
+    """
+    results: list[tuple[str, int]] = []
+    in_fence = False
+    for raw_line in content.split("\n"):
+        stripped = raw_line.lstrip()
+        # フェンス境界 (```/~~~ で始まる行) でトグル
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        results.extend(_scan_line(raw_line))
+    return results
+
+
+def _scan_line(line: str) -> list[tuple[str, int]]:
+    """1 行内の citation を走査。インラインバッククォート / エスケープをスキップ。"""
+    out: list[tuple[str, int]] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "`":
+            # 対応する閉じバッククォートまでスキップ
+            close = line.find("`", i + 1)
+            if close == -1:
+                # 未閉じインラインコード: 行末まで保守的にスキップ
+                break
+            i = close + 1
+            continue
+        if ch == "\\" and line[i + 1 : i + 3] == "{{":
+            # エスケープ `\{{cite:...}}` 全体をスキップ
+            end = line.find("}}", i + 1)
+            if end == -1:
+                i += 1
+                continue
+            i = end + 2
+            continue
+        m = _CITE_PATTERN.match(line, i)
+        if m:
+            code = m.group(1)
+            target_id_str = m.group(2)
+            target_type = TYPE_CODE_TO_NAME.get(code)
+            if target_type is None:
+                logger.warning("citation parser: unknown type code %r", code)
+                i = m.end()
+                continue
+            try:
+                target_id = int(target_id_str)
+            except ValueError:
+                logger.warning("citation parser: invalid id %r", target_id_str)
+                i = m.end()
+                continue
+            out.append((target_type, target_id))
+            i = m.end()
+            continue
+        # 不正形式テンプレ (`{{cite:foo}}` 等) は警告
+        like = _CITE_LIKE_PATTERN.match(line, i)
+        if like:
+            logger.warning("citation parser: malformed template skipped: %r", like.group(0))
+            i = like.end()
+            continue
+        i += 1
+    return out
+
+
+def _validate_owner_type(owner_type: str) -> None:
+    if owner_type not in VALID_OWNER_TYPES:
+        raise ValueError(
+            f"Invalid owner_type {owner_type!r}; must be one of {VALID_OWNER_TYPES}"
+        )
+
+
+def _combine_owner_text(owner_type: str, fields: dict) -> str:
+    """owner の本文を occurrence 計算用に決定的順序で結合する。"""
+    cols = OWNER_TEXT_FIELDS[owner_type]
+    return "\n".join(fields.get(c) or "" for c in cols)
+
+
+def _new_convert_counters() -> dict:
+    return {
+        "sanitized_count": 0,
+        "skipped_in_codeblock": 0,
+        "skipped_in_existing_cite": 0,
+        "skipped_escape": 0,
+        "skipped_dangling": 0,
+    }
+
+
+def _count_raw_in_segment(segment: str) -> int:
+    """セグメント内の生 `X#NNN` パターン数を boundary 付きで数える。"""
+    return len(_RAW_CITE_PATTERN.findall(segment))
+
+
+def _convert_line_raw_to_cite(
+    line: str,
+    target_validator: Callable[[str, int], bool] | None,
+    counters: dict,
+) -> str:
+    """1 行内の生 `X#NNN` を `{{cite:X#NNN}}` に変換する。
+
+    スキップ対象:
+    - インラインバッククォート区間 (`...`)
+    - エスケープ `\\X#NNN` (バッククスラッシュ直後の生リテラル)
+    - 既に `{{cite:X#NNN}}` の中にあるもの (二重変換防止)
+    各スキップ区間に含まれる生リテラル数は counters の対応キーへ加算する。
+    target_validator が False を返した target は変換せず skipped_dangling にカウント。
+    """
+    out_parts: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        # インラインバッククォート: 対応する閉じまで丸ごとスキップ
+        if ch == "`":
+            close = line.find("`", i + 1)
+            if close == -1:
+                # 未閉じ: 行末まで保守的にスキップ
+                segment = line[i:]
+                counters["skipped_in_codeblock"] += _count_raw_in_segment(segment)
+                out_parts.append(segment)
+                i = n
+                continue
+            segment = line[i : close + 1]
+            counters["skipped_in_codeblock"] += _count_raw_in_segment(segment)
+            out_parts.append(segment)
+            i = close + 1
+            continue
+        # 既存 `{{cite:...}}` テンプレ: 内部の `X#NNN` は変換しない
+        if line[i : i + 7] == "{{cite:":
+            end = line.find("}}", i + 7)
+            if end == -1:
+                out_parts.append(ch)
+                i += 1
+                continue
+            segment = line[i : end + 2]
+            counters["skipped_in_existing_cite"] += _count_raw_in_segment(segment)
+            out_parts.append(segment)
+            i = end + 2
+            continue
+        # エスケープ: `\X#NNN` または `\{{cite:...}}`
+        if ch == "\\":
+            # `\{{cite:...}}` は既存パーサと同じく全体スキップ
+            if line[i + 1 : i + 3] == "{{":
+                end = line.find("}}", i + 1)
+                if end == -1:
+                    out_parts.append(ch)
+                    i += 1
+                    continue
+                segment = line[i : end + 2]
+                counters["skipped_in_existing_cite"] += _count_raw_in_segment(segment)
+                out_parts.append(segment)
+                i = end + 2
+                continue
+            # `\X#NNN`: バックスラッシュは lookbehind 非該当なので明示判定する
+            tail = line[i + 1 : i + 2]
+            if tail in TYPE_CODE_TO_NAME:
+                m = _RAW_CITE_PATTERN.match(line, i + 1)
+                if m and m.start() == i + 1:
+                    out_parts.append(line[i : m.end()])
+                    counters["skipped_escape"] += 1
+                    i = m.end()
+                    continue
+            out_parts.append(ch)
+            i += 1
+            continue
+        # 生 `X#NNN`
+        m = _RAW_CITE_PATTERN.match(line, i)
+        if m:
+            code = m.group(1)
+            target_id = int(m.group(2))
+            target_type = TYPE_CODE_TO_NAME[code]
+            if target_validator is not None and not target_validator(target_type, target_id):
+                out_parts.append(line[i : m.end()])
+                counters["skipped_dangling"] += 1
+                i = m.end()
+                continue
+            out_parts.append("{{cite:" + code + "#" + str(target_id) + "}}")
+            counters["sanitized_count"] += 1
+            i = m.end()
+            continue
+        out_parts.append(ch)
+        i += 1
+    return "".join(out_parts)
+
+
+def convert_raw_to_cite(
+    text: str,
+    *,
+    target_validator: Callable[[str, int], bool] | None = None,
+) -> tuple[str, dict]:
+    """テキスト中の生 `X#NNN` を `{{cite:X#NNN}}` に変換する (sanitize)。
+
+    フェンスコードブロック (``` / ~~~)、インラインバッククォート、エスケープ
+    (`\\X#NNN` / `\\{{cite:...}}`)、既に `{{cite:X#NNN}}` 形式のものはスキップする。
+    冪等: `convert_raw_to_cite(convert_raw_to_cite(text)[0])[0] == convert_raw_to_cite(text)[0]`。
+
+    Args:
+        text: 入力テキスト
+        target_validator: `(target_type, target_id) -> bool` を返す関数。
+            None なら存在チェックなし (debug モード、全変換)。
+            False を返した target は変換せず skipped_dangling にカウントする。
+
+    Returns:
+        (変換後テキスト, counters)
+        counters = {
+            "sanitized_count": 変換した生リテラル数,
+            "skipped_in_codeblock": フェンス + インラインバッククォート内に含まれた生リテラル数,
+            "skipped_in_existing_cite": 既存 `{{cite:...}}` 内に含まれた生リテラル数,
+            "skipped_escape": `\\X#NNN` エスケープでスキップした生リテラル数,
+            "skipped_dangling": target_validator が False を返してスキップした target 数,
+        }
+    """
+    counters = _new_convert_counters()
+    out_lines: list[str] = []
+    in_fence = False
+    lines = text.split("\n")
+    for raw_line in lines:
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            out_lines.append(raw_line)
+            continue
+        if in_fence:
+            counters["skipped_in_codeblock"] += _count_raw_in_segment(raw_line)
+            out_lines.append(raw_line)
+            continue
+        out_lines.append(_convert_line_raw_to_cite(raw_line, target_validator, counters))
+    return "\n".join(out_lines), counters
+
+
+def check_target_exists(
+    conn: sqlite3.Connection, target_type: str, target_id: int
+) -> bool:
+    """target が DB に物理的に存在するか判定する (retracted_at は無視)。
+
+    引数 conn は呼び出し元が開いた接続を使う (read-only でもよい)。
+    target_type が未知のときは False を返す。
+    """
+    if target_type not in TYPE_TO_TABLE:
+        return False
+    table = TYPE_TO_TABLE[target_type]
+    row = conn.execute(
+        f"SELECT 1 FROM {table} WHERE id = ? LIMIT 1", (target_id,)
+    ).fetchone()
+    return row is not None

--- a/src/services/citations_pure.py
+++ b/src/services/citations_pure.py
@@ -16,6 +16,28 @@ from typing import Callable
 
 logger = logging.getLogger(__name__)
 
+# 同パッケージの他モジュール (citations_service / citation_renderer) と、
+# transcript sanitize hook が import する公開シンボルを明示する。アンダースコア
+# プレフィックスのままだが「pure 層が抱える公開 API」として明示的に export する。
+__all__ = [
+    "VALID_OWNER_TYPES",
+    "VALID_TARGET_TYPES",
+    "TYPE_CODE_TO_NAME",
+    "TYPE_NAME_TO_CODE",
+    "TYPE_TO_TABLE",
+    "TYPE_TO_TITLE_EXPR",
+    "TYPES_WITH_RETRACT",
+    "OWNER_TEXT_FIELDS",
+    "_CITE_PATTERN",
+    "_CITE_LIKE_PATTERN",
+    "_RAW_CITE_PATTERN",
+    "extract_citations",
+    "convert_raw_to_cite",
+    "check_target_exists",
+    "_validate_owner_type",
+    "_combine_owner_text",
+]
+
 VALID_OWNER_TYPES = ("material", "decision", "log", "activity", "topic")
 VALID_TARGET_TYPES = VALID_OWNER_TYPES
 
@@ -218,7 +240,7 @@ def _convert_line_raw_to_cite(
             continue
         # エスケープ: `\X#NNN` または `\{{cite:...}}`
         if ch == "\\":
-            # `\{{cite:...}}` は既存パーサと同じく全体スキップ
+            # `\{{cite:...}}` は既存パーサと同じく全体スキップ (エスケープ扱い)
             if line[i + 1 : i + 3] == "{{":
                 end = line.find("}}", i + 1)
                 if end == -1:
@@ -226,7 +248,7 @@ def _convert_line_raw_to_cite(
                     i += 1
                     continue
                 segment = line[i : end + 2]
-                counters["skipped_in_existing_cite"] += _count_raw_in_segment(segment)
+                counters["skipped_escape"] += _count_raw_in_segment(segment)
                 out_parts.append(segment)
                 i = end + 2
                 continue

--- a/src/services/citations_service.py
+++ b/src/services/citations_service.py
@@ -1,146 +1,35 @@
-"""citation 参照テンプレ (`{{cite:X#NNN}}`) の抽出・保存・引き当てを行うサービス。
+"""citation 参照テンプレ (`{{cite:X#NNN}}`) の DB 永続化を担うサービス。
 
 本文中の `{{cite:X#NNN}}` テンプレを `citations` テーブルに保存し、
 read 経路では `flavor` で展開形式を切り替える前提の参照基盤を提供する。
 
+pure (副作用なし) なロジック — 定数表・正規表現・抽出器・型バリデータ・本文結合・
+target 存在チェック — は `src.services.citations_pure` 側へ集約済み。本モジュールは
+そちらを import して DB I/O を伴う高レベル API (extract_and_insert / replace_all /
+upsert_citations_for_owner_with_conn / get_in_out 等) を提供する。
+
 X は M/D/L/A/T のいずれかで、それぞれ material/decision/log/activity/topic に対応する。
 """
-import logging
-import re
 import sqlite3
-from typing import Literal
 
 from src.db import get_connection
+from src.services.citations_pure import (
+    OWNER_TEXT_FIELDS,
+    TYPE_TO_TABLE,
+    TYPE_TO_TITLE_EXPR,
+    TYPES_WITH_RETRACT,
+    _combine_owner_text,
+    _validate_owner_type,
+    extract_citations,
+)
 
-logger = logging.getLogger(__name__)
-
-VALID_OWNER_TYPES = ("material", "decision", "log", "activity", "topic")
-VALID_TARGET_TYPES = VALID_OWNER_TYPES
-
-TYPE_CODE_TO_NAME: dict[str, str] = {
-    "M": "material",
-    "D": "decision",
-    "L": "log",
-    "A": "activity",
-    "T": "topic",
-}
-TYPE_NAME_TO_CODE: dict[str, str] = {v: k for k, v in TYPE_CODE_TO_NAME.items()}
-
-TYPE_TO_TABLE: dict[str, str] = {
-    "material": "materials",
-    "decision": "decisions",
-    "log": "discussion_logs",
-    "activity": "activities",
-    "topic": "discussion_topics",
-}
-
-# 各 entity 種別の表示タイトル取得式 (SELECT 内で使用)。
-# decision は title が NULL のとき decision 本文へ fall back する。
-TYPE_TO_TITLE_EXPR: dict[str, str] = {
-    "material": "title",
-    "decision": "COALESCE(NULLIF(TRIM(title), ''), substr(decision, 1, 80))",
-    "log": "COALESCE(NULLIF(TRIM(title), ''), substr(content, 1, 30))",
-    "activity": "title",
-    "topic": "title",
-}
-
-# retract カラムを持つ entity 種別
-TYPES_WITH_RETRACT = {"decision", "log", "material"}
-
-# owner 種別ごとに、本文中の citation 抽出対象となるテキストフィールド
-# (DB カラム名そのまま、結合順は occurrence の決定要因)
-OWNER_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
-    "material": ("title", "content"),
-    "decision": ("decision", "reason"),
-    "log": ("content",),
-    "activity": ("title", "description"),
-    "topic": ("title", "description"),
-}
-
-_CITE_PATTERN = re.compile(r"\{\{cite:([MDLAT])#(\d+)\}\}")
-_CITE_LIKE_PATTERN = re.compile(r"\{\{cite:[^}]*\}\}")
-
-
-def extract_citations(content: str) -> list[tuple[str, int]]:
-    """本文から citation 参照を出現順に抽出する。
-
-    コードブロック (フェンス ``` / ~~~ と インラインバッククォート) 内の
-    テンプレはスキップする。`\\{{cite:...}}` のエスケープもスキップする。
-    不正形式 (`{{cite:Z#1}}`, `{{cite:foo}}` 等) は警告ログを出して無視する。
-
-    Returns:
-        [(target_type, target_id), ...] の出現順リスト。occurrence は 1 始まりで連番。
-    """
-    results: list[tuple[str, int]] = []
-    in_fence = False
-    for raw_line in content.split("\n"):
-        stripped = raw_line.lstrip()
-        # フェンス境界 (```/~~~ で始まる行) でトグル
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        results.extend(_scan_line(raw_line))
-    return results
-
-
-def _scan_line(line: str) -> list[tuple[str, int]]:
-    """1 行内の citation を走査。インラインバッククォート / エスケープをスキップ。"""
-    out: list[tuple[str, int]] = []
-    i = 0
-    n = len(line)
-    while i < n:
-        ch = line[i]
-        if ch == "`":
-            # 対応する閉じバッククォートまでスキップ
-            close = line.find("`", i + 1)
-            if close == -1:
-                # 未閉じインラインコード: 行末まで保守的にスキップ
-                break
-            i = close + 1
-            continue
-        if ch == "\\" and line[i + 1 : i + 3] == "{{":
-            # エスケープ `\{{cite:...}}` 全体をスキップ
-            end = line.find("}}", i + 1)
-            if end == -1:
-                i += 1
-                continue
-            i = end + 2
-            continue
-        m = _CITE_PATTERN.match(line, i)
-        if m:
-            code = m.group(1)
-            target_id_str = m.group(2)
-            target_type = TYPE_CODE_TO_NAME.get(code)
-            if target_type is None:
-                logger.warning("citation parser: unknown type code %r", code)
-                i = m.end()
-                continue
-            try:
-                target_id = int(target_id_str)
-            except ValueError:
-                logger.warning("citation parser: invalid id %r", target_id_str)
-                i = m.end()
-                continue
-            out.append((target_type, target_id))
-            i = m.end()
-            continue
-        # 不正形式テンプレ (`{{cite:foo}}` 等) は警告
-        like = _CITE_LIKE_PATTERN.match(line, i)
-        if like:
-            logger.warning("citation parser: malformed template skipped: %r", like.group(0))
-            i = like.end()
-            continue
-        i += 1
-    return out
-
-
-def _validate_owner_type(owner_type: str) -> None:
-    if owner_type not in VALID_OWNER_TYPES:
-        raise ValueError(
-            f"Invalid owner_type {owner_type!r}; must be one of {VALID_OWNER_TYPES}"
-        )
+__all__ = [
+    "extract_and_insert",
+    "replace_all",
+    "delete_all_for_owner",
+    "upsert_citations_for_owner_with_conn",
+    "get_in_out",
+]
 
 
 def extract_and_insert(owner_type: str, owner_id: int, content: str) -> int:
@@ -212,18 +101,12 @@ def _delete_all_for_owner_with_conn(
     return cur.rowcount
 
 
-def _combine_owner_text(owner_type: str, fields: dict) -> str:
-    """owner の本文を occurrence 計算用に決定的順序で結合する。"""
-    cols = OWNER_TEXT_FIELDS[owner_type]
-    return "\n".join(fields.get(c) or "" for c in cols)
-
-
 def upsert_citations_for_owner_with_conn(
     conn: sqlite3.Connection, owner_type: str, owner_id: int, **fields
 ) -> int:
     """add/update 共通: 既存 citations を全削除 → 本文結合 → 再投入。
 
-    本文無変更でも呼ぶことで occurrence の一貫性が保たれる (M#373 §3.4.4)。
+    本文無変更でも呼ぶことで occurrence の一貫性が保たれる。
     fields は OWNER_TEXT_FIELDS で定義された名前の部分集合を渡す
     (未指定キーは空文字扱い)。
     """

--- a/tests/unit/test_citations_parser.py
+++ b/tests/unit/test_citations_parser.py
@@ -1,7 +1,7 @@
-"""citations_service.extract_citations のパーサ単体テスト"""
+"""citations_pure.extract_citations のパーサ単体テスト"""
 import pytest
 
-from src.services.citations_service import extract_citations
+from src.services.citations_pure import extract_citations
 
 
 class TestBasicParse:

--- a/tests/unit/test_citations_pure.py
+++ b/tests/unit/test_citations_pure.py
@@ -1,0 +1,293 @@
+"""citations_pure の pure 関数群の単体テスト。
+
+extract_citations / convert_raw_to_cite / check_target_exists を対象とする。
+extract_citations の挙動は test_citations_parser.py で既に網羅されているため、
+ここでは convert_raw_to_cite を中心に検証する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.services.citations_pure import (
+    TYPE_CODE_TO_NAME,
+    TYPE_TO_TABLE,
+    check_target_exists,
+    convert_raw_to_cite,
+)
+
+
+def _allow_all(target_type: str, target_id: int) -> bool:
+    return True
+
+
+def _deny_all(target_type: str, target_id: int) -> bool:
+    return False
+
+
+class TestBasicConversion:
+    def test_single_material_raw_to_cite(self):
+        out, counters = convert_raw_to_cite("See M#123 here.")
+        assert out == "See {{cite:M#123}} here."
+        assert counters["sanitized_count"] == 1
+
+    def test_all_five_type_codes(self):
+        text = "M#1 D#2 L#3 A#4 T#5"
+        out, counters = convert_raw_to_cite(text)
+        assert out == "{{cite:M#1}} {{cite:D#2}} {{cite:L#3}} {{cite:A#4}} {{cite:T#5}}"
+        assert counters["sanitized_count"] == 5
+
+    def test_no_raw_literals(self):
+        out, counters = convert_raw_to_cite("plain text without ids")
+        assert out == "plain text without ids"
+        assert counters["sanitized_count"] == 0
+
+    def test_empty_string(self):
+        out, counters = convert_raw_to_cite("")
+        assert out == ""
+        assert counters["sanitized_count"] == 0
+
+    def test_large_id_allowed(self):
+        out, _ = convert_raw_to_cite("ref M#9999999 ok")
+        assert out == "ref {{cite:M#9999999}} ok"
+
+
+class TestCodeBlockSkip:
+    """エッジケース表 #2, #3: コードブロック内は変換しない"""
+
+    def test_inline_backtick_skips(self):
+        out, counters = convert_raw_to_cite("see `D#456 raw` next")
+        assert out == "see `D#456 raw` next"
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_in_codeblock"] == 1
+
+    def test_inline_backtick_does_not_swallow_after_close(self):
+        out, counters = convert_raw_to_cite("`inline` then M#1")
+        assert out == "`inline` then {{cite:M#1}}"
+        assert counters["sanitized_count"] == 1
+
+    def test_fenced_code_block_skips(self):
+        text = "intro\n```\nL#789 inside\n```\nafter D#1"
+        out, counters = convert_raw_to_cite(text)
+        assert out == "intro\n```\nL#789 inside\n```\nafter {{cite:D#1}}"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_in_codeblock"] == 1
+
+    def test_tilde_fence_skips(self):
+        text = "intro\n~~~\nM#99 inside\n~~~\nafter"
+        out, counters = convert_raw_to_cite(text)
+        assert "M#99" in out
+        assert "{{cite:M#99}}" not in out
+        assert counters["skipped_in_codeblock"] == 1
+
+
+class TestEscape:
+    """エッジケース表 #4: エスケープ `\\X#NNN` は変換しない"""
+
+    def test_backslash_escape_raw_skips(self):
+        out, counters = convert_raw_to_cite(r"see \A#42 escaped")
+        assert out == r"see \A#42 escaped"
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_escape"] == 1
+
+    def test_backslash_cite_template_passes_through(self):
+        # `\{{cite:M#1}}` 形式: 既存パーサの規律と同じく丸ごとスキップ
+        text = r"shown \{{cite:M#1}} only"
+        out, counters = convert_raw_to_cite(text)
+        assert out == text
+        assert counters["sanitized_count"] == 0
+
+
+class TestExistingCiteSkip:
+    """エッジケース表 #5: 既に `{{cite:X#NNN}}` 形式は二重変換しない"""
+
+    def test_existing_cite_not_doubled(self):
+        text = "already {{cite:T#7}} formed"
+        out, counters = convert_raw_to_cite(text)
+        assert out == text
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_in_existing_cite"] == 1
+
+
+class TestIdempotent:
+    """エッジケース表 #6: 2 回適用しても結果不変"""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "single M#1",
+            "mixed M#1 and `D#2` and \\A#3 and {{cite:T#4}}",
+            "intro\n```\nM#9\n```\nafter D#5",
+            "multi-line\nwith M#1\nand D#2 ref\nplus existing {{cite:L#3}}",
+            "edge: empty",
+        ],
+    )
+    def test_idempotent(self, text):
+        first, _ = convert_raw_to_cite(text)
+        second, _ = convert_raw_to_cite(first)
+        assert first == second
+
+
+class TestTargetValidator:
+    """エッジケース表 #7, #8: target_validator の挙動"""
+
+    def test_validator_false_keeps_dangling(self):
+        out, counters = convert_raw_to_cite(
+            "ref M#9999999 missing", target_validator=_deny_all
+        )
+        assert out == "ref M#9999999 missing"
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_dangling"] == 1
+
+    def test_validator_true_converts(self):
+        out, counters = convert_raw_to_cite(
+            "ref M#1 ok", target_validator=_allow_all
+        )
+        assert out == "ref {{cite:M#1}} ok"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_dangling"] == 0
+
+    def test_validator_none_converts_all(self):
+        # debug モード: 存在チェックなしで全変換
+        out, counters = convert_raw_to_cite("ref M#1 D#2", target_validator=None)
+        assert out == "ref {{cite:M#1}} {{cite:D#2}}"
+        assert counters["sanitized_count"] == 2
+
+    def test_validator_called_with_correct_args(self):
+        seen: list[tuple[str, int]] = []
+
+        def spy(target_type: str, target_id: int) -> bool:
+            seen.append((target_type, target_id))
+            return True
+
+        convert_raw_to_cite("M#1 and D#2", target_validator=spy)
+        assert seen == [("material", 1), ("decision", 2)]
+
+    def test_validator_mixed_allow_deny(self):
+        def selective(target_type: str, target_id: int) -> bool:
+            return target_id < 100
+
+        out, counters = convert_raw_to_cite(
+            "M#1 and M#999", target_validator=selective
+        )
+        assert out == "{{cite:M#1}} and M#999"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_dangling"] == 1
+
+
+class TestWordBoundary:
+    """エッジケース表 #9 派生: 識別子の途中・JSON 数値フィールドは変換しない"""
+
+    def test_id_inside_identifier_not_converted(self):
+        # `XM#1` のように直前に英字が付くケース
+        out, counters = convert_raw_to_cite("foo_M#1 keep")
+        assert out == "foo_M#1 keep"
+        assert counters["sanitized_count"] == 0
+
+    def test_id_with_alphanumeric_suffix_not_converted(self):
+        # `M#1a` のように直後に英字
+        out, counters = convert_raw_to_cite("ref M#1a end")
+        assert out == "ref M#1a end"
+        assert counters["sanitized_count"] == 0
+
+    def test_json_numeric_field_unchanged(self):
+        # JSON の数値フィールドは X#NNN 形式ではないので影響なし
+        text = '{"activity_id": 123, "title": "x"}'
+        out, counters = convert_raw_to_cite(text)
+        assert out == text
+        assert counters["sanitized_count"] == 0
+
+    def test_id_after_url_slash_not_converted(self):
+        # URL の path 末尾 `/M#1` も識別子の一部とみなしてスキップ
+        out, _ = convert_raw_to_cite("https://x.example/M#1")
+        assert out == "https://x.example/M#1"
+
+
+class TestMultilineMixed:
+    def test_multi_line_japanese_text(self):
+        text = "本文の中で M#100 を参照する。\n別段落で D#200 も触れる。"
+        out, counters = convert_raw_to_cite(text)
+        assert out == "本文の中で {{cite:M#100}} を参照する。\n別段落で {{cite:D#200}} も触れる。"
+        assert counters["sanitized_count"] == 2
+
+    def test_counters_aggregate_across_lines(self):
+        text = "first M#1\n`second L#2`\n```\nthird A#3\n```\nfourth T#4\nfifth \\D#5"
+        out, counters = convert_raw_to_cite(text)
+        assert counters["sanitized_count"] == 2  # M#1 と T#4
+        assert counters["skipped_in_codeblock"] == 2  # `L#2` とフェンス内 A#3
+        assert counters["skipped_escape"] == 1  # \D#5
+
+    def test_idempotent_with_validator(self):
+        text = "M#1 and M#999"
+
+        def selective(t: str, i: int) -> bool:
+            return i < 100
+
+        first, _ = convert_raw_to_cite(text, target_validator=selective)
+        second, _ = convert_raw_to_cite(first, target_validator=selective)
+        assert first == second
+
+
+@pytest.fixture
+def temp_conn():
+    """簡易 DB を作って citations_pure 関連テーブルを用意する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "t.db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        for table in TYPE_TO_TABLE.values():
+            conn.execute(
+                f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, retracted_at TEXT)"
+            )
+        conn.commit()
+        yield conn
+        conn.close()
+
+
+class TestCheckTargetExists:
+    """エッジケース表 #10, #11: 存在判定は物理削除のみで判断 (retracted_at は無視)"""
+
+    def test_existing_row_returns_true(self, temp_conn):
+        temp_conn.execute("INSERT INTO materials (id) VALUES (?)", (42,))
+        temp_conn.commit()
+        assert check_target_exists(temp_conn, "material", 42) is True
+
+    def test_missing_row_returns_false(self, temp_conn):
+        assert check_target_exists(temp_conn, "decision", 99) is False
+
+    def test_retracted_row_still_returns_true(self, temp_conn):
+        temp_conn.execute(
+            "INSERT INTO decisions (id, retracted_at) VALUES (?, ?)",
+            (7, "2026-06-21T00:00:00Z"),
+        )
+        temp_conn.commit()
+        assert check_target_exists(temp_conn, "decision", 7) is True
+
+    def test_all_five_target_types_supported(self, temp_conn):
+        for table in TYPE_TO_TABLE.values():
+            temp_conn.execute(f"INSERT INTO {table} (id) VALUES (?)", (1,))
+        temp_conn.commit()
+        for code, type_name in TYPE_CODE_TO_NAME.items():
+            assert check_target_exists(temp_conn, type_name, 1) is True
+
+    def test_unknown_target_type_returns_false(self, temp_conn):
+        assert check_target_exists(temp_conn, "unknown_type", 1) is False
+
+
+class TestConvertWithValidatorAgainstDb:
+    """convert_raw_to_cite + check_target_exists の結合動作"""
+
+    def test_validator_using_check_target_exists(self, temp_conn):
+        temp_conn.execute("INSERT INTO materials (id) VALUES (?)", (1,))
+        temp_conn.commit()
+
+        def validator(t: str, i: int) -> bool:
+            return check_target_exists(temp_conn, t, i)
+
+        out, counters = convert_raw_to_cite(
+            "exists M#1 missing M#999", target_validator=validator
+        )
+        assert out == "exists {{cite:M#1}} missing M#999"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_dangling"] == 1

--- a/tests/unit/test_citations_pure.py
+++ b/tests/unit/test_citations_pure.py
@@ -92,11 +92,22 @@ class TestEscape:
         assert counters["skipped_escape"] == 1
 
     def test_backslash_cite_template_passes_through(self):
-        # `\{{cite:M#1}}` 形式: 既存パーサの規律と同じく丸ごとスキップ
+        # `\{{cite:M#1}}` 形式: 既存パーサの規律と同じく丸ごとスキップ。
+        # 内部に含まれる `M#1` は escape による不変扱いとして skipped_escape に集計する。
         text = r"shown \{{cite:M#1}} only"
         out, counters = convert_raw_to_cite(text)
         assert out == text
         assert counters["sanitized_count"] == 0
+        assert counters["skipped_escape"] == 1
+        assert counters["skipped_in_existing_cite"] == 0
+
+    def test_backslash_cite_template_then_raw_literal(self):
+        # `\{{cite:M#1}}` の後ろに生リテラルがある: escape 内はスキップ、後者は変換される
+        text = r"escaped \{{cite:M#1}} then real M#2"
+        out, counters = convert_raw_to_cite(text)
+        assert out == r"escaped \{{cite:M#1}} then real {{cite:M#2}}"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_escape"] == 1
 
 
 class TestExistingCiteSkip:


### PR DESCRIPTION
## 概要

`src/services/citations_service.py` から DB アクセスを伴わない pure な処理を
新規 `src/services/citations_pure.py` に切り出した。`citations_service.py` は
DB I/O 専任に整理し、pure 層を import して利用する。

将来追加予定の transcript sanitize hook が cc-memory 本体の重い import 連鎖を
辿らず軽量に再利用できるよう、pure 層は `src.db.get_connection` を呼ばず、
DB アクセスは引数 conn 経由のみとする。

## 追加 API

- `convert_raw_to_cite(text, *, target_validator=None) -> (str, dict)`
  - テキスト中の生 `X#NNN` リテラルを `{{cite:X#NNN}}` へ変換する
  - コードブロック (バッククォート / フェンス)、エスケープ `\\X#NNN`、既存テンプレ内は無加工
  - `target_validator(target_type, target_id) -> bool` で dangling target をスキップできる
  - 冪等。再適用しても結果は変わらない
  - counters で sanitized / skipped を内訳別に返す

- `check_target_exists(conn, target_type, target_id) -> bool`
  - 呼び出し元が開いた conn (read-only でも可) で存在判定する
  - 物理削除のみ False を返し、retracted_at は無視する

## 変更ファイル

- `src/services/citations_pure.py` (新規)
- `src/services/citations_service.py` (pure 層を import する DB I/O 専任に整理)
- `src/services/citation_renderer.py` (pure 定数の import を citations_pure へ付け替え)
- `tests/unit/test_citations_pure.py` (新規 unit test、35 ケース)
- `tests/unit/test_citations_parser.py` (import 先を citations_pure に追従)

## テスト

- `uv run pytest tests/` → 1973 passed / 1 skipped
- 既存 `extract_citations` / `get_in_out` 等の振る舞いは不変 (`tests/integration/test_citations_service.py` 全 green)

## 後方互換

- 他サービス (`material_service` 等) からの
  `from src.services.citations_service import upsert_citations_for_owner_with_conn` は不変
- public API (`extract_and_insert` / `replace_all` / `get_in_out` 等) のシグネチャ・挙動は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)