### PR TITLE
refactor: SearchPipeline Phase A 導入

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -5,8 +5,9 @@ import math
 import re
 import sqlite3
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Literal, Optional
 
 from sqlite_vec import serialize_float32
 
@@ -81,6 +82,101 @@ QE_EXCLUDE_NAMESPACES = True   # namespace付きタグを除外するか
 
 # nearby_tags パラメータ
 NEARBY_TAGS_LIMIT = 5          # 返却するnearby_tagsの最大件数
+
+# RRF / recency boost 後に offset+limit で切り詰めるための拡大係数。
+# search() が retriever に渡す fetch_limit = (offset + limit) * FETCH_LIMIT_MULTIPLIER
+FETCH_LIMIT_MULTIPLIER = 5
+
+
+@dataclass(frozen=True)
+class SearchContext:
+    """search() のステージ間で受け渡す検索パラメータコンテキスト。
+
+    フィールドは Validate / Normalize / Expand 完了後の確定値を保持する。
+    frozen のため後段ステージで書き換える場合は dataclasses.replace を使う。
+
+    SearchPipeline 構造化は段階移行で進める。本 Phase A は SearchContext と
+    build_common_where を導入し、3 retriever (_fts_search / _vector_search /
+    _tag_like_search) が ctx を引数に取る形まで揃える。Phase B 以降は順次:
+
+    - Phase B: 3 retriever を fts_retrieve / vector_retrieve / tag_like_retrieve
+      として個別関数に整理する（_fts_search 等は薄いアダプタとして残置）
+    - Phase C: search() orchestrator を _validate / _normalize / _expand /
+      _retrieve / _merge / _rerank / _slice / _decorate に分割し、各ステージを
+      明示化する
+    - Phase D: P1-3 (score_breakdown / final_score) との接合を Decorate ステージで
+      整理する
+
+    fields:
+        keywords: 正規化済み元キーワード（QE 拡張を含まない）
+        fts_keywords: FTS5 用キーワード（QE 拡張済みの場合がある）
+        original_keyword_count: QE 拡張時の元キーワード件数。未拡張時は None
+        tag_ids: タグフィルタ用に解決済みの tag_id（未指定時は None）
+        entity_type: 検索対象 entity_type フィルタ（未指定時は None）
+        limit: 最終 limit（1..50）
+        offset: ページネーション offset
+        fetch_limit: 各 retriever に渡す多めの取得件数
+        keyword_mode: "and" / "or"
+        include_details: details 添付フラグ
+        date_after: 日付フィルタ下限（補完なし）
+        date_before: 日付フィルタ上限（日付のみ指定時は 23:59:59 補完済）
+        domain: telemetry 用に保持する元 domain 引数
+    """
+    keywords: tuple[str, ...]
+    fts_keywords: tuple[str, ...]
+    original_keyword_count: Optional[int]
+    tag_ids: Optional[tuple[int, ...]]
+    entity_type: Optional[str]
+    limit: int
+    offset: int
+    fetch_limit: int
+    keyword_mode: Literal["and", "or"]
+    include_details: bool
+    date_after: Optional[str]
+    date_before: Optional[str]
+    domain: Optional[str]
+
+
+def build_common_where(
+    ctx: SearchContext,
+    *,
+    si_alias: str = "si",
+    include_entity_type: bool = True,
+) -> tuple[str, list]:
+    """3 retriever で共通する WHERE 句（entity_type / date 範囲）を組み立てる。
+
+    Args:
+        ctx: SearchContext
+        si_alias: 参照するテーブルエイリアス。空文字列の場合はカラム prefix なし
+            （例: _vector_search の "FROM search_index ..." のような無エイリアス参照用）
+        include_entity_type: entity_type フィルタを含めるか
+
+    Returns:
+        (sql_fragment, params)
+        sql_fragment は "AND ..." で始まる WHERE 連結用フラグメント（複数 AND 句）。
+        params は ? の順序に沿ったパラメータリスト。
+
+    retract フィルタは search_index / FTS5 / vec_index からの物理削除モデルへ移行済の
+    ため含めない。
+    """
+    prefix = f"{si_alias}." if si_alias else ""
+    parts: list[str] = []
+    params: list = []
+
+    if include_entity_type:
+        parts.append(f"AND (? IS NULL OR {prefix}source_type = ?)")
+        params.append(ctx.entity_type)
+        params.append(ctx.entity_type)
+
+    if ctx.date_after:
+        parts.append(f"AND {prefix}created_at >= ?")
+        params.append(ctx.date_after)
+
+    if ctx.date_before:
+        parts.append(f"AND {prefix}created_at <= ?")
+        params.append(ctx.date_before)
+
+    return "\n          ".join(parts), params
 
 
 def _escape_fts5_query(keyword: str) -> str:
@@ -555,44 +651,32 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
     return cte_sql, params
 
 
