### PR TITLE
refactor: SearchPipeline retriever 切り出し + 8 ステージ orchestrator

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,4 +1,5 @@
 """FTS5 + ベクトル ハイブリッド検索サービス"""
+import dataclasses
 import json
 import logging
 import math
@@ -718,13 +719,6 @@ def fts_retrieve(ctx: SearchContext, conn) -> list[dict]:
     return results
 
 
-def _fts_search(ctx: SearchContext) -> list[dict]:
-    """旧シグネチャアダプタ。自前で conn を開閉して fts_retrieve に委譲する。"""
-    conn = get_connection()
-    try:
-        return fts_retrieve(ctx, conn)
-    finally:
-        conn.close()
 
 
 def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
@@ -885,13 +879,6 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
         return None
 
 
-def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
-    """旧シグネチャアダプタ。自前で conn を開閉して vector_retrieve に委譲する。"""
-    conn = get_connection()
-    try:
-        return vector_retrieve(ctx, conn)
-    finally:
-        conn.close()
 
 
 def find_similar_topics(
@@ -1182,13 +1169,6 @@ def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
     return results
 
 
-def _tag_like_search(ctx: SearchContext) -> list[dict]:
-    """旧シグネチャアダプタ。自前で conn を開閉して tag_like_retrieve に委譲する。"""
-    conn = get_connection()
-    try:
-        return tag_like_retrieve(ctx, conn)
-    finally:
-        conn.close()
 
 
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:
@@ -1199,7 +1179,7 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
     各結果に以下を付与する:
     - score_breakdown.recency_factor: 適用された減衰係数（created_at取得不可時は1.0）
     - final_score: rrf_normalized * recency_factor
-    - score: final_score と同値（互換のため残置。Phase Bで削除予定）
+    - score: final_score と同値（旧 API 互換のため残置）
 
     確定後、final_score 降順で再ソートする。
     """
@@ -1245,7 +1225,6 @@ def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> No
                 item["score_breakdown"]["recency_factor"] = recency_factor
 
     # final_score = rrf_normalized * recency_factor を確定
-    # TODO(Phase B): 既存 score フィールドは廃止し final_score のみに統一する。
     for item in results:
         bd = item["score_breakdown"]
         final_score = bd["rrf_normalized"] * bd["recency_factor"]
@@ -1347,14 +1326,315 @@ def _rrf_merge(
         bd["vec"] = round(bd["vec"], 6)
         bd["tag"] = round(bd["tag"], 6)
         bd["rrf_normalized"] = rrf_normalized
-        # recency boost 前のスコアを score にセット。
+        # recency boost 前のスコアを score にセット (旧 API 互換)。
         # _apply_recency_boost で recency_factor 乗算後に final_score を確定する。
-        # TODO(Phase B): 既存 score フィールドは廃止し final_score のみに統一する。
         entry["score"] = rrf_normalized
 
     # RRFスコア降順でソートし、上位limit件を返す
     merged = sorted(scores.values(), key=lambda x: x["score"], reverse=True)
     return merged[:limit]
+
+
+class _SearchEarlyReturn(Exception):
+    """search パイプラインのステージから早期 return を要求するための内部 sentinel。
+
+    バリデーションエラーやタグ未登録などで途中ステージが「ここで終了して
+    特定のレスポンスを返したい」と判断したとき、orchestrator まで例外で抜けて
+    レスポンス dict を組み立てる。
+    """
+
+    def __init__(self, response: dict):
+        self.response = response
+        super().__init__()
+
+
+def _validate(
+    keyword: str | list[str],
+    keyword_mode: str,
+    entity_type: Optional[str],
+    domain: Optional[str],
+    date_after: Optional[str],
+    date_before: Optional[str],
+) -> tuple[list[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """search 引数のバリデーションと表層的な正規化 (空文字 → None, strip) を行う。
+
+    Returns:
+        (keywords, entity_type, domain, date_after, date_before) — 検証後の値。
+
+    Raises:
+        _SearchEarlyReturn: バリデーションエラー時、対応する error dict を載せて投げる。
+    """
+    if keyword_mode not in ("and", "or"):
+        raise _SearchEarlyReturn({
+            "error": {
+                "code": "INVALID_KEYWORD_MODE",
+                "message": f"Invalid keyword_mode: {keyword_mode}. Must be 'and' or 'or'",
+            }
+        })
+
+    if isinstance(keyword, str):
+        keywords = [keyword.strip()]
+    else:
+        keywords = [k.strip() for k in keyword]
+
+    if not keywords:
+        raise _SearchEarlyReturn({
+            "error": {
+                "code": "KEYWORD_TOO_SHORT",
+                "message": "keyword must be at least 2 characters",
+            }
+        })
+
+    for kw in keywords:
+        if len(kw) < 2:
+            raise _SearchEarlyReturn({
+                "error": {
+                    "code": "KEYWORD_TOO_SHORT",
+                    "message": "keyword must be at least 2 characters",
+                }
+            })
+
+    if entity_type == "":
+        entity_type = None
+    if domain == "":
+        domain = None
+    if date_after == "":
+        date_after = None
+    if date_before == "":
+        date_before = None
+
+    if entity_type is not None and entity_type not in SEARCHABLE_TYPES:
+        raise _SearchEarlyReturn({
+            "error": {
+                "code": "INVALID_ENTITY_TYPE",
+                "message": f"Invalid entity_type: {entity_type}. Must be one of {sorted(SEARCHABLE_TYPES)}",
+            }
+        })
+
+    date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$")
+    for param_name, param_value in [("date_after", date_after), ("date_before", date_before)]:
+        if param_value is None:
+            continue
+        if not date_pattern.match(param_value):
+            raise _SearchEarlyReturn({
+                "error": {
+                    "code": "INVALID_PARAMETER",
+                    "message": f"{param_name} must be ISO date format (YYYY-MM-DD or YYYY-MM-DD HH:MM:SS), got '{param_value}'",
+                }
+            })
+        try:
+            fmt = "%Y-%m-%d %H:%M:%S" if len(param_value) > 10 else "%Y-%m-%d"
+            datetime.strptime(param_value, fmt)
+        except ValueError:
+            raise _SearchEarlyReturn({
+                "error": {
+                    "code": "INVALID_PARAMETER",
+                    "message": f"{param_name} contains invalid date value: '{param_value}'",
+                }
+            })
+
+    return keywords, entity_type, domain, date_after, date_before
+
+
+def _normalize(
+    keywords: list[str],
+    tags: Optional[list[str]],
+    entity_type: Optional[str],
+    domain: Optional[str],
+    date_after: Optional[str],
+    date_before: Optional[str],
+    limit: int,
+    offset: int,
+    keyword_mode: str,
+    include_details: bool,
+    conn,
+) -> tuple[SearchContext, Optional[list[int]], Optional[list[str]]]:
+    """SearchContext を組み立てるステージ。
+
+    - domain → tags マージ (元 list があれば破壊的更新、None なら新規生成)
+    - date_before に時刻が無ければ " 23:59:59" 補完
+    - limit / offset の範囲補正
+    - fetch_limit = (offset + limit) * FETCH_LIMIT_MULTIPLIER を計算
+    - tag_ids を DB 解決 (一部が見つからなければ早期 return = 空結果)
+
+    Returns:
+        (ctx, query_tag_ids, effective_tags) — effective_tags は domain 補完後の tags
+        (telemetry parameters 用に保持)。
+
+    Raises:
+        _SearchEarlyReturn: 指定タグの一部が DB に存在しないとき、空結果 dict を載せて投げる。
+    """
+    if domain:
+        domain_tag = f"domain:{domain}"
+        if tags is None:
+            tags = [domain_tag]
+        elif domain_tag not in tags:
+            tags.append(domain_tag)
+
+    if date_before is not None and len(date_before) == 10:
+        date_before = date_before + " 23:59:59"
+
+    limit = max(1, min(limit, 50))
+    offset = max(0, offset)
+
+    tag_ids: Optional[list[int]] = None
+    if tags:
+        tag_ids = _resolve_tag_ids_readonly(conn, tags)
+        # 指定タグの一部でも DB に存在しない場合、AND フィルタは必ず空結果
+        if len(tag_ids) < len(tags):
+            raise _SearchEarlyReturn({
+                "results": [],
+                "total_count": 0,
+                "search_methods_used": [],
+            })
+
+    fetch_limit = (offset + limit) * FETCH_LIMIT_MULTIPLIER
+
+    ctx = SearchContext(
+        keywords=tuple(keywords),
+        fts_keywords=tuple(keywords),
+        original_keyword_count=None,
+        tag_ids=tuple(tag_ids) if tag_ids is not None else None,
+        entity_type=entity_type,
+        limit=limit,
+        offset=offset,
+        fetch_limit=fetch_limit,
+        keyword_mode=keyword_mode,
+        include_details=include_details,
+        date_after=date_after,
+        date_before=date_before,
+        domain=domain,
+    )
+    return ctx, tag_ids, tags
+
+
+def _expand(ctx: SearchContext) -> SearchContext:
+    """Query Expansion: tag_vec KNN で fts_keywords を構築した新 ctx を返す。
+
+    元キーワードは ctx.keywords に保持されたまま。ベクトル検索・タグ LIKE 検索は
+    元キーワードを使い、FTS のみが拡張済み fts_keywords を使う。
+    """
+    fts_keywords = _expand_query_with_tags(list(ctx.keywords))
+    original_kw_count: Optional[int] = None
+    if len(fts_keywords) > len(ctx.keywords):
+        logger.info(
+            "Query expanded: %s -> %s",
+            ctx.keywords,
+            fts_keywords[len(ctx.keywords):],
+        )
+        original_kw_count = len(ctx.keywords)
+
+    return dataclasses.replace(
+        ctx,
+        fts_keywords=tuple(fts_keywords),
+        original_keyword_count=original_kw_count,
+    )
+
+
+def _retrieve(ctx: SearchContext, conn) -> dict:
+    """3 retriever (fts / vector / tag_like) を逐次呼び出して結果を集約する。
+
+    Returns:
+        {"fts": list[dict], "vec": list[dict] | None, "tag": list[dict],
+         "methods_used": list[str]}
+
+    Raises:
+        _SearchEarlyReturn: 2 文字以下キーワード + ベクトル無効 + tag_like 空、で
+            ハイブリッド検索が成立しないとき KEYWORD_TOO_SHORT を投げる。
+    """
+    keywords = list(ctx.keywords)
+    fts_keywords = list(ctx.fts_keywords)
+    min_len = min(len(kw) for kw in keywords)
+    methods_used: list[str] = []
+
+    fts_results: list[dict] = []
+    if ctx.keyword_mode == "or":
+        # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
+        if any(len(kw) >= 3 for kw in fts_keywords):
+            fts_results = fts_retrieve(ctx, conn)
+            methods_used.append("fts5")
+    else:
+        # AND時: 全キーワードが3文字以上のときのみ FTS を使う
+        # (QE 拡張分は OR 結合で追加されるので、元キーワードの文字数で判定する)
+        if min_len >= 3:
+            fts_results = fts_retrieve(ctx, conn)
+            methods_used.append("fts5")
+
+    vec_results = vector_retrieve(ctx, conn)
+    if vec_results is not None:
+        methods_used.append("vector")
+
+    tag_like_results = tag_like_retrieve(ctx, conn)
+    if tag_like_results:
+        methods_used.append("tag_like")
+
+    fts_available = (
+        any(len(kw) >= 3 for kw in keywords) if ctx.keyword_mode == "or"
+        else min_len >= 3
+    )
+    if not fts_available and vec_results is None and not tag_like_results:
+        raise _SearchEarlyReturn({
+            "error": {
+                "code": "KEYWORD_TOO_SHORT",
+                "message": "keyword must be at least 3 characters when vector search is unavailable",
+            }
+        })
+
+    return {
+        "fts": fts_results,
+        "vec": vec_results,
+        "tag": tag_like_results,
+        "methods_used": methods_used,
+    }
+
+
+def _merge(ctx: SearchContext, retrieval: dict) -> list[dict]:
+    """RRF 統合ステージ。各 result に score_breakdown.{fts,vec,tag,rrf_normalized} を付与する。"""
+    effective_vec = retrieval["vec"] if retrieval["vec"] is not None else []
+    return _rrf_merge(
+        retrieval["fts"],
+        effective_vec,
+        ctx.fetch_limit,
+        tag_results=retrieval["tag"],
+    )
+
+
+def _rerank(ctx: SearchContext, merged: list[dict]) -> list[dict]:
+    """recency boost ステージ。score_breakdown.recency_factor / final_score を確定し、final_score 降順に再ソートする。"""
+    _apply_recency_boost(merged)
+    return merged
+
+
+def _slice(ctx: SearchContext, results: list[dict]) -> tuple[list[dict], int]:
+    """offset + limit で切り出す。total_count は切り出し前の件数。"""
+    total_count = len(results)
+    sliced = results[ctx.offset:ctx.offset + ctx.limit]
+    return sliced, total_count
+
+
+def _decorate(
+    ctx: SearchContext,
+    sliced: list[dict],
+    query_tag_ids: Optional[list[int]],
+) -> list[dict]:
+    """検索結果に snippet / tags / details / readable_id を付与し、nearby_tags を返す。
+
+    Returns:
+        nearby_tags: [{"tag": "...", "co_count": N}, ...]。offset>0 の場合は空リスト。
+    """
+    _attach_snippets(sliced)
+    _attach_tags(sliced)
+    if ctx.include_details:
+        _attach_details(sliced[:DETAILS_MAX_RESULTS])
+
+    nearby_tags = _compute_nearby_tags(sliced, query_tag_ids, ctx.offset)
+
+    # readable_id 化: 各結果の id を「title (#NNN)」形式に置換し、元の id を id_raw に退避
+    # type フィールドは置換前に確定済みなのでそのまま参照する
+    for item in sliced:
+        apply_readable_id_inplace(item, item["type"])
+
+    return nearby_tags
 
 
 def search(
@@ -1385,7 +1665,6 @@ def search(
         keyword: 検索キーワード（2文字以上）。配列で複数指定時はAND検索
         tags: タグフィルタ（AND条件。未指定=全件検索）
         entity_type: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log', 'material'。未指定で全種類）
-        entity_type: 検索対象の絞り込み（'topic', 'decision', 'activity', 'log', 'material'。未指定で全種類）
         limit: 取得件数上限（デフォルト10件、最大50件）
         offset: スキップ件数（デフォルト0）。ページネーション用
         keyword_mode: キーワード結合モード（"and" または "or"。デフォルト "and"）
@@ -1401,219 +1680,38 @@ def search(
           - fts / vec / tag: 各ソースのRRF生寄与（正規化前、recency適用前）
           - rrf_normalized: 3寄与の合計を理論最大値で割った正規化済み値（0〜1、recency適用前）
           - recency_factor: created_atに基づく指数減衰係数（0〜1）
-        既存 score フィールドは互換のため final_score と同値で残置されている（Phase Bで廃止予定）。
+        既存 score フィールドは final_score と同値で互換のため残置されている。
         snippetは各typeの対応するソースカラムの先頭200文字（materialはtitle優先表示）。
         tagsはエンティティに紐づくタグ文字列のリスト。
         include_details=Trueの場合、上位DETAILS_MAX_RESULTS件にdetailsが追加される。
     """
-    # keyword_modeバリデーション
-    if keyword_mode not in ("and", "or"):
-        return {
-            "error": {
-                "code": "INVALID_KEYWORD_MODE",
-                "message": f"Invalid keyword_mode: {keyword_mode}. Must be 'and' or 'or'"
-            }
-        }
-
-    # 正規化: str → list[str]
-    if isinstance(keyword, str):
-        keywords = [keyword.strip()]
-    else:
-        keywords = [k.strip() for k in keyword]
-
-    # 空配列チェック
-    if not keywords:
-        return {
-            "error": {
-                "code": "KEYWORD_TOO_SHORT",
-                "message": "keyword must be at least 2 characters"
-            }
-        }
-
-    # バリデーション: 各要素2文字以上
-    for kw in keywords:
-        if len(kw) < 2:
-            return {
-                "error": {
-                    "code": "KEYWORD_TOO_SHORT",
-                    "message": "keyword must be at least 2 characters"
-                }
-            }
-
-    # 空文字→None正規化（entity_type, domain, date_after, date_before）
-    if entity_type is not None and entity_type == "":
-        entity_type = None
-    if domain is not None and domain == "":
-        domain = None
-    if date_after is not None and date_after == "":
-        date_after = None
-    if date_before is not None and date_before == "":
-        date_before = None
-
-    if entity_type is not None and entity_type not in SEARCHABLE_TYPES:
-        return {
-            "error": {
-                "code": "INVALID_ENTITY_TYPE",
-                "message": f"Invalid entity_type: {entity_type}. Must be one of {sorted(SEARCHABLE_TYPES)}"
-            }
-        }
-
-    # 日付バリデーション（形式チェック + 値の妥当性チェック）
-    date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$")
-    for param_name, param_value in [("date_after", date_after), ("date_before", date_before)]:
-        if param_value is not None:
-            if not date_pattern.match(param_value):
-                return {
-                    "error": {
-                        "code": "INVALID_PARAMETER",
-                        "message": f"{param_name} must be ISO date format (YYYY-MM-DD or YYYY-MM-DD HH:MM:SS), got '{param_value}'",
-                    }
-                }
-            try:
-                fmt = "%Y-%m-%d %H:%M:%S" if len(param_value) > 10 else "%Y-%m-%d"
-                datetime.strptime(param_value, fmt)
-            except ValueError:
-                return {
-                    "error": {
-                        "code": "INVALID_PARAMETER",
-                        "message": f"{param_name} contains invalid date value: '{param_value}'",
-                    }
-                }
-
-    # date_before: 日付のみ指定時に" 23:59:59"を付与して当日を含む
-    if date_before is not None and len(date_before) == 10:
-        date_before = date_before + " 23:59:59"
-
-    # domain → tagsマージ（重複除去）
-    if domain:
-        domain_tag = f"domain:{domain}"
-        if tags is None:
-            tags = [domain_tag]
-        elif domain_tag not in tags:
-            tags.append(domain_tag)
-
-    limit = max(1, min(limit, 50))
-    offset = max(0, offset)
-
     try:
-        # タグフィルタの解決
-        tag_ids = None
-        if tags:
-            conn = get_connection()
-            try:
-                tag_ids = _resolve_tag_ids_readonly(conn, tags)
-                # 指定タグの一部でもDBに存在しない場合、ANDフィルタは必ず空結果
-                if len(tag_ids) < len(tags):
-                    return {"results": [], "total_count": 0, "search_methods_used": []}
-            finally:
-                conn.close()
+        keywords, entity_type, domain, date_after, date_before = _validate(
+            keyword, keyword_mode, entity_type, domain, date_after, date_before,
+        )
 
-        # RRFで両ソースをマージした後にoffset+limitで切るため、各ソースから多めに取得する
-        fetch_limit = (offset + limit) * FETCH_LIMIT_MULTIPLIER
-
-        # 使用された検索手法を追跡
-        methods_used: list[str] = []
-
-        # Query Expansion: tag_vec KNN検索でFTSクエリを拡張
-        # ベクトル検索には元のキーワードをそのまま渡す
-        fts_keywords = _expand_query_with_tags(keywords)
-        if len(fts_keywords) > len(keywords):
-            logger.info(
-                "Query expanded: %s -> %s",
-                keywords,
-                fts_keywords[len(keywords):],
+        conn = get_connection()
+        try:
+            ctx, query_tag_ids, effective_tags = _normalize(
+                keywords, tags, entity_type, domain, date_after, date_before,
+                limit, offset, keyword_mode, include_details, conn,
             )
-
-        # FTS5検索判定
-        min_len = min(len(kw) for kw in keywords)
-        fts_results = []
-        # QE拡張がある場合、元のキーワード数を記録
-        original_kw_count = len(keywords) if len(fts_keywords) > len(keywords) else None
-
-        ctx = SearchContext(
-            keywords=tuple(keywords),
-            fts_keywords=tuple(fts_keywords),
-            original_keyword_count=original_kw_count,
-            tag_ids=tuple(tag_ids) if tag_ids is not None else None,
-            entity_type=entity_type,
-            limit=limit,
-            offset=offset,
-            fetch_limit=fetch_limit,
-            keyword_mode=keyword_mode,
-            include_details=include_details,
-            date_after=date_after,
-            date_before=date_before,
-            domain=domain,
-        )
-
-        if ctx.keyword_mode == "or":
-            # OR時: 3文字以上のキーワードが1つでもあればFTSを使う
-            if any(len(kw) >= 3 for kw in fts_keywords):
-                fts_results = _fts_search(ctx)
-                methods_used.append("fts5")
-        else:
-            # AND時（現行通り）: 全キーワードが3文字以上の場合のみ
-            # QE拡張分はOR結合で追加されるため、元のキーワードの文字数チェックを使用
-            if min_len >= 3:
-                fts_results = _fts_search(ctx)
-                methods_used.append("fts5")
-
-        # ベクトル検索（元のキーワードのまま、拡張なし）
-        vec_results = _vector_search(ctx)
-        if vec_results is not None:
-            methods_used.append("vector")
-
-        # タグLIKE検索（キーワード長の制限なし）
-        tag_like_results = _tag_like_search(ctx)
-        if tag_like_results:
-            methods_used.append("tag_like")
-
-        # 2文字キーワード + ベクトル検索無効 → エラー
-        # OR時: 3文字以上が1つでもあればFTSで検索できるのでエラーにしない
-        # タグLIKE検索結果がある場合もエラーにしない
-        fts_available = (
-            any(len(kw) >= 3 for kw in keywords) if ctx.keyword_mode == "or"
-            else min_len >= 3
-        )
-        if not fts_available and vec_results is None and not tag_like_results:
-            return {
-                "error": {
-                    "code": "KEYWORD_TOO_SHORT",
-                    "message": "keyword must be at least 3 characters when vector search is unavailable"
-                }
-            }
-
-        # RRF統合（recency boost前なのでfetch_limitで多めに保持）
-        effective_vec = vec_results if vec_results is not None else []
-        results = _rrf_merge(fts_results, effective_vec, fetch_limit, tag_results=tag_like_results)
-
-        _apply_recency_boost(results)
-
-        # recency boost後にoffset+limitで切り詰め
-        total_count = len(results)
-        results = results[offset:offset + limit]
-
-        _attach_snippets(results)
-        _attach_tags(results)
-
-        if include_details:
-            details_targets = results[:DETAILS_MAX_RESULTS]
-            _attach_details(details_targets)
-
-        nearby_tags = _compute_nearby_tags(results, tag_ids, offset)
-
-        # readable_id 化: 各結果の id を「title (#NNN)」形式に置換し、元の id を id_raw に退避
-        # type フィールドは置換前に確定済みなのでそのまま参照する
-        for item in results:
-            apply_readable_id_inplace(item, item["type"])
+            ctx = _expand(ctx)
+            retrieval = _retrieve(ctx, conn)
+            merged = _merge(ctx, retrieval)
+            merged = _rerank(ctx, merged)
+            sliced, total_count = _slice(ctx, merged)
+            nearby_tags = _decorate(ctx, sliced, query_tag_ids)
+        finally:
+            conn.close()
 
         _record_search_telemetry_async(
             query=keyword,
             parameters={
-                "tags": tags,
+                "tags": effective_tags,
                 "entity_type": entity_type,
-                "limit": limit,
-                "offset": offset,
+                "limit": ctx.limit,
+                "offset": ctx.offset,
                 "keyword_mode": keyword_mode,
                 "include_details": include_details,
                 "domain": domain,
@@ -1624,12 +1722,14 @@ def search(
         )
 
         return {
-            "results": results,
+            "results": sliced,
             "total_count": total_count,
-            "search_methods_used": methods_used,
+            "search_methods_used": retrieval["methods_used"],
             "nearby_tags": nearby_tags,
         }
 
+    except _SearchEarlyReturn as early:
+        return early.response
     except Exception as e:
         return {
             "error": {

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -164,6 +164,18 @@ def build_common_where(
     return "\n".join(parts), params
 
 
+def _exec_select(conn: sqlite3.Connection, query: str, params=()) -> list[sqlite3.Row]:
+    """共有 conn 上で SELECT を実行する内部ヘルパ。
+
+    旧 ``execute_query`` (自前で conn を開閉する版) と同じ ``sqlite3.Error`` ラップ規約
+    (``"クエリ実行エラー: {e}"``) を維持するため、retriever 群はこのヘルパを使う。
+    """
+    try:
+        return conn.execute(query, params).fetchall()
+    except sqlite3.Error as e:
+        raise sqlite3.Error(f"クエリ実行エラー: {e}") from e
+
+
 def _escape_fts5_query(keyword: str) -> str:
     """FTS5クエリ用のエスケープ処理。ダブルクォートで囲む。"""
     # ダブルクォート内のダブルクォートは2つ重ねてエスケープ
@@ -636,7 +648,7 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
     return cte_sql, params
 
 
-def fts_retrieve(ctx: SearchContext, conn) -> list[dict]:
+def fts_retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> list[dict]:
     """FTS5 retriever。bm25 ランク順の結果リストを返す。
 
     retract 時に search_index / search_index_fts / vec_index から物理削除されるため、
@@ -707,7 +719,7 @@ def fts_retrieve(ctx: SearchContext, conn) -> list[dict]:
         """
         params = (escaped_keyword, *common_params, ctx.fetch_limit)
 
-    rows = conn.execute(query, params).fetchall()
+    rows = _exec_select(conn, query, params)
     results = []
     for row in rows:
         r = row_to_dict(row)
@@ -719,9 +731,7 @@ def fts_retrieve(ctx: SearchContext, conn) -> list[dict]:
     return results
 
 
-
-
-def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
+def vector_retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> Optional[list[dict]]:
     """ベクトル retriever。ベクトル検索が無効/失敗時は None を返す。
 
     retract 時に vec_index から物理削除されるため、取り消し済みエンティティは
@@ -750,10 +760,11 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
                     continue
 
                 blob = serialize_float32(query_embedding)
-                vec_rows = conn.execute(
+                vec_rows = _exec_select(
+                    conn,
                     "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
                     (blob, fetch_limit),
-                ).fetchall()
+                )
                 if not vec_rows:
                     continue
 
@@ -789,7 +800,7 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
                     """
                     params = (*rowids, *common_params)
 
-                filter_rows = conn.execute(query, params).fetchall()
+                filter_rows = _exec_select(conn, query, params)
                 for row in filter_rows:
                     r = row_to_dict(row)
                     key = (r["source_type"], r["source_id"])
@@ -818,10 +829,11 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
 
             # vec_indexからKNN取得（タグフィルタ不可なので多めに取得）
             # fetch_limitはsearch()側で (offset+limit)*FETCH_LIMIT_MULTIPLIER に拡大済み
-            vec_rows = conn.execute(
+            vec_rows = _exec_select(
+                conn,
                 "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
                 (blob, fetch_limit),
-            ).fetchall()
+            )
 
             if not vec_rows:
                 return []
@@ -858,7 +870,7 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
                 """
                 params = (*rowids, *common_params)
 
-            filter_rows = conn.execute(query, params).fetchall()
+            filter_rows = _exec_select(conn, query, params)
 
             results = []
             for row in filter_rows:
@@ -877,8 +889,6 @@ def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
     except (ValueError, RuntimeError, OSError):
         logger.warning("Vector search failed, falling back to FTS-only", exc_info=True)
         return None
-
-
 
 
 def find_similar_topics(
@@ -1037,7 +1047,7 @@ def find_similar_decisions(
         return []
 
 
-def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
+def tag_like_retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> list[dict]:
     """タグ名 LIKE retriever。キーワードにマッチするタグを持つエンティティを返す。
 
     entity_tags の各中間テーブルからタグ名 LIKE 検索し、search_index 経由で結果を返す。
@@ -1078,10 +1088,11 @@ def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
         for p in like_patterns:
             params.extend([p, p])
 
-    matching_tags = conn.execute(
+    matching_tags = _exec_select(
+        conn,
         f"SELECT id FROM tags WHERE {conditions}",
         tuple(params),
-    ).fetchall()
+    )
     if not matching_tags:
         return []
 
@@ -1157,7 +1168,7 @@ def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
         query_params.extend(matched_tag_ids)
     query_params.append(ctx.fetch_limit)
 
-    rows = conn.execute(query, tuple(query_params)).fetchall()
+    rows = _exec_select(conn, query, tuple(query_params))
     results = []
     for row in rows:
         r = row_to_dict(row)
@@ -1167,8 +1178,6 @@ def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
             "title": r["title"],
         })
     return results
-
-
 
 
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:
@@ -1447,7 +1456,7 @@ def _normalize(
     offset: int,
     keyword_mode: str,
     include_details: bool,
-    conn,
+    conn: sqlite3.Connection,
 ) -> tuple[SearchContext, Optional[list[int]], Optional[list[str]]]:
     """SearchContext を組み立てるステージ。
 
@@ -1531,7 +1540,7 @@ def _expand(ctx: SearchContext) -> SearchContext:
     )
 
 
-def _retrieve(ctx: SearchContext, conn) -> dict:
+def _retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> dict:
     """3 retriever (fts / vector / tag_like) を逐次呼び出して結果を集約する。
 
     Returns:
@@ -1600,7 +1609,13 @@ def _merge(ctx: SearchContext, retrieval: dict) -> list[dict]:
 
 
 def _rerank(ctx: SearchContext, merged: list[dict]) -> list[dict]:
-    """recency boost ステージ。score_breakdown.recency_factor / final_score を確定し、final_score 降順に再ソートする。"""
+    """recency boost ステージ。score_breakdown.recency_factor / final_score を確定し、final_score 降順に再ソートする。
+
+    ``ctx`` は他ステージとシグネチャを揃えるために受け取るが、現状の recency 減衰は
+    created_at と RECENCY_DECAY_RATE / RECENCY_DECAY_FLOOR のみで決まるため、本関数内では
+    ``ctx`` を参照しない。ctx 依存のブースト (domain 別重み付け等) を後段で追加する余地を
+    残しておく。
+    """
     _apply_recency_boost(merged)
     return merged
 
@@ -1616,10 +1631,16 @@ def _decorate(
     ctx: SearchContext,
     sliced: list[dict],
     query_tag_ids: Optional[list[int]],
-) -> list[dict]:
-    """検索結果に snippet / tags / details / readable_id を付与し、nearby_tags を返す。
+) -> tuple[list[dict], list[dict]]:
+    """検索結果に snippet / tags / details / readable_id を付与し、nearby_tags を計算する。
+
+    ``sliced`` は in-place で書き換わるが、データフローを明示するため戻り値にも含める。
+    呼出元 (orchestrator) は ``decorated, nearby_tags = _decorate(...)`` のパターンで
+    両方を受け取る。
 
     Returns:
+        (decorated, nearby_tags)
+        decorated: 引数 sliced と同一の list (in-place 装飾済)。
         nearby_tags: [{"tag": "...", "co_count": N}, ...]。offset>0 の場合は空リスト。
     """
     _attach_snippets(sliced)
@@ -1634,7 +1655,7 @@ def _decorate(
     for item in sliced:
         apply_readable_id_inplace(item, item["type"])
 
-    return nearby_tags
+    return sliced, nearby_tags
 
 
 def search(
@@ -1701,7 +1722,7 @@ def search(
             merged = _merge(ctx, retrieval)
             merged = _rerank(ctx, merged)
             sliced, total_count = _slice(ctx, merged)
-            nearby_tags = _decorate(ctx, sliced, query_tag_ids)
+            sliced, nearby_tags = _decorate(ctx, sliced, query_tag_ids)
         finally:
             conn.close()
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -635,16 +635,17 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
     return cte_sql, params
 
 
-def _fts_search(ctx: SearchContext) -> list[dict]:
-    """FTS5検索。結果はBM25ランク順のリスト。
+def fts_retrieve(ctx: SearchContext, conn) -> list[dict]:
+    """FTS5 retriever。bm25 ランク順の結果リストを返す。
 
-    retract時にsearch_index/search_index_fts/vec_indexから物理削除されるため、
+    retract 時に search_index / search_index_fts / vec_index から物理削除されるため、
     取り消し済みエンティティは検索対象に現れない。
 
     Args:
         ctx: SearchContext。ctx.fts_keywords / ctx.keyword_mode /
             ctx.original_keyword_count / ctx.tag_ids / ctx.entity_type /
             ctx.fetch_limit / ctx.date_after / ctx.date_before を参照する。
+        conn: 呼出元 (orchestrator) が開いた共有 SQLite コネクション。
     """
     keywords = list(ctx.fts_keywords)
 
@@ -705,7 +706,7 @@ def _fts_search(ctx: SearchContext) -> list[dict]:
         """
         params = (escaped_keyword, *common_params, ctx.fetch_limit)
 
-    rows = execute_query(query, params)
+    rows = conn.execute(query, params).fetchall()
     results = []
     for row in rows:
         r = row_to_dict(row)
@@ -717,15 +718,25 @@ def _fts_search(ctx: SearchContext) -> list[dict]:
     return results
 
 
-def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
-    """ベクトル検索。ベクトル検索無効時はNoneを返す。
+def _fts_search(ctx: SearchContext) -> list[dict]:
+    """旧シグネチャアダプタ。自前で conn を開閉して fts_retrieve に委譲する。"""
+    conn = get_connection()
+    try:
+        return fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
 
-    retract時にvec_indexから物理削除されるため、取り消し済みエンティティは
-    KNNの候補スロットを食わない（KNN実効recall改善）。
+
+def vector_retrieve(ctx: SearchContext, conn) -> Optional[list[dict]]:
+    """ベクトル retriever。ベクトル検索が無効/失敗時は None を返す。
+
+    retract 時に vec_index から物理削除されるため、取り消し済みエンティティは
+    KNN の候補スロットを食わない（KNN 実効 recall 改善）。
 
     Args:
         ctx: SearchContext。ベクトル検索は元の ctx.keywords を使用し、
             QE 拡張済みの ctx.fts_keywords は参照しない。
+        conn: 呼出元 (orchestrator) が開いた共有 SQLite コネクション。
     """
     keywords = list(ctx.keywords)
     fetch_limit = ctx.fetch_limit
@@ -745,10 +756,10 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                     continue
 
                 blob = serialize_float32(query_embedding)
-                vec_rows = execute_query(
+                vec_rows = conn.execute(
                     "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
                     (blob, fetch_limit),
-                )
+                ).fetchall()
                 if not vec_rows:
                     continue
 
@@ -784,7 +795,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                     """
                     params = (*rowids, *common_params)
 
-                filter_rows = execute_query(query, params)
+                filter_rows = conn.execute(query, params).fetchall()
                 for row in filter_rows:
                     r = row_to_dict(row)
                     key = (r["source_type"], r["source_id"])
@@ -813,10 +824,10 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
 
             # vec_indexからKNN取得（タグフィルタ不可なので多めに取得）
             # fetch_limitはsearch()側で (offset+limit)*FETCH_LIMIT_MULTIPLIER に拡大済み
-            vec_rows = execute_query(
+            vec_rows = conn.execute(
                 "SELECT rowid, distance FROM vec_index WHERE embedding MATCH ? AND k = ?",
                 (blob, fetch_limit),
-            )
+            ).fetchall()
 
             if not vec_rows:
                 return []
@@ -853,7 +864,7 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
                 """
                 params = (*rowids, *common_params)
 
-            filter_rows = execute_query(query, params)
+            filter_rows = conn.execute(query, params).fetchall()
 
             results = []
             for row in filter_rows:
@@ -872,6 +883,15 @@ def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
     except (ValueError, RuntimeError, OSError):
         logger.warning("Vector search failed, falling back to FTS-only", exc_info=True)
         return None
+
+
+def _vector_search(ctx: SearchContext) -> Optional[list[dict]]:
+    """旧シグネチャアダプタ。自前で conn を開閉して vector_retrieve に委譲する。"""
+    conn = get_connection()
+    try:
+        return vector_retrieve(ctx, conn)
+    finally:
+        conn.close()
 
 
 def find_similar_topics(
@@ -1030,19 +1050,19 @@ def find_similar_decisions(
         return []
 
 
-def _tag_like_search(ctx: SearchContext) -> list[dict]:
-    """タグ名のLIKE検索。キーワードにマッチするタグを持つエンティティを返す。
+def tag_like_retrieve(ctx: SearchContext, conn) -> list[dict]:
+    """タグ名 LIKE retriever。キーワードにマッチするタグを持つエンティティを返す。
 
-    entity_tagsの各中間テーブルからタグ名LIKE検索し、
-    search_index経由で結果を返す。
+    entity_tags の各中間テーブルからタグ名 LIKE 検索し、search_index 経由で結果を返す。
 
-    ANDモードでは「全キーワードを名前に含む単一タグ」を探す。
-    FTS/ベクトルのAND（複数語を含む文書）とは異なる意味論であり、
+    AND モードでは「全キーワードを名前に含む単一タグ」を探す。
+    FTS/ベクトルの AND（複数語を含む文書）とは異なる意味論であり、
     マッチするのは "domain:api-design" のような複合タグ名に限られる。
 
     Args:
         ctx: SearchContext。タグ LIKE 検索は元の ctx.keywords を使用し、
             QE 拡張済みの ctx.fts_keywords は参照しない。
+        conn: 呼出元 (orchestrator) が開いた共有 SQLite コネクション。
     """
     keywords = list(ctx.keywords)
     tag_ids = list(ctx.tag_ids) if ctx.tag_ids else None
@@ -1071,10 +1091,10 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
         for p in like_patterns:
             params.extend([p, p])
 
-    matching_tags = execute_query(
+    matching_tags = conn.execute(
         f"SELECT id FROM tags WHERE {conditions}",
         tuple(params),
-    )
+    ).fetchall()
     if not matching_tags:
         return []
 
@@ -1150,7 +1170,7 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
         query_params.extend(matched_tag_ids)
     query_params.append(ctx.fetch_limit)
 
-    rows = execute_query(query, tuple(query_params))
+    rows = conn.execute(query, tuple(query_params)).fetchall()
     results = []
     for row in rows:
         r = row_to_dict(row)
@@ -1161,6 +1181,14 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
         })
     return results
 
+
+def _tag_like_search(ctx: SearchContext) -> list[dict]:
+    """旧シグネチャアダプタ。自前で conn を開閉して tag_like_retrieve に委譲する。"""
+    conn = get_connection()
+    try:
+        return tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
 
 
 def _apply_recency_boost(results: list[dict], now: datetime | None = None) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,11 +2,40 @@
 
 add_logs / add_decisions のバッチAPIを単件呼び出し形式でラップする。
 旧 add_log / add_decision と同じインターフェースを提供する。
+
+検索 retriever / orchestrator のテストで使う SearchContext のファクトリも
+ここに集約する。
 """
 from typing import Optional
 from src.services.discussion_log_service import add_logs
 from src.services.decision_service import add_decisions
 from src.services.retract_service import retract
+from src.services.search_service import SearchContext
+
+
+def make_search_context(**overrides) -> SearchContext:
+    """テスト用のデフォルト SearchContext を生成する。
+
+    overrides で必要なフィールドだけ上書きできる。検索 retriever / orchestrator の
+    各テストで重複していた _make_ctx を集約したもの。
+    """
+    defaults = dict(
+        keywords=("alpha",),
+        fts_keywords=("alpha",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
 
 
 def add_log(

--- a/tests/unit/test_search_orchestrator.py
+++ b/tests/unit/test_search_orchestrator.py
@@ -13,27 +13,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.services import search_service
-from src.services.search_service import SearchContext, _SearchEarlyReturn
-
-
-def _make_ctx(**overrides) -> SearchContext:
-    defaults = dict(
-        keywords=("alpha",),
-        fts_keywords=("alpha",),
-        original_keyword_count=None,
-        tag_ids=None,
-        entity_type=None,
-        limit=10,
-        offset=0,
-        fetch_limit=50,
-        keyword_mode="and",
-        include_details=False,
-        date_after=None,
-        date_before=None,
-        domain=None,
-    )
-    defaults.update(overrides)
-    return SearchContext(**defaults)
+from src.services.search_service import _SearchEarlyReturn
+from tests.helpers import make_search_context as _make_ctx
 
 
 @pytest.fixture
@@ -57,7 +38,7 @@ def stub_stages(monkeypatch):
         "_merge": MagicMock(return_value=merged_results),
         "_rerank": MagicMock(return_value=merged_results),
         "_slice": MagicMock(return_value=(sliced_results, 1)),
-        "_decorate": MagicMock(return_value=nearby_tags),
+        "_decorate": MagicMock(return_value=(sliced_results, nearby_tags)),
         "get_connection": MagicMock(return_value=MagicMock()),
         "_record_search_telemetry_async": MagicMock(return_value=None),
     }

--- a/tests/unit/test_search_orchestrator.py
+++ b/tests/unit/test_search_orchestrator.py
@@ -1,0 +1,174 @@
+"""search() orchestrator のステージ駆動構造のテスト。
+
+各ステージ関数 (_validate / _normalize / _expand / _retrieve / _merge / _rerank /
+_slice / _decorate) を monkeypatch で差し替えて、orchestrator が期待される順序で
+呼び出し、戻り値を組み立てることを検証する。
+
+DB を立ち上げないことでオーケストレータ単独の挙動 (ステージ呼び出し順序、
+戻り値合成、_SearchEarlyReturn のキャッチ、例外時の DATABASE_ERROR 化) を
+集中して確認する。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services import search_service
+from src.services.search_service import SearchContext, _SearchEarlyReturn
+
+
+def _make_ctx(**overrides) -> SearchContext:
+    defaults = dict(
+        keywords=("alpha",),
+        fts_keywords=("alpha",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
+
+
+@pytest.fixture
+def stub_stages(monkeypatch):
+    """orchestrator の全ステージ + DB / telemetry を MagicMock で差し替える fixture。
+
+    Returns:
+        各ステージの mock dict。テスト側は call_args / return_value を操作できる。
+    """
+    ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+    sliced_results = [{"type": "topic", "id": 1, "title": "hello"}]
+    merged_results = [{"type": "topic", "id": 1, "title": "hello", "score": 0.5}]
+    retrieval = {"fts": [], "vec": None, "tag": [], "methods_used": ["fts5"]}
+    nearby_tags = [{"tag": "x", "co_count": 3}]
+
+    stubs = {
+        "_validate": MagicMock(return_value=(["alpha"], None, None, None, None)),
+        "_normalize": MagicMock(return_value=(ctx, None, None)),
+        "_expand": MagicMock(return_value=ctx),
+        "_retrieve": MagicMock(return_value=retrieval),
+        "_merge": MagicMock(return_value=merged_results),
+        "_rerank": MagicMock(return_value=merged_results),
+        "_slice": MagicMock(return_value=(sliced_results, 1)),
+        "_decorate": MagicMock(return_value=nearby_tags),
+        "get_connection": MagicMock(return_value=MagicMock()),
+        "_record_search_telemetry_async": MagicMock(return_value=None),
+    }
+    for name, mock in stubs.items():
+        monkeypatch.setattr(search_service, name, mock)
+    return stubs
+
+
+def test_orchestrator_runs_stages_in_order(stub_stages):
+    """search() は _validate → _normalize → _expand → _retrieve → _merge → _rerank → _slice → _decorate の順で呼び、レスポンス dict を組み立てる。"""
+    result = search_service.search(keyword="alpha")
+
+    # 8 ステージはすべて 1 回ずつ呼ばれる
+    for name in [
+        "_validate", "_normalize", "_expand", "_retrieve",
+        "_merge", "_rerank", "_slice", "_decorate",
+    ]:
+        assert stub_stages[name].call_count == 1, f"{name} not called once"
+
+    # レスポンス dict のキーは契約通り
+    assert set(result.keys()) == {"results", "total_count", "search_methods_used", "nearby_tags"}
+    assert result["total_count"] == 1
+    assert result["search_methods_used"] == ["fts5"]
+    assert result["nearby_tags"] == [{"tag": "x", "co_count": 3}]
+
+
+def test_orchestrator_opens_conn_once_and_closes_it(stub_stages):
+    """search() は orchestrator で 1 度だけ get_connection() を呼び、最後に close する。"""
+    conn_mock = stub_stages["get_connection"].return_value
+
+    search_service.search(keyword="alpha")
+
+    assert stub_stages["get_connection"].call_count == 1
+    assert conn_mock.close.call_count == 1
+
+
+def test_orchestrator_passes_shared_conn_to_retrieve_and_normalize(stub_stages):
+    """同じ conn インスタンスが _normalize と _retrieve に渡される。"""
+    conn_mock = stub_stages["get_connection"].return_value
+
+    search_service.search(keyword="alpha")
+
+    # _normalize の最後の引数が conn
+    normalize_call = stub_stages["_normalize"].call_args
+    assert normalize_call.args[-1] is conn_mock
+
+    # _retrieve の 2 番目の引数が conn
+    retrieve_call = stub_stages["_retrieve"].call_args
+    assert retrieve_call.args[1] is conn_mock
+
+
+def test_orchestrator_calls_telemetry_with_result_count(stub_stages):
+    """telemetry は total_count を result_count として渡される。"""
+    search_service.search(keyword="alpha")
+
+    telem_call = stub_stages["_record_search_telemetry_async"].call_args
+    assert telem_call.kwargs["result_count"] == 1
+
+
+def test_orchestrator_early_return_from_validate_is_caught(monkeypatch):
+    """_validate が _SearchEarlyReturn を投げると、その response がそのまま返る。"""
+    expected = {"error": {"code": "INVALID_KEYWORD_MODE", "message": "x"}}
+    monkeypatch.setattr(
+        search_service,
+        "_validate",
+        MagicMock(side_effect=_SearchEarlyReturn(expected)),
+    )
+    # validate より後ろのステージは呼ばれてはならない
+    get_conn = MagicMock()
+    monkeypatch.setattr(search_service, "get_connection", get_conn)
+
+    result = search_service.search(keyword="alpha", keyword_mode="bogus")
+
+    assert result == expected
+    assert get_conn.call_count == 0
+
+
+def test_orchestrator_early_return_from_normalize_closes_conn(stub_stages):
+    """_normalize の _SearchEarlyReturn でも conn は close され、レスポンスが返る。"""
+    early = {"results": [], "total_count": 0, "search_methods_used": []}
+    stub_stages["_normalize"].side_effect = _SearchEarlyReturn(early)
+    conn_mock = stub_stages["get_connection"].return_value
+
+    result = search_service.search(keyword="alpha")
+
+    assert result == early
+    assert conn_mock.close.call_count == 1
+    # 後続ステージは呼ばれない
+    assert stub_stages["_expand"].call_count == 0
+    assert stub_stages["_retrieve"].call_count == 0
+
+
+def test_orchestrator_early_return_from_retrieve_is_caught(stub_stages):
+    """_retrieve が _SearchEarlyReturn (KEYWORD_TOO_SHORT) を投げてもレスポンスが返る。"""
+    early = {"error": {"code": "KEYWORD_TOO_SHORT", "message": "x"}}
+    stub_stages["_retrieve"].side_effect = _SearchEarlyReturn(early)
+
+    result = search_service.search(keyword="alpha")
+
+    assert result == early
+    # _merge 以降は呼ばれない
+    assert stub_stages["_merge"].call_count == 0
+    assert stub_stages["_rerank"].call_count == 0
+
+
+def test_orchestrator_unexpected_exception_returns_database_error(stub_stages):
+    """ステージ内で予期しない例外が発生したら DATABASE_ERROR にラップされる。"""
+    stub_stages["_retrieve"].side_effect = RuntimeError("boom")
+
+    result = search_service.search(keyword="alpha")
+
+    assert "error" in result
+    assert result["error"]["code"] == "DATABASE_ERROR"
+    assert "boom" in result["error"]["message"]

--- a/tests/unit/test_search_retriever_fts.py
+++ b/tests/unit/test_search_retriever_fts.py
@@ -1,0 +1,188 @@
+"""fts_retrieve retriever 単体テスト。
+
+SearchContext と共有 conn を直接渡したときに FTS5 ベースのランキング結果が
+正しく返ることを確認する。
+"""
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import get_connection, init_database
+from src.services import search_service
+from src.services.activity_service import add_activity
+from src.services.search_service import SearchContext, fts_retrieve
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _make_ctx(**overrides) -> SearchContext:
+    defaults = dict(
+        keywords=("alpha",),
+        fts_keywords=("alpha",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
+
+
+def test_fts_retrieve_uses_shared_conn(temp_db, monkeypatch):
+    """fts_retrieve は共有 conn を使い、自前で get_connection() を呼ばない。"""
+    add_topic(title="alpha topic", description="hello world", tags=DEFAULT_TAGS)
+
+    # search_service モジュールの get_connection が呼ばれないことを検証
+    call_count = {"n": 0}
+    real_get_connection = search_service.get_connection
+
+    def tracking_get_connection():
+        call_count["n"] += 1
+        return real_get_connection()
+
+    monkeypatch.setattr(search_service, "get_connection", tracking_get_connection)
+
+    conn = real_get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert call_count["n"] == 0
+    assert any(r["type"] == "topic" and r["title"] == "alpha topic" for r in results)
+
+
+def test_fts_retrieve_returns_basic_shape(temp_db):
+    """fts_retrieve は type / id / title の dict のリストを返す。"""
+    add_topic(title="alpha topic", description="hello world", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert isinstance(results, list)
+    assert all(set(r.keys()) >= {"type", "id", "title"} for r in results)
+
+
+def test_fts_retrieve_or_mode_filters_short_keywords(temp_db):
+    """OR モードでは 3 文字未満のキーワードは FTS クエリに含まれない。"""
+    add_topic(title="hello hi", description="content", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        # "hi" は 2 文字なので OR モードでは除外され、"hello" のみで検索される
+        ctx = _make_ctx(
+            keywords=("hello", "hi"),
+            fts_keywords=("hello", "hi"),
+            keyword_mode="or",
+        )
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert any(r["title"] == "hello hi" for r in results)
+
+
+def test_fts_retrieve_returns_empty_when_or_mode_has_only_short_keywords(temp_db):
+    """OR モードで 3 文字以上のキーワードが 1 件もないと空リストを返す。"""
+    add_topic(title="hello world", description="content", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(
+            keywords=("hi", "ok"),
+            fts_keywords=("hi", "ok"),
+            keyword_mode="or",
+        )
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert results == []
+
+
+def test_fts_retrieve_entity_type_filter(temp_db):
+    """entity_type=decision でフィルタすると decision のみが返る。"""
+    topic_id = add_topic(title="alpha topic", description="x", tags=DEFAULT_TAGS)["topic_id"]
+    add_activity(title="alpha activity", description="x", tags=DEFAULT_TAGS)
+    add_decision(decision="alpha decision body", reason="r", topic_id=topic_id, tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",), entity_type="decision")
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert results
+    assert all(r["type"] == "decision" for r in results)
+
+
+def test_fts_retrieve_respects_fetch_limit(temp_db):
+    """fetch_limit で結果件数が切り詰められる。"""
+    for i in range(5):
+        add_topic(title=f"alpha topic {i}", description=f"hello {i}", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",), fetch_limit=2)
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert len(results) <= 2
+
+
+def test_fts_retrieve_qe_expansion_or_combines_with_and(temp_db):
+    """QE 拡張があるとき AND の元キーワード群と OR の拡張タグが結合される。"""
+    add_topic(title="alpha doc", description="content beta", tags=DEFAULT_TAGS)
+    add_topic(title="expanded-only", description="zeta", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        # fts_keywords = (alpha, beta, zeta) で original=2 → (alpha AND beta) OR zeta
+        ctx = _make_ctx(
+            keywords=("alpha", "beta"),
+            fts_keywords=("alpha", "beta", "zeta"),
+            original_keyword_count=2,
+        )
+        results = fts_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    titles = {r["title"] for r in results}
+    assert "alpha doc" in titles
+    assert "expanded-only" in titles

--- a/tests/unit/test_search_retriever_fts.py
+++ b/tests/unit/test_search_retriever_fts.py
@@ -12,9 +12,9 @@ import src.services.embedding_service as emb
 from src.db import get_connection, init_database
 from src.services import search_service
 from src.services.activity_service import add_activity
-from src.services.search_service import SearchContext, fts_retrieve
+from src.services.search_service import fts_retrieve
 from src.services.topic_service import add_topic
-from tests.helpers import add_decision
+from tests.helpers import add_decision, make_search_context as _make_ctx
 
 DEFAULT_TAGS = ["domain:test"]
 
@@ -35,26 +35,6 @@ def temp_db():
         yield db_path
         if "DISCUSSION_DB_PATH" in os.environ:
             del os.environ["DISCUSSION_DB_PATH"]
-
-
-def _make_ctx(**overrides) -> SearchContext:
-    defaults = dict(
-        keywords=("alpha",),
-        fts_keywords=("alpha",),
-        original_keyword_count=None,
-        tag_ids=None,
-        entity_type=None,
-        limit=10,
-        offset=0,
-        fetch_limit=50,
-        keyword_mode="and",
-        include_details=False,
-        date_after=None,
-        date_before=None,
-        domain=None,
-    )
-    defaults.update(overrides)
-    return SearchContext(**defaults)
 
 
 def test_fts_retrieve_uses_shared_conn(temp_db, monkeypatch):

--- a/tests/unit/test_search_retriever_tag_like.py
+++ b/tests/unit/test_search_retriever_tag_like.py
@@ -11,8 +11,9 @@ import pytest
 import src.services.embedding_service as emb
 from src.db import get_connection, init_database
 from src.services import search_service
-from src.services.search_service import SearchContext, tag_like_retrieve
+from src.services.search_service import tag_like_retrieve
 from src.services.topic_service import add_topic
+from tests.helpers import make_search_context as _make_ctx
 
 
 @pytest.fixture(autouse=True)
@@ -31,26 +32,6 @@ def temp_db():
         yield db_path
         if "DISCUSSION_DB_PATH" in os.environ:
             del os.environ["DISCUSSION_DB_PATH"]
-
-
-def _make_ctx(**overrides) -> SearchContext:
-    defaults = dict(
-        keywords=("alpha",),
-        fts_keywords=("alpha",),
-        original_keyword_count=None,
-        tag_ids=None,
-        entity_type=None,
-        limit=10,
-        offset=0,
-        fetch_limit=50,
-        keyword_mode="and",
-        include_details=False,
-        date_after=None,
-        date_before=None,
-        domain=None,
-    )
-    defaults.update(overrides)
-    return SearchContext(**defaults)
 
 
 def test_tag_like_retrieve_uses_shared_conn(temp_db, monkeypatch):

--- a/tests/unit/test_search_retriever_tag_like.py
+++ b/tests/unit/test_search_retriever_tag_like.py
@@ -1,0 +1,145 @@
+"""tag_like_retrieve retriever 単体テスト。
+
+キーワードを含むタグ名のエンティティが返ること、共有 conn が使われることを
+直接シグネチャ経由で検証する。
+"""
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import get_connection, init_database
+from src.services import search_service
+from src.services.search_service import SearchContext, tag_like_retrieve
+from src.services.topic_service import add_topic
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _make_ctx(**overrides) -> SearchContext:
+    defaults = dict(
+        keywords=("alpha",),
+        fts_keywords=("alpha",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
+
+
+def test_tag_like_retrieve_uses_shared_conn(temp_db, monkeypatch):
+    """tag_like_retrieve は共有 conn を使い、自前で get_connection() を呼ばない。"""
+    add_topic(title="x", description="x", tags=["domain:alpha-test"])
+
+    call_count = {"n": 0}
+    real_get_connection = search_service.get_connection
+
+    def tracking_get_connection():
+        call_count["n"] += 1
+        return real_get_connection()
+
+    monkeypatch.setattr(search_service, "get_connection", tracking_get_connection)
+
+    conn = real_get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert call_count["n"] == 0
+
+
+def test_tag_like_retrieve_finds_entity_by_tag_substring(temp_db):
+    """キーワードがタグ名 (namespace:name) の一部として含まれるエンティティを返す。"""
+    add_topic(title="topicA", description="x", tags=["domain:alpha-design"])
+    add_topic(title="topicB", description="x", tags=["domain:other"])
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        results = tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    titles = {r["title"] for r in results}
+    assert "topicA" in titles
+    assert "topicB" not in titles
+
+
+def test_tag_like_retrieve_returns_empty_for_no_matching_tags(temp_db):
+    """キーワードに該当するタグが 1 つも無ければ空リストを返す。"""
+    add_topic(title="topicA", description="x", tags=["domain:other"])
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("zzz",), fts_keywords=("zzz",))
+        results = tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert results == []
+
+
+def test_tag_like_retrieve_and_mode_requires_single_tag_containing_all(temp_db):
+    """AND モードでは 1 つのタグ名が全キーワードを含む必要がある。"""
+    # "alpha-beta" は alpha と beta 両方を含むので AND でヒット
+    add_topic(title="topicAB", description="x", tags=["alpha-beta"])
+    # "alpha" タグと "beta" タグが別々だと AND ではヒットしない
+    add_topic(title="topicSep", description="x", tags=["alpha", "beta"])
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha", "beta"), fts_keywords=("alpha", "beta"), keyword_mode="and")
+        results = tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    titles = {r["title"] for r in results}
+    assert "topicAB" in titles
+    assert "topicSep" not in titles
+
+
+def test_tag_like_retrieve_or_mode_matches_any_keyword(temp_db):
+    """OR モードでは「いずれかのキーワードを含むタグ」を持つエンティティが返る。"""
+    add_topic(title="topicA", description="x", tags=["alpha-tag"])
+    add_topic(title="topicB", description="x", tags=["beta-tag"])
+    add_topic(title="topicC", description="x", tags=["gamma-tag"])
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha", "beta"), fts_keywords=("alpha", "beta"), keyword_mode="or")
+        results = tag_like_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    titles = {r["title"] for r in results}
+    assert "topicA" in titles
+    assert "topicB" in titles
+    assert "topicC" not in titles

--- a/tests/unit/test_search_retriever_vector.py
+++ b/tests/unit/test_search_retriever_vector.py
@@ -14,8 +14,9 @@ import pytest
 import src.services.embedding_service as emb
 from src.db import get_connection, init_database
 from src.services import search_service
-from src.services.search_service import SearchContext, vector_retrieve
+from src.services.search_service import vector_retrieve
 from src.services.topic_service import add_topic
+from tests.helpers import make_search_context as _make_ctx
 
 EMBEDDING_DIM = 384
 DEFAULT_TAGS = ["domain:test"]
@@ -54,26 +55,6 @@ def disable_embedding(monkeypatch):
     monkeypatch.setattr(emb, "_server_initialized", False)
     monkeypatch.setattr(emb, "_backfill_done", True)
     monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
-
-
-def _make_ctx(**overrides) -> SearchContext:
-    defaults = dict(
-        keywords=("alpha",),
-        fts_keywords=("alpha",),
-        original_keyword_count=None,
-        tag_ids=None,
-        entity_type=None,
-        limit=10,
-        offset=0,
-        fetch_limit=50,
-        keyword_mode="and",
-        include_details=False,
-        date_after=None,
-        date_before=None,
-        domain=None,
-    )
-    defaults.update(overrides)
-    return SearchContext(**defaults)
 
 
 def test_vector_retrieve_returns_none_when_embedding_disabled(temp_db, disable_embedding):

--- a/tests/unit/test_search_retriever_vector.py
+++ b/tests/unit/test_search_retriever_vector.py
@@ -1,0 +1,148 @@
+"""vector_retrieve retriever 単体テスト。
+
+embedding サーバー失敗時の None 返却と、共有 conn の使用を確認する。
+実際のベクトル検索結果は test_hybrid_search 側の統合テストで担保しているため、
+ここでは retriever のシグネチャ・null フォールバック・例外ハンドリングに焦点を当てる。
+"""
+import hashlib
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import get_connection, init_database
+from src.services import search_service
+from src.services.search_service import SearchContext, vector_retrieve
+from src.services.topic_service import add_topic
+
+EMBEDDING_DIM = 384
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def mock_embedding_model(monkeypatch):
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            seed = int(hashlib.sha256((prefix_str + text).encode()).hexdigest(), 16) % (2**32)
+            np.random.seed(seed)
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, "_encode_batch", mock_encode_batch)
+    monkeypatch.setattr(emb, "_server_initialized", True)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    yield
+
+
+@pytest.fixture
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+def _make_ctx(**overrides) -> SearchContext:
+    defaults = dict(
+        keywords=("alpha",),
+        fts_keywords=("alpha",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=50,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return SearchContext(**defaults)
+
+
+def test_vector_retrieve_returns_none_when_embedding_disabled(temp_db, disable_embedding):
+    """encode_query が None を返すと (= 埋め込みサーバー未稼働) vector_retrieve は None。"""
+    add_topic(title="alpha topic", description="hello", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        result = vector_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert result is None
+
+
+def test_vector_retrieve_uses_shared_conn(temp_db, mock_embedding_model, monkeypatch):
+    """vector_retrieve は共有 conn を使い、自前で get_connection() を呼ばない。"""
+    add_topic(title="alpha topic", description="hello world", tags=DEFAULT_TAGS)
+
+    call_count = {"n": 0}
+    real_get_connection = search_service.get_connection
+
+    def tracking_get_connection():
+        call_count["n"] += 1
+        return real_get_connection()
+
+    monkeypatch.setattr(search_service, "get_connection", tracking_get_connection)
+
+    conn = real_get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        vector_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert call_count["n"] == 0
+
+
+def test_vector_retrieve_returns_list_when_embedding_available(temp_db, mock_embedding_model):
+    """埋め込みサーバー稼働時は AND モードで list を返す（None ではない）。"""
+    add_topic(title="alpha topic", description="hello world", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(keywords=("alpha",), fts_keywords=("alpha",))
+        result = vector_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    assert isinstance(result, list)
+
+
+def test_vector_retrieve_or_mode_merges_per_keyword(temp_db, mock_embedding_model):
+    """OR モードでは各キーワードを個別に埋め込み → 結果をマージして返す。"""
+    add_topic(title="alpha topic", description="hello", tags=DEFAULT_TAGS)
+    add_topic(title="beta topic", description="world", tags=DEFAULT_TAGS)
+
+    conn = get_connection()
+    try:
+        ctx = _make_ctx(
+            keywords=("alpha", "beta"),
+            fts_keywords=("alpha", "beta"),
+            keyword_mode="or",
+        )
+        result = vector_retrieve(ctx, conn)
+    finally:
+        conn.close()
+
+    # OR モードで両 keyword に対応する KNN を回すので None ではないはず
+    assert result is not None
+    assert isinstance(result, list)


### PR DESCRIPTION
## Summary

- 検索 retriever (`fts_retrieve` / `vector_retrieve` / `tag_like_retrieve`) を共有 conn 受け取りの公開関数として切り出し、旧 `_fts_search` / `_vector_search` / `_tag_like_search` を撤去
- `search()` を `_validate` / `_normalize` / `_expand` / `_retrieve` / `_merge` / `_rerank` / `_slice` / `_decorate` の 8 ステージに分離し、orchestrator は 1 度だけ `get_connection()` で conn を開いて normalize + 3 retriever に共有する
- 早期 return (タグ未登録による空結果、バリデーションエラーなど) は内部例外 `_SearchEarlyReturn` で表現し、orchestrator 末尾でレスポンス dict に変換する
- レスポンス dict のキー (`results` / `total_count` / `search_methods_used` / `nearby_tags`) と `score_breakdown` / `final_score` の構造は不変

## 設計メモ

- conn 共有は retriever までを対象とした。decorate 系ヘルパ (`_attach_*` / `_compute_nearby_tags`) は内部で自前 conn を開く既存実装のまま据え置き
- `_apply_recency_boost` / `_rrf_merge` は score_breakdown 生成ロジックを内包しており、stage 関数はその薄いラッパとして機能する
- `_SearchEarlyReturn` は外部公開しない (検索結果生成のフロー制御専用)
- `score` フィールドは旧 API 互換のため `final_score` と同値で残置

## Test plan

- [x] 既存 unit テスト 1602 件 pass (1 skip)
- [x] integration テスト 356 件 pass
- [x] 新規 retriever 単体テスト (`tests/unit/test_search_retriever_{fts,vector,tag_like}.py`) で各 retriever が共有 conn のみを使うこと・基本挙動を検証
- [x] 新規 orchestrator テスト (`tests/unit/test_search_orchestrator.py`) でステージモック注入によりステージ呼び出し順序・conn の単一開閉・例外処理を検証
- [x] `search()` 戻り dict のキー不変性 (`tests/unit/test_search_pipeline.py::test_phase_a_search_preserves_response_keys`) で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)