### PR TITLE
refactor: sentinel pgrep を re.escape し、コード内の PR 番号参照を削除

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -314,7 +314,7 @@ orch が参照する情報は 4 層に分かれる:
 
 **起動 cwd 規約**: orch は作業ルート (例: `~/workspace`) で起動する。dispatcher にはリポジトリの cwd (もしくは worktree 親ディレクトリ) を割り当てる。
 
-**stagnation detector の自動起動**: Step 2 の `ow_status(channel_code, topic_id)` を呼んだ時点で `ensure_sentinel_process(channel_code)` が内部で実行され、`scripts/ow/sentinel.py` が channel ごとに 1 プロセスで起動される (D#2752 Phase A 配線、PR #432)。orch は明示的に sentinel を起動するアクションを取らなくてよい。起動は `uv run --directory <project_root> python scripts/ow/sentinel.py <channel_code>` 経由で、stderr は `/tmp/sentinel-<channel_code>.log` に追記される。過渡期は sentinel が `to:"orch"` で送信するケースが残り、relay 側 recv_filter の alias マッピングで吸収される (sentinel.py の `to` 統一は別 PR)。詳細仕様 / 受信時対処は `skills/dispatcher/SKILL.md` §stagnation detector を参照。
+**stagnation detector の自動起動**: Step 2 の `ow_status(channel_code, topic_id)` を呼んだ時点で `ensure_sentinel_process(channel_code)` が内部で実行され、`scripts/ow/sentinel.py` が channel ごとに 1 プロセスで起動される (D#2752 Phase A 配線)。orch は明示的に sentinel を起動するアクションを取らなくてよい。起動は `uv run --directory <project_root> python scripts/ow/sentinel.py <channel_code>` 経由で、stderr は `/tmp/sentinel-<channel_code>.log` に追記される。過渡期は sentinel が `to:"orch"` で送信するケースが残り、relay 側 recv_filter の alias マッピングで吸収される (`to` の `dispatcher` 統一は別途対応)。詳細仕様 / 受信時対処は `skills/dispatcher/SKILL.md` §stagnation detector を参照。
 
 ## 運転ループ
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -565,7 +565,7 @@ def _is_sentinel_running(channel_code: str) -> bool:
     """
     try:
         result = subprocess.run(
-            ["pgrep", "-f", f"{_SENTINEL_SCRIPT_REL}.*{channel_code}$"],
+            ["pgrep", "-f", f"{_SENTINEL_SCRIPT_REL}.*{re.escape(channel_code)}$"],
             capture_output=True,
             text=True,
             timeout=2,
@@ -580,7 +580,7 @@ def ensure_sentinel_process(channel_code: str) -> bool:
 
     orch が `ow_status` を呼ぶたびに通過するため、AI セッションが SKILL.md の
     起動手順を読み飛ばしても sentinel が自動的に立ち上がる (D#2752 Phase A の
-    起動配線、PR #432)。
+    起動配線)。
 
     - 既に同 channel の sentinel が pgrep で見つかれば何もしない (1 channel = 1 プロセス)
     - `OW_SKIP_SENTINEL_AUTOSPAWN=1` 環境変数で skip 可能 (test / 一時無効化用)
@@ -1429,7 +1429,7 @@ def ow_status(channel: str, topic_id: str | None = None) -> dict:
     if channel:
         if not ensure_channel(channel):
             return {"error": {"code": "CHANNEL_UNAVAILABLE", "message": f"channel {channel} could not be created"}}
-        # stagnation detector (sentinel.py) を auto-start する (PR #432, D#2752 Phase A)。
+        # stagnation detector (sentinel.py) を auto-start する (D#2752 Phase A)。
         # orch 起動時に必ず通る経路なので、AI が SKILL.md を読み飛ばしても sentinel が起動される。
         ensure_sentinel_process(channel)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def _clear_ow_env(monkeypatch):
 def _skip_sentinel_autospawn(monkeypatch):
     """ow_status 呼び出し時の sentinel.py auto-spawn をテストでは抑止する。
 
-    PR #432 で導入された ensure_sentinel_process はテスト中に呼ばれると
+    ensure_sentinel_process (D#2752 Phase A 配線) はテスト中に呼ばれると
     永続 polling プロセスを残し、test runner 終了後もゾンビになる。
     OW_SKIP_SENTINEL_AUTOSPAWN=1 で default skip。auto-spawn 自体を検証する
     テストは個別に monkeypatch.delenv で外す。

--- a/tests/unit/test_ow_sentinel_autospawn.py
+++ b/tests/unit/test_ow_sentinel_autospawn.py
@@ -1,7 +1,7 @@
 """ow_service.ensure_sentinel_process の auto-start ロジックを検証する unit test。
 
-PR #432 で導入された「ow_status 呼び出し時に sentinel.py を channel ごと 1 プロセス
-起動する」配線の振る舞いを確認する。
+「ow_status 呼び出し時に sentinel.py を channel ごと 1 プロセス起動する」配線
+(D#2752 Phase A) の振る舞いを確認する。
 
 - 既に走っていれば spawn しない (pgrep でヒット時)
 - 走っていなければ subprocess.Popen で spawn する


### PR DESCRIPTION
## Summary

- `ensure_sentinel_process` の `_is_sentinel_running` で `pgrep` 引数を `re.escape(channel_code)` でエスケープ
- src / tests / skills 配下に残っていた直前 PR の番号参照を削除し、CLAUDE.md の「PR/issue 番号をコードに残さない」規約に合わせる
- D#2752 / decision 参照は残す

## なぜこの変更が必要か

### 1. pgrep の re.escape

`pgrep -f` は引数を拡張正規表現として解釈する。`channel_code` に正規表現メタ文字 (`.` `*` `?` 等) が混入すると、本来存在しないプロセスにマッチして「既に起動済み」と誤判定する余地がある。

現在の実運用 channel 値 (`ow1`, `d-sani` 等) は英数字とハイフンのみで実害は出ていないが、命名規則に制約がないまま `$` アンカーを設けた意義を完全に満たすため、`re.escape` で防御する。

### 2. コード内 PR 番号削除

CLAUDE.md (システム規約): *"Don't reference the current task, fix, or callers … since those belong in the PR description and rot as the codebase evolves."*

直前 PR の番号がコード・テスト docstring・SKILL.md に残っており、コードが長く生き残ったあとに文脈のない参照として残る。commit message / PR description に留めて、コードからは削除する。

## 変更箇所

- `src/services/ow_service.py`: `re.escape(channel_code)`、docstring と inline comment から PR 番号削除
- `tests/conftest.py`: autouse fixture の docstring から PR 番号削除
- `tests/unit/test_ow_sentinel_autospawn.py`: module docstring から PR 番号削除、D# 参照に置換
- `skills/orch/SKILL.md`: §起動フローの補足文から PR 番号削除

## Test plan

- [x] `uv run pytest tests/unit/test_ow_sentinel_autospawn.py tests/unit/test_ow_sentinel.py -x -q` ローカル 33 件 pass
- [ ] CI で test (unit) / test (integration-e2e) が pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)