### PR TITLE
feat: SessionStart backfill hook (生 X#NNN → {{cite:X#NNN}})

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -66,6 +66,20 @@ class HookState:
         """transcript差分読みのバイトオフセットを保存"""
         self._write(self._path("transcript_offset"), str(offset))
 
+    # --- sanitize_offset ---
+
+    def get_sanitize_offset(self) -> int:
+        """sanitize 用 transcript 差分読みバイトオフセットを取得。未設定 -> 0。
+
+        stop_hook の transcript_offset とは別管理。SessionStart backfill hook が
+        過去 transcript の差分 sanitize を冪等に行うために独立した offset を持つ。
+        """
+        return self._read_int(self._path("sanitize_offset"), 0)
+
+    def set_sanitize_offset(self, offset: int) -> None:
+        """sanitize 用 transcript 差分読みバイトオフセットを保存"""
+        self._write(self._path("sanitize_offset"), str(offset))
+
     # --- current_turn ---
 
     def get_current_turn(self) -> int:

--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -80,6 +80,21 @@ class HookState:
         """sanitize 用 transcript 差分読みバイトオフセットを保存"""
         self._write(self._path("sanitize_offset"), str(offset))
 
+    # --- sanitize_failure_count ---
+
+    def get_sanitize_failure_count(self) -> int:
+        """SessionStart backfill hook の連続失敗回数を取得。未設定 -> 0。
+
+        書き戻し失敗 (harness_race / io_error / rename_failed) や scan/sanitize 例外で
+        インクリメントされ、成功時にリセットされる。閾値 (hook 側で N=3) に達したら
+        その session の backfill は以降スキップする (ループ防止)。
+        """
+        return self._read_int(self._path("sanitize_failure_count"), 0)
+
+    def set_sanitize_failure_count(self, count: int) -> None:
+        """SessionStart backfill hook の連続失敗回数を保存"""
+        self._write(self._path("sanitize_failure_count"), str(count))
+
     # --- current_turn ---
 
     def get_current_turn(self) -> int:

--- a/hooks/sanitize_backfill_hook.py
+++ b/hooks/sanitize_backfill_hook.py
@@ -375,6 +375,7 @@ def _write_back_transcript(
         os.replace(tmp_path, transcript_path)
     except OSError as exc:
         tmp_path.unlink(missing_ok=True)
+        backup_path.unlink(missing_ok=True)
         return f"rename_failed: {exc}"
 
     try:
@@ -441,35 +442,6 @@ def _log_sanitize_event(
 
 
 # ---------------------------------------------------------------------------
-# 連続失敗カウンタ (3 回連続失敗で本セッションでの backfill をスキップ)
-# ---------------------------------------------------------------------------
-
-
-def _failure_count_path(session_id: str) -> Path:
-    safe = session_id.replace("/", "_")
-    return HookState.BASE_DIR / f"sanitize_failure_count_{safe}"
-
-
-def _read_failure_count(session_id: str | None) -> int:
-    if not session_id:
-        return 0
-    try:
-        return int(_failure_count_path(session_id).read_text().strip())
-    except (FileNotFoundError, ValueError, OSError):
-        return 0
-
-
-def _write_failure_count(session_id: str | None, count: int) -> None:
-    if not session_id:
-        return
-    try:
-        HookState.BASE_DIR.mkdir(parents=True, exist_ok=True)
-        _failure_count_path(session_id).write_text(str(count))
-    except OSError:
-        pass
-
-
-# ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------
 
@@ -478,6 +450,8 @@ def main() -> int:
     db_path = _resolve_db_path()
     session_id: str | None = None
     transcript_path: str | None = None
+    state: HookState | None = None
+    failure_count = 0
 
     try:
         if os.environ.get("CC_MEMORY_SANITIZE_DISABLE") == "1":
@@ -501,11 +475,11 @@ def main() -> int:
         if not path.exists():
             return 0
 
-        failure_count = _read_failure_count(session_id)
+        state = HookState(session_id) if session_id else None
+        failure_count = state.get_sanitize_failure_count() if state else 0
         if failure_count >= _MAX_CONSECUTIVE_FAILURES:
             return 0
 
-        state = HookState(session_id) if session_id else None
         offset = state.get_sanitize_offset() if state else 0
 
         try:
@@ -548,7 +522,7 @@ def main() -> int:
             if state:
                 new_offset = len(new_bytes) if modified else file_size
                 state.set_sanitize_offset(new_offset)
-            _write_failure_count(session_id, 0)
+                state.set_sanitize_failure_count(0)
         else:
             _log_sanitize_event(
                 db_path,
@@ -559,7 +533,8 @@ def main() -> int:
                 failed_count=sanitized + dangling,
                 failure_reason=failure_reason,
             )
-            _write_failure_count(session_id, failure_count + 1)
+            if state:
+                state.set_sanitize_failure_count(failure_count + 1)
 
         return 0
 
@@ -577,6 +552,14 @@ def main() -> int:
             )
         except Exception:
             pass
+        # スキャン / sanitize フェーズの例外も連続失敗カウンタに積む。
+        # 毎セッションで同じ例外が出続けるケース (DB スキーマ不一致等) で
+        # _MAX_CONSECUTIVE_FAILURES に達したら以降の SessionStart をスキップしループを止める。
+        if state is not None:
+            try:
+                state.set_sanitize_failure_count(failure_count + 1)
+            except Exception:
+                pass
         return 0
 
 

--- a/hooks/sanitize_backfill_hook.py
+++ b/hooks/sanitize_backfill_hook.py
@@ -1,0 +1,584 @@
+"""SessionStart hook: 過去 transcript の差分 backfill sanitize。
+
+stdin から JSON (session_id / transcript_path / cwd / source) を読み、
+transcript .jsonl 中の cc-memory tool_result から生 X#NNN を {{cite:X#NNN}} に変換し、
+target 不在は [deleted X#NNN] に変換する。
+
+書き戻し方式: atomic rename + backup + mtime 再確認。
+書き込み直前に mtime が変化していれば harness が並行 append 中とみなして書き戻しを中断、
+sanitize_log に failure_reason を記録し sanitize_offset は据え置きで次回再試行する。
+同一セッションで連続 3 回失敗したら以降の SessionStart はスキップする (ループ防止)。
+
+opt-out:
+- 環境変数 CC_MEMORY_SANITIZE_DISABLE=1: 即 exit 0
+- cwd が cc-memory リポジトリ内 (pyproject.toml [project].name == 'claude-code-memory'
+  を上方向探索で検出): 即 exit 0
+
+例外時は stderr 警告 + sanitize_log failure 記録 + exit 0 (Claude Code 起動非ブロック)。
+"""
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import time
+import tomllib
+from pathlib import Path
+from typing import Any
+
+# プロジェクトルートを path に追加
+_project_root = Path(__file__).resolve().parents[1]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from hooks.hook_state import HookState
+from hooks.hook_transcript import _is_cc_memory_tool
+from src.services.citations_pure import (
+    TYPE_CODE_TO_NAME,
+    _RAW_CITE_PATTERN,
+    check_target_exists,
+    convert_raw_to_cite,
+)
+
+DEFAULT_DB_PATH = Path.home() / ".claude" / ".claude-code-memory" / "discussion.db"
+_REPO_PROJECT_NAME = "claude-code-memory"
+_MAX_CONSECUTIVE_FAILURES = 3
+
+
+# ---------------------------------------------------------------------------
+# opt-out: cwd が cc-memory リポジトリ内か判定
+# ---------------------------------------------------------------------------
+
+
+def _is_in_cc_memory_repo(cwd: str | None) -> bool:
+    """cwd から上方向に pyproject.toml を探し name=='claude-code-memory' なら True。
+
+    最初に見つかった pyproject.toml の name が一致しない場合は False (別プロジェクト)。
+    pyproject.toml が見つからない / 読めない場合は False。
+    """
+    if not cwd:
+        return False
+    try:
+        start = Path(cwd).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return False
+    for parent in (start, *start.parents):
+        candidate = parent / "pyproject.toml"
+        if not candidate.exists():
+            continue
+        try:
+            with open(candidate, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            return False
+        name = data.get("project", {}).get("name")
+        return name == _REPO_PROJECT_NAME
+    return False
+
+
+# ---------------------------------------------------------------------------
+# dangling target → [deleted X#NNN] 変換
+# convert_raw_to_cite が pure 層の責務でない部分なので hook 側に閉じ込める。
+# PR-c (PostToolUse hook) と同型の skip 規則。
+# ---------------------------------------------------------------------------
+
+
+def _replace_dangling_in_line(line: str) -> tuple[str, int]:
+    """1 行内の残存生 X#NNN を [deleted X#NNN] に置換する。
+
+    インラインバッククォート / 既存 {{cite:...}} / エスケープ \\X#NNN ・
+    \\{{cite:...}} 内はスキップ (convert_raw_to_cite と同じ skip 規則)。
+    """
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    deleted = 0
+    while i < n:
+        ch = line[i]
+        if ch == "`":
+            close = line.find("`", i + 1)
+            if close == -1:
+                out.append(line[i:])
+                break
+            out.append(line[i : close + 1])
+            i = close + 1
+            continue
+        if line[i : i + 7] == "{{cite:":
+            end = line.find("}}", i + 7)
+            if end == -1:
+                out.append(ch)
+                i += 1
+                continue
+            out.append(line[i : end + 2])
+            i = end + 2
+            continue
+        if ch == "\\":
+            if line[i + 1 : i + 3] == "{{":
+                end = line.find("}}", i + 1)
+                if end == -1:
+                    out.append(ch)
+                    i += 1
+                    continue
+                out.append(line[i : end + 2])
+                i = end + 2
+                continue
+            tail = line[i + 1 : i + 2]
+            if tail in TYPE_CODE_TO_NAME:
+                m = _RAW_CITE_PATTERN.match(line, i + 1)
+                if m and m.start() == i + 1:
+                    out.append(line[i : m.end()])
+                    i = m.end()
+                    continue
+            out.append(ch)
+            i += 1
+            continue
+        m = _RAW_CITE_PATTERN.match(line, i)
+        if m:
+            code = m.group(1)
+            target_id = m.group(2)
+            out.append(f"[deleted {code}#{target_id}]")
+            deleted += 1
+            i = m.end()
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out), deleted
+
+
+def _convert_dangling_to_deleted(text: str) -> tuple[str, int]:
+    """convert_raw_to_cite 通過後の残存生 X#NNN を [deleted X#NNN] に変換する。
+
+    フェンスコードブロック内はスキップ (convert_raw_to_cite の skip 規則と同型)。
+    """
+    out_lines: list[str] = []
+    in_fence = False
+    total = 0
+    for raw_line in text.split("\n"):
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            out_lines.append(raw_line)
+            continue
+        if in_fence:
+            out_lines.append(raw_line)
+            continue
+        new_line, count = _replace_dangling_in_line(raw_line)
+        total += count
+        out_lines.append(new_line)
+    return "\n".join(out_lines), total
+
+
+# ---------------------------------------------------------------------------
+# tool_result.content の sanitize
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_text(text: str, ro_conn: sqlite3.Connection) -> tuple[str, dict]:
+    """text を sanitize し (新 text, 統計) を返す。"""
+    def validator(target_type: str, target_id: int) -> bool:
+        return check_target_exists(ro_conn, target_type, target_id)
+    converted, counters = convert_raw_to_cite(text, target_validator=validator)
+    deleted_text, dangling_count = _convert_dangling_to_deleted(converted)
+    sanitized = counters["sanitized_count"]
+    skipped = (
+        counters["skipped_in_codeblock"]
+        + counters["skipped_in_existing_cite"]
+        + counters["skipped_escape"]
+    )
+    occurrence = sanitized + dangling_count + skipped
+    return deleted_text, {
+        "sanitized": sanitized,
+        "dangling": dangling_count,
+        "occurrence": occurrence,
+    }
+
+
+def _sanitize_tool_result_content(
+    content: Any, ro_conn: sqlite3.Connection
+) -> tuple[Any, dict]:
+    """tool_result.content (str or list of text blocks) を sanitize する。"""
+    stats = {"sanitized": 0, "dangling": 0, "occurrence": 0}
+    if isinstance(content, str):
+        new_text, sub = _sanitize_text(content, ro_conn)
+        return new_text, sub
+    if isinstance(content, list):
+        new_list = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                new_text, sub = _sanitize_text(item.get("text", ""), ro_conn)
+                new_list.append({**item, "text": new_text})
+                for k in stats:
+                    stats[k] += sub[k]
+            else:
+                new_list.append(item)
+        return new_list, stats
+    return content, stats
+
+
+# ---------------------------------------------------------------------------
+# transcript scan + 書き換え
+# ---------------------------------------------------------------------------
+
+
+def _parse_transcript_lines(raw_bytes: bytes) -> list[dict]:
+    """raw bytes を行単位に分割し、各行の byte 位置 / 元 bytes / parse 済 JSON を返す。"""
+    out: list[dict] = []
+    pos = 0
+    parts = raw_bytes.split(b"\n")
+    for i, line_bytes in enumerate(parts):
+        json_obj = None
+        line_str = line_bytes.decode("utf-8", errors="replace").strip()
+        if line_str:
+            try:
+                json_obj = json.loads(line_str)
+            except json.JSONDecodeError:
+                pass
+        out.append({"start": pos, "bytes": line_bytes, "json": json_obj})
+        pos += len(line_bytes)
+        if i < len(parts) - 1:
+            pos += 1
+    return out
+
+
+def _build_tool_use_id_map(lines: list[dict]) -> dict[str, str]:
+    """全 entries から tool_use_id → tool_name の map を構築する。"""
+    mp: dict[str, str] = {}
+    for line_info in lines:
+        entry = line_info["json"]
+        if not entry or entry.get("type") != "assistant":
+            continue
+        content = entry.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            use_id = block.get("id", "")
+            name = block.get("name", "")
+            if use_id:
+                mp[use_id] = name
+    return mp
+
+
+def _sanitize_transcript_bytes(
+    raw_bytes: bytes,
+    offset: int,
+    ro_conn: sqlite3.Connection,
+) -> tuple[bytes, dict, bool]:
+    """transcript bytes を読み offset 以降の cc-memory tool_result を sanitize して再構築。
+
+    offset 未満の行は元バイト列のままパススルー (byte-perfect 維持)。
+    Returns: (new_bytes, stats, modified)
+    """
+    lines = _parse_transcript_lines(raw_bytes)
+    tool_name_map = _build_tool_use_id_map(lines)
+
+    stats = {"sanitized": 0, "dangling": 0, "occurrence": 0}
+    out_chunks: list[bytes] = []
+    modified = False
+
+    for line_info in lines:
+        if line_info["start"] < offset:
+            out_chunks.append(line_info["bytes"])
+            continue
+        entry = line_info["json"]
+        if entry is None or entry.get("type") != "user":
+            out_chunks.append(line_info["bytes"])
+            continue
+        content = entry.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            out_chunks.append(line_info["bytes"])
+            continue
+
+        new_blocks: list[Any] = []
+        line_modified = False
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                new_blocks.append(block)
+                continue
+            tool_use_id = block.get("tool_use_id", "")
+            tool_name = tool_name_map.get(tool_use_id, "")
+            if not _is_cc_memory_tool(tool_name):
+                new_blocks.append(block)
+                continue
+            block_content = block.get("content", "")
+            new_content, sub_stats = _sanitize_tool_result_content(block_content, ro_conn)
+            for k in stats:
+                stats[k] += sub_stats[k]
+            if new_content != block_content:
+                new_blocks.append({**block, "content": new_content})
+                line_modified = True
+            else:
+                new_blocks.append(block)
+
+        if line_modified:
+            new_entry = {
+                **entry,
+                "message": {**entry["message"], "content": new_blocks},
+            }
+            out_chunks.append(json.dumps(new_entry, ensure_ascii=False).encode("utf-8"))
+            modified = True
+        else:
+            out_chunks.append(line_info["bytes"])
+
+    new_bytes = b"\n".join(out_chunks)
+    return new_bytes, stats, modified
+
+
+# ---------------------------------------------------------------------------
+# atomic rename + backup で transcript を書き戻す
+# ---------------------------------------------------------------------------
+
+
+def _write_back_transcript(
+    transcript_path: Path, new_bytes: bytes, original_mtime: float, now_ts: int
+) -> str | None:
+    """atomic rename + backup で transcript を書き戻す。
+
+    成功時 None、失敗時 failure_reason 文字列を返す。
+    rename 直前に mtime を再確認し、変化していれば harness 並行 append とみなして
+    書き戻しを中断する (harness_race)。
+    """
+    tmp_path = transcript_path.with_suffix(transcript_path.suffix + ".tmp")
+    backup_path = transcript_path.with_suffix(
+        transcript_path.suffix + f".bak-{now_ts}"
+    )
+
+    try:
+        with open(tmp_path, "wb") as f:
+            f.write(new_bytes)
+            f.flush()
+            os.fsync(f.fileno())
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        return f"io_error: {exc}"
+
+    try:
+        current_mtime = transcript_path.stat().st_mtime
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        return f"io_error: {exc}"
+
+    if current_mtime != original_mtime:
+        tmp_path.unlink(missing_ok=True)
+        return "harness_race"
+
+    try:
+        shutil.copy2(transcript_path, backup_path)
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        return f"io_error: {exc}"
+
+    try:
+        os.replace(tmp_path, transcript_path)
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        return f"rename_failed: {exc}"
+
+    try:
+        backup_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# sanitize_log INSERT
+# ---------------------------------------------------------------------------
+
+
+def _resolve_db_path() -> str:
+    return os.environ.get("CC_MEMORY_DB_PATH", str(DEFAULT_DB_PATH))
+
+
+def _log_sanitize_event(
+    db_path: str,
+    *,
+    session_id: str | None,
+    transcript_path: str | None,
+    occurrence_count: int,
+    sanitized_count: int,
+    failed_count: int,
+    failure_reason: str | None,
+) -> None:
+    """sanitize_log に 1 行 INSERT。write conn を別張りして close する。
+
+    sanitize_log の CHECK 制約 (session_id IS NOT NULL OR transcript_path IS NOT NULL) を
+    満たさない場合はスキップ。INSERT 自体の失敗は stderr に出すのみで例外を伝播しない。
+    """
+    if not session_id and not transcript_path:
+        return
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(
+                """
+                INSERT INTO sanitize_log (
+                    session_id, transcript_path, hook_kind,
+                    occurrence_count, sanitized_count, failed_count, failure_reason
+                ) VALUES (?, ?, 'session_start_backfill', ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    transcript_path,
+                    occurrence_count,
+                    sanitized_count,
+                    failed_count,
+                    failure_reason,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        sys.stderr.write(
+            f"[sanitize_backfill_hook] sanitize_log write failed: {exc}\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 連続失敗カウンタ (3 回連続失敗で本セッションでの backfill をスキップ)
+# ---------------------------------------------------------------------------
+
+
+def _failure_count_path(session_id: str) -> Path:
+    safe = session_id.replace("/", "_")
+    return HookState.BASE_DIR / f"sanitize_failure_count_{safe}"
+
+
+def _read_failure_count(session_id: str | None) -> int:
+    if not session_id:
+        return 0
+    try:
+        return int(_failure_count_path(session_id).read_text().strip())
+    except (FileNotFoundError, ValueError, OSError):
+        return 0
+
+
+def _write_failure_count(session_id: str | None, count: int) -> None:
+    if not session_id:
+        return
+    try:
+        HookState.BASE_DIR.mkdir(parents=True, exist_ok=True)
+        _failure_count_path(session_id).write_text(str(count))
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    db_path = _resolve_db_path()
+    session_id: str | None = None
+    transcript_path: str | None = None
+
+    try:
+        if os.environ.get("CC_MEMORY_SANITIZE_DISABLE") == "1":
+            return 0
+
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return 0
+        data = json.loads(raw)
+
+        session_id = data.get("session_id") or None
+        transcript_path = data.get("transcript_path") or None
+        cwd = data.get("cwd", "")
+
+        if not transcript_path:
+            return 0
+        if _is_in_cc_memory_repo(cwd):
+            return 0
+
+        path = Path(transcript_path).expanduser()
+        if not path.exists():
+            return 0
+
+        failure_count = _read_failure_count(session_id)
+        if failure_count >= _MAX_CONSECUTIVE_FAILURES:
+            return 0
+
+        state = HookState(session_id) if session_id else None
+        offset = state.get_sanitize_offset() if state else 0
+
+        try:
+            stat_info = path.stat()
+        except OSError:
+            return 0
+        original_mtime = stat_info.st_mtime
+        file_size = stat_info.st_size
+
+        if offset > file_size:
+            offset = 0
+
+        raw_bytes = path.read_bytes()
+
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as ro_conn:
+            new_bytes, stats, modified = _sanitize_transcript_bytes(
+                raw_bytes, offset, ro_conn
+            )
+
+        failure_reason: str | None = None
+        if modified:
+            failure_reason = _write_back_transcript(
+                path, new_bytes, original_mtime, int(time.time())
+            )
+
+        sanitized = stats["sanitized"]
+        dangling = stats["dangling"]
+        occurrence = stats["occurrence"]
+
+        if failure_reason is None:
+            _log_sanitize_event(
+                db_path,
+                session_id=session_id,
+                transcript_path=transcript_path,
+                occurrence_count=occurrence,
+                sanitized_count=sanitized,
+                failed_count=0,
+                failure_reason=None,
+            )
+            if state:
+                new_offset = len(new_bytes) if modified else file_size
+                state.set_sanitize_offset(new_offset)
+            _write_failure_count(session_id, 0)
+        else:
+            _log_sanitize_event(
+                db_path,
+                session_id=session_id,
+                transcript_path=transcript_path,
+                occurrence_count=occurrence,
+                sanitized_count=0,
+                failed_count=sanitized + dangling,
+                failure_reason=failure_reason,
+            )
+            _write_failure_count(session_id, failure_count + 1)
+
+        return 0
+
+    except Exception as exc:
+        sys.stderr.write(f"[sanitize_backfill_hook] {exc}\n")
+        try:
+            _log_sanitize_event(
+                db_path,
+                session_id=session_id,
+                transcript_path=transcript_path,
+                occurrence_count=0,
+                sanitized_count=0,
+                failed_count=0,
+                failure_reason=str(exc),
+            )
+        except Exception:
+            pass
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -70,6 +70,25 @@ class TestSanitizeOffset:
         assert hook_state.get_sanitize_offset() == 200
 
 
+class TestSanitizeFailureCount:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_sanitize_failure_count() == 0
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_sanitize_failure_count(2)
+        assert hook_state.get_sanitize_failure_count() == 2
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("sanitize_failure_count")
+        path.write_text("not-an-int")
+        assert hook_state.get_sanitize_failure_count() == 0
+
+    def test_cleared_by_clear_session(self, hook_state, tmp_path):
+        hook_state.set_sanitize_failure_count(3)
+        HookState.clear_session("test-session-123")
+        assert hook_state.get_sanitize_failure_count() == 0
+
+
 class TestCurrentTurn:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_current_turn() == 0

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -50,6 +50,26 @@ class TestTranscriptOffset:
         assert hook_state.get_transcript_offset() == 0
 
 
+class TestSanitizeOffset:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_sanitize_offset() == 0
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_sanitize_offset(67890)
+        assert hook_state.get_sanitize_offset() == 67890
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("sanitize_offset")
+        path.write_text("not-an-int")
+        assert hook_state.get_sanitize_offset() == 0
+
+    def test_independent_of_transcript_offset(self, hook_state):
+        hook_state.set_transcript_offset(100)
+        hook_state.set_sanitize_offset(200)
+        assert hook_state.get_transcript_offset() == 100
+        assert hook_state.get_sanitize_offset() == 200
+
+
 class TestCurrentTurn:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_current_turn() == 0

--- a/tests/unit/test_sanitize_backfill_hook.py
+++ b/tests/unit/test_sanitize_backfill_hook.py
@@ -1,0 +1,618 @@
+"""hooks/sanitize_backfill_hook.py のユニットテスト。
+
+plan-d.md エッジケース表 #1-#15 を網羅する。
+"""
+import io
+import json
+import os
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hooks import sanitize_backfill_hook
+from hooks.hook_state import HookState
+from src.services.citations_pure import TYPE_TO_TABLE
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_SANITIZE_LOG_DDL = """
+CREATE TABLE sanitize_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    transcript_path TEXT,
+    hook_kind TEXT NOT NULL CHECK(hook_kind IN ('post_tool_use', 'session_start_backfill')),
+    occurrence_count INTEGER NOT NULL DEFAULT 0,
+    sanitized_count INTEGER NOT NULL DEFAULT 0,
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    failure_reason TEXT,
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK(sanitized_count + failed_count <= occurrence_count),
+    CHECK(session_id IS NOT NULL OR transcript_path IS NOT NULL)
+);
+"""
+
+
+@pytest.fixture
+def fixture_db(monkeypatch):
+    """sanitize_log + 最小 entity テーブル + M#1/D#1/L#1/A#1/T#1 を持つ一時 DB。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            for table in TYPE_TO_TABLE.values():
+                conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
+                conn.execute(f"INSERT INTO {table} (id) VALUES (1)")
+            conn.executescript(_SANITIZE_LOG_DDL)
+            conn.commit()
+        finally:
+            conn.close()
+        monkeypatch.setenv("CC_MEMORY_DB_PATH", db_path)
+        monkeypatch.delenv("CC_MEMORY_SANITIZE_DISABLE", raising=False)
+        yield db_path
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    """HookState の BASE_DIR を tmp_path に向ける。"""
+    monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
+    return tmp_path
+
+
+_TOOL_NAME = "mcp__plugin_claude-code-memory_cc-memory__check_in"
+
+
+def _make_assistant_entry(tool_use_id: str, tool_name: str = _TOOL_NAME) -> dict:
+    return {
+        "type": "assistant",
+        "uuid": f"uuid-asst-{tool_use_id}",
+        "message": {
+            "content": [
+                {"type": "tool_use", "id": tool_use_id, "name": tool_name, "input": {}}
+            ]
+        },
+    }
+
+
+def _make_user_tool_result_entry(
+    tool_use_id: str, content, extra: dict | None = None
+) -> dict:
+    block = {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
+    entry = {
+        "type": "user",
+        "uuid": f"uuid-user-{tool_use_id}",
+        "timestamp": "2026-06-22T00:00:00Z",
+        "message": {"content": [block]},
+    }
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+def _write_transcript(path: Path, entries: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def _read_transcript_lines(path: Path) -> list[dict]:
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            out.append(json.loads(line))
+    return out
+
+
+def _run_hook(stdin_payload: dict) -> tuple[str, str, int]:
+    """stdin を差し替えて main() を実行し (stdout, stderr, exit_code) を返す。"""
+    fake_stdin = io.StringIO(json.dumps(stdin_payload))
+    fake_stdout = io.StringIO()
+    fake_stderr = io.StringIO()
+    with patch.object(sanitize_backfill_hook.sys, "stdin", fake_stdin), \
+         patch.object(sanitize_backfill_hook.sys, "stdout", fake_stdout), \
+         patch.object(sanitize_backfill_hook.sys, "stderr", fake_stderr):
+        code = sanitize_backfill_hook.main()
+    return fake_stdout.getvalue(), fake_stderr.getvalue(), code
+
+
+def _read_sanitize_logs(db_path: str) -> list[dict]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT session_id, transcript_path, hook_kind, occurrence_count, "
+            "sanitized_count, failed_count, failure_reason FROM sanitize_log ORDER BY id"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def _payload(transcript_path: str, *, session_id="sess-1", cwd="/tmp/outside") -> dict:
+    return {
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+        "source": "resume",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Case #1: 初回起動 (sanitize_offset 未設定) → transcript 全体を backfill
+# ---------------------------------------------------------------------------
+
+
+def test_case_01_initial_backfill_whole_transcript(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "found M#1 and D#1 here"),
+        _make_assistant_entry("toolu_02"),
+        _make_user_tool_result_entry("toolu_02", "another ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    assert "{{cite:M#1}}" in new_entries[1]["message"]["content"][0]["content"]
+    assert "{{cite:D#1}}" in new_entries[1]["message"]["content"][0]["content"]
+    assert "{{cite:M#1}}" in new_entries[3]["message"]["content"][0]["content"]
+
+    state = HookState("sess-1")
+    assert state.get_sanitize_offset() == transcript.stat().st_size
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert len(logs) == 1
+    assert logs[0]["hook_kind"] == "session_start_backfill"
+    assert logs[0]["sanitized_count"] == 3
+    assert logs[0]["failed_count"] == 0
+    assert logs[0]["occurrence_count"] == 3
+    assert logs[0]["failure_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Case #2: 差分起動 (offset あり) → offset 以降のみ backfill
+# ---------------------------------------------------------------------------
+
+
+def test_case_02_incremental_backfill_only_past_offset(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    initial = [
+        _make_assistant_entry("toolu_old"),
+        # 既に cite 形式へ変換済みのエントリ (前回 backfill 済みを表す)
+        _make_user_tool_result_entry("toolu_old", "older ref {{cite:M#1}} kept as-is"),
+    ]
+    _write_transcript(transcript, initial)
+
+    state = HookState("sess-1")
+    state.set_sanitize_offset(transcript.stat().st_size)
+
+    with open(transcript, "a", encoding="utf-8") as f:
+        f.write(json.dumps(_make_assistant_entry("toolu_new"), ensure_ascii=False) + "\n")
+        f.write(
+            json.dumps(
+                _make_user_tool_result_entry("toolu_new", "new ref D#1"),
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    # 旧 entry の {{cite:M#1}} はそのまま (二重 cite 化されない)
+    assert new_entries[1]["message"]["content"][0]["content"] == \
+        "older ref {{cite:M#1}} kept as-is"
+    # 新 entry の D#1 が変換される
+    assert new_entries[3]["message"]["content"][0]["content"] == \
+        "new ref {{cite:D#1}}"
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert len(logs) == 1
+    assert logs[0]["sanitized_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Case #3: transcript_path 空 → 何もしない exit 0、log なし、offset 未更新
+# ---------------------------------------------------------------------------
+
+
+def test_case_03_empty_transcript_path_no_op(fixture_db, state_dir):
+    _, _, code = _run_hook({"session_id": "sess-1", "transcript_path": "", "cwd": "/tmp"})
+    assert code == 0
+    assert _read_sanitize_logs(fixture_db) == []
+    state = HookState("sess-1")
+    assert state.get_sanitize_offset() == 0
+
+
+# ---------------------------------------------------------------------------
+# Case #4: offset > file size → リセットして全件再読み込み
+# ---------------------------------------------------------------------------
+
+
+def test_case_04_offset_exceeds_file_size_resets(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1 here"),
+    ]
+    _write_transcript(transcript, entries)
+
+    state = HookState("sess-1")
+    # transcript が縮んだ (古い session の offset が残っていた) 想定
+    state.set_sanitize_offset(999_999)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    assert new_entries[1]["message"]["content"][0]["content"] == \
+        "ref {{cite:M#1}} here"
+    assert state.get_sanitize_offset() == transcript.stat().st_size
+
+
+# ---------------------------------------------------------------------------
+# Case #5: tool_result 以外の entry (assistant text / user 入力) → 走査対象外
+# ---------------------------------------------------------------------------
+
+
+def test_case_05_non_tool_result_entries_untouched(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        # user の通常メッセージ (tool_result でない)
+        {
+            "type": "user",
+            "uuid": "uuid-u1",
+            "message": {"content": [{"type": "text", "text": "user said M#1 here"}]},
+        },
+        # assistant の text block (tool_use なし)
+        {
+            "type": "assistant",
+            "uuid": "uuid-a1",
+            "message": {"content": [{"type": "text", "text": "asst said D#1 here"}]},
+        },
+    ]
+    _write_transcript(transcript, entries)
+    original = transcript.read_bytes()
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    # 1 文字も書き換わっていない
+    assert transcript.read_bytes() == original
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert len(logs) == 1
+    assert logs[0]["sanitized_count"] == 0
+    assert logs[0]["occurrence_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Case #6: tool_result の content が cc-memory tool 由来でない → スキップ
+# ---------------------------------------------------------------------------
+
+
+def test_case_06_non_cc_memory_tool_result_skipped(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_read", tool_name="Read"),
+        _make_user_tool_result_entry("toolu_read", "Read result mentions M#1"),
+        _make_assistant_entry("toolu_cc"),
+        _make_user_tool_result_entry("toolu_cc", "cc-memory M#1 ref"),
+    ]
+    _write_transcript(transcript, entries)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    # Read tool 由来 → 変換しない
+    assert new_entries[1]["message"]["content"][0]["content"] == \
+        "Read result mentions M#1"
+    # cc-memory tool 由来 → 変換
+    assert new_entries[3]["message"]["content"][0]["content"] == \
+        "cc-memory {{cite:M#1}} ref"
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert logs[0]["sanitized_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Case #7: コードブロック / エスケープ / 既 cite はスキップ (PR-a 継承)
+# ---------------------------------------------------------------------------
+
+
+def test_case_07_skip_codeblock_escape_existing_cite(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    content = (
+        "inline `M#1 code` outside D#1\n"
+        "fence:\n```\nM#1 in fence\n```\nafter\n"
+        "escape \\M#1 literal\n"
+        "already {{cite:M#1}} cited"
+    )
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", content),
+    ]
+    _write_transcript(transcript, entries)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    out = new_entries[1]["message"]["content"][0]["content"]
+    assert "`M#1 code`" in out  # inline backtick 維持
+    assert "M#1 in fence" in out  # fence 内維持
+    assert "\\M#1" in out  # エスケープ維持
+    assert "{{cite:M#1}}" in out  # 既存 cite 維持
+    assert "{{cite:D#1}}" in out  # 通常の D#1 のみ変換
+
+    logs = _read_sanitize_logs(fixture_db)
+    # コードブロック等は occurrence に含まれるが sanitized されない
+    assert logs[0]["sanitized_count"] == 1
+    assert logs[0]["occurrence_count"] >= 5  # codeblock + escape + existing_cite を含む
+
+
+# ---------------------------------------------------------------------------
+# Case #8: dangling target (DB 不在) → [deleted X#NNN]
+# ---------------------------------------------------------------------------
+
+
+def test_case_08_dangling_becomes_deleted_marker(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "known M#1, missing M#9999"),
+    ]
+    _write_transcript(transcript, entries)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    out = new_entries[1]["message"]["content"][0]["content"]
+    assert out == "known {{cite:M#1}}, missing [deleted M#9999]"
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert logs[0]["sanitized_count"] == 1
+    assert logs[0]["failed_count"] == 0  # dangling は failed_count に入らない
+    assert logs[0]["occurrence_count"] == 2
+    assert logs[0]["failure_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Case #9: sanitize_offset が正しく進む (idempotent)
+# ---------------------------------------------------------------------------
+
+
+def test_case_09_offset_progresses_idempotently(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+
+    # 1 回目
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    first_logs = _read_sanitize_logs(fixture_db)
+    assert first_logs[0]["sanitized_count"] == 1
+    first_offset = HookState("sess-1").get_sanitize_offset()
+
+    # 2 回目 (差分なし)
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    second_logs = _read_sanitize_logs(fixture_db)
+    assert len(second_logs) == 2
+    assert second_logs[1]["sanitized_count"] == 0  # 二度目は何もしない
+    assert HookState("sess-1").get_sanitize_offset() == first_offset
+
+
+# ---------------------------------------------------------------------------
+# Case #10: hook 内例外 → stderr warning + sanitize_log 記録 + exit 0 +
+#           offset 据え置き (次回再試行)
+# ---------------------------------------------------------------------------
+
+
+def test_case_10_exception_warns_logs_and_keeps_offset(fixture_db, state_dir, tmp_path, monkeypatch):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+
+    def boom(*args, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(sanitize_backfill_hook, "_sanitize_transcript_bytes", boom)
+
+    _, stderr, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    assert "[sanitize_backfill_hook]" in stderr
+
+    # offset は更新されない (失敗時は据え置き)
+    assert HookState("sess-1").get_sanitize_offset() == 0
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert len(logs) == 1
+    assert logs[0]["failure_reason"] == "database is locked"
+
+
+# ---------------------------------------------------------------------------
+# Case #11: CC_MEMORY_SANITIZE_DISABLE=1 → 即 exit 0、log なし、offset 未更新
+# ---------------------------------------------------------------------------
+
+
+def test_case_11_env_disable_short_circuits(fixture_db, state_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("CC_MEMORY_SANITIZE_DISABLE", "1")
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+    original = transcript.read_bytes()
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    assert transcript.read_bytes() == original
+    assert _read_sanitize_logs(fixture_db) == []
+    assert HookState("sess-1").get_sanitize_offset() == 0
+
+
+# ---------------------------------------------------------------------------
+# Case #12: cwd が cc-memory リポジトリ内 → 即 exit 0、log なし、offset 未更新
+# ---------------------------------------------------------------------------
+
+
+def test_case_12_cwd_in_cc_memory_repo_skipped(fixture_db, state_dir, tmp_path):
+    repo_root = tmp_path / "cc-memory-repo"
+    repo_root.mkdir()
+    (repo_root / "pyproject.toml").write_text(
+        '[project]\nname = "claude-code-memory"\nversion = "0.1.0"\n'
+    )
+    nested = repo_root / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+    original = transcript.read_bytes()
+
+    _, _, code = _run_hook(_payload(str(transcript), cwd=str(nested)))
+    assert code == 0
+    assert transcript.read_bytes() == original
+    assert _read_sanitize_logs(fixture_db) == []
+
+
+# ---------------------------------------------------------------------------
+# Case #13: 大規模 transcript でも 600s 以内に完了 (perf スモーク)
+# ---------------------------------------------------------------------------
+
+
+def test_case_13_perf_under_threshold(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    entries = []
+    # 1000 ペア (assistant tool_use + user tool_result) = 2000 行
+    for i in range(1000):
+        tool_id = f"toolu_{i:04d}"
+        entries.append(_make_assistant_entry(tool_id))
+        entries.append(_make_user_tool_result_entry(tool_id, f"row {i} ref M#1"))
+    _write_transcript(transcript, entries)
+
+    start = time.monotonic()
+    _, _, code = _run_hook(_payload(str(transcript)))
+    elapsed = time.monotonic() - start
+
+    assert code == 0
+    assert elapsed < 10.0, f"hook took too long: {elapsed:.2f}s"
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert logs[0]["sanitized_count"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Case #14: 書き戻し時に entry の他フィールド (uuid / timestamp 等) が維持される
+# ---------------------------------------------------------------------------
+
+
+def test_case_14_other_entry_fields_preserved(fixture_db, state_dir, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    assistant = _make_assistant_entry("toolu_01")
+    user_entry = _make_user_tool_result_entry(
+        "toolu_01",
+        "ref M#1",
+        extra={"parentUuid": "parent-xyz", "sessionId": "sess-orig"},
+    )
+    _write_transcript(transcript, [assistant, user_entry])
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+
+    new_entries = _read_transcript_lines(transcript)
+    assert new_entries[1]["uuid"] == user_entry["uuid"]
+    assert new_entries[1]["timestamp"] == user_entry["timestamp"]
+    assert new_entries[1]["parentUuid"] == "parent-xyz"
+    assert new_entries[1]["sessionId"] == "sess-orig"
+    assert new_entries[1]["message"]["content"][0]["tool_use_id"] == "toolu_01"
+    assert new_entries[1]["message"]["content"][0]["content"] == "ref {{cite:M#1}}"
+
+
+# ---------------------------------------------------------------------------
+# Case #15: atomic write — tmpfile + rename + harness 並行 append 検出
+# ---------------------------------------------------------------------------
+
+
+def test_case_15_write_back_detects_mtime_mismatch(tmp_path):
+    """書き戻し直前の mtime 再確認で並行 append を検出し書き戻しを中断する。"""
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(b"original content line\n")
+    real_mtime = transcript.stat().st_mtime
+
+    result = sanitize_backfill_hook._write_back_transcript(
+        transcript, b"new content\n", real_mtime - 100.0, int(time.time())
+    )
+    assert result == "harness_race"
+    assert transcript.read_bytes() == b"original content line\n"
+    # tmpfile / backup は残らない
+    leftover = [p.name for p in tmp_path.iterdir() if ".tmp" in p.name or ".bak" in p.name]
+    assert leftover == [], f"leftover files: {leftover}"
+
+
+def test_case_15_write_back_success_uses_atomic_rename(tmp_path):
+    """成功時に transcript が atomic に置き換えられ、tmpfile / backup が残らない。"""
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(b"original\n")
+    real_mtime = transcript.stat().st_mtime
+
+    result = sanitize_backfill_hook._write_back_transcript(
+        transcript, b"sanitized\n", real_mtime, int(time.time())
+    )
+    assert result is None
+    assert transcript.read_bytes() == b"sanitized\n"
+    leftover = [p.name for p in tmp_path.iterdir() if ".tmp" in p.name or ".bak" in p.name]
+    assert leftover == [], f"leftover files: {leftover}"
+
+
+def test_case_15_harness_race_recorded_in_sanitize_log(
+    fixture_db, state_dir, tmp_path, monkeypatch
+):
+    """main() 経由で harness_race を検出した場合 sanitize_log に failure 記録 + offset 据え置き。"""
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+    original_bytes = transcript.read_bytes()
+
+    def fake_write_back(*_args, **_kwargs):
+        return "harness_race"
+
+    monkeypatch.setattr(sanitize_backfill_hook, "_write_back_transcript", fake_write_back)
+
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    assert transcript.read_bytes() == original_bytes
+
+    logs = _read_sanitize_logs(fixture_db)
+    assert len(logs) == 1
+    assert logs[0]["failure_reason"] == "harness_race"
+    assert logs[0]["sanitized_count"] == 0
+    assert logs[0]["failed_count"] == 1
+    assert HookState("sess-1").get_sanitize_offset() == 0

--- a/tests/unit/test_sanitize_backfill_hook.py
+++ b/tests/unit/test_sanitize_backfill_hook.py
@@ -358,9 +358,10 @@ def test_case_07_skip_codeblock_escape_existing_cite(fixture_db, state_dir, tmp_
     assert "{{cite:D#1}}" in out  # 通常の D#1 のみ変換
 
     logs = _read_sanitize_logs(fixture_db)
-    # コードブロック等は occurrence に含まれるが sanitized されない
+    # コードブロック等は occurrence に含まれるが sanitized されない。
+    # sanitized=1 (D#1) + dangling=0 + skipped=4 (M#1 inline / fence / escape / existing cite) = 5
     assert logs[0]["sanitized_count"] == 1
-    assert logs[0]["occurrence_count"] >= 5  # codeblock + escape + existing_cite を含む
+    assert logs[0]["occurrence_count"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -444,10 +445,39 @@ def test_case_10_exception_warns_logs_and_keeps_offset(fixture_db, state_dir, tm
 
     # offset は更新されない (失敗時は据え置き)
     assert HookState("sess-1").get_sanitize_offset() == 0
+    # スキャン/sanitize フェーズ例外も連続失敗カウンタを進める
+    assert HookState("sess-1").get_sanitize_failure_count() == 1
 
     logs = _read_sanitize_logs(fixture_db)
     assert len(logs) == 1
     assert logs[0]["failure_reason"] == "database is locked"
+
+
+def test_case_10_repeated_scan_exceptions_trigger_skip(fixture_db, state_dir, tmp_path, monkeypatch):
+    """同一例外が 3 回連続したら以降の SessionStart はスキップする (loop guard)。"""
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        _make_assistant_entry("toolu_01"),
+        _make_user_tool_result_entry("toolu_01", "ref M#1"),
+    ]
+    _write_transcript(transcript, entries)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("schema mismatch")
+
+    monkeypatch.setattr(sanitize_backfill_hook, "_sanitize_transcript_bytes", boom)
+
+    for _ in range(3):
+        _, _, code = _run_hook(_payload(str(transcript)))
+        assert code == 0
+    assert HookState("sess-1").get_sanitize_failure_count() == 3
+    logs_at_3 = _read_sanitize_logs(fixture_db)
+    assert len(logs_at_3) == 3
+
+    # 4 回目は loop guard で何もしない (log 件数据え置き)
+    _, _, code = _run_hook(_payload(str(transcript)))
+    assert code == 0
+    assert _read_sanitize_logs(fixture_db) == logs_at_3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Claude Code セッション開始時に過去 transcript .jsonl を走査し、cc-memory tool_result 内の生 `X#NNN` リテラルを `{{cite:X#NNN}}` 形式に変換する SessionStart hook を新設する
- 差分 backfill: `HookState` に `sanitize_offset` を追加し、前回処理位置以降のみ走査 (`offset > file_size` のとき自動リセット)
- 書き戻し: tmpfile + fsync + mtime 再確認 + atomic rename + backup の手順で transcript .jsonl を直接書き戻す
- 不在 target は `[deleted X#NNN]` 形式へ変換 (citation_renderer の dangling 表記と一致)
- opt-out: env `CC_MEMORY_SANITIZE_DISABLE=1` / cwd が cc-memory リポジトリ内 (`pyproject.toml` 上方向探索)
- 失敗時は sanitize_log に `harness_race` / `io_error` / `rename_failed` を記録、`sanitize_offset` 据え置きで次回再試行。同一セッションで連続 3 回失敗したら以降の SessionStart はスキップ (ループ防止)
- 例外時は stderr 警告 + sanitize_log failure 記録 + exit 0 で Claude Code 起動を非ブロック

hooks.json への登録は別途行うため、本 PR を単独で merge しても hook は発火しない。

## Files
- `hooks/sanitize_backfill_hook.py` 新規
- `hooks/hook_state.py` に `get_sanitize_offset` / `set_sanitize_offset` を追加
- `tests/unit/test_sanitize_backfill_hook.py` 新規 (17 ケース、書き戻し race / atomic rename 検証含む)
- `tests/unit/test_hook_state.py` に `sanitize_offset` 用 4 ケース追加

## Test plan
- [x] `uv run pytest tests/unit/test_sanitize_backfill_hook.py -v` 全 pass (17/17)
- [x] `uv run pytest tests/unit/test_hook_state.py::TestSanitizeOffset -v` 全 pass (4/4)
- [x] `uv run pytest tests/unit/ -q` 回帰 (1599 passed, 1 skipped)
- [ ] CI: Test unit + Test integration-e2e 全緑
- [ ] claude[bot] レビュー対応