### PR TITLE
feat: activities.orch_managed カラム追加 (orch-managed タグ運用を撤廃)

### DIFF
--- a/hooks/hook_transcript.py
+++ b/hooks/hook_transcript.py
@@ -29,8 +29,6 @@ def _extract_short_name(name: str) -> str:
 
 # --- ow worker判定 ---
 
-_ORCH_MANAGED_TAG = "orch-managed"
-
 
 def _is_worker_session() -> bool:
     """ow workerとして起動されたセッションかを判定する。

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -27,7 +27,7 @@ from src.services.habit_service import get_active_habit_contents_with_conn
 from src.services.tag_service import get_entity_tags_batch
 from src.services.topic_service import get_activity_topics_batch
 from scripts.snapshot import health_check, should_take_snapshot, take_snapshot
-from hooks.hook_transcript import _ORCH_MANAGED_TAG, _is_worker_session
+from hooks.hook_transcript import _is_worker_session
 
 # description先頭の切り出し文字数
 _DESCRIPTION_SNIPPET_LENGTH = 100
@@ -153,7 +153,7 @@ def _build_activities_section(conn, session_id: str | None = None) -> str:
     - 末尾にスコアリング指示を付与
 
     worker セッション（OW_ROLE=worker）はメインセッション作業文脈なので注入しない (D#2662)。
-    通常セッションでは orch-managed タグ付きアクティビティを除外する。
+    通常セッションでは activities.orch_managed = 1 のアクティビティを除外する。
     """
     # P0-8 (D#2662): worker は担当 activity に閉じて動く設計のため、
     # メインセッション作業文脈であるアクティビティ一覧は注入しない。
@@ -189,25 +189,24 @@ def _build_activities_section(conn, session_id: str | None = None) -> str:
             else:
                 normal_activities.append(a)
 
-    # 収集した全アクティビティのタグを一括取得し、orch-managedを除外する。
-    # heartbeat/normal両セクションが対象（個人フローからorchフローを分離）。
-    collected_ids = [a["id"] for a in heartbeat_activities + normal_activities]
-    tags_map = get_entity_tags_batch(
-        conn, "activity_tags", "activity_id", collected_ids
-    )
+    # activities.orch_managed=1 のアクティビティを除外する
+    # （個人フローからorchフローを分離）。
+    # get_active_activities_by_tag_with_conn が返す dict に orch_managed が含まれる。
     heartbeat_activities = [
-        a for a in heartbeat_activities
-        if _ORCH_MANAGED_TAG not in tags_map.get(a["id"], [])
+        a for a in heartbeat_activities if not a.get("orch_managed")
     ]
     normal_activities = [
-        a for a in normal_activities
-        if _ORCH_MANAGED_TAG not in tags_map.get(a["id"], [])
+        a for a in normal_activities if not a.get("orch_managed")
     ]
 
     if not heartbeat_activities and not normal_activities:
         return ""
 
-    # メタデータ一括取得（tags_mapは収集時に取得済み・全idを網羅）
+    # メタデータ一括取得
+    collected_ids = [a["id"] for a in heartbeat_activities + normal_activities]
+    tags_map = get_entity_tags_batch(
+        conn, "activity_tags", "activity_id", collected_ids
+    )
     all_ids = [a["id"] for a in normal_activities]
     unresolved_deps = _get_unresolved_deps(conn, all_ids)
     descriptions = _get_descriptions(conn, all_ids)

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -133,7 +133,7 @@ def main() -> None:
             # activity_idを抽出して保存
             _update_checked_in_activity(state, all_events, transcript_path)
 
