### PR TITLE
test: heartbeat_sh flaky テストの ready phase 待機を 3s→6s に調整

### DIFF
--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -263,11 +263,14 @@ class TestHeartbeatShLoopControl:
         )
 
         # loading フェーズで数件届くのを確認
-        deadline = time.time() + 1.5
+        deadline = time.time() + 3.0
         while len(server.received) < 2 and time.time() < deadline:
             time.sleep(0.05)
 
         loading_count = len(server.received)
+        assert loading_count >= 1, (
+            f"loading フェーズのメッセージが届かなかった (deadline 3.0s 内に 0 件)"
+        )
 
         # ready フェーズに切り替え
         tmp_phase_file.write_text("ready")

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -272,7 +272,7 @@ class TestHeartbeatShLoopControl:
         # ready フェーズに切り替え
         tmp_phase_file.write_text("ready")
 
-        deadline = time.time() + 3.0
+        deadline = time.time() + 6.0
         while len(server.received) < loading_count + 1 and time.time() < deadline:
             time.sleep(0.05)
 


### PR DESCRIPTION
## Summary

- `tests/unit/test_heartbeat_sh.py::TestHeartbeatShLoopControl::test_interval_switches_with_phase` の ready phase 待機 deadline を 3.0s → 6.0s に伸ばす
- CI runner 負荷で 3 秒以内に ready メッセージが届かず flaky 失敗するケースが PR #432 の run で再発したため

## なぜこの変更が必要か

本テストは bash subprocess (`heartbeat.sh`) を起動し、phase file を `loading` → `ready` に書き換えて heartbeat 間隔切り替えを検証する。`HEARTBEAT_INTERVAL_*=0` を渡してビジーループさせる前提なので、bash subprocess + http relay + GitHub Actions runner の負荷揺らぎに弱い。

過去にも同テストで 1s → 3s の引き上げ (commit `d6b714f`) が行われており、今回は 3s でも GitHub Actions 上で間に合わないケースが発生した。本質的には `pytest-rerunfailures` 等の flaky マーカー導入が筋だが、まず最小変更で deadline 引き上げのみ行う。

## Test plan

- [ ] CI で test (unit) が通ること
- [ ] ローカルで `uv run pytest tests/unit/test_heartbeat_sh.py::TestHeartbeatShLoopControl::test_interval_switches_with_phase -v` が通ること

## 関連

- 観察 run: https://github.com/isizono/cc-memory/actions/runs/27953053778/job/82714442746 (PR #432 の unit test 失敗)
- 過去の同種引き上げ: commit d6b714f

🤖 Generated with [Claude Code](https://claude.com/claude-code)