### PR TITLE
feat: FTS5同期トリガーDDLをfts5_sync_serviceに集約

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -9,6 +9,7 @@ from . import (
     pin_service,
     timeline_service,
     guard_service,
+    fts5_sync_service,
 )
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "pin_service",
     "timeline_service",
     "guard_service",
+    "fts5_sync_service",
 ]

--- a/src/services/fts5_sync_service.py
+++ b/src/services/fts5_sync_service.py
@@ -1,0 +1,221 @@
+"""FTS5 同期トリガーの単一真実源 (single source of truth)。
+
+migrations/ 内に手書きで散在していた `trg_search_<entity>_{insert,update,delete}`
+の DDL を、`Fts5SyncSpec` から決定論的に生成する。
+
+新しい src_table を FTS5 検索対象に追加するときの規約:
+1. `FTS5_SPECS` に `Fts5SyncSpec(...)` を追加する。
+2. その変更を投入する migration で `install(conn, spec)` を呼ぶ。
+
+src_table の列名や display title 式が変わるときの規約:
+1. `FTS5_SPECS` の該当 spec を更新する。
+2. その変更を投入する migration で `install(conn, spec)` を呼ぶ。
+
+Expand-Contract:
+- Expand 段階 (本モジュール導入時): 既存 migration のトリガー記述は不変。
+  本モジュールから生成される DDL は既存最終形と機能的に等価。
+- Contract 段階 (後続 PR): 別 migration で `install_all(conn)` を呼んで
+  既存トリガーを spec ベースで全量再構築する。
+"""
+
+import re
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# CREATE/DROP TRIGGER の DDL に直接埋め込まれる識別子は、SQL 文字列補間で
+# bind parameter を使えないため、事前に文字種を制限してインジェクション余地を消す。
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class Fts5SyncSpec:
+    """1 src_table に対する FTS5 同期ルール。
+
+    Attributes:
+        source_type: `search_index.source_type` に格納する短い literal ('topic'/'decision'/'activity'/'log'/'material')
+        src_table: トリガー対象の SQLite テーブル名 (例: 'discussion_topics')
+        trigger_basename: トリガー名の中央部分 (`trg_search_<basename>_{insert,update,delete}` の `<basename>`)。
+            既存 migration での命名 (topics/decisions/activities/logs/materials) を踏襲する。
+            英語複数形は規則的とは限らない (activity→activities) ため source_type/src_table から自動導出しない。
+        fts_title_column: NEW.<fts_title_column> を `search_index_fts.title` に投入する列名
+        fts_body_column: NEW.<fts_body_column> を `search_index_fts.body` に投入する列名
+        display_title_expr: `search_index.title` (display 用) に投入する SQL 式
+            (例: "NEW.title" / "COALESCE(NEW.title, NEW.decision)")
+            None のときは "NEW.<fts_title_column>" として扱う
+    """
+
+    source_type: str
+    src_table: str
+    trigger_basename: str
+    fts_title_column: str
+    fts_body_column: str
+    display_title_expr: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "source_type",
+            "src_table",
+            "trigger_basename",
+            "fts_title_column",
+            "fts_body_column",
+        ):
+            value = getattr(self, field_name)
+            if not _IDENT_RE.match(value):
+                raise ValueError(
+                    f"Fts5SyncSpec.{field_name}={value!r} は識別子として不正 "
+                    f"(英数字・アンダースコアのみ、先頭は英字 or _)"
+                )
+
+    @property
+    def trigger_insert_name(self) -> str:
+        return f"trg_search_{self.trigger_basename}_insert"
+
+    @property
+    def trigger_update_name(self) -> str:
+        return f"trg_search_{self.trigger_basename}_update"
+
+    @property
+    def trigger_delete_name(self) -> str:
+        return f"trg_search_{self.trigger_basename}_delete"
+
+    @property
+    def effective_display_title_expr(self) -> str:
+        return self.display_title_expr or f"NEW.{self.fts_title_column}"
+
+
+# === FTS5 同期対象の最終形レジストリ ===
+# search_index.title (display) と search_index_fts.title/body (検索用) の列マッピングを
+# 一元宣言する。新しい src_table を加えるとき or 列マッピングを変えるときはここを編集する。
+FTS5_SPECS: tuple[Fts5SyncSpec, ...] = (
+    Fts5SyncSpec(
+        source_type="topic",
+        src_table="discussion_topics",
+        trigger_basename="topics",
+        fts_title_column="title",
+        fts_body_column="description",
+    ),
+    Fts5SyncSpec(
+        source_type="decision",
+        src_table="decisions",
+        trigger_basename="decisions",
+        fts_title_column="decision",
+        fts_body_column="reason",
+        display_title_expr="COALESCE(NEW.title, NEW.decision)",
+    ),
+    Fts5SyncSpec(
+        source_type="activity",
+        src_table="activities",
+        trigger_basename="activities",
+        fts_title_column="title",
+        fts_body_column="description",
+    ),
+    Fts5SyncSpec(
+        source_type="log",
+        src_table="discussion_logs",
+        trigger_basename="logs",
+        fts_title_column="title",
+        fts_body_column="content",
+    ),
+    Fts5SyncSpec(
+        source_type="material",
+        src_table="materials",
+        trigger_basename="materials",
+        fts_title_column="title",
+        fts_body_column="content",
+    ),
+)
+
+
+def render_insert_trigger(spec: Fts5SyncSpec) -> str:
+    """INSERT トリガーの CREATE 文を生成する。"""
+    return (
+        f"CREATE TRIGGER IF NOT EXISTS {spec.trigger_insert_name}\n"
+        f"AFTER INSERT ON {spec.src_table}\n"
+        f"BEGIN\n"
+        f"  INSERT INTO search_index (source_type, source_id, title, created_at)\n"
+        f"  VALUES ('{spec.source_type}', NEW.id, {spec.effective_display_title_expr}, NEW.created_at);\n"
+        f"  INSERT INTO search_index_fts (rowid, title, body)\n"
+        f"  VALUES (last_insert_rowid(), NEW.{spec.fts_title_column}, NEW.{spec.fts_body_column});\n"
+        f"END"
+    )
+
+
+def render_update_trigger(spec: Fts5SyncSpec) -> str:
+    """UPDATE トリガーの CREATE 文を生成する。
+
+    contentless FTS5 の 'delete' コマンドは INSERT 時と同じ title/body を渡す必要があり、
+    OLD.<fts_title_column> / OLD.<fts_body_column> で対応する。
+    """
+    return (
+        f"CREATE TRIGGER IF NOT EXISTS {spec.trigger_update_name}\n"
+        f"AFTER UPDATE ON {spec.src_table}\n"
+        f"BEGIN\n"
+        f"  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)\n"
+        f"  VALUES ('delete',\n"
+        f"    (SELECT id FROM search_index WHERE source_type = '{spec.source_type}' AND source_id = OLD.id),\n"
+        f"    OLD.{spec.fts_title_column}, OLD.{spec.fts_body_column});\n"
+        f"  UPDATE search_index\n"
+        f"  SET title = {spec.effective_display_title_expr}\n"
+        f"  WHERE source_type = '{spec.source_type}' AND source_id = NEW.id;\n"
+        f"  INSERT INTO search_index_fts (rowid, title, body)\n"
+        f"  VALUES (\n"
+        f"    (SELECT id FROM search_index WHERE source_type = '{spec.source_type}' AND source_id = NEW.id),\n"
+        f"    NEW.{spec.fts_title_column}, NEW.{spec.fts_body_column});\n"
+        f"END"
+    )
+
+
+def render_delete_trigger(spec: Fts5SyncSpec) -> str:
+    """DELETE トリガーの CREATE 文を生成する。"""
+    return (
+        f"CREATE TRIGGER IF NOT EXISTS {spec.trigger_delete_name}\n"
+        f"AFTER DELETE ON {spec.src_table}\n"
+        f"BEGIN\n"
+        f"  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)\n"
+        f"  VALUES ('delete',\n"
+        f"    (SELECT id FROM search_index WHERE source_type = '{spec.source_type}' AND source_id = OLD.id),\n"
+        f"    OLD.{spec.fts_title_column}, OLD.{spec.fts_body_column});\n"
+        f"  DELETE FROM search_index WHERE source_type = '{spec.source_type}' AND source_id = OLD.id;\n"
+        f"END"
+    )
+
+
+def render_create_triggers(spec: Fts5SyncSpec) -> tuple[str, str, str]:
+    """insert/update/delete の CREATE TRIGGER SQL を順に返す。"""
+    return (
+        render_insert_trigger(spec),
+        render_update_trigger(spec),
+        render_delete_trigger(spec),
+    )
+
+
+def render_drop_triggers(spec: Fts5SyncSpec) -> tuple[str, str, str]:
+    """insert/update/delete の DROP TRIGGER SQL を順に返す。"""
+    return (
+        f"DROP TRIGGER IF EXISTS {spec.trigger_insert_name}",
+        f"DROP TRIGGER IF EXISTS {spec.trigger_update_name}",
+        f"DROP TRIGGER IF EXISTS {spec.trigger_delete_name}",
+    )
+
+
+def install(conn: sqlite3.Connection, spec: Fts5SyncSpec) -> None:
+    """1 spec を DB に適用する。既存同名トリガーを drop してから create する。
+
+    呼び出し側がトランザクション/コミット境界を管理する。
+    """
+    for drop_sql in render_drop_triggers(spec):
+        conn.execute(drop_sql)
+    for create_sql in render_create_triggers(spec):
+        conn.execute(create_sql)
+
+
+def install_all(
+    conn: sqlite3.Connection, specs: Iterable[Fts5SyncSpec] = FTS5_SPECS
+) -> None:
+    """全 spec をまとめて適用する。Contract migration から呼ぶことを想定。
+
+    呼び出し側がトランザクション/コミット境界を管理する。
+    """
+    for spec in specs:
+        install(conn, spec)