-def _fts_search(
-    keywords: list[str],
-    tag_ids: Optional[list[int]],
-    entity_type: Optional[str],
-    limit: int,
-    keyword_mode: str = "and",
-    original_keyword_count: Optional[int] = None,
-    date_after: Optional[str] = None,
-    date_before: Optional[str] = None,
-) -> list[dict]:
+def _fts_search(ctx: SearchContext) -> list[dict]:
     """FTS5検索。結果はBM25ランク順のリスト。
 
     retract時にsearch_index/search_index_fts/vec_indexから物理削除されるため、
     取り消し済みエンティティは検索対象に現れない。
 
     Args:
-        keywords: 検索キーワードリスト（QE拡張分を含む場合がある）
-        tag_ids: タグフィルタ用のtag_idリスト
-        entity_type: 検索対象の絞り込み
-        limit: 取得件数上限
-        keyword_mode: キーワード結合モード（"and" / "or"）
-        original_keyword_count: 元のキーワード数。指定時、先頭N個をAND結合し
-            残りをOR追加する（Query Expansion用）。未指定時は従来通り。
-        date_after: 日付フィルタ（以降）
-        date_before: 日付フィルタ（以前）
+        ctx: SearchContext。ctx.fts_keywords / ctx.keyword_mode /
+            ctx.original_keyword_count / ctx.tag_ids / ctx.entity_type /
+            ctx.fetch_limit / ctx.date_after / ctx.date_before を参照する。
     """
+    keywords = list(ctx.fts_keywords)
+
     # OR時: 3文字以上のキーワードだけでFTS5クエリを組む（2文字はフィルタ除外）
-    if keyword_mode == "or":
+    if ctx.keyword_mode == "or":
         fts_keywords = [kw for kw in keywords if len(kw) >= 3]
         if not fts_keywords:
             return []
         escaped_parts = [_escape_fts5_query(kw) for kw in fts_keywords]
         escaped_keyword = " OR ".join(escaped_parts)
     else:
-        if original_keyword_count is not None and original_keyword_count < len(keywords):
+        original_kw_count = ctx.original_keyword_count
+        if original_kw_count is not None and original_kw_count < len(keywords):
             # QE拡張あり: 元キーワードをAND結合し、拡張タグをOR追加
-            original_parts = [_escape_fts5_query(kw) for kw in keywords[:original_keyword_count]]
-            expanded_parts = [_escape_fts5_query(kw) for kw in keywords[original_keyword_count:]]
+            original_parts = [_escape_fts5_query(kw) for kw in keywords[:original_kw_count]]
+            expanded_parts = [_escape_fts5_query(kw) for kw in keywords[original_kw_count:]]
             original_query = " AND ".join(original_parts)
             # (元kw1 AND 元kw2) OR 拡張1 OR 拡張2
             all_parts = [f"({original_query})"] + expanded_parts