-        # orchフロー（worker セッション or orch-managedアクティビティ）では
+        # orchフロー（worker セッション or orch_managed=1 のアクティビティ）では
         # 個人フロー用のcheck-inブロック・nudgeを抑制する。
         suppress_personal_flow = (
             _is_worker_session()

--- a/hooks/stop_hook.py
+++ b/hooks/stop_hook.py
@@ -24,7 +24,6 @@ from hooks.heartbeat import update_heartbeat
 from hooks.hook_state import HookState
 from hooks.hook_transcript import (
     _CHECKIN_TOOLS,
-    _ORCH_MANAGED_TAG,
     _RECORDING_TOOLS,
     _is_worker_session,
     extract_events,
@@ -39,7 +38,7 @@ _NUDGE_INTERVAL = 2
 
 
 def _is_orch_managed_activity(activity_id) -> bool:
-    """指定アクティビティが orch-managed タグを持つかを判定する。
+    """指定アクティビティが orch 管理かを activities.orch_managed カラムで判定する。
 
     orchが管理するアクティビティにcheck-in済みのセッションは個人フローでなく
     orchフローなので、check-inブロック・nudgeの対象外とする。
@@ -49,16 +48,18 @@ def _is_orch_managed_activity(activity_id) -> bool:
         return False
     try:
         from src.db import get_connection
-        from src.services.tag_service import get_entity_tags_batch
 
         conn = get_connection()
         try:
-            tags_map = get_entity_tags_batch(
-                conn, "activity_tags", "activity_id", [int(activity_id)]
-            )
+            row = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (int(activity_id),),
+            ).fetchone()
         finally:
             conn.close()
-        return _ORCH_MANAGED_TAG in tags_map.get(int(activity_id), [])
+        if row is None:
+            return False
+        return bool(row["orch_managed"])
     except Exception:
         return False
 

--- a/migrations/0045_add_activities_orch_managed.sql
+++ b/migrations/0045_add_activities_orch_managed.sql
@@ -1,0 +1,33 @@
+-- Migration 0045: activitiesテーブルに orch_managed BOOLEAN カラムを追加
+--
+-- depends: 0044_sanitize_log_table
+--
+-- 背景:
+--   orch-managed (orchが管理するアクティビティであることを表す属性) は
+--   これまで素タグ "orch-managed" を付けることで表現していたが、
+--   タグ運用を構造的属性 (カラム) に昇格させる。
+--
+--   タグ運用のデメリット:
+--     - "活動が orch 管轄かどうか" という静的属性をタグの存在/不在で表すと
+--       読み手側で毎回 JOIN が必要、メモリ上での判定もタグ展開を経由する
+--     - 「タグの意味」をコード側に注入する形になり、データモデルに表れない
+--
+--   構造的属性に昇格することで、JOIN 不要のカラム参照で
+--   一次判定 (Stop hook / SessionStart hook / hint 抑制) が完結する。
+--
+-- 変更内容:
+--   - activities.orch_managed (BOOLEAN NOT NULL DEFAULT FALSE) を追加。
+--     SQLite は BOOLEAN を INTEGER affinity で扱う (0/1)。
+--   - 既存の素タグ "orch-managed" を持つ activity に対し orch_managed=1 を反映するデータ移行を含む。
+--     タグ自体 (tags 行および activity_tags 行) は本 migration では削除しない (後続で扱う)。
+
+ALTER TABLE activities ADD COLUMN orch_managed BOOLEAN NOT NULL DEFAULT 0;
+
+UPDATE activities
+SET orch_managed = 1
+WHERE id IN (
+    SELECT at.activity_id
+    FROM activity_tags at
+    JOIN tags t ON t.id = at.tag_id
+    WHERE t.namespace = '' AND t.name = 'orch-managed'
+);

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -385,7 +385,7 @@ audit skill は HintService (`src/services/hint_service.py`) とは**経路と�
 | 発火経路 | `check_in` 同期 / Stop hook 経由 additionalContext | description トリガー + ユーザー発話 |
 | 永続化 | hint type 表現 + tag note 内ハッシュタグマーカー (`#audited-YYYY-MM-DD` 等の suppress 用途) | audit material + 各種 pin |
 | severity | info/warn のみ (block 不採用) | severity 概念なし (skill は手続き) |
-| orch-managed activity | 全 suppress | orch では発動可 (worker 制限) |
+| orch_managed=True activity | 全 suppress | orch では発動可 (worker 制限) |
 
 完了マーカー `#audited-YYYY-MM-DD` は HintService 側 hint 重複抑制と共通の仕組みを意図しているが、audit skill 自身の 24h 重複防止 (T-C2) の判定にも使う。
 

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -149,14 +149,14 @@ self-check で穴があれば dispatcher に渡さず、user 確認や過去議�
 
 - dispatcher からの progress event (semantic 単位)
 - dispatcher への drill-down 要求 (`command:relay-query`)
-- cc-memory activity の状態 (orch-managed タグ付き)
+- cc-memory activity の状態 (`orch_managed=true` の activity)
 
 ### タスク管理ループ
 
 ```
 on user 発言 / dispatcher event / 自発タイミング:
   1. dispatcher progress を確認 (最新の event:progress)
-  2. cc-memory activity 状態を確認 (orch-managed タグ)
+  2. cc-memory activity 状態を確認 (orch_managed=true の activity)
   3. user へ常時可視化更新 (§visibility) を出力
   4. 次のアクション判断:
      - 新規 task → dispatcher へ relay-spawn
@@ -302,7 +302,7 @@ orch が参照する情報は 4 層に分かれる:
 ## 起動フロー
 
 0. **§0 不変責務 + §責務 を thinking で読み上げる**
-1. **再開候補列挙**: `ow_recover_candidates()` (cache 由来候補) と `get_activities(tags=["orch-managed"], status="in_progress")` (cc-memory 由来候補) の和集合を取り、user に提示
+1. **再開候補列挙**: `ow_recover_candidates()` (cache 由来候補) と `get_activities(orch_managed=True, status="in_progress")` (cc-memory 由来候補) の和集合を取り、user に提示
 2. **relay 疎通確認**: `ow_status(channel_code, topic_id)` を呼ぶ
 3. **不在中メッセージ回収**: `ow_history(since=last_seen_msg_id)` で不在中メッセージを pull し処理する
 4. **orch identity 発火**: `ow_send` で `event:identity (role=orch)` を broadcast する。data に `orch_cwd` (現在の cwd) / `orch_activity_id` / `started_at` 等を含める
@@ -434,7 +434,7 @@ worker 個別の状態取得 (workload state / cache.workers[alias]) は dispatc
 
 ## activity との対応
 
-- orch が作成する [作業] activity には **専用タグ `orch-managed` を必須付与**する
+- orch が作成する [作業] activity には **`orch_managed=True` を必須指定**する (個人フロー一覧から除外され、Stop hook の check-in ブロック・nudge も抑制される)
 - タスク終端 (workload terminated event) → activity status のマッピングは projector が自動実行する (詳細は dispatcher SKILL.md §projector マッピング表)
 - **activity.status は projector 自動更新の派生**。orch は `update_activity` で status を直接書き換えてはならない
 
@@ -524,7 +524,7 @@ dispatcher が稼働中なら worker pool 状態は dispatcher 側で保持さ�
 | `ow_get_presence(channel, handle)` | presence 取得 |
 | `ow_get_workload_state(channel, handle)` | workload state (主に dispatcher / worker) |
 | `check_in(activity_id)` | cc-memory アクティビティ check-in |
-| `add_activity(...)` / `update_activity(...)` | アクティビティ管理 (orch-managed タグ必須、稼働状態 status 直接変更は禁止) |
+| `add_activity(...)` / `update_activity(...)` | アクティビティ管理 (`orch_managed=True` 必須、稼働状態 status 直接変更は禁止) |
 | `add_decisions(...)` | decision 物理記録 (§decision-arbitration 例外時のみ、原則は dispatcher 経由) |
 | `add_material(...)` | 議論・設計 material 書き込み (orch 主担当)、pin 操作 |
 | `search(...)` | 特化プレイブック・過去エスカレーションログ検索 |

--- a/src/main.py
+++ b/src/main.py
@@ -621,6 +621,7 @@ def add_activity(
     tags: list[str],
     related: list[dict] | None = None,
     check_in: bool = True,
+    orch_managed: bool = False,
 ) -> dict:
     """
     新しいアクティビティを追加する。デフォルトで作成後にcheck_inも実行する。
@@ -631,6 +632,7 @@ def add_activity(
     - 複数関連: add_activity("...", "...", [...], related=[{"type": "topic", "ids": [1, 2]}, {"type": "activity", "ids": [3]}])
     - intent:implementは合意済みdecisionをrelateする: add_activity("...", "...", ["domain:cc-memory", "intent:implement"], related=[{"type": "decision", "ids": [10, 11]}])
     - check_inなしで作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], check_in=False)
+    - orchが管理するアクティビティとして作成: add_activity("...", "...", [...], orch_managed=True)
 
     Args:
         title: アクティビティのタイトル
@@ -638,12 +640,14 @@ def add_activity(
         tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
         related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1]}, {"type": "decision", "ids": [10, 11]}]。作成と同時にリレーションを張る。intent:implementタグを含む場合、relatedにtype='decision'のエントリを最低1件含めないとIMPLEMENT_WORKFLOW_GUARDエラーで弾かれる（議論・設計フェーズで合意したdecisionか、いきなりimplementする理由を記録したdecisionをrelateする）
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）。Trueの場合、返り値にcheck_in_resultが含まれる
+        orch_managed: orchが管理するアクティビティか（デフォルト: False）。Trueを指定すると個人フローのSessionStart一覧から除外され、Stop hookのcheck-inブロック・nudgeも抑制される。orchワークフローで作成するアクティビティに付与する
 
     Returns:
         作成されたアクティビティ情報（check_in=Trueの場合はcheck_in_resultにtag_notes等を含む）
     """
     result = activity_service.add_activity(
         title, description, tags, related=related, check_in=check_in,
+        orch_managed=orch_managed,
     )
     if "error" not in result:
         # check_in=Trueの場合、check_in_resultにtag_notesが含まれるため
@@ -661,9 +665,10 @@ def get_activities(
     since: str | None = None,
     until: str | None = None,
     flavor: _FlavorArg = "internal",
+    orch_managed: bool | None = None,
 ) -> dict:
     """
-    アクティビティ一覧を取得する（tagsでフィルタリング、statusでフィルタリング可能）。
+    アクティビティ一覧を取得する（tags/status/orch_managed でフィルタリング可能）。
 
     典型的な使い方:
     - 全アクティビティ確認: get_activities()
@@ -671,6 +676,7 @@ def get_activities(
     - 進行中のみ: get_activities(["domain:cc-memory"], status="in_progress")
     - 完了アクティビティの確認: get_activities(status="completed")
     - 最近1週間: get_activities(since="2026-03-09")
+    - orch管理のみ: get_activities(orch_managed=True, status="in_progress")
 
     ワークフロー位置: アクティビティ状況の確認時
 
@@ -681,12 +687,15 @@ def get_activities(
         limit: 取得件数上限（デフォルト: 5）
         since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
         until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す
+        orch_managed: True/False を指定すると activities.orch_managed カラムでフィルタする。None（デフォルト）はフィルタなし
 
     Returns:
         アクティビティ一覧（total_countで該当ステータスの全件数を確認可能）
     """
     flavor = _normalize_flavor(flavor)
-    result = activity_service.get_activities(tags, status, limit, since, until)
+    result = activity_service.get_activities(
+        tags, status, limit, since, until, orch_managed=orch_managed,
+    )
     if "error" not in result:
         _apply_flavor_to_items(result.get("activities", []), "activity", flavor)
         all_tags = _collect_result_tags(result.get("activities", []))
@@ -702,9 +711,10 @@ def update_activity(
     title: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[list[str]] = None,
+    orch_managed: Optional[bool] = None,
 ) -> dict:
     """
-    アクティビティのステータス・タイトル・説明・タグを更新する。
+    アクティビティのステータス・タイトル・説明・タグ・orch_managedを更新する。
 
     典型的な使い方:
     - アクティビティ開始: update_activity(activity_id, status="in_progress")
@@ -714,6 +724,7 @@ def update_activity(
     - タイトル変更: update_activity(activity_id, title="新しいタイトル")
     - 説明更新: update_activity(activity_id, description="新しい説明")
     - タグ変更: update_activity(activity_id, tags=["domain:cc-memory", "intent:implement"])
+    - orch管理に切り替え: update_activity(activity_id, orch_managed=True)
 
     ワークフロー位置: アクティビティ進行状況の更新時
 
@@ -723,11 +734,14 @@ def update_activity(
         title: 新しいタイトル
         description: 新しい説明
         tags: 新しいタグ配列（指定時は全置換。1個以上必須）
+        orch_managed: orchが管理するアクティビティかを切り替える（True/False/None）。Noneなら変更しない
 
     Returns:
         更新されたアクティビティ情報
     """
-    return activity_service.update_activity(activity_id, status, title, description, tags)
+    return activity_service.update_activity(
+        activity_id, status, title, description, tags, orch_managed=orch_managed,
+    )
 
 
 @mcp.tool()

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -393,6 +393,7 @@ def get_activities(
                 "created_at": activity["created_at"],
                 "updated_at": activity["updated_at"],
                 "is_heartbeat_active": bool(activity["is_heartbeat_active"]),
+                "orch_managed": bool(activity["orch_managed"]),
             }
             apply_readable_id_inplace(item, "activity")
             activities.append(item)

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -116,6 +116,7 @@ def add_activity(
     tags: list[str],
     related: list[dict] | None = None,
     check_in: bool = True,
+    orch_managed: bool = False,
 ) -> dict:
     """
     アクティビティを作成してIDを返す
@@ -131,6 +132,10 @@ def add_activity(
             intent:implement タグを含む場合、related に type='decision' のエントリを
             最低1件含めないと IMPLEMENT_WORKFLOW_GUARD エラーで弾かれる。
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）
+        orch_managed: orch が管理する activity か（デフォルト: False）。
+            True を指定すると activities.orch_managed = 1 で作成される。
+            Stop hook の check-in ブロック・nudge 抑制、SessionStart hook
+            の一覧除外、hint 抑制の一次判定に使われる。
 
     Returns:
         作成されたアクティビティ情報（check_in=Trueの場合はcheck_in_resultを含む）
@@ -155,8 +160,9 @@ def add_activity(
 
         # アクティビティをINSERT
         cursor = conn.execute(
-            "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
-            (title, description, 'pending'),
+            "INSERT INTO activities (title, description, status, orch_managed) "
+            "VALUES (?, ?, ?, ?)",
+            (title, description, 'pending', 1 if orch_managed else 0),
         )
         activity_id = cursor.lastrowid
 
@@ -222,9 +228,10 @@ def get_activities(
     limit: int = 5,
     since: str | None = None,
     until: str | None = None,
+    orch_managed: bool | None = None,
 ) -> dict:
     """
-    アクティビティ一覧を取得（tagsでフィルタリング、statusでフィルタリング）
+    アクティビティ一覧を取得（tags/status/orch_managed でフィルタリング）
 
     Args:
         tags: タグ配列（optional。指定時はAND条件でフィルタ、未指定時は全件）
@@ -233,6 +240,8 @@ def get_activities(
         limit: 取得件数上限（デフォルト: 5）
         since: ISO日付文字列（例: "2026-03-10"）。この日付以降に更新されたアクティビティのみ返す
         until: ISO日付文字列。この日付以前に更新されたアクティビティのみ返す
+        orch_managed: True/False を指定すると activities.orch_managed カラムでフィルタする。
+            None（デフォルト）はフィルタなし。
 
     Returns:
         アクティビティ一覧とtotal_count
@@ -339,6 +348,10 @@ def get_activities(
             conditions.append("updated_at <= ?")
             where_params.append(until_value)
 
+        if orch_managed is not None:
+            conditions.append("orch_managed = ?")
+            where_params.append(1 if orch_managed else 0)
+
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)
         else:
@@ -434,12 +447,14 @@ def get_active_activities_by_tag_with_conn(conn, tag_id: int) -> list[dict]:
 
     Returns:
         [{"id": int, "title": str, "status": str, "updated_at": str,
-          "last_heartbeat_session_id": str | None, "is_heartbeat_active": bool}, ...]
+          "last_heartbeat_session_id": str | None, "is_heartbeat_active": bool,
+          "orch_managed": bool}, ...]
         （in_progress優先、updated_at降順）
     """
     rows = conn.execute(
         """
         SELECT a.id, a.title, a.status, a.updated_at, a.last_heartbeat_session_id,
+               a.orch_managed,
                CASE WHEN a.last_heartbeat_at > datetime('now', '-' || ? || ' minutes') THEN 1 ELSE 0 END AS is_heartbeat_active
         FROM activities a
         JOIN activity_tags at ON a.id = at.activity_id
@@ -454,6 +469,7 @@ def get_active_activities_by_tag_with_conn(conn, tag_id: int) -> list[dict]:
     for r in rows:
         d = row_to_dict(r)
         d["is_heartbeat_active"] = bool(d["is_heartbeat_active"])
+        d["orch_managed"] = bool(d["orch_managed"])
         result.append(d)
     return result
 
@@ -473,9 +489,10 @@ def update_activity(
     title: Optional[str] = None,
     description: Optional[str] = None,
     tags: Optional[list[str]] = None,
+    orch_managed: Optional[bool] = None,
 ) -> dict:
     """
-    アクティビティを更新する（ステータス、タイトル、説明、タグを変更可能）
+    アクティビティを更新する（ステータス、タイトル、説明、タグ、orch_managed を変更可能）
 
     Args:
         activity_id: アクティビティID
@@ -483,16 +500,27 @@ def update_activity(
         title: 新しいタイトル（optional）
         description: 新しい説明（optional）
         tags: 新しいタグ配列（optional、指定時は全置換。1個以上必須）
+        orch_managed: orch が管理する activity かどうかを切り替える（optional）。
+            True/False のみ受け付ける。None なら変更しない。
 
     Returns:
         更新されたアクティビティ情報
     """
     # 最低1つのオプショナルパラメータが必要
-    if status is None and title is None and description is None and tags is None:
+    if (
+        status is None
+        and title is None
+        and description is None
+        and tags is None
+        and orch_managed is None
+    ):
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "At least one of status, title, description, or tags must be provided",
+                "message": (
+                    "At least one of status, title, description, tags, or "
+                    "orch_managed must be provided"
+                ),
             }
         }
 
@@ -561,6 +589,10 @@ def update_activity(
         if description is not None:
             set_parts.append("description = ?")
             values.append(description)
+
+        if orch_managed is not None:
+            set_parts.append("orch_managed = ?")
+            values.append(1 if orch_managed else 0)
 
         # タグの全置換（tags指定時のみ）
         if parsed_tags is not None:

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -106,20 +106,19 @@ def _recompose_delta_message(tag_name: str, delta_count: int) -> str:
 
 
 def is_orch_managed_activity(conn: sqlite3.Connection, activity_id: int) -> bool:
-    """activityがorch-managed素タグを持つかを判定する。
+    """activityがorch管理かを判定する。
 
+    activities.orch_managed カラムを参照する。
     orch-managed activityでは全hint suppressとする呼出側ガードに使う。
+    存在しない activity_id は False を返す（フェイルオープン）。
     """
     row = conn.execute(
-        """
-        SELECT 1 FROM tags t
-        JOIN activity_tags at ON at.tag_id = t.id
-        WHERE at.activity_id = ? AND t.namespace = '' AND t.name = 'orch-managed'
-        LIMIT 1
-        """,
+        "SELECT orch_managed FROM activities WHERE id = ?",
         (activity_id,),
     ).fetchone()
-    return row is not None
+    if row is None:
+        return False
+    return bool(row["orch_managed"])
 
 
 def get_hints(scope: Scope, target_id: int) -> list[Hint]:

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -128,6 +128,19 @@ def _tag_activity_bare(activity_id: int, tag_name: str) -> None:
         conn.close()
 
 
+def _mark_orch_managed(activity_id: int) -> None:
+    """アクティビティの orch_managed カラムを 1 に設定する"""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE activities SET orch_managed = 1 WHERE id = ?",
+            (activity_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _seed_topic(title: str) -> int:
     """テスト用トピックを作成"""
     conn = get_connection()
@@ -360,12 +373,12 @@ class TestSessionStartHookWorkerSuppression:
 
 
 class TestSessionStartHookOrchManagedExclusion:
-    """orch-managedタグ付きアクティビティの除外テスト"""
+    """orch_managed=1 アクティビティの除外テスト"""
 
     def test_orch_managed_activity_excluded(self, temp_db):
-        """orch-managedタグ付きアクティビティはアクティビティ一覧に出ない"""
+        """orch_managed=1 のアクティビティはアクティビティ一覧に出ない"""
         activity_id = _seed_activity("[作業] orch管理タスク", status="in_progress")
-        _tag_activity_bare(activity_id, "orch-managed")
+        _mark_orch_managed(activity_id)
 
         result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -374,10 +387,10 @@ class TestSessionStartHookOrchManagedExclusion:
         assert f"(#{activity_id})" not in context
 
     def test_non_orch_managed_activity_still_shown(self, temp_db):
-        """orch-managedタグのない通常アクティビティは引き続き表示される"""
+        """orch_managed=0 の通常アクティビティは引き続き表示される"""
         normal_id = _seed_activity("[作業] 個人タスク", status="in_progress")
         orch_id = _seed_activity("[作業] orch管理タスク", status="in_progress")
-        _tag_activity_bare(orch_id, "orch-managed")
+        _mark_orch_managed(orch_id)
 
         result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -387,10 +400,22 @@ class TestSessionStartHookOrchManagedExclusion:
         assert "orch管理タスク" not in context
         assert f"(#{orch_id})" not in context
 
-    def test_all_orch_managed_yields_no_activity_section(self, temp_db):
-        """全アクティビティがorch-managedなら一覧セクション自体が出ない"""
-        activity_id = _seed_activity("[作業] orch管理のみ", status="in_progress")
+    def test_orch_managed_tag_without_column_is_still_shown(self, temp_db):
+        """旧 orch-managed 素タグだけ付いていて orch_managed カラムが 0 のアクティビティは
+        新仕様では普通に表示される（タグ判定は撤廃済み）。"""
+        activity_id = _seed_activity("[作業] レガシータグ", status="in_progress")
         _tag_activity_bare(activity_id, "orch-managed")
+
+        result = _run_session_start_hook(temp_db, env_remove=["OW_ROLE"])
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "レガシータグ" in context
+        assert f"(#{activity_id})" in context
+
+    def test_all_orch_managed_yields_no_activity_section(self, temp_db):
+        """全アクティビティが orch_managed=1 なら一覧セクション自体が出ない"""
+        activity_id = _seed_activity("[作業] orch管理のみ", status="in_progress")
+        _mark_orch_managed(activity_id)
 
         # 初期振る舞いを削除してアクティビティ一覧の有無を純粋に判定
         conn = get_connection()

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -729,7 +729,7 @@ class TestRecordNudgeMultiplication:
 
 
 def _seed_orch_managed_db(db_path: str, activity_id: int, monkeypatch) -> None:
-    """テスト用DBを初期化し、orch-managed素タグ付きアクティビティを作成する"""
+    """テスト用DBを初期化し、orch_managed=1 のアクティビティを作成する"""
     import src.config
     from src.db import init_database, get_connection
 
@@ -740,16 +740,9 @@ def _seed_orch_managed_db(db_path: str, activity_id: int, monkeypatch) -> None:
     conn = get_connection()
     try:
         conn.execute(
-            "INSERT INTO activities (id, title, description, status) VALUES (?, ?, ?, ?)",
-            (activity_id, "[作業] orch管理タスク", "desc", "in_progress"),
-        )
-        cursor = conn.execute(
-            "INSERT INTO tags (namespace, name) VALUES ('', 'orch-managed')"
-        )
-        tag_id = cursor.lastrowid
-        conn.execute(
-            "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
-            (activity_id, tag_id),
+            "INSERT INTO activities (id, title, description, status, orch_managed) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (activity_id, "[作業] orch管理タスク", "desc", "in_progress", 1),
         )
         conn.commit()
     finally:
@@ -757,7 +750,7 @@ def _seed_orch_managed_db(db_path: str, activity_id: int, monkeypatch) -> None:
 
 
 class TestOrchFlowSuppression:
-    """orchフロー（worker セッション・orch-managedアクティビティ）でのcheck-inブロック/nudge抑制"""
+    """orchフロー（worker セッション・orch_managed=1 アクティビティ）でのcheck-inブロック/nudge抑制"""
 
     def test_worker_session_no_checkin_block(self, env_setup):
         """OW_ROLE=worker時はcheck-in未呼出でもturn>=2でblockしない"""
@@ -809,7 +802,7 @@ class TestOrchFlowSuppression:
         assert len(record_nudges) == 0
 
     def test_orch_managed_activity_no_record_nudge(self, env_setup, monkeypatch):
-        """orch-managedアクティビティにcheck-in済みなら記録なしでもrecord nudgeを生成しない"""
+        """orch_managed=1 アクティビティにcheck-in済みなら記録なしでもrecord nudgeを生成しない"""
         state_dir = env_setup["state_dir"]
         db_path = str(env_setup["tmp_path"] / "orch.db")
         _seed_orch_managed_db(db_path, activity_id=1, monkeypatch=monkeypatch)
@@ -835,7 +828,7 @@ class TestOrchFlowSuppression:
         )
 
         env_override = {**env_setup["env_override"], "DISCUSSION_DB_PATH": db_path}
-        # OW_ROLEは設定しない（orch-managedタグのみで抑制されることを確認）
+        # OW_ROLEは設定しない（orch_managed=1 カラムのみで抑制されることを確認）
         env_override.pop("OW_ROLE", None)
         result = _run_stop_hook(str(transcript), "test-session", env_override)
         assert result["decision"] == "approve"
@@ -845,10 +838,10 @@ class TestOrchFlowSuppression:
         assert len(record_nudges) == 0
 
     def test_normal_activity_still_nudges(self, env_setup, monkeypatch):
-        """orch-managedでない通常アクティビティでは従来通りrecord nudgeを生成する"""
+        """orch_managed=0 の通常アクティビティでは record nudge を生成する"""
         state_dir = env_setup["state_dir"]
         db_path = str(env_setup["tmp_path"] / "normal.db")
-        # 通常アクティビティ（orch-managedタグなし）のDBを作る
+        # 通常アクティビティ（orch_managed=0、デフォルト）のDBを作る
         import src.config
         from src.db import init_database, get_connection
         monkeypatch.setenv("DISCUSSION_DB_PATH", db_path)

--- a/tests/test_migrations/test_0045_add_activities_orch_managed.py
+++ b/tests/test_migrations/test_0045_add_activities_orch_managed.py
@@ -1,0 +1,225 @@
+"""migration 0045_add_activities_orch_managed のテスト
+
+0045適用後に activities テーブルへ orch_managed 列が追加され、
+既存の素タグ "orch-managed" を持つ activity の orch_managed が 1 でバックフィルされることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0045含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0045():
+    """0044までのmigrationを適用したDBを提供する。0045の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0045 = MigrationList([m for m in all_migs if m.id < "0045"])
+        with backend.lock():
+            backend.apply_migrations(pre_0045)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0045(db_path: str) -> None:
+    """db_pathに対してmigration 0045のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0045 = MigrationList(
+        [m for m in all_migs if m.id.startswith("0045")]
+    )
+    with backend.lock():
+        backend.apply_migrations(only_0045)
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    """指定テーブルのカラム名セットを返す。"""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _insert_activity(conn: sqlite3.Connection, title: str) -> int:
+    """activitiesに1行INSERTしてidを返す。"""
+    cur = conn.execute(
+        "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+        (title, "desc", "pending"),
+    )
+    return cur.lastrowid
+
+
+def _attach_orch_managed_tag(conn: sqlite3.Connection, activity_id: int) -> None:
+    """素タグ 'orch-managed' を activity_id にリンクする。"""
+    cur = conn.execute(
+        "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+        ("", "orch-managed"),
+    )
+    tag_id = conn.execute(
+        "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+        ("", "orch-managed"),
+    ).fetchone()["id"]
+    conn.execute(
+        "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+        (activity_id, tag_id),
+    )
+
+
+class TestOrchManagedColumnAdded:
+    """0045適用後に orch_managed 列が追加されていることの確認"""
+
+    def test_activities_has_orch_managed_column_after_0045(self, migrated_db):
+        """migration 0045 適用後、activities テーブルに orch_managed 列が存在する"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "activities")
+            assert "orch_managed" in column_names, (
+                "activities.orch_managed が 0045 適用後に存在しない"
+            )
+        finally:
+            conn.close()
+
+    def test_activities_has_no_orch_managed_column_before_0045(self, db_before_0045):
+        """0044 適用時点では activities に orch_managed 列が存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            assert "orch_managed" not in _get_column_names(conn, "activities"), (
+                "0045 適用前の activities に orch_managed 列が既に存在している"
+            )
+        finally:
+            conn.close()
+
+    def test_default_false_for_new_rows(self, migrated_db):
+        """0045 適用後、orch_managed を指定せず INSERT した行は 0 になる"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO activities (title, description, status) "
+                "VALUES (?, ?, ?)",
+                ("通常 activity", "desc", "pending"),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (cur.lastrowid,),
+            ).fetchone()
+            assert row["orch_managed"] == 0
+        finally:
+            conn.close()
+
+    def test_insert_with_orch_managed_true(self, migrated_db):
+        """0045 適用後、orch_managed=1 を明示 INSERT できる"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO activities (title, description, status, orch_managed) "
+                "VALUES (?, ?, ?, ?)",
+                ("orch activity", "desc", "pending", 1),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (cur.lastrowid,),
+            ).fetchone()
+            assert row["orch_managed"] == 1
+        finally:
+            conn.close()
+
+
+class TestBackfillFromTag:
+    """0045 適用時の既存 orch-managed タグからのバックフィル確認"""
+
+    def test_existing_tagged_activity_is_marked_true(self, db_before_0045):
+        """0044 時点で orch-managed タグを持つ activity は、0045 適用後 orch_managed=1 になる"""
+        conn = get_connection()
+        try:
+            tagged_id = _insert_activity(conn, "orch-managed 付与済 activity")
+            _attach_orch_managed_tag(conn, tagged_id)
+            untagged_id = _insert_activity(conn, "通常 activity")
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0045(db_before_0045)
+
+        conn = get_connection()
+        try:
+            row_tagged = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (tagged_id,),
+            ).fetchone()
+            row_untagged = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (untagged_id,),
+            ).fetchone()
+            assert row_tagged["orch_managed"] == 1, (
+                "orch-managed タグ付き activity が 0045 後に orch_managed=1 になっていない"
+            )
+            assert row_untagged["orch_managed"] == 0, (
+                "タグなし activity が誤って orch_managed=1 に設定されている"
+            )
+        finally:
+            conn.close()
+
+    def test_namespaced_orch_managed_tag_is_not_picked_up(self, db_before_0045):
+        """namespace 付きの :orch-managed タグ（例: foo:orch-managed）は対象外（素タグのみ）"""
+        conn = get_connection()
+        try:
+            aid = _insert_activity(conn, "namespaced tag activity")
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+                ("foo", "orch-managed"),
+            )
+            tag_id = conn.execute(
+                "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+                ("foo", "orch-managed"),
+            ).fetchone()["id"]
+            conn.execute(
+                "INSERT INTO activity_tags (activity_id, tag_id) VALUES (?, ?)",
+                (aid, tag_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0045(db_before_0045)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT orch_managed FROM activities WHERE id = ?",
+                (aid,),
+            ).fetchone()
+            assert row["orch_managed"] == 0, (
+                "namespace 付きタグが誤ってバックフィルの対象になっている"
+            )
+        finally:
+            conn.close()

--- a/tests/unit/test_activity_orch_managed.py
+++ b/tests/unit/test_activity_orch_managed.py
@@ -8,7 +8,7 @@ temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
 import pytest
 
 from src.db import get_connection
-from src.services.activity_service import add_activity, update_activity
+from src.services.activity_service import add_activity, get_activities, update_activity
 from src.services.hint_service import is_orch_managed_activity
 from src.services.topic_service import add_topic
 from tests.helpers import add_decision
@@ -212,3 +212,88 @@ class TestUpdateActivityOrchManaged:
         assert row["title"] == "[作業] 保持確認"
         assert row["description"] == "original description"
         assert row["orch_managed"] == 1
+
+
+class TestGetActivitiesOrchManaged:
+    """get_activities の orch_managed フィルタおよび返却 dict の orch_managed フィールド"""
+
+    def test_response_includes_orch_managed_field(
+        self, temp_db, topic_with_decision
+    ):
+        """get_activities が返す各 item に orch_managed フィールドが含まれる"""
+        _, decision_id = topic_with_decision
+        add_activity(
+            title="[作業] 通常",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        add_activity(
+            title="[作業] orch",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        result = get_activities(tags=["domain:test"], status="active")
+        assert "activities" in result, result
+        for item in result["activities"]:
+            assert "orch_managed" in item, item
+            assert isinstance(item["orch_managed"], bool)
+        flags = {item["title"]: item["orch_managed"] for item in result["activities"]}
+        assert flags.get("[作業] 通常") is False
+        assert flags.get("[作業] orch") is True
+
+    def test_filter_true_returns_only_orch_managed(
+        self, temp_db, topic_with_decision
+    ):
+        """orch_managed=True 指定で orch_managed=1 のみが返る"""
+        _, decision_id = topic_with_decision
+        add_activity(
+            title="[作業] 通常",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        add_activity(
+            title="[作業] orch",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        result = get_activities(
+            tags=["domain:test"], status="active", orch_managed=True,
+        )
+        titles = [item["title"] for item in result["activities"]]
+        assert titles == ["[作業] orch"]
+
+    def test_filter_false_returns_only_non_orch_managed(
+        self, temp_db, topic_with_decision
+    ):
+        """orch_managed=False 指定で orch_managed=0 のみが返る"""
+        _, decision_id = topic_with_decision
+        add_activity(
+            title="[作業] 通常",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        add_activity(
+            title="[作業] orch",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        result = get_activities(
+            tags=["domain:test"], status="active", orch_managed=False,
+        )
+        titles = [item["title"] for item in result["activities"]]
+        assert titles == ["[作業] 通常"]

--- a/tests/unit/test_activity_orch_managed.py
+++ b/tests/unit/test_activity_orch_managed.py
@@ -1,0 +1,214 @@
+"""add_activity / update_activity の orch_managed フィールド受付テスト
+
+カラム判定機構が API 経由で直接設定できることを検証する (タグ自動付与に
+依存しない経路)。
+
+temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
+"""
+import pytest
+
+from src.db import get_connection
+from src.services.activity_service import add_activity, update_activity
+from src.services.hint_service import is_orch_managed_activity
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+
+@pytest.fixture(autouse=True)
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストで embedding 生成を無効化する"""
+
+
+@pytest.fixture
+def topic_with_decision(temp_db):
+    """テスト用に topic と decision を 1 件作成し、(topic_id, decision_id) を返す"""
+    topic = add_topic(
+        title="orch_managed test topic",
+        description="topic for orch_managed API tests",
+        tags=["domain:test"],
+    )
+    topic_id = topic["topic_id"]
+    decision = add_decision(
+        decision="Approved direction",
+        reason="Reviewed and agreed",
+        topic_id=topic_id,
+    )
+    return topic_id, decision["decision_id"]
+
+
+def _get_orch_managed(activity_id: int) -> int:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT orch_managed FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return row["orch_managed"]
+
+
+class TestAddActivityOrchManaged:
+    """add_activity が orch_managed パラメータを受け付ける"""
+
+    def test_default_is_false(self, temp_db, topic_with_decision):
+        """orch_managed を指定せず作成すると activities.orch_managed=0 になる"""
+        _, decision_id = topic_with_decision
+        result = add_activity(
+            title="[作業] 通常",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        assert "error" not in result, result
+        assert _get_orch_managed(result["activity_id"]) == 0
+
+    def test_true_sets_column(self, temp_db, topic_with_decision):
+        """orch_managed=True を指定すると activities.orch_managed=1 になる"""
+        _, decision_id = topic_with_decision
+        result = add_activity(
+            title="[作業] orch 管理",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        assert "error" not in result, result
+        assert _get_orch_managed(result["activity_id"]) == 1
+
+    def test_orch_managed_true_without_tag_is_detected_by_hint_service(
+        self, temp_db, topic_with_decision
+    ):
+        """orch-managed タグ自動付与に依存せず、hint_service の判定で True になる"""
+        _, decision_id = topic_with_decision
+        result = add_activity(
+            title="[作業] orch 管理",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        assert "error" not in result, result
+        conn = get_connection()
+        try:
+            assert is_orch_managed_activity(conn, result["activity_id"]) is True
+        finally:
+            conn.close()
+
+    def test_false_explicit_is_same_as_default(self, temp_db, topic_with_decision):
+        """orch_managed=False 明示は orch_managed 未指定と同等"""
+        _, decision_id = topic_with_decision
+        result = add_activity(
+            title="[作業] 明示 false",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=False,
+        )
+        assert "error" not in result, result
+        assert _get_orch_managed(result["activity_id"]) == 0
+
+
+class TestUpdateActivityOrchManaged:
+    """update_activity が orch_managed パラメータを受け付ける"""
+
+    def test_update_to_true(self, temp_db, topic_with_decision):
+        """既存 activity の orch_managed を 0 → 1 に切り替えできる"""
+        _, decision_id = topic_with_decision
+        created = add_activity(
+            title="[作業] 切替対象",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        aid = created["activity_id"]
+        assert _get_orch_managed(aid) == 0
+
+        result = update_activity(aid, orch_managed=True)
+        assert "error" not in result, result
+        assert _get_orch_managed(aid) == 1
+
+    def test_update_to_false(self, temp_db, topic_with_decision):
+        """既存 activity の orch_managed を 1 → 0 に切り替えできる"""
+        _, decision_id = topic_with_decision
+        created = add_activity(
+            title="[作業] 切替対象",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+            orch_managed=True,
+        )
+        aid = created["activity_id"]
+        assert _get_orch_managed(aid) == 1
+
+        result = update_activity(aid, orch_managed=False)
+        assert "error" not in result, result
+        assert _get_orch_managed(aid) == 0
+
+    def test_orch_managed_only_update_does_not_require_other_fields(
+        self, temp_db, topic_with_decision
+    ):
+        """orch_managed 単独指定で update_activity がエラーにならない"""
+        _, decision_id = topic_with_decision
+        created = add_activity(
+            title="[作業] 単独更新",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        aid = created["activity_id"]
+        result = update_activity(aid, orch_managed=True)
+        assert "error" not in result, result
+
+    def test_no_fields_provided_returns_validation_error(
+        self, temp_db, topic_with_decision
+    ):
+        """全フィールド未指定は VALIDATION_ERROR を返す"""
+        _, decision_id = topic_with_decision
+        created = add_activity(
+            title="[作業] no-op",
+            description="d",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        aid = created["activity_id"]
+        result = update_activity(aid)
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_other_fields_unchanged_when_only_orch_managed_updated(
+        self, temp_db, topic_with_decision
+    ):
+        """orch_managed のみ更新でも他フィールドは保持される"""
+        _, decision_id = topic_with_decision
+        created = add_activity(
+            title="[作業] 保持確認",
+            description="original description",
+            tags=["domain:test", "intent:implement"],
+            related=[{"type": "decision", "ids": [decision_id]}],
+            check_in=False,
+        )
+        aid = created["activity_id"]
+
+        update_activity(aid, orch_managed=True)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT title, description, orch_managed FROM activities WHERE id = ?",
+                (aid,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row["title"] == "[作業] 保持確認"
+        assert row["description"] == "original description"
+        assert row["orch_managed"] == 1

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -240,14 +240,15 @@ class TestActivityScope:
 
 
 class TestIsOrchManagedActivity:
-    def test_true_when_orch_managed_tag_present(self, temp_db):
+    def test_true_when_orch_managed_column_set(self, temp_db):
         topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
         dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
         a = add_activity(
             title="[orch] x", description="d",
-            tags=[DOMAIN_TAG, "orch-managed", "intent:implement"],
+            tags=[DOMAIN_TAG, "intent:implement"],
             related=[{"type": "decision", "ids": [dec["decision_id"]]}],
             check_in=False,
+            orch_managed=True,
         )
         conn = get_connection()
         try:
@@ -255,7 +256,7 @@ class TestIsOrchManagedActivity:
         finally:
             conn.close()
 
-    def test_false_when_tag_absent(self, temp_db):
+    def test_false_when_orch_managed_column_not_set(self, temp_db):
         topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
         dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
         a = add_activity(
@@ -267,6 +268,33 @@ class TestIsOrchManagedActivity:
         conn = get_connection()
         try:
             assert is_orch_managed_activity(conn, a["activity_id"]) is False
+        finally:
+            conn.close()
+
+    def test_false_when_only_tag_present_without_column(self, temp_db):
+        """orch-managed タグだけ付与しても orch_managed カラムが 0 なら False (カラム判定優先)。
+
+        移行期にタグだけ残った状態でも、判定はカラム値のみに依存する。
+        """
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        dec = add_decision(decision="d", reason="r", topic_id=topic["topic_id"])
+        a = add_activity(
+            title="[orch] x", description="d",
+            tags=[DOMAIN_TAG, "orch-managed", "intent:implement"],
+            related=[{"type": "decision", "ids": [dec["decision_id"]]}],
+            check_in=False,
+        )
+        conn = get_connection()
+        try:
+            assert is_orch_managed_activity(conn, a["activity_id"]) is False
+        finally:
+            conn.close()
+
+    def test_false_for_unknown_activity_id(self, temp_db):
+        """存在しない activity_id は False (フェイルオープン)。"""
+        conn = get_connection()
+        try:
+            assert is_orch_managed_activity(conn, 999_999) is False
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

- migration 0045 で `activities.orch_managed BOOLEAN NOT NULL DEFAULT 0` を追加し、既存の素タグ `orch-managed` を持つ activity に対して `orch_managed=1` をバックフィルする
- `add_activity` / `update_activity` / `get_activities` API に `orch_managed` パラメータを追加。タグ自動付与に依存しない経路で値の設定・絞り込みができる
- 各所のタグ判定ロジック (`hint_service.is_orch_managed_activity` / `hooks/stop_hook` / `hooks/session_start_hook`) を `activities.orch_managed` カラム判定に置換
- `hooks/hook_transcript._ORCH_MANAGED_TAG` 定数を撤去
- `skills/orch/SKILL.md` / `skills/audit/SKILL.md` のタグ依存記述を `orch_managed=True` パラメータに更新

タグ自体 (tags 行 / activity_tags 行) は本 PR では削除しない (後続で扱う)。

## Test plan

- [x] tests/test_migrations/test_0045_add_activities_orch_managed.py を追加 (カラム追加 / バックフィル / 適用前後の差分検証)
- [x] tests/unit/test_activity_orch_managed.py を追加 (`add_activity` / `update_activity` の orch_managed 受付・反映)
- [x] tests/unit/test_hint_service.py を更新 (カラム判定の True / False / タグだけで列が 0 のケース / 未知 ID)
- [x] tests/e2e/test_stop_hook.py / tests/e2e/test_session_start_hook.py を更新 (タグセットアップを `orch_managed=1` セットアップに置換)
- [x] `uv run pytest tests/unit tests/integration` 全件緑 (1945 passed / 1 skipped)
- [x] `uv run pytest tests/e2e tests/test_migrations` 全件緑 (171 passed)