--- a/src/services/fts5_sync_service.py
+++ b/src/services/fts5_sync_service.py
@@ -27,6 +27,16 @@ from dataclasses import dataclass
 # bind parameter を使えないため、事前に文字種を制限してインジェクション余地を消す。
 _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# display_title_expr に許可する形式:
+# - "NEW.<ident>" 単独
+# - "COALESCE(NEW.<ident>, NEW.<ident>[, NEW.<ident>...])"
+# それ以外の任意 SQL 式は受け付けない (DDL 直接補間されるため)。
+_DISPLAY_TITLE_NEW_RE = re.compile(r"^NEW\.[A-Za-z_][A-Za-z0-9_]*$")
+_DISPLAY_TITLE_COALESCE_RE = re.compile(
+    r"^COALESCE\(\s*NEW\.[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\s*,\s*NEW\.[A-Za-z_][A-Za-z0-9_]*)+\s*\)$"
+)
+
 
 @dataclass(frozen=True)
 class Fts5SyncSpec:
@@ -65,6 +75,16 @@ class Fts5SyncSpec:
                 raise ValueError(
                     f"Fts5SyncSpec.{field_name}={value!r} は識別子として不正 "
                     f"(英数字・アンダースコアのみ、先頭は英字 or _)"
+                )
+        if self.display_title_expr is not None:
+            expr = self.display_title_expr
+            if not (
+                _DISPLAY_TITLE_NEW_RE.match(expr)
+                or _DISPLAY_TITLE_COALESCE_RE.match(expr)
+            ):
+                raise ValueError(
+                    f"Fts5SyncSpec.display_title_expr={expr!r} は許可されない式 "
+                    f"('NEW.<ident>' または 'COALESCE(NEW.<ident>, NEW.<ident>[, ...])' のみ)"
                 )
 
     @property