@@ -601,16 +685,8 @@ def _fts_search(
             escaped_parts = [_escape_fts5_query(kw) for kw in keywords]
             escaped_keyword = " AND ".join(escaped_parts)
 
-    # 日付フィルタの動的WHERE句構築
-    date_clauses = []
-    date_params: list = []
-    if date_after:
-        date_clauses.append("AND si.created_at >= ?")
-        date_params.append(date_after)
-    if date_before:
-        date_clauses.append("AND si.created_at <= ?")
-        date_params.append(date_before)
-    date_sql = "\n          ".join(date_clauses)
+    common_where, common_params = build_common_where(ctx, si_alias="si")
+    tag_ids = list(ctx.tag_ids) if ctx.tag_ids else None
 
     if tag_ids:
         cte_sql, cte_params = _build_tag_filter_cte(tag_ids)
@@ -624,12 +700,11 @@ def _fts_search(
         JOIN search_index si ON si.id = search_index_fts.rowid
         JOIN tag_filtered tf ON tf.source_type = si.source_type AND tf.source_id = si.source_id
         WHERE search_index_fts MATCH ?
-          AND (? IS NULL OR si.source_type = ?)
-          {date_sql}
+          {common_where}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
-        params = (*cte_params, escaped_keyword, entity_type, entity_type, *date_params, limit)
+        params = (*cte_params, escaped_keyword, *common_params, ctx.fetch_limit)
     else:
         query = f"""
         SELECT
@@ -639,12 +714,11 @@ def _fts_search(
         FROM search_index_fts
         JOIN search_index si ON si.id = search_index_fts.rowid
         WHERE search_index_fts MATCH ?
-          AND (? IS NULL OR si.source_type = ?)
-          {date_sql}
+          {common_where}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
-        params = (escaped_keyword, entity_type, entity_type, *date_params, limit)
+        params = (escaped_keyword, *common_params, ctx.fetch_limit)
 
     rows = execute_query(query, params)
     results = []
@@ -658,33 +732,24 @@ def _fts_search(
     return results
 
 
-def _vector_search(
-    keywords: list[str],
-    tag_ids: Optional[list[int]],
-    entity_type: Optional[str],
-    limit: int,
-    keyword_mode: str = "and",
-    date_after: Optional[str] = None,
-    date_before: Optional[str] = None,
-) -> Optional[list[dict]]:
+def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
     """ベクトル検索。ベクトル検索無効時はNoneを返す。
 
     retract時にvec_indexから物理削除されるため、取り消し済みエンティティは
     KNNの候補スロットを食わない（KNN実効recall改善）。
-    """
-    try:
-        # 日付フィルタの動的WHERE句構築
-        date_clauses = []
-        date_params_list: list = []
-        if date_after:
-            date_clauses.append("AND created_at >= ?")
-            date_params_list.append(date_after)
-        if date_before:
-            date_clauses.append("AND created_at <= ?")
-            date_params_list.append(date_before)
-        date_sql = "\n                      ".join(date_clauses)
 
-        if keyword_mode == "or" and len(keywords) > 1:
+    Args:
+        ctx: SearchContext。ベクトル検索は元の ctx.keywords を使用し、
+            QE 拡張済みの ctx.fts_keywords は参照しない。
+    """
+    keywords = list(ctx.keywords)
+    fetch_limit = ctx.fetch_limit
+    tag_ids = list(ctx.tag_ids) if ctx.tag_ids else None
+
+    try:
+        common_where, common_params = build_common_where(ctx, si_alias="")
+
+        if ctx.keyword_mode == "or" and len(keywords) > 1:
             # OR時: 各キーワードで個別にベクトル検索し、結果をマージ
             merged: dict[tuple, dict] = {}  # key: (type, id)
             for kw in keywords:
@@ -695,7 +760,7 @@ def _vector_search(
                 blob = serialize_float32(query_embedding)
                 vec_rows = execute_query(
                     "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
-                    (blob, limit),
+                    (blob, fetch_limit),
                 )
                 if not vec_rows:
                     continue
@@ -715,24 +780,22 @@ def _vector_search(
                     SELECT id, source_type, source_id, title
                     FROM search_index
                     WHERE id IN ({rowid_placeholders})
-                      AND (? IS NULL OR source_type = ?)
                       AND EXISTS (
                         SELECT 1 FROM tag_filtered tf
                         WHERE tf.source_type = search_index.source_type
                           AND tf.source_id = search_index.source_id
                       )
-                      {date_sql}
+                      {common_where}
                     """
-                    params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
+                    params = (*cte_params, *rowids, *common_params)
                 else:
                     query = f"""
                     SELECT id, source_type, source_id, title
                     FROM search_index
                     WHERE id IN ({rowid_placeholders})
-                      AND (? IS NULL OR source_type = ?)
-                      {date_sql}
+                      {common_where}
                     """
-                    params = (*rowids, entity_type, entity_type, *date_params_list)
+                    params = (*rowids, *common_params)
 
                 filter_rows = execute_query(query, params)
                 for row in filter_rows:
@@ -762,10 +825,10 @@ def _vector_search(
             blob = serialize_float32(query_embedding)
 
             # vec_indexからKNN取得（タグフィルタ不可なので多めに取得）
-            # limitはsearch()側でlimit*5に拡大済み
+            # fetch_limitはsearch()側で (offset+limit)*FETCH_LIMIT_MULTIPLIER に拡大済み
             vec_rows = execute_query(
                 "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
-                (blob, limit),
+                (blob, fetch_limit),
             )
 
             if not vec_rows:
@@ -786,24 +849,22 @@ def _vector_search(
                 SELECT id, source_type, source_id, title
                 FROM search_index
                 WHERE id IN ({rowid_placeholders})
-                  AND (? IS NULL OR source_type = ?)
                   AND EXISTS (
                     SELECT 1 FROM tag_filtered tf
                     WHERE tf.source_type = search_index.source_type
                       AND tf.source_id = search_index.source_id
                   )
-                  {date_sql}
+                  {common_where}
                 """
-                params = (*cte_params, *rowids, entity_type, entity_type, *date_params_list)
+                params = (*cte_params, *rowids, *common_params)
             else:
                 query = f"""
                 SELECT id, source_type, source_id, title
                 FROM search_index
                 WHERE id IN ({rowid_placeholders})
-                  AND (? IS NULL OR source_type = ?)
-                  {date_sql}
+                  {common_where}
                 """
-                params = (*rowids, entity_type, entity_type, *date_params_list)
+                params = (*rowids, *common_params)
 
             filter_rows = execute_query(query, params)
 
@@ -819,7 +880,7 @@ def _vector_search(
 
             # distance順でソート（小さいほど類似度が高い）
             results.sort(key=lambda x: x["distance"])
-            return results[:limit]
+            return results[:fetch_limit]
 
     except (ValueError, RuntimeError, OSError):
         logger.warning("Vector search failed, falling back to FTS-only", exc_info=True)
@@ -982,15 +1043,7 @@ def find_similar_decisions(
         return []
 
 
-def _tag_like_search(
-    keywords: list[str],
-    tag_ids: Optional[list[int]],
-    entity_type: Optional[str],
-    limit: int,
-    keyword_mode: str = "and",
-    date_after: Optional[str] = None,
-    date_before: Optional[str] = None,
-) -> list[dict]:
+def _tag_like_search(ctx: SearchContext) -> list[dict]:
     """タグ名のLIKE検索。キーワードにマッチするタグを持つエンティティを返す。
 
     entity_tagsの各中間テーブルからタグ名LIKE検索し、
@@ -999,7 +1052,14 @@ def _tag_like_search(
     ANDモードでは「全キーワードを名前に含む単一タグ」を探す。
     FTS/ベクトルのAND（複数語を含む文書）とは異なる意味論であり、
     マッチするのは "domain:api-design" のような複合タグ名に限られる。
+
+    Args:
+        ctx: SearchContext。タグ LIKE 検索は元の ctx.keywords を使用し、
+            QE 拡張済みの ctx.fts_keywords は参照しない。
     """
+    keywords = list(ctx.keywords)
+    tag_ids = list(ctx.tag_ids) if ctx.tag_ids else None
+
     # LIKEワイルドカード文字をエスケープ
     def _escape_like(s: str) -> str:
         return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -1011,7 +1071,7 @@ def _tag_like_search(
     # name単体 or namespace:name の結合文字列に対してLIKE検索する
     tag_full_expr = "CASE WHEN namespace != '' THEN namespace || ':' || name ELSE name END"
     single_cond = f"(name LIKE ? ESCAPE '\\' OR {tag_full_expr} LIKE ? ESCAPE '\\')"
-    if keyword_mode == "or":
+    if ctx.keyword_mode == "or":
         # OR: いずれかのキーワードにマッチするタグ
         conditions = " OR ".join([single_cond] * len(like_patterns))
         params: list = []
@@ -1045,24 +1105,15 @@ def _tag_like_search(
     # マッチしたタグを持つエンティティをsearch_index経由で取得
     tag_placeholders = ",".join("?" * len(matched_tag_ids))
 
-    # 日付フィルタの動的WHERE句構築
-    date_clauses = []
-    date_params_tl: list = []
-    if date_after:
-        date_clauses.append("AND si.created_at >= ?")
-        date_params_tl.append(date_after)
-    if date_before:
-        date_clauses.append("AND si.created_at <= ?")
-        date_params_tl.append(date_before)
-    date_sql = "\n      ".join(date_clauses)
+    common_where, common_params = build_common_where(ctx, si_alias="si")
 
     # 各中間テーブルからエンティティを収集（UNION ALL）
+    # WHERE 1=1 を起点に common_where（"AND ..." で始まる）を連結する。
     query = f"""
     SELECT DISTINCT si.source_type AS type, si.source_id AS id, si.title
     FROM search_index si
-    WHERE
-      (? IS NULL OR si.source_type = ?)
-      {date_sql}
+    WHERE 1=1
+      {common_where}
       AND (
         EXISTS (
             SELECT 1 FROM topic_tags tt
@@ -1105,12 +1156,11 @@ def _tag_like_search(
     ORDER BY si.id DESC
     LIMIT ?
     """
-    # パラメータ: entity_type × 2 + date_params + matched_tag_ids × 7 + limit
-    query_params = [entity_type, entity_type]
-    query_params.extend(date_params_tl)
+    # パラメータ: common_params + matched_tag_ids × 7 + fetch_limit
+    query_params: list = list(common_params)
     for _ in range(7):
         query_params.extend(matched_tag_ids)
-    query_params.append(limit)
+    query_params.append(ctx.fetch_limit)
 
     rows = execute_query(query, tuple(query_params))
     results = []
@@ -1443,7 +1493,7 @@ def search(
                 conn.close()
 
         # RRFで両ソースをマージした後にoffset+limitで切るため、各ソースから多めに取得する
-        fetch_limit = (offset + limit) * 5
+        fetch_limit = (offset + limit) * FETCH_LIMIT_MULTIPLIER
 
         # 使用された検索手法を追跡
         methods_used: list[str] = []
@@ -1464,25 +1514,43 @@ def search(
         # QE拡張がある場合、元のキーワード数を記録
         original_kw_count = len(keywords) if len(fts_keywords) > len(keywords) else None
 
+        # SearchPipeline Phase A: SearchContext で retriever 共通パラメータを集約する。
+        # Phase B 以降の TODO は SearchContext docstring 参照。
+        ctx = SearchContext(
+            keywords=tuple(keywords),
+            fts_keywords=tuple(fts_keywords),
+            original_keyword_count=original_kw_count,
+            tag_ids=tuple(tag_ids) if tag_ids is not None else None,
+            entity_type=entity_type,
+            limit=limit,
+            offset=offset,
+            fetch_limit=fetch_limit,
+            keyword_mode=keyword_mode,
+            include_details=include_details,
+            date_after=date_after,
+            date_before=date_before,
+            domain=domain,
+        )
+
         if keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, None, date_after, date_before)
+                fts_results = _fts_search(ctx)
                 methods_used.append("fts5")
         else:
             # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
             # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
             if min_len >= 3:
-                fts_results = _fts_search(fts_keywords, tag_ids, entity_type, fetch_limit, keyword_mode, original_kw_count, date_after, date_before)
+                fts_results = _fts_search(ctx)
                 methods_used.append("fts5")
 
         # ベクトル検索（元のキーワードのまま、拡張なし）
-        vec_results = _vector_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
+        vec_results = _vector_search(ctx)
         if vec_results is not None:
             methods_used.append("vector")
 
         # タグLIKE検索（キーワード長の制限なし）
-        tag_like_results = _tag_like_search(keywords, tag_ids, entity_type, fetch_limit, keyword_mode, date_after, date_before)
+        tag_like_results = _tag_like_search(ctx)
         if tag_like_results:
             methods_used.append("tag_like")
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -4,6 +4,7 @@ import logging
 import math
 import re
 import sqlite3
+import textwrap
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -95,18 +96,6 @@ class SearchContext:
     フィールドは Validate / Normalize / Expand 完了後の確定値を保持する。
     frozen のため後段ステージで書き換える場合は dataclasses.replace を使う。
 
-    SearchPipeline 構造化は段階移行で進める。本 Phase A は SearchContext と
-    build_common_where を導入し、3 retriever (_fts_search / _vector_search /
-    _tag_like_search) が ctx を引数に取る形まで揃える。Phase B 以降は順次:
-
-    - Phase B: 3 retriever を fts_retrieve / vector_retrieve / tag_like_retrieve
-      として個別関数に整理する（_fts_search 等は薄いアダプタとして残置）
-    - Phase C: search() orchestrator を _validate / _normalize / _expand /
-      _retrieve / _merge / _rerank / _slice / _decorate に分割し、各ステージを
-      明示化する
-    - Phase D: P1-3 (score_breakdown / final_score) との接合を Decorate ステージで
-      整理する
-
     fields:
         keywords: 正規化済み元キーワード（QE 拡張を含まない）
         fts_keywords: FTS5 用キーワード（QE 拡張済みの場合がある）
@@ -141,7 +130,6 @@ def build_common_where(
     ctx: SearchContext,
     *,
     si_alias: str = "si",
-    include_entity_type: bool = True,
 ) -> tuple[str, list]:
     """3 retriever で共通する WHERE 句（entity_type / date 範囲）を組み立てる。
 
@@ -149,24 +137,20 @@ def build_common_where(
         ctx: SearchContext
         si_alias: 参照するテーブルエイリアス。空文字列の場合はカラム prefix なし
             （例: _vector_search の "FROM search_index ..." のような無エイリアス参照用）
-        include_entity_type: entity_type フィルタを含めるか
 
     Returns:
         (sql_fragment, params)
-        sql_fragment は "AND ..." で始まる WHERE 連結用フラグメント（複数 AND 句）。
+        sql_fragment は "AND ..." で始まる WHERE 連結用フラグメント（複数 AND 句を
+        改行で連結）。呼び出し元で SQL テンプレート内のインデントに合わせて
+        textwrap.indent で字下げする想定。
         params は ? の順序に沿ったパラメータリスト。
 
     retract フィルタは search_index / FTS5 / vec_index からの物理削除モデルへ移行済の
     ため含めない。
     """
     prefix = f"{si_alias}." if si_alias else ""
-    parts: list[str] = []
-    params: list = []
-
-    if include_entity_type:
-        parts.append(f"AND (? IS NULL OR {prefix}source_type = ?)")
-        params.append(ctx.entity_type)
-        params.append(ctx.entity_type)
+    parts: list[str] = [f"AND (? IS NULL OR {prefix}source_type = ?)"]
+    params: list = [ctx.entity_type, ctx.entity_type]
 
     if ctx.date_after:
         parts.append(f"AND {prefix}created_at >= ?")
@@ -176,7 +160,7 @@ def build_common_where(
         parts.append(f"AND {prefix}created_at <= ?")
         params.append(ctx.date_before)
 
-    return "\n          ".join(parts), params
+    return "\n".join(parts), params
 
 
 def _escape_fts5_query(keyword: str) -> str:
@@ -686,6 +670,7 @@ def _fts_search(ctx: SearchContext) -> list[dict]:
             escaped_keyword = " AND ".join(escaped_parts)
 
     common_where, common_params = build_common_where(ctx, si_alias="si")
+    common_where_indented = textwrap.indent(common_where, " " * 10).lstrip()
     tag_ids = list(ctx.tag_ids) if ctx.tag_ids else None
 
     if tag_ids:
@@ -700,7 +685,7 @@ def _fts_search(ctx: SearchContext) -> list[dict]:
         JOIN search_index si ON si.id = search_index_fts.rowid
         JOIN tag_filtered tf ON tf.source_type = si.source_type AND tf.source_id = si.source_id
         WHERE search_index_fts MATCH ?
-          {common_where}
+          {common_where_indented}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -714,7 +699,7 @@ def _fts_search(ctx: SearchContext) -> list[dict]:
         FROM search_index_fts
         JOIN search_index si ON si.id = search_index_fts.rowid
         WHERE search_index_fts MATCH ?
-          {common_where}
+          {common_where_indented}
         ORDER BY bm25(search_index_fts, 5.0, 1.0)
         LIMIT ?
         """
@@ -748,6 +733,8 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
 
     try:
         common_where, common_params = build_common_where(ctx, si_alias="")
+        common_where_or = textwrap.indent(common_where, " " * 22).lstrip()
+        common_where_and = textwrap.indent(common_where, " " * 18).lstrip()
 
         if ctx.keyword_mode == "or" and len(keywords) > 1:
             # OR時: 各キーワードで個別にベクトル検索し、結果をマージ
@@ -785,7 +772,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                         WHERE tf.source_type = search_index.source_type
                           AND tf.source_id = search_index.source_id
                       )
-                      {common_where}
+                      {common_where_or}
                     """
                     params = (*cte_params, *rowids, *common_params)
                 else:
@@ -793,7 +780,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                     SELECT id, source_type, source_id, title
                     FROM search_index
                     WHERE id IN ({rowid_placeholders})
-                      {common_where}
+                      {common_where_or}
                     """
                     params = (*rowids, *common_params)
 
@@ -854,7 +841,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                     WHERE tf.source_type = search_index.source_type
                       AND tf.source_id = search_index.source_id
                   )
-                  {common_where}
+                  {common_where_and}
                 """
                 params = (*cte_params, *rowids, *common_params)
             else:
@@ -862,7 +849,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                 SELECT id, source_type, source_id, title
                 FROM search_index
                 WHERE id IN ({rowid_placeholders})
-                  {common_where}
+                  {common_where_and}
                 """
                 params = (*rowids, *common_params)
 
@@ -1106,6 +1093,7 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
     tag_placeholders = ",".join("?" * len(matched_tag_ids))
 
     common_where, common_params = build_common_where(ctx, si_alias="si")
+    common_where_indented = textwrap.indent(common_where, " " * 6).lstrip()
 
     # 各中間テーブルからエンティティを収集（UNION ALL）
     # WHERE 1=1 を起点に common_where（"AND ..." で始まる）を連結する。
@@ -1113,7 +1101,7 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
     SELECT DISTINCT si.source_type AS type, si.source_id AS id, si.title
     FROM search_index si
     WHERE 1=1
-      {common_where}
+      {common_where_indented}
       AND (
         EXISTS (
             SELECT 1 FROM topic_tags tt
@@ -1514,8 +1502,6 @@ def search(
         # QE拡張がある場合、元のキーワード数を記録
         original_kw_count = len(keywords) if len(fts_keywords) > len(keywords) else None
 
-        # SearchPipeline Phase A: SearchContext で retriever 共通パラメータを集約する。
-        # Phase B 以降の TODO は SearchContext docstring 参照。
         ctx = SearchContext(
             keywords=tuple(keywords),
             fts_keywords=tuple(fts_keywords),
@@ -1532,7 +1518,7 @@ def search(
             domain=domain,
         )
 
-        if keyword_mode == "or":
+        if ctx.keyword_mode == "or":
             # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
             if any(len(kw) >= 3 for kw in fts_keywords):
                 fts_results = _fts_search(ctx)
@@ -1558,7 +1544,7 @@ def search(
         # OR時: 3文字以上が1つでもあればFTSで検索できるのでエラーにしない
         # タグLIKE検索結果がある場合もエラーにしない
         fts_available = (
-            any(len(kw) >= 3 for kw in keywords) if keyword_mode == "or"
+            any(len(kw) >= 3 for kw in keywords) if ctx.keyword_mode == "or"
             else min_len >= 3
         )
         if not fts_available and vec_results is None and not tag_like_results:

--- a/tests/unit/test_search_pipeline.py
+++ b/tests/unit/test_search_pipeline.py
@@ -1,0 +1,297 @@
+"""SearchPipeline Phase A: SearchContext / build_common_where のテスト。
+
+Phase A スコープ:
+- SearchContext frozen dataclass の構築可能性と frozen 性
+- build_common_where が entity_type / date_after / date_before を組み立てる出力
+- search() が SearchContext 経由で既存挙動を保つ等価性
+"""
+import dataclasses
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database
+from src.services import search_service
+from src.services.activity_service import add_activity
+from src.services.search_service import SearchContext, build_common_where
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision, add_log as add_log_entry
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    """Phase A の等価性テストでも embedding サービスは無効化する。"""
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _make_ctx(**overrides) -> SearchContext:
+    """テスト用のデフォルト SearchContext を生成する。"""
+    defaults = dict(
+        keywords=("hello",),
+        fts_keywords=("hello",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
+
+
+# ========================================
+# SearchContext 構築
+# ========================================
+
+
+def test_search_context_construct_minimal():
+    """必須フィールドを与えれば SearchContext が構築できる。"""
+    ctx = _make_ctx()
+    assert ctx.keywords == ("hello",)
+    assert ctx.fts_keywords == ("hello",)
+    assert ctx.original_keyword_count is None
+    assert ctx.tag_ids is None
+    assert ctx.entity_type is None
+    assert ctx.limit == 10
+    assert ctx.offset == 0
+    assert ctx.fetch_limit == 50
+    assert ctx.keyword_mode == "and"
+    assert ctx.include_details is False
+    assert ctx.date_after is None
+    assert ctx.date_before is None
+    assert ctx.domain is None
+
+
+def test_search_context_construct_full():
+    """全フィールドを指定して構築できる。"""
+    ctx = _make_ctx(
+        keywords=("alpha", "beta"),
+        fts_keywords=("alpha", "beta", "expanded"),
+        original_keyword_count=2,
+        tag_ids=(1, 2, 3),
+        entity_type="decision",
+        limit=20,
+        offset=5,
+        fetch_limit=100,
+        keyword_mode="or",
+        include_details=True,
+        date_after="2026-01-01",
+        date_before="2026-06-30 23:59:59",
+        domain="cc-memory",
+    )
+    assert ctx.keywords == ("alpha", "beta")
+    assert ctx.fts_keywords == ("alpha", "beta", "expanded")
+    assert ctx.original_keyword_count == 2
+    assert ctx.tag_ids == (1, 2, 3)
+    assert ctx.entity_type == "decision"
+    assert ctx.keyword_mode == "or"
+    assert ctx.include_details is True
+    assert ctx.date_after == "2026-01-01"
+    assert ctx.date_before == "2026-06-30 23:59:59"
+    assert ctx.domain == "cc-memory"
+
+
+def test_search_context_is_frozen():
+    """SearchContext は frozen のため属性の上書きは FrozenInstanceError を投げる。"""
+    ctx = _make_ctx()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.limit = 999  # type: ignore[misc]
+
+
+def test_search_context_replace_creates_new_instance():
+    """dataclasses.replace で新規インスタンスが生成される。"""
+    ctx = _make_ctx()
+    ctx2 = dataclasses.replace(ctx, limit=20, offset=5)
+    assert ctx.limit == 10 and ctx.offset == 0
+    assert ctx2.limit == 20 and ctx2.offset == 5
+    assert ctx is not ctx2
+
+
+# ========================================
+# build_common_where
+# ========================================
+
+
+def test_build_common_where_default_no_filters():
+    """date 指定なし・entity_type=None でも entity_type プレースホルダ句は出る。"""
+    ctx = _make_ctx()
+    sql, params = build_common_where(ctx)
+    # entity_type=None でも "AND (? IS NULL OR si.source_type = ?)" の形は出力する
+    # （? に NULL がバインドされて常時 True 扱いになる）
+    assert "AND (? IS NULL OR si.source_type = ?)" in sql
+    assert params == [None, None]
+
+
+def test_build_common_where_with_entity_type():
+    ctx = _make_ctx(entity_type="decision")
+    sql, params = build_common_where(ctx)
+    assert "AND (? IS NULL OR si.source_type = ?)" in sql
+    assert params == ["decision", "decision"]
+
+
+def test_build_common_where_with_date_after_only():
+    ctx = _make_ctx(entity_type="decision", date_after="2026-01-01")
+    sql, params = build_common_where(ctx)
+    assert "AND (? IS NULL OR si.source_type = ?)" in sql
+    assert "AND si.created_at >= ?" in sql
+    assert "AND si.created_at <= ?" not in sql
+    assert params == ["decision", "decision", "2026-01-01"]
+
+
+def test_build_common_where_with_date_before_only():
+    ctx = _make_ctx(date_before="2026-06-30 23:59:59")
+    sql, params = build_common_where(ctx)
+    assert "AND si.created_at <= ?" in sql
+    assert "AND si.created_at >= ?" not in sql
+    # entity_type=None でも entity_type 句は出る + date_before
+    assert params == [None, None, "2026-06-30 23:59:59"]
+
+
+def test_build_common_where_with_both_dates():
+    ctx = _make_ctx(
+        entity_type="log",
+        date_after="2026-01-01",
+        date_before="2026-06-30 23:59:59",
+    )
+    sql, params = build_common_where(ctx)
+    assert "AND (? IS NULL OR si.source_type = ?)" in sql
+    assert "AND si.created_at >= ?" in sql
+    assert "AND si.created_at <= ?" in sql
+    assert params == ["log", "log", "2026-01-01", "2026-06-30 23:59:59"]
+
+
+def test_build_common_where_alias_empty_prefix():
+    """si_alias='' でカラム参照に prefix を付けない（_vector_search 用）。"""
+    ctx = _make_ctx(entity_type="decision", date_after="2026-01-01")
+    sql, params = build_common_where(ctx, si_alias="")
+    assert "AND (? IS NULL OR source_type = ?)" in sql
+    assert "AND created_at >= ?" in sql
+    assert "si.source_type" not in sql
+    assert "si.created_at" not in sql
+    assert params == ["decision", "decision", "2026-01-01"]
+
+
+def test_build_common_where_custom_alias():
+    """si_alias を任意の文字列に切り替えられる。"""
+    ctx = _make_ctx(entity_type="topic")
+    sql, params = build_common_where(ctx, si_alias="search_index")
+    assert "AND (? IS NULL OR search_index.source_type = ?)" in sql
+    assert params == ["topic", "topic"]
+
+
+def test_build_common_where_exclude_entity_type():
+    """include_entity_type=False で entity_type 句を抑止できる。"""
+    ctx = _make_ctx(entity_type="decision", date_after="2026-01-01")
+    sql, params = build_common_where(ctx, include_entity_type=False)
+    assert "source_type" not in sql
+    assert "AND si.created_at >= ?" in sql
+    assert params == ["2026-01-01"]
+
+
+# ========================================
+# Phase A 等価性: search() が SearchContext 経由でも既存挙動を保つ
+# ========================================
+
+
+def test_phase_a_search_preserves_response_keys(temp_db):
+    """search() の返却辞書は results / total_count / search_methods_used /
+    nearby_tags の4キーを保つ。"""
+    add_topic(
+        title="SearchPipelineテストトピック",
+        description="Phase A 等価性確認用",
+        tags=DEFAULT_TAGS,
+    )
+    result = search_service.search(keyword="SearchPipeline")
+    assert "error" not in result
+    assert set(result.keys()) == {
+        "results",
+        "total_count",
+        "search_methods_used",
+        "nearby_tags",
+    }
+    assert isinstance(result["results"], list)
+    assert isinstance(result["total_count"], int)
+    assert isinstance(result["search_methods_used"], list)
+    assert isinstance(result["nearby_tags"], list)
+
+
+def test_phase_a_search_entity_type_filter(temp_db):
+    """entity_type フィルタは Phase A 後も SearchContext 経由で機能する。"""
+    add_topic(
+        title="topicEntityFilterCheck",
+        description="topic 側",
+        tags=DEFAULT_TAGS,
+    )
+    add_activity(
+        title="activityEntityFilterCheck",
+        description="activity 側",
+        tags=DEFAULT_TAGS,
+    )
+    result = search_service.search(
+        keyword="EntityFilterCheck", entity_type="topic"
+    )
+    assert "error" not in result
+    types_seen = {r["type"] for r in result["results"]}
+    assert types_seen <= {"topic"}
+    assert any(r["type"] == "topic" for r in result["results"])
+
+
+def test_phase_a_search_date_filter(temp_db):
+    """date_after / date_before フィルタは SearchContext 経由でも反映される。"""
+    add_topic(
+        title="DateFilterPhaseATopic",
+        description="日付フィルタテスト",
+        tags=DEFAULT_TAGS,
+    )
+    # 未来の date_after で 0 件
+    result = search_service.search(
+        keyword="DateFilterPhaseATopic", date_after="2099-01-01"
+    )
+    assert "error" not in result
+    assert result["total_count"] == 0
+    assert result["results"] == []
+
+    # 過去の date_after で >= 1 件
+    result2 = search_service.search(
+        keyword="DateFilterPhaseATopic", date_after="2020-01-01"
+    )
+    assert "error" not in result2
+    assert result2["total_count"] >= 1
+
+
+def test_phase_a_search_keyword_mode_or(temp_db):
+    """keyword_mode='or' は SearchContext 経由でも OR ヒットを返す。"""
+    add_topic(title="alphaOnlyTopic", description="alpha", tags=DEFAULT_TAGS)
+    add_topic(title="betaOnlyTopic", description="beta", tags=DEFAULT_TAGS)
+
+    result = search_service.search(
+        keyword=["alphaOnlyTopic", "betaOnlyTopic"], keyword_mode="or"
+    )
+    assert "error" not in result
+    titles = {r["title"] for r in result["results"]}
+    assert "alphaOnlyTopic" in titles
+    assert "betaOnlyTopic" in titles

--- a/tests/unit/test_search_pipeline.py
+++ b/tests/unit/test_search_pipeline.py
@@ -203,15 +203,6 @@ def test_build_common_where_custom_alias():
     assert params == ["topic", "topic"]
 
 
-def test_build_common_where_exclude_entity_type():
-    """include_entity_type=False で entity_type 句を抑止できる。"""
-    ctx = _make_ctx(entity_type="decision", date_after="2026-01-01")
-    sql, params = build_common_where(ctx, include_entity_type=False)
-    assert "source_type" not in sql
-    assert "AND si.created_at >= ?" in sql
-    assert params == ["2026-01-01"]
-
-
 # ========================================
 # Phase A 等価性: search() が SearchContext 経由でも既存挙動を保つ
 # ========================================


### PR DESCRIPTION
## Summary

- `_fts_search` / `_vector_search` / `_tag_like_search` の 3 retriever で重複していた共通フィルタ (`entity_type` / 日付範囲) を `build_common_where` ヘルパに集約
- `SearchContext` frozen dataclass を導入し、retriever 共通パラメータを 1 引数に統一
- 後続フェーズで進める個別関数化 / orchestrator 分割 / score_breakdown 接合の足場を作る段階的リファクタの第一歩

## 変更点

### 追加
- `SearchContext` frozen dataclass — `keywords` / `fts_keywords` / `original_keyword_count` / `tag_ids` / `entity_type` / `limit` / `offset` / `fetch_limit` / `keyword_mode` / `include_details` / `date_after` / `date_before` / `domain` を保持
- `build_common_where(ctx, *, si_alias, include_entity_type)` — entity_type + 日付範囲 の WHERE フラグメントを 1 箇所で生成。`si_alias=""` で無エイリアス参照（`_vector_search` 用）にも対応
- `FETCH_LIMIT_MULTIPLIER` 定数 — 旧来のハードコード `5` を抽出

### 変更
- `_fts_search` / `_vector_search` / `_tag_like_search` のシグネチャを `ctx: SearchContext` に統一し、内部 SQL は `build_common_where` の出力を埋め込む形に書き換え
- `search()` orchestrator は `SearchContext` を構築して 3 retriever を呼び出す形に薄く調整。RRF / recency boost / decorate / telemetry の挙動は未変更

### 触らない範囲
- スキーマ / migration なし
- `_rrf_merge` / `_apply_recency_boost` / `decorate 系` / `search_telemetry` は本 PR では未変更

## Test plan

- [x] 既存 search 関連テスト (test_fts5_search / test_hybrid_search / test_search_tags / test_search_telemetry) 213 件パス
- [x] tests/unit フル実行 1440 passed / 1 skipped
- [x] 新規 `tests/unit/test_search_pipeline.py` 16 件追加・パス
  - SearchContext 構築 (minimal / full / frozen / replace)
  - build_common_where 出力検証 (no filters / entity_type / date_after / date_before / both dates / alias empty / custom alias / exclude entity_type)
  - Phase A 等価性 (response keys / entity_type filter / date filter / keyword_mode=or)