### PR TITLE
feat: ow_status 内で stagnation detector (sentinel.py) を auto-spawn

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -314,6 +314,8 @@ orch が参照する情報は 4 層に分かれる:
 
 **起動 cwd 規約**: orch は作業ルート (例: `~/workspace`) で起動する。dispatcher にはリポジトリの cwd (もしくは worktree 親ディレクトリ) を割り当てる。
 
+**stagnation detector の自動起動**: Step 2 の `ow_status(channel_code, topic_id)` を呼んだ時点で `ensure_sentinel_process(channel_code)` が内部で実行され、`scripts/ow/sentinel.py` が channel ごとに 1 プロセスで起動される (D#2752 Phase A 配線、PR #432)。orch は明示的に sentinel を起動するアクションを取らなくてよい。起動は `uv run --directory <project_root> python scripts/ow/sentinel.py <channel_code>` 経由で、stderr は `/tmp/sentinel-<channel_code>.log` に追記される。過渡期は sentinel が `to:"orch"` で送信するケースが残り、relay 側 recv_filter の alias マッピングで吸収される (sentinel.py の `to` 統一は別 PR)。詳細仕様 / 受信時対処は `skills/dispatcher/SKILL.md` §stagnation detector を参照。
+
 ## 運転ループ
 
 Monitor 発火 (user 入力 / dispatcher event / sentinel event) を起点とする:

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -534,6 +534,109 @@ def _is_relay_running() -> bool:
     return _get_relay_health() is not None
 
 
+# ----------------------------
+# stagnation detector (sentinel.py) auto-start
+# ----------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SENTINEL_SCRIPT = _PROJECT_ROOT / "scripts" / "ow" / "sentinel.py"
+_SENTINEL_SCRIPT_REL = "scripts/ow/sentinel.py"
+
+
+def _sentinel_log_path(channel_code: str) -> Path:
+    """sentinel の stderr を書き出す追記ログのパス。
+
+    `Bash(run_in_background=true)` 経由で起動された場合に stderr が失われると、
+    起動失敗 / relay 接続エラー / stagnation 検知の証跡が残らないため、channel
+    ごとに固定パスへ追記する。
+    """
+    return Path("/tmp") / f"sentinel-{channel_code}.log"
+
+
+def _is_sentinel_running(channel_code: str) -> bool:
+    """同 channel の sentinel.py プロセスが既に走っているか pgrep で判定する。
+
+    pgrep が無い・タイムアウト等の例外時は False を返す (呼び出し側で spawn を
+    試みる)。sentinel.py 自体は in-memory state + 冪等 polling なので最悪重複
+    起動しても致命的にはならない。
+
+    パターン末尾に `$` アンカーを付け、`ow1` を渡したときに `ow10` / `ow100` 等の
+    prefix 衝突で誤検知するのを防ぐ。
+    """
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", f"{_SENTINEL_SCRIPT_REL}.*{channel_code}$"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        return result.returncode == 0 and bool(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def ensure_sentinel_process(channel_code: str) -> bool:
+    """ow stagnation detector (scripts/ow/sentinel.py) を channel ごとに 1 プロセスで起動する。
+
+    orch が `ow_status` を呼ぶたびに通過するため、AI セッションが SKILL.md の
+    起動手順を読み飛ばしても sentinel が自動的に立ち上がる (D#2752 Phase A の
+    起動配線、PR #432)。
+
+    - 既に同 channel の sentinel が pgrep で見つかれば何もしない (1 channel = 1 プロセス)
+    - `OW_SKIP_SENTINEL_AUTOSPAWN=1` 環境変数で skip 可能 (test / 一時無効化用)
+    - 起動失敗は logger.warning に流すだけで呼び出し元には伝播させない
+      (`ow_status` を fail させてはいけない)
+    - 起動コマンドは `uv run --directory <project_root> python scripts/ow/sentinel.py`。
+      hooks/hooks.json の他 Python 呼び出しと一貫させ、将来 sentinel.py に外部依存
+      が追加されても project venv で解決されるようにする。
+    - sentinel の stderr は `/tmp/sentinel-<channel>.log` に追記する。診断ログ
+      (起動失敗・relay 接続エラー・stagnation 検知) が捨てられないようにする。
+
+    Returns:
+        True なら起動成功 or 既に起動済み、False なら起動失敗 or skip。
+    """
+    if os.environ.get("OW_SKIP_SENTINEL_AUTOSPAWN") == "1":
+        return False
+    if not _SENTINEL_SCRIPT.is_file():
+        logger.warning("sentinel script not found at %s — skip auto-start", _SENTINEL_SCRIPT)
+        return False
+    if _is_sentinel_running(channel_code):
+        return True
+    log_path = _sentinel_log_path(channel_code)
+    try:
+        log_fh = open(log_path, "ab")
+    except OSError as exc:
+        logger.warning("failed to open sentinel log %s: %s — fallback to DEVNULL", log_path, exc)
+        log_fh = None
+    try:
+        subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "--directory",
+                str(_PROJECT_ROOT),
+                "python",
+                _SENTINEL_SCRIPT_REL,
+                channel_code,
+            ],
+            cwd=str(_PROJECT_ROOT),
+            stdout=subprocess.DEVNULL,
+            stderr=log_fh if log_fh is not None else subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except OSError as exc:
+        logger.warning("failed to spawn sentinel for channel=%s: %s", channel_code, exc)
+        return False
+    finally:
+        # Popen 側で fd は dup される。親プロセスのハンドルは閉じてよい。
+        if log_fh is not None:
+            try:
+                log_fh.close()
+            except OSError:
+                pass
+
+
 def ensure_channel(channel_code: str) -> bool:
     """channelが存在しなければrelayに作成する（idempotent）。
 
@@ -1326,6 +1429,9 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
     if channel:
         if not ensure_channel(channel):
             return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
+        # stagnation detector (sentinel.py) を auto-start する (PR #432, D#2752 Phase A)。
+        # orch 起動時に必ず通る経路なので、AI が SKILL.md を読み飛ばしても sentinel が起動される。
+        ensure_sentinel_process(channel)
 
     presence_result = _relay_request("GET", f"/presence?{urllib.parse.urlencode({'channel': channel})}")
     if "error" in presence_result:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,18 @@ def _clear_ow_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _skip_sentinel_autospawn(monkeypatch):
+    """ow_status 呼び出し時の sentinel.py auto-spawn をテストでは抑止する。
+
+    PR #432 で導入された ensure_sentinel_process はテスト中に呼ばれると
+    永続 polling プロセスを残し、test runner 終了後もゾンビになる。
+    OW_SKIP_SENTINEL_AUTOSPAWN=1 で default skip。auto-spawn 自体を検証する
+    テストは個別に monkeypatch.delenv で外す。
+    """
+    monkeypatch.setenv("OW_SKIP_SENTINEL_AUTOSPAWN", "1")
+
+
+@pytest.fixture(autouse=True)
 def _synchronous_telemetry(monkeypatch):
     """search_telemetry 書込を同期実行に切り替える。
 