@@ -202,7 +222,13 @@ def render_drop_triggers(spec: Fts5SyncSpec) -> tuple[str, str, str]:
 def install(conn: sqlite3.Connection, spec: Fts5SyncSpec) -> None:
     """1 spec を DB に適用する。既存同名トリガーを drop してから create する。
 
-    呼び出し側がトランザクション/コミット境界を管理する。
+    注意: Python 標準 ``sqlite3`` モジュールは default の ``isolation_level=""``
+    では DDL (CREATE/DROP TRIGGER 等) の実行直前に pending transaction を
+    暗黙 commit する。このため本関数の drop→create 系列は原子的ではなく、
+    途中失敗時には trigger が消えたまま残る可能性がある。
+    呼び出し側でこの非原子性が問題になる場合は、``isolation_level=None`` で
+    接続して BEGIN/COMMIT を明示制御するか、`DROP TRIGGER` / `CREATE TRIGGER`
+    の各 statement が独立に成功することを前提に設計すること。
     """
     for drop_sql in render_drop_triggers(spec):
         conn.execute(drop_sql)
@@ -215,7 +241,8 @@ def install_all(
 ) -> None:
     """全 spec をまとめて適用する。Contract migration から呼ぶことを想定。
 
-    呼び出し側がトランザクション/コミット境界を管理する。
+    原子性については `install` の docstring 参照 (Python sqlite3 の DDL
+    auto-commit 挙動により本関数も原子的ではない)。
     """
     for spec in specs:
         install(conn, spec)

--- a/tests/unit/test_fts5_sync_service.py
+++ b/tests/unit/test_fts5_sync_service.py
@@ -150,6 +150,51 @@ def test_invalid_identifier_rejected(kwargs):
         Fts5SyncSpec(**kwargs)
 
 
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "NEW.title; DROP TABLE search_index",  # SQL injection 形
+        "(SELECT 'x')",  # 任意の SQL 式
+        "OLD.title",  # OLD は不可
+        "COALESCE(NEW.title)",  # 引数 1 個は許容しない (COALESCE の意味がない)
+        "COALESCE(NEW.title, 'literal')",  # NEW.<ident> 以外の引数
+        "coalesce(NEW.title, NEW.decision)",  # 小文字 (大文字のみ許容)
+        "NEW.title || NEW.decision",  # 任意の式
+    ],
+)
+def test_invalid_display_title_expr_rejected(expr):
+    with pytest.raises(ValueError):
+        Fts5SyncSpec(
+            source_type="x",
+            src_table="t",
+            trigger_basename="ts",
+            fts_title_column="a",
+            fts_body_column="b",
+            display_title_expr=expr,
+        )
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "NEW.title",
+        "NEW.decision",
+        "COALESCE(NEW.title, NEW.decision)",
+        "COALESCE(NEW.a, NEW.b, NEW.c)",
+    ],
+)
+def test_valid_display_title_expr_accepted(expr):
+    spec = Fts5SyncSpec(
+        source_type="x",
+        src_table="t",
+        trigger_basename="ts",
+        fts_title_column="a",
+        fts_body_column="b",
+        display_title_expr=expr,
+    )
+    assert spec.display_title_expr == expr
+
+
 # ============================
 # Parity: 生成 DDL が現行 migration 最終形と等価
 # ============================

--- a/tests/unit/test_fts5_sync_service.py
+++ b/tests/unit/test_fts5_sync_service.py
@@ -1,0 +1,402 @@
+"""fts5_sync_service の DDL 生成・install 経路テスト。
+
+検証対象:
+- 各 spec の render_* が現行 migration 最終形の DDL と意味的に等価
+- install() で drop→create した後の挙動が既存トリガーと同等 (INSERT/UPDATE/DELETE 同期)
+- install_all() の冪等性
+- spec の識別子バリデーション
+"""
+
+import os
+import re
+import sqlite3
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database
+from src.services.fts5_sync_service import (
+    FTS5_SPECS,
+    Fts5SyncSpec,
+    install,
+    install_all,
+    render_create_triggers,
+    render_delete_trigger,
+    render_drop_triggers,
+    render_insert_trigger,
+    render_update_trigger,
+)
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _normalize_sql(sql: str) -> str:
+    """空白を圧縮して比較しやすくする。CREATE TRIGGER の本体比較用。
+
+    SQLite は sqlite_master.sql に保存するときに `IF NOT EXISTS` を剥がして格納するため、
+    比較時にもこのキーワードを除去して揃える。
+    """
+    collapsed = re.sub(r"\s+", " ", sql).strip()
+    return re.sub(r"\bIF NOT EXISTS\s+", "", collapsed)
+
+
+def _trigger_sql_from_db(db_path: str, trigger_name: str) -> str | None:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?",
+            (trigger_name,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+# ============================
+# DDL 生成 (render_*) 単体テスト
+# ============================
+
+
+def test_render_insert_trigger_topic():
+    spec = FTS5_SPECS[0]  # topic
+    sql = render_insert_trigger(spec)
+    assert "CREATE TRIGGER IF NOT EXISTS trg_search_topics_insert" in sql
+    assert "AFTER INSERT ON discussion_topics" in sql
+    assert "INSERT INTO search_index (source_type, source_id, title, created_at)" in sql
+    assert "'topic', NEW.id, NEW.title, NEW.created_at" in sql
+    assert "INSERT INTO search_index_fts (rowid, title, body)" in sql
+    assert "NEW.title, NEW.description" in sql
+
+
+def test_render_insert_trigger_decision_uses_coalesce_for_display_title():
+    spec = next(s for s in FTS5_SPECS if s.source_type == "decision")
+    sql = render_insert_trigger(spec)
+    # display title (search_index.title) は COALESCE
+    assert "COALESCE(NEW.title, NEW.decision), NEW.created_at" in sql
+    # FTS title/body は decision/reason
+    assert "NEW.decision, NEW.reason" in sql
+
+
+def test_render_update_trigger_decision_uses_coalesce():
+    spec = next(s for s in FTS5_SPECS if s.source_type == "decision")
+    sql = render_update_trigger(spec)
+    assert "SET title = COALESCE(NEW.title, NEW.decision)" in sql
+    # 'delete' marker は OLD.decision/OLD.reason
+    assert "OLD.decision, OLD.reason" in sql
+    assert "NEW.decision, NEW.reason" in sql
+
+
+def test_render_delete_trigger_material():
+    spec = next(s for s in FTS5_SPECS if s.source_type == "material")
+    sql = render_delete_trigger(spec)
+    assert "AFTER DELETE ON materials" in sql
+    assert "DELETE FROM search_index WHERE source_type = 'material'" in sql
+    assert "OLD.title, OLD.content" in sql
+
+
+def test_render_create_triggers_returns_three():
+    spec = FTS5_SPECS[0]
+    triggers = render_create_triggers(spec)
+    assert len(triggers) == 3
+    assert "AFTER INSERT" in triggers[0]
+    assert "AFTER UPDATE" in triggers[1]
+    assert "AFTER DELETE" in triggers[2]
+
+
+def test_render_drop_triggers_returns_three_names():
+    spec = next(s for s in FTS5_SPECS if s.source_type == "log")
+    drops = render_drop_triggers(spec)
+    assert drops == (
+        "DROP TRIGGER IF EXISTS trg_search_logs_insert",
+        "DROP TRIGGER IF EXISTS trg_search_logs_update",
+        "DROP TRIGGER IF EXISTS trg_search_logs_delete",
+    )
+
+
+# ============================
+# spec バリデーション
+# ============================
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"source_type": "bad name", "src_table": "t", "trigger_basename": "ts", "fts_title_column": "a", "fts_body_column": "b"},
+        {"source_type": "x", "src_table": "1bad", "trigger_basename": "ts", "fts_title_column": "a", "fts_body_column": "b"},
+        {"source_type": "x", "src_table": "t", "trigger_basename": "ts", "fts_title_column": "a;DROP", "fts_body_column": "b"},
+        {"source_type": "x", "src_table": "t", "trigger_basename": "ts", "fts_title_column": "a", "fts_body_column": "b'c"},
+        {"source_type": "x", "src_table": "t", "trigger_basename": "bad name", "fts_title_column": "a", "fts_body_column": "b"},
+    ],
+)
+def test_invalid_identifier_rejected(kwargs):
+    with pytest.raises(ValueError):
+        Fts5SyncSpec(**kwargs)
+
+
+# ============================
+# Parity: 生成 DDL が現行 migration 最終形と等価
+# ============================
+
+
+@pytest.mark.parametrize("spec", FTS5_SPECS, ids=[s.source_type for s in FTS5_SPECS])
+def test_parity_with_existing_migrations(temp_db, spec):
+    """init_database() 適用後の DB に存在する各 src_type の insert/update/delete トリガー
+    DDL が、render_* の出力と空白正規化後に一致することを確認する。
+
+    既存 migration を一切変更せずに新レイヤが「同じ DDL」を吐けることを担保する。
+    """
+    for trigger_name, rendered_sql in (
+        (spec.trigger_insert_name, render_insert_trigger(spec)),
+        (spec.trigger_update_name, render_update_trigger(spec)),
+        (spec.trigger_delete_name, render_delete_trigger(spec)),
+    ):
+        existing_sql = _trigger_sql_from_db(temp_db, trigger_name)
+        assert existing_sql is not None, f"既存 DB に {trigger_name} が存在しない"
+        assert _normalize_sql(existing_sql) == _normalize_sql(rendered_sql), (
+            f"{trigger_name} の生成 DDL が migration の最終形と一致しない\n"
+            f"existing: {existing_sql}\nrendered: {rendered_sql}"
+        )
+
+
+def test_install_re_emits_same_ddl(temp_db):
+    """install() で drop→create した後の sqlite_master.sql が render 出力と一致する。"""
+    for spec in FTS5_SPECS:
+        conn = sqlite3.connect(temp_db)
+        try:
+            install(conn, spec)
+            conn.commit()
+        finally:
+            conn.close()
+
+        for trigger_name, rendered_sql in (
+            (spec.trigger_insert_name, render_insert_trigger(spec)),
+            (spec.trigger_update_name, render_update_trigger(spec)),
+            (spec.trigger_delete_name, render_delete_trigger(spec)),
+        ):
+            stored = _trigger_sql_from_db(temp_db, trigger_name)
+            assert stored is not None
+            assert _normalize_sql(stored) == _normalize_sql(rendered_sql)
+
+
+def test_install_all_idempotent(temp_db):
+    """install_all() を 2 回呼んでもエラーにならず、最終状態が変わらないこと。"""
+    conn = sqlite3.connect(temp_db)
+    try:
+        install_all(conn)
+        conn.commit()
+        install_all(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    for spec in FTS5_SPECS:
+        for trigger_name in (
+            spec.trigger_insert_name,
+            spec.trigger_update_name,
+            spec.trigger_delete_name,
+        ):
+            assert _trigger_sql_from_db(temp_db, trigger_name) is not None
+
+
+# ============================
+# Runtime parity: install 後の同期挙動
+# ============================
+
+
+def test_runtime_sync_topic_after_install(temp_db):
+    """install 後でも discussion_topics の INSERT/UPDATE/DELETE で
+    search_index / search_index_fts が同期されることを確認する。
+    """
+    spec = next(s for s in FTS5_SPECS if s.source_type == "topic")
+    conn = sqlite3.connect(temp_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        install(conn, spec)
+        conn.execute(
+            "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+            ("ユニーク見出し abcfooxyz", "本文 quxbarzzz"),
+        )
+        topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # search_index 同期
+        si_row = conn.execute(
+            "SELECT * FROM search_index WHERE source_type='topic' AND source_id=?",
+            (topic_id,),
+        ).fetchone()
+        assert si_row is not None
+        assert si_row["title"] == "ユニーク見出し abcfooxyz"
+
+        # FTS5 検索ヒット (insert)
+        hit_title = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("abcfooxyz",),
+        ).fetchone()
+        assert hit_title is not None
+        hit_body = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("quxbarzzz",),
+        ).fetchone()
+        assert hit_body is not None
+
+        # UPDATE で旧マーカーが消え、新マーカーがヒット
+        conn.execute(
+            "UPDATE discussion_topics SET title=?, description=? WHERE id=?",
+            ("新タイトル qqqfoo123", "新本文 wwwbar456", topic_id),
+        )
+        # 旧 token は消えている
+        old_hit = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("abcfooxyz",),
+        ).fetchone()
+        assert old_hit is None
+        # 新 token はヒット
+        new_hit = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("qqqfoo123",),
+        ).fetchone()
+        assert new_hit is not None
+        # display title も追従
+        updated_si = conn.execute(
+            "SELECT title FROM search_index WHERE source_type='topic' AND source_id=?",
+            (topic_id,),
+        ).fetchone()
+        assert updated_si["title"] == "新タイトル qqqfoo123"
+
+        # DELETE で search_index も search_index_fts も消える
+        conn.execute("DELETE FROM discussion_topics WHERE id=?", (topic_id,))
+        gone = conn.execute(
+            "SELECT * FROM search_index WHERE source_type='topic' AND source_id=?",
+            (topic_id,),
+        ).fetchone()
+        assert gone is None
+        no_hit = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("qqqfoo123",),
+        ).fetchone()
+        assert no_hit is None
+    finally:
+        conn.close()
+
+
+def test_runtime_sync_decision_display_title_null(temp_db):
+    """decisions.title が NULL のとき search_index.title に decision 本文が入る (COALESCE)。"""
+    spec = next(s for s in FTS5_SPECS if s.source_type == "decision")
+    conn = sqlite3.connect(temp_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        install(conn, spec)
+        # decisions に投入するには topic が要る
+        conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+        topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, NULL)",
+            (topic_id, "決定本文 uniqdectoken", "理由 uniqreasontoken"),
+        )
+        d_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        si = conn.execute(
+            "SELECT title FROM search_index WHERE source_type='decision' AND source_id=?",
+            (d_id,),
+        ).fetchone()
+        # title=NULL なので decision 本文が display title になる
+        assert si["title"] == "決定本文 uniqdectoken"
+        # FTS body は reason
+        body_hit = conn.execute(
+            "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+            ("uniqreasontoken",),
+        ).fetchone()
+        assert body_hit is not None
+    finally:
+        conn.close()
+
+
+def test_runtime_sync_decision_display_title_set(temp_db):
+    """decisions.title が非 NULL のとき search_index.title に title が入る (COALESCE)。"""
+    spec = next(s for s in FTS5_SPECS if s.source_type == "decision")
+    conn = sqlite3.connect(temp_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        install(conn, spec)
+        conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t2', 'd2')")
+        topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
+            (topic_id, "本文タイトルではない", "理由本文", "短いタイトル uniqshort"),
+        )
+        d_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        si = conn.execute(
+            "SELECT title FROM search_index WHERE source_type='decision' AND source_id=?",
+            (d_id,),
+        ).fetchone()
+        assert si["title"] == "短いタイトル uniqshort"
+    finally:
+        conn.close()
+
+
+def test_runtime_sync_all_specs_after_install_all(temp_db):
+    """install_all() 後でも全 src_type の INSERT が同期される。"""
+    conn = sqlite3.connect(temp_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        install_all(conn)
+        # topic
+        conn.execute(
+            "INSERT INTO discussion_topics (title, description) VALUES ('tp uniqA001', 'dp uniqA002')"
+        )
+        topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        # activity
+        conn.execute(
+            "INSERT INTO activities (title, description, status) VALUES ('act uniqA003', 'desc uniqA004', 'in_progress')"
+        )
+        # log (discussion_logs requires topic_id)
+        conn.execute(
+            "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, 'log uniqA005', 'cont uniqA006')",
+            (topic_id,),
+        )
+        # material
+        conn.execute(
+            "INSERT INTO materials (title, content) VALUES ('mat uniqA007', 'cont uniqA008')"
+        )
+        # decision
+        conn.execute(
+            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, 'dec uniqA009', 'rea uniqA010', NULL)",
+            (topic_id,),
+        )
+
+        for token in [
+            "uniqA001",  # topic title
+            "uniqA002",  # topic body
+            "uniqA003",  # activity title
+            "uniqA004",  # activity body
+            "uniqA005",  # log title
+            "uniqA006",  # log body
+            "uniqA007",  # material title
+            "uniqA008",  # material body
+            "uniqA009",  # decision title (= NEW.decision)
+            "uniqA010",  # decision body (= NEW.reason)
+        ]:
+            row = conn.execute(
+                "SELECT rowid FROM search_index_fts WHERE search_index_fts MATCH ?",
+                (token,),
+            ).fetchone()
+            assert row is not None, f"token {token} がヒットしない"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- migration 0001-0043 に散在していた FTS5 同期トリガー (5 src_table × INSERT/UPDATE/DELETE = 15 個) を `Fts5SyncSpec` から決定論的に生成する単一同期レイヤ `src/services/fts5_sync_service.py` を追加
- 既存 migration 内のトリガー記述は変更せず維持 (Expand-Contract の Expand 段階)
- 新規 migration 以降は `FTS5_SPECS` を編集して `install(conn, spec)` を呼ぶ規約。既存トリガー一括再構築 (Contract) は別 PR で実施

## 設計の骨子

`Fts5SyncSpec` (5 フィールド) を spec の単一真実源として宣言:

- `source_type`: `search_index.source_type` の literal
- `src_table`: トリガー対象テーブル
- `trigger_basename`: トリガー名の中央部分 (英語複数形が不規則なため別 field)
- `fts_title_column` / `fts_body_column`: NEW.X が `search_index_fts.title`/`body` に入る列名
- `display_title_expr`: `search_index.title` (display 用) の式。None なら `NEW.<fts_title_column>` を使う。decisions のみ `COALESCE(NEW.title, NEW.decision)` を指定

5 spec で現状の最終形 (migration 0030 + 0037 を反映した状態) と意味的に等価な DDL を生成する。

## 検証

- **Parity**: `init_database()` で全 migration 適用後の `sqlite_master.sql` と `render_*_trigger(spec)` 出力を空白正規化して比較 (5 spec × 3 event = 15 ケース全 pass)
- **Runtime parity**: install() で drop→create 後、5 src_type 全件で INSERT/UPDATE/DELETE → `search_index` / `search_index_fts` 同期が期待通り動作することを検証
- **decisions の COALESCE**: title=NULL / title=set の両ケースで `search_index.title` が期待通りになることを検証
- **冪等性**: `install_all()` を 2 回呼んでもエラーなし、最終状態が同じ
- **識別子バリデーション**: 不正識別子 (空白入り・記号入り) は ValueError でリジェクト
- 既存テスト: migration tests 53 pass、unit 全体 1424 pass + 1 skip (regression なし)

## Test plan

- [ ] CI が green になること
- [ ] bot レビュー指摘があれば対応
- [ ] 人間 approve を得てから merge