--- a/tests/unit/test_ow_sentinel_autospawn.py
+++ b/tests/unit/test_ow_sentinel_autospawn.py
@@ -1,0 +1,151 @@
+"""ow_service.ensure_sentinel_process の auto-start ロジックを検証する unit test。
+
+PR #432 で導入された「ow_status 呼び出し時に sentinel.py を channel ごと 1 プロセス
+起動する」配線の振る舞いを確認する。
+
+- 既に走っていれば spawn しない (pgrep でヒット時)
+- 走っていなければ subprocess.Popen で spawn する
+- OW_SKIP_SENTINEL_AUTOSPAWN=1 で skip
+- spawn 失敗 (OSError) は logger.warning に流して False を返すだけ (例外を伝播しない)
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services import ow_service
+
+
+@pytest.fixture
+def unset_skip_env(monkeypatch):
+    """テストで OW_SKIP_SENTINEL_AUTOSPAWN が外部から渡っていても落とす。"""
+    monkeypatch.delenv("OW_SKIP_SENTINEL_AUTOSPAWN", raising=False)
+
+
+def _completed_process(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestIsSentinelRunning:
+    def test_returns_true_when_pgrep_hits(self, unset_skip_env):
+        with patch("src.services.ow_service.subprocess.run") as mock_run:
+            mock_run.return_value = _completed_process(stdout="12345\n", returncode=0)
+            assert ow_service._is_sentinel_running("CH123") is True
+
+    def test_returns_false_when_pgrep_no_match(self, unset_skip_env):
+        with patch("src.services.ow_service.subprocess.run") as mock_run:
+            mock_run.return_value = _completed_process(stdout="", returncode=1)
+            assert ow_service._is_sentinel_running("CH123") is False
+
+    def test_returns_false_when_pgrep_missing(self, unset_skip_env):
+        with patch("src.services.ow_service.subprocess.run", side_effect=FileNotFoundError):
+            assert ow_service._is_sentinel_running("CH123") is False
+
+    def test_returns_false_on_timeout(self, unset_skip_env):
+        with patch(
+            "src.services.ow_service.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pgrep", timeout=2),
+        ):
+            assert ow_service._is_sentinel_running("CH123") is False
+
+    def test_pgrep_pattern_uses_trailing_anchor(self, unset_skip_env):
+        """`ow1` を渡したとき `ow10` / `ow100` などの prefix 衝突で誤検知しないこと。"""
+        with patch("src.services.ow_service.subprocess.run") as mock_run:
+            mock_run.return_value = _completed_process(stdout="", returncode=1)
+            ow_service._is_sentinel_running("ow1")
+            args, _ = mock_run.call_args
+            cmd = args[0]
+            # cmd = ["pgrep", "-f", "<pattern>"]
+            assert cmd[0] == "pgrep"
+            assert cmd[-1].endswith("ow1$"), f"pattern must end with $ anchor, got: {cmd[-1]!r}"
+
+
+class TestEnsureSentinelProcess:
+    def test_spawns_when_not_running(self, unset_skip_env, tmp_path, monkeypatch):
+        # log open 先を tmp_path に逃がして /tmp を汚さない
+        monkeypatch.setattr(
+            ow_service, "_sentinel_log_path", lambda code: tmp_path / f"sentinel-{code}.log"
+        )
+        with patch("src.services.ow_service._is_sentinel_running", return_value=False), \
+             patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            mock_script.is_file.return_value = True
+            mock_script.__str__ = lambda self: "/path/to/sentinel.py"
+            assert ow_service.ensure_sentinel_process("CH123") is True
+            mock_popen.assert_called_once()
+            # spawn 引数の末尾に channel_code が乗ること
+            args, _ = mock_popen.call_args
+            cmd = args[0]
+            assert cmd[-1] == "CH123"
+
+    def test_spawn_uses_uv_run_with_project_directory(self, unset_skip_env, tmp_path, monkeypatch):
+        """hooks/hooks.json と一貫させるため `uv run --directory <root> python ...` で起動すること。"""
+        monkeypatch.setattr(
+            ow_service, "_sentinel_log_path", lambda code: tmp_path / f"sentinel-{code}.log"
+        )
+        with patch("src.services.ow_service._is_sentinel_running", return_value=False), \
+             patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            mock_script.is_file.return_value = True
+            ow_service.ensure_sentinel_process("CH123")
+            args, _ = mock_popen.call_args
+            cmd = args[0]
+            assert cmd[0] == "uv"
+            assert cmd[1] == "run"
+            assert "--directory" in cmd
+            assert "python" in cmd
+            assert "scripts/ow/sentinel.py" in cmd
+
+    def test_spawn_redirects_stderr_to_log_file(self, unset_skip_env, tmp_path, monkeypatch):
+        """sentinel の stderr を /tmp/sentinel-<channel>.log に追記すること。"""
+        log_path = tmp_path / "sentinel-CH123.log"
+        monkeypatch.setattr(ow_service, "_sentinel_log_path", lambda code: log_path)
+        with patch("src.services.ow_service._is_sentinel_running", return_value=False), \
+             patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            mock_script.is_file.return_value = True
+            ow_service.ensure_sentinel_process("CH123")
+            _, kwargs = mock_popen.call_args
+            stderr = kwargs.get("stderr")
+            # DEVNULL ではなく実ファイル fd が渡されること
+            assert stderr is not subprocess.DEVNULL
+            assert stderr is not None
+            # ログファイルが open 済みであること (Popen に渡した時点で create される)
+            assert log_path.exists()
+
+    def test_skips_when_already_running(self, unset_skip_env):
+        with patch("src.services.ow_service._is_sentinel_running", return_value=True), \
+             patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            mock_script.is_file.return_value = True
+            assert ow_service.ensure_sentinel_process("CH123") is True
+            mock_popen.assert_not_called()
+
+    def test_skips_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("OW_SKIP_SENTINEL_AUTOSPAWN", "1")
+        with patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            assert ow_service.ensure_sentinel_process("CH123") is False
+            mock_popen.assert_not_called()
+
+    def test_skips_when_sentinel_script_missing(self, unset_skip_env):
+        with patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch("src.services.ow_service.subprocess.Popen") as mock_popen:
+            mock_script.is_file.return_value = False
+            assert ow_service.ensure_sentinel_process("CH123") is False
+            mock_popen.assert_not_called()
+
+    def test_returns_false_and_does_not_raise_on_oserror(self, unset_skip_env, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            ow_service, "_sentinel_log_path", lambda code: tmp_path / f"sentinel-{code}.log"
+        )
+        with patch("src.services.ow_service._is_sentinel_running", return_value=False), \
+             patch("src.services.ow_service._SENTINEL_SCRIPT") as mock_script, \
+             patch(
+                 "src.services.ow_service.subprocess.Popen",
+                 side_effect=OSError("fork failed"),
+             ):
+            mock_script.is_file.return_value = True
+            # 例外を伝播しないこと
+            assert ow_service.ensure_sentinel_process("CH123") is False


### PR DESCRIPTION
## Summary

- `ow_status` 内で `ensure_sentinel_process(channel)` を呼び、`scripts/ow/sentinel.py` を channel ごとに 1 プロセス background spawn する
- orch session が起動時に必ず `ow_status` を呼ぶ性質 (D#2454) を利用し、AI が SKILL.md を読み飛ばしても sentinel が立ち上がる構造にする
- 既に走っている場合は `pgrep` で重複検知して skip (1 channel = 1 プロセス)

## なぜこの変更が必要か

PR #410 (commit `eaf8c2a`, 2026-06-20) は `sentinel.py` の本体・unit test・dispatcher SKILL の受信節を整備したが、**sentinel を実際に起動する経路はどこにも組み込まれていなかった**。結果、実機では sentinel プロセスは一切立ち上がらず、stagnation 検知は無効化されたまま稼働していた。

最近観察された待ち状態:
- worker ready 滞留 9 時間 (Wave 4 spawn 経路、2026-06-22)
- worker ready 滞留 1 時間 (w-sani-5a-prb、2026-06-21)
- 思考worker auto-assign 不発 (w-cs, effort=ultratink)
- worker ready 滞留 15 分 (w-doc/T95)

設計上は sentinel が ready 滞留 60 秒で `ow_sentinel` handle から stagnation event を broadcast し、orch / dispatcher が `command:assign` 明示送信などで対処する想定だった。

## 設計判断

**SKILL.md に Step 10 で「Bash 起動しろ」と書く案 (初版)** は AI 判断に依存し、SKILL を読み飛ばすと再発するため不採用。代わりに **`ow_status` 内部で auto-start** する形に変更した。`ow_status` は D#2454 で「orch 起動時に必ず 1 回呼ぶ」と確定済みのツールで、起動契機として確実。

## 実装ポイント

- **pgrep pattern に `$` anchor**: `f"{_SENTINEL_SCRIPT_REL}.*{channel_code}$"`。`ow1` を渡したとき `ow10` 等の prefix 衝突で誤検知しないようにする
- **`uv run --directory <project_root> python ...` で起動**: hooks/hooks.json の他 Python 呼び出しと一貫させ、将来 sentinel.py に外部依存が追加されても project venv で解決される
- **stderr → `/tmp/sentinel-<channel>.log` 追記**: 起動失敗・relay 接続エラー・stagnation 検知の証跡が捨てられないようにする
- **`OW_SKIP_SENTINEL_AUTOSPAWN=1` で skip 可能**: `tests/conftest.py` の autouse fixture で default skip し、test runner 終了後の永続 polling プロセスのゾンビ化を防ぐ
- **起動失敗 (OSError) は logger.warning のみ**: 呼び出し元 (`ow_status`) には伝播させない

SKILL.md には「Step 2 の `ow_status` 内部で auto-start される」旨を補足するに留め、明示的な起動アクションは要求しない。

## Test plan

- [x] `uv run pytest tests/unit/test_ow_sentinel_autospawn.py tests/unit/test_ow_sentinel.py -x` ローカル通過 (33 件)
- [x] unit test 全件ローカル通過 (autouse fixture で auto-spawn 抑止)
- [ ] CI で test (unit) / test (integration-e2e) / claude-review が pass すること
- [ ] merge 後の実機で orch session 起動時に `ps aux | grep sentinel.py` で 1 プロセス確認
- [ ] worker を ready 状態で 60 秒以上滞留させ、`ow_history` に `from:"ow_sentinel"` の stagnation event が現れることを確認

## 関連

- 実装本体: PR #410 (commit `eaf8c2a`)
- 仕様: D#2752 (ow stagnation detector v0 確定)
- 設計棚卸し: M#388 (T96 v0 設計)
- 配線抜け発覚: L#2907
- 観察 log: L#2904 (9h idle), L#2906 (1h ready 滑り)
- 採用方針 decision: D#2864 (SKILL.md 経路から ow_status 内 auto-spawn へ書き換え)

🤖 Generated with [Claude Code](https://claude.com/claude-code)