### PR TITLE
feat: relations.belongs_to で全エンティティの親帰属を統一

### DIFF
--- a/migrations/0046_relations_belongs_to_unify.sql
+++ b/migrations/0046_relations_belongs_to_unify.sql
@@ -1,0 +1,337 @@
+-- Migration 0046: relations.belongs_to 統一化 — 全エンティティの親帰属を relations 経由で表現
+--
+-- depends: 0045_add_activities_orch_managed
+--
+-- 背景:
+--   decision/log の親 topic は `decisions.topic_id NOT NULL FK` / `discussion_logs.topic_id NOT NULL FK`
+--   で直接保持する一方、material/activity の親 topic は `relations` テーブルに
+--   `relation_type='related'` として書き込む非対称な状態だった。
+--
+--   全エンティティの親帰属を `relations.relation_type='belongs_to'` に統一することで、
+--   親帰属の表現を 1 経路にまとめる。search / 依存解決 / recompose の経路も `belongs_to`
+--   ベースで動かす。
+--
+-- 変更内容:
+--   1. relations テーブル再作成: relation_type CHECK 制約を ('related','belongs_to') に緩和
+--   2. relations の partial index 2 本を追加 (belongs_to クエリ hot path 用)
+--   3. relations_view 再作成: relation_type を直接返す (旧版は 'related' リテラルだった)
+--   4. 既存 material/activity → topic の 'related' 行を全件 'belongs_to' に変換
+--   5. decisions/discussion_logs.topic_id を relations.belongs_to に複製
+--   6. decisions / discussion_logs テーブル再作成:
+--      - topic_id を NULLABLE 化 (FK 制約も削除)
+--      - 親帰属は relations.belongs_to を正としつつ、当面は topic_id 列も残置 (0047 で物理削除)
+--      - 関連トリガー (search_index 3 本 + CASCADE 3 本) を再作成
+--
+-- 設計メモ:
+--   - relations の PK は (source_type, source_id, target_type, target_id) のまま据置。
+--     relation_type は PK に含めない (同一ペアで related/belongs_to が同居しない)
+--   - 既存 'related' 行は UPDATE で 'belongs_to' に書き換える (新規 INSERT で重複しない)
+--   - dual-write は行わない: 書き込みパスは migration 適用と同時にコード側で belongs_to 一本に切替
+--   - subject_id 同期トリガーは migration 0010 で既に撤去済みのため変更不要
+
+-- legacy_alter_table=ON: ALTER TABLE RENAME 時に既存トリガー本体内のテーブル参照を
+-- 自動更新しない (デフォルト挙動だと relations を rename した瞬間 CASCADE トリガー
+-- 5 本の本体が renamed 名を指すように書き換えられ、後段の DROP TABLE で参照崩壊する)
+PRAGMA legacy_alter_table = ON;
+
+-- テーブル再作成中の FK 違反を commit 時まで遅延 (decisions / discussion_logs を
+-- 参照する decision_supersedes 等の FK 整合性を中間状態で守る)
+PRAGMA defer_foreign_keys = ON;
+
+-- ============================================
+-- Step 1: relations テーブル再作成 (CHECK 緩和) + partial index 2 本
+-- ============================================
+
+ALTER TABLE relations RENAME TO relations_old_0046;
+
+CREATE TABLE relations (
+    source_type TEXT NOT NULL CHECK(source_type IN ('topic', 'activity', 'material', 'decision', 'log')),
+    source_id INTEGER NOT NULL,
+    target_type TEXT NOT NULL CHECK(target_type IN ('topic', 'activity', 'material', 'decision', 'log')),
+    target_id INTEGER NOT NULL,
+    -- 'related' は対称関係、'belongs_to' は子→親 (decision/log/material/activity → topic) を表す
+    relation_type TEXT NOT NULL DEFAULT 'related' CHECK(relation_type IN ('related', 'belongs_to')),
+    created_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (source_type, source_id, target_type, target_id),
+    CHECK (source_type < target_type OR (source_type = target_type AND source_id < target_id))
+);
+
+INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type, created_at)
+SELECT source_type, source_id, target_type, target_id, relation_type, created_at FROM relations_old_0046;
+
+DROP TABLE relations_old_0046;
+
+-- 既存の target 逆引き index を再作成
+CREATE INDEX idx_relations_target ON relations(target_type, target_id);
+
+-- partial index: belongs_to クエリの hot path 用
+-- 子 → 親方向 (例: get_decisions(topic) で decision の親 topic 経由集約)
+CREATE INDEX idx_relations_belongs_to_tgt
+  ON relations(target_type, target_id, source_type, source_id)
+  WHERE relation_type = 'belongs_to';
+
+-- 親 → 子方向 (例: timeline で topic 配下の decision/log 集約)
+CREATE INDEX idx_relations_belongs_to_src
+  ON relations(source_type, source_id, target_id)
+  WHERE relation_type = 'belongs_to';
+
+-- ============================================
+-- Step 2: relations_view 再作成 (relation_type を直接返す)
+-- ============================================
+
+DROP VIEW IF EXISTS relations_view;
+
+CREATE VIEW relations_view AS
+  -- relations 正方向 (related + belongs_to)
+  SELECT source_type, source_id, target_type, target_id, relation_type, created_at
+  FROM relations
+  UNION ALL
+  -- relations 逆方向 (related + belongs_to の対称展開)
+  SELECT target_type, target_id, source_type, source_id, relation_type, created_at
+  FROM relations
+  UNION ALL
+  -- depends_on (activity_dependencies)
+  SELECT 'activity' AS source_type, dependent_id AS source_id,
+         'activity' AS target_type, dependency_id AS target_id,
+         'depends_on' AS relation_type, created_at
+  FROM activity_dependencies
+  UNION ALL
+  -- supersedes (decision_supersedes)
+  SELECT 'decision' AS source_type, source_id,
+         'decision' AS target_type, target_id,
+         'supersedes' AS relation_type, created_at
+  FROM decision_supersedes;
+
+-- ============================================
+-- Step 3: 既存 'related' 行を 'belongs_to' に変換
+-- 正規化制約により source_type < target_type なので必ず source=子, target=topic の形。
+--
+-- - material/activity → topic: 全件変換 (これらは元々 relations 一本管理、すべて親帰属)
+-- - decision/log → topic:      FK (decisions.topic_id / discussion_logs.topic_id) と
+--                              一致する行のみ変換。FK と一致しない副たる関連 ('related')
+--                              は据置 ── 主たる親 1 個 + 副は related の運用ルールを保つ。
+--                              (これをやらないと Step 4 の INSERT OR IGNORE が PK 衝突
+--                               をスキップして主たる親が belongs_to で表現されない不整合になる)
+-- ============================================
+
+UPDATE relations
+SET relation_type = 'belongs_to'
+WHERE relation_type = 'related'
+  AND target_type = 'topic'
+  AND source_type IN ('activity', 'material');
+
+UPDATE relations
+SET relation_type = 'belongs_to'
+WHERE relation_type = 'related'
+  AND target_type = 'topic'
+  AND source_type = 'decision'
+  AND EXISTS (
+    SELECT 1 FROM decisions d
+    WHERE d.id = relations.source_id AND d.topic_id = relations.target_id
+  );
+
+UPDATE relations
+SET relation_type = 'belongs_to'
+WHERE relation_type = 'related'
+  AND target_type = 'topic'
+  AND source_type = 'log'
+  AND EXISTS (
+    SELECT 1 FROM discussion_logs l
+    WHERE l.id = relations.source_id AND l.topic_id = relations.target_id
+  );
+
+-- ============================================
+-- Step 4: decisions/discussion_logs.topic_id を relations.belongs_to に複製
+-- 'decision' < 'topic'、'log' < 'topic' なので正規化形 (source=子) のまま挿入
+-- ============================================
+
+INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id, relation_type)
+SELECT 'decision', d.id, 'topic', d.topic_id, 'belongs_to'
+FROM decisions d
+WHERE d.topic_id IS NOT NULL;
+
+INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id, relation_type)
+SELECT 'log', l.id, 'topic', l.topic_id, 'belongs_to'
+FROM discussion_logs l
+WHERE l.topic_id IS NOT NULL;
+
+-- ============================================
+-- Step 5: decisions テーブル再作成 (topic_id NULLABLE 化 + FK 削除)
+-- 旧テーブルに紐づく全トリガー (search_index 3 + CASCADE 3) は再作成必要
+-- ============================================
+
+-- 旧トリガー DROP (テーブル DROP で自動 DROP されるが明示)
+DROP TRIGGER IF EXISTS trg_search_decisions_insert;
+DROP TRIGGER IF EXISTS trg_search_decisions_update;
+DROP TRIGGER IF EXISTS trg_search_decisions_delete;
+DROP TRIGGER IF EXISTS trg_relations_cascade_delete_decision;
+DROP TRIGGER IF EXISTS trg_pins_cascade_delete_decision;
+DROP TRIGGER IF EXISTS trg_citations_cascade_delete_decision;
+
+DROP INDEX IF EXISTS idx_decisions_topic_id;
+
+ALTER TABLE decisions RENAME TO decisions_old_0046;
+
+CREATE TABLE decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- topic_id は 0047 で物理削除予定。当面は NULL 許容で残置 (旧 INSERT パスの後方互換ではなく、
+  -- migration 適用直後の中間状態で SELECT 互換性を維持するための残置)
+  topic_id INTEGER,
+  decision TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  retracted_at TIMESTAMP NULL,
+  title TEXT
+);
+
+INSERT INTO decisions (id, topic_id, decision, reason, created_at, retracted_at, title)
+SELECT id, topic_id, decision, reason, created_at, retracted_at, title FROM decisions_old_0046;
+
+DROP TABLE decisions_old_0046;
+
+-- search_index 同期トリガー 3 本 (topic_id 不参照、migration 0037 と同形)
+CREATE TRIGGER trg_search_decisions_insert
+AFTER INSERT ON decisions
+BEGIN
+  INSERT INTO search_index (source_type, source_id, title, created_at)
+  VALUES ('decision', NEW.id, COALESCE(NEW.title, NEW.decision), NEW.created_at);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.decision, NEW.reason);
+END;
+
+CREATE TRIGGER trg_search_decisions_update
+AFTER UPDATE ON decisions
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  UPDATE search_index
+  SET title = COALESCE(NEW.title, NEW.decision)
+  WHERE source_type = 'decision' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = NEW.id),
+    NEW.decision, NEW.reason);
+END;
+
+CREATE TRIGGER trg_search_decisions_delete
+AFTER DELETE ON decisions
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id),
+    OLD.decision, OLD.reason);
+  DELETE FROM search_index WHERE source_type = 'decision' AND source_id = OLD.id;
+END;
+
+-- CASCADE トリガー 3 本 (relations / pins / citations)
+CREATE TRIGGER trg_relations_cascade_delete_decision
+AFTER DELETE ON decisions
+FOR EACH ROW
+BEGIN
+    DELETE FROM relations WHERE (source_type = 'decision' AND source_id = OLD.id)
+                             OR (target_type = 'decision' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_decision
+AFTER DELETE ON decisions
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'decision' AND source_id = OLD.id)
+                       OR (target_type = 'decision' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_decision
+AFTER DELETE ON decisions
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'decision' AND owner_id = OLD.id;
+END;
+
+-- ============================================
+-- Step 6: discussion_logs テーブル再作成 (同様の手順)
+-- ============================================
+
+DROP TRIGGER IF EXISTS trg_search_logs_insert;
+DROP TRIGGER IF EXISTS trg_search_logs_update;
+DROP TRIGGER IF EXISTS trg_search_logs_delete;
+DROP TRIGGER IF EXISTS trg_relations_cascade_delete_log;
+DROP TRIGGER IF EXISTS trg_pins_cascade_delete_log;
+DROP TRIGGER IF EXISTS trg_citations_cascade_delete_log;
+
+DROP INDEX IF EXISTS idx_logs_topic_id;
+
+ALTER TABLE discussion_logs RENAME TO discussion_logs_old_0046;
+
+CREATE TABLE discussion_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  topic_id INTEGER,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  title TEXT NOT NULL DEFAULT '',
+  retracted_at TIMESTAMP NULL
+);
+
+INSERT INTO discussion_logs (id, topic_id, content, created_at, title, retracted_at)
+SELECT id, topic_id, content, created_at, title, retracted_at FROM discussion_logs_old_0046;
+
+DROP TABLE discussion_logs_old_0046;
+
+CREATE TRIGGER trg_search_logs_insert
+AFTER INSERT ON discussion_logs
+BEGIN
+  INSERT INTO search_index (source_type, source_id, title, created_at)
+  VALUES ('log', NEW.id, NEW.title, NEW.created_at);
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (last_insert_rowid(), NEW.title, NEW.content);
+END;
+
+CREATE TRIGGER trg_search_logs_update
+AFTER UPDATE ON discussion_logs
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'log' AND source_id = OLD.id),
+    OLD.title, OLD.content);
+  UPDATE search_index
+  SET title = NEW.title
+  WHERE source_type = 'log' AND source_id = NEW.id;
+  INSERT INTO search_index_fts (rowid, title, body)
+  VALUES (
+    (SELECT id FROM search_index WHERE source_type = 'log' AND source_id = NEW.id),
+    NEW.title, NEW.content);
+END;
+
+CREATE TRIGGER trg_search_logs_delete
+AFTER DELETE ON discussion_logs
+BEGIN
+  INSERT INTO search_index_fts (search_index_fts, rowid, title, body)
+  VALUES ('delete',
+    (SELECT id FROM search_index WHERE source_type = 'log' AND source_id = OLD.id),
+    OLD.title, OLD.content);
+  DELETE FROM search_index WHERE source_type = 'log' AND source_id = OLD.id;
+END;
+
+CREATE TRIGGER trg_relations_cascade_delete_log
+AFTER DELETE ON discussion_logs
+FOR EACH ROW
+BEGIN
+    DELETE FROM relations WHERE (source_type = 'log' AND source_id = OLD.id)
+                             OR (target_type = 'log' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_pins_cascade_delete_log
+AFTER DELETE ON discussion_logs
+FOR EACH ROW
+BEGIN
+    DELETE FROM pins WHERE (source_type = 'log' AND source_id = OLD.id)
+                       OR (target_type = 'log' AND target_id = OLD.id);
+END;
+
+CREATE TRIGGER trg_citations_cascade_delete_log
+AFTER DELETE ON discussion_logs
+FOR EACH ROW
+BEGIN
+    DELETE FROM citations WHERE owner_type = 'log' AND owner_id = OLD.id;
+END;

--- a/migrations/0047_drop_decisions_logs_topic_id.sql
+++ b/migrations/0047_drop_decisions_logs_topic_id.sql
@@ -1,0 +1,24 @@
+-- Migration 0047: decisions.topic_id / discussion_logs.topic_id カラム物理削除 (Contract)
+--
+-- depends: 0046_relations_belongs_to_unify
+--
+-- 背景:
+--   migration 0046 で親 topic との紐付けを relations.belongs_to に統一し、
+--   `decisions.topic_id` / `discussion_logs.topic_id` カラムは NULLABLE 化したうえで
+--   書き込みパス・読み取り経路を relations.belongs_to 一本に切替えた。
+--   旧 FK カラムは中間状態で互換性のために残置していたが、本 migration で物理削除する。
+--
+-- 変更内容:
+--   - decisions.topic_id カラムを DROP
+--   - discussion_logs.topic_id カラムを DROP
+--
+-- 前提条件 (0046 で確保済):
+--   - idx_decisions_topic_id / idx_logs_topic_id は DROP 済
+--   - decisions / discussion_logs のトリガーは topic_id を参照しない形に再作成済
+--   - 書き込みコード (add_decisions / add_logs) は topic_id を INSERT に含めない
+--   - 読み取りコード (get_decisions / get_logs / search / timeline / checkin / topic / hint)
+--     は relations.belongs_to 経由
+
+ALTER TABLE decisions DROP COLUMN topic_id;
+
+ALTER TABLE discussion_logs DROP COLUMN topic_id;

--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -93,10 +93,13 @@ def _get_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int]) -
     placeholders = ",".join("?" * len(topic_ids))
     rows = conn.execute(
         f"""
-        SELECT id, decision, title
-        FROM decisions
-        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
-        ORDER BY id DESC
+        SELECT DISTINCT d.id, d.decision, d.title
+        FROM decisions d
+        JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                        AND r.target_id IN ({placeholders})
+        WHERE d.retracted_at IS NULL
+        ORDER BY d.id DESC
         LIMIT {DECISIONS_FULL_LIMIT}
         """,
         tuple(topic_ids),
@@ -117,7 +120,14 @@ def _count_decisions_from_topics(conn: sqlite3.Connection, topic_ids: list[int])
         return 0
     placeholders = ",".join("?" * len(topic_ids))
     row = conn.execute(
-        f"SELECT COUNT(*) FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL",
+        f"""
+        SELECT COUNT(DISTINCT d.id)
+        FROM decisions d
+        JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                        AND r.target_id IN ({placeholders})
+        WHERE d.retracted_at IS NULL
+        """,
         tuple(topic_ids),
     ).fetchone()
     return row[0] if row else 0
@@ -143,10 +153,13 @@ def _get_logs_catalog_from_topics(
     # 最新1件: content付き
     latest_row = conn.execute(
         f"""
-        SELECT id, title, content
-        FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
-        ORDER BY id DESC
+        SELECT DISTINCT l.id, l.title, l.content
+        FROM discussion_logs l
+        JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                        AND r.target_id IN ({placeholders})
+        WHERE l.retracted_at IS NULL
+        ORDER BY l.id DESC
         LIMIT 1
         """,
         params,
@@ -162,10 +175,13 @@ def _get_logs_catalog_from_topics(
     # 残り: id + titleのみ（titleが空の場合はcontentの先頭50文字をfallback）
     catalog_rows = conn.execute(
         f"""
-        SELECT id, title, content
-        FROM discussion_logs
-        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL AND id != ?
-        ORDER BY id DESC
+        SELECT DISTINCT l.id, l.title, l.content
+        FROM discussion_logs l
+        JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                        AND r.target_id IN ({placeholders})
+        WHERE l.retracted_at IS NULL AND l.id != ?
+        ORDER BY l.id DESC
         """,
         params + (latest_row["id"],),
     ).fetchall()

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -14,6 +14,7 @@ from src.services.tag_service import (
     _append_tag_notes_with_conn,
 )
 from src.services.habit_service import _add_habit_with_conn
+from src.services.relation_service import _add_relation_with_conn
 
 PROPAGATE_TYPES = {"habit", "tag_note"}
 
@@ -77,12 +78,30 @@ def add_decisions(items: list[dict]) -> dict:
                     if isinstance(parsed_tags, dict):
                         raise ValueError(parsed_tags["error"]["message"])
 
-                # decisionをINSERT
+                # 親 topic の存在チェック (旧 FK 制約相当の不変条件を維持)
+                if topic_id is not None:
+                    exists = conn.execute(
+                        "SELECT 1 FROM discussion_topics WHERE id = ?",
+                        (topic_id,),
+                    ).fetchone()
+                    if not exists:
+                        raise sqlite3.IntegrityError(
+                            f"topic_id {topic_id} does not exist in discussion_topics"
+                        )
+
+                # decisionをINSERT (親 topic は relations.belongs_to で表現するため topic_id は持たせない)
                 cursor = conn.execute(
-                    "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
-                    (topic_id, decision, reason, title),
+                    "INSERT INTO decisions (decision, reason, title) VALUES (?, ?, ?)",
+                    (decision, reason, title),
                 )
                 decision_id = cursor.lastrowid
+
+                # 親 topic との belongs_to リレーションを記録
+                if topic_id is not None:
+                    _add_relation_with_conn(
+                        conn, "decision", decision_id,
+                        [{"type": "topic", "ids": [topic_id]}],
+                    )
 
                 # タグをリンク（指定された場合のみ）
                 if parsed_tags:
@@ -244,12 +263,17 @@ def get_decisions(
                     "decisions": [],
                 }
 
+            # decisions の親 topic は relations.belongs_to 経由で解決する
+            decision_retract_filter = retract_filter.replace("retracted_at", "d.retracted_at")
             if start_id is None:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM decisions
-                    WHERE topic_id = ?{retract_filter}
-                    ORDER BY created_at ASC, id ASC
+                    SELECT d.* FROM decisions d
+                    JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                                    AND r.target_type = 'topic' AND r.target_id = ?
+                                    AND r.relation_type = 'belongs_to'
+                    WHERE 1=1{decision_retract_filter}
+                    ORDER BY d.created_at ASC, d.id ASC
                     LIMIT ?
                     """,
                     (topic_id, limit),
@@ -257,9 +281,12 @@ def get_decisions(
             else:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM decisions
-                    WHERE topic_id = ? AND id >= ?{retract_filter}
-                    ORDER BY created_at ASC, id ASC
+                    SELECT d.* FROM decisions d
+                    JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                                    AND r.target_type = 'topic' AND r.target_id = ?
+                                    AND r.relation_type = 'belongs_to'
+                    WHERE d.id >= ?{decision_retract_filter}
+                    ORDER BY d.created_at ASC, d.id ASC
                     LIMIT ?
                     """,
                     (topic_id, start_id, limit),
@@ -304,12 +331,18 @@ def get_decisions(
                 return {"decisions": []}
 
             placeholders = ",".join("?" * len(topic_ids))
+            # decisions の親 topic 集約も relations.belongs_to 経由。
+            # DISTINCT で複数 topic に belongs_to する decision の重複を抑制
+            decision_retract_filter = retract_filter.replace("retracted_at", "d.retracted_at")
             if start_id is None:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM decisions
-                    WHERE topic_id IN ({placeholders}){retract_filter}
-                    ORDER BY id DESC
+                    SELECT DISTINCT d.* FROM decisions d
+                    JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                                    AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                                    AND r.target_id IN ({placeholders})
+                    WHERE 1=1{decision_retract_filter}
+                    ORDER BY d.id DESC
                     LIMIT ?
                     """,
                     tuple(topic_ids) + (limit,),
@@ -317,9 +350,12 @@ def get_decisions(
             else:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM decisions
-                    WHERE topic_id IN ({placeholders}) AND id <= ?{retract_filter}
-                    ORDER BY id DESC
+                    SELECT DISTINCT d.* FROM decisions d
+                    JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                                    AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                                    AND r.target_id IN ({placeholders})
+                    WHERE d.id <= ?{decision_retract_filter}
+                    ORDER BY d.id DESC
                     LIMIT ?
                     """,
                     tuple(topic_ids) + (start_id, limit),

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -199,9 +199,11 @@ def get_logs(
         include_retracted: Trueのとき取り消し済みログも含める（デフォルトFalse）
 
     Returns:
-        議論ログ一覧（各logにtags付き）
-        entity_type == "topic": 従来通りtopic_idで直接取得
-        entity_type == "activity": related topics（上限10件）経由でlogs集約
+        議論ログ一覧（各logにtags付き）。
+        entity_type == "topic" のとき、各 item は要求された topic_id を `topic_id` フィールドで返す。
+        entity_type == "activity" のとき、各 item は `topic_id` フィールドを含まない
+        (複数 topic に belongs_to する場合に「主たる親」を一意に決められないため、
+         呼び出し側で必要なら relations.belongs_to を別途 query する設計)。
     """
     retract_filter = "" if include_retracted else " AND retracted_at IS NULL"
 

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -13,6 +13,7 @@ from src.services.tag_service import (
     get_effective_tags_batch,
     get_effective_tags_batch_by_ids,
 )
+from src.services.relation_service import _add_relation_with_conn
 
 
 def _auto_generate_title(content: str) -> str | None:
@@ -81,12 +82,30 @@ def add_logs(items: list[dict]) -> dict:
                     if isinstance(parsed_tags, dict):
                         raise ValueError(parsed_tags["error"]["message"])
 
-                # ログをINSERT
+                # 親 topic の存在チェック (旧 FK 制約相当の不変条件を維持)
+                if topic_id is not None:
+                    exists = conn.execute(
+                        "SELECT 1 FROM discussion_topics WHERE id = ?",
+                        (topic_id,),
+                    ).fetchone()
+                    if not exists:
+                        raise sqlite3.IntegrityError(
+                            f"topic_id {topic_id} does not exist in discussion_topics"
+                        )
+
+                # ログをINSERT (親 topic は relations.belongs_to で表現するため topic_id は持たせない)
                 cursor = conn.execute(
-                    "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, ?, ?)",
-                    (topic_id, title, content),
+                    "INSERT INTO discussion_logs (title, content) VALUES (?, ?)",
+                    (title, content),
                 )
                 log_id = cursor.lastrowid
+
+                # 親 topic との belongs_to リレーションを記録
+                if topic_id is not None:
+                    _add_relation_with_conn(
+                        conn, "log", log_id,
+                        [{"type": "topic", "ids": [topic_id]}],
+                    )
 
                 # タグをリンク（指定された場合のみ）
                 if parsed_tags:
@@ -99,6 +118,8 @@ def add_logs(items: list[dict]) -> dict:
                 )
 
                 conn.execute(f"RELEASE SAVEPOINT item_{i}")
+                # topic_id は API 互換のため返す (DB カラムは 0047 で物理削除済み、
+                # 親 topic 情報は relations.belongs_to が正)
                 created.append({
                     "log_id": log_id,
                     "topic_id": topic_id,
@@ -191,12 +212,18 @@ def get_logs(
 
         if entity_type == "topic":
             topic_id = entity_id
+            include_topic_id = topic_id
+            # discussion_logs の親 topic は relations.belongs_to 経由で解決
+            log_retract_filter = retract_filter.replace("retracted_at", "l.retracted_at")
             if start_id is None:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM discussion_logs
-                    WHERE topic_id = ?{retract_filter}
-                    ORDER BY created_at ASC, id ASC
+                    SELECT l.* FROM discussion_logs l
+                    JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                                    AND r.target_type = 'topic' AND r.target_id = ?
+                                    AND r.relation_type = 'belongs_to'
+                    WHERE 1=1{log_retract_filter}
+                    ORDER BY l.created_at ASC, l.id ASC
                     LIMIT ?
                     """,
                     (topic_id, limit),
@@ -204,9 +231,12 @@ def get_logs(
             else:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM discussion_logs
-                    WHERE topic_id = ? AND id >= ?{retract_filter}
-                    ORDER BY created_at ASC, id ASC
+                    SELECT l.* FROM discussion_logs l
+                    JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                                    AND r.target_type = 'topic' AND r.target_id = ?
+                                    AND r.relation_type = 'belongs_to'
+                    WHERE l.id >= ?{log_retract_filter}
+                    ORDER BY l.created_at ASC, l.id ASC
                     LIMIT ?
                     """,
                     (topic_id, start_id, limit),
@@ -222,7 +252,7 @@ def get_logs(
                 display_title = log["title"] or (log["content"] or "")[:50]
                 item = {
                     "id": log["id"],
-                    "topic_id": log["topic_id"],
+                    "topic_id": include_topic_id,
                     "title": display_title,
                     "content": log["content"],
                     "tags": tags_map.get(log["id"], []),
@@ -247,12 +277,16 @@ def get_logs(
                 return {"logs": []}
 
             placeholders = ",".join("?" * len(topic_ids))
+            log_retract_filter = retract_filter.replace("retracted_at", "l.retracted_at")
             if start_id is None:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM discussion_logs
-                    WHERE topic_id IN ({placeholders}){retract_filter}
-                    ORDER BY id DESC
+                    SELECT DISTINCT l.* FROM discussion_logs l
+                    JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                                    AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                                    AND r.target_id IN ({placeholders})
+                    WHERE 1=1{log_retract_filter}
+                    ORDER BY l.id DESC
                     LIMIT ?
                     """,
                     tuple(topic_ids) + (limit,),
@@ -260,9 +294,12 @@ def get_logs(
             else:
                 rows = conn.execute(
                     f"""
-                    SELECT * FROM discussion_logs
-                    WHERE topic_id IN ({placeholders}) AND id <= ?{retract_filter}
-                    ORDER BY id DESC
+                    SELECT DISTINCT l.* FROM discussion_logs l
+                    JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                                    AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                                    AND r.target_id IN ({placeholders})
+                    WHERE l.id <= ?{log_retract_filter}
+                    ORDER BY l.id DESC
                     LIMIT ?
                     """,
                     tuple(topic_ids) + (start_id, limit),
@@ -279,7 +316,6 @@ def get_logs(
                 display_title = log["title"] or (log["content"] or "")[:50]
                 item = {
                     "id": log["id"],
-                    "topic_id": log["topic_id"],
                     "title": display_title,
                     "content": log["content"],
                     "tags": tags_map.get(log["id"], []),

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -244,7 +244,8 @@ def _count_tag_scope_decisions(
 ) -> int:
     """tagスコープのdecision件数 (retracted除外)。
 
-    tagスコープは decision_tags 直付け OR decisions.topic_id 経由で topic_tags 継承の和。
+    tagスコープは decision_tags 直付け OR relations.belongs_to 経由で
+    親 topic の topic_tags 継承の和。
     """
     sql = """
         SELECT COUNT(*) FROM decisions d
@@ -255,8 +256,12 @@ def _count_tag_scope_decisions(
                 WHERE dt.decision_id = d.id AND dt.tag_id = ?
             )
             OR EXISTS (
-                SELECT 1 FROM topic_tags tt
-                WHERE tt.topic_id = d.topic_id AND tt.tag_id = ?
+                SELECT 1 FROM relations r
+                JOIN topic_tags tt ON tt.topic_id = r.target_id
+                WHERE r.source_type = 'decision' AND r.source_id = d.id
+                  AND r.target_type = 'topic'
+                  AND r.relation_type = 'belongs_to'
+                  AND tt.tag_id = ?
             )
           )
     """
@@ -274,8 +279,15 @@ def _count_tag_scope_decisions(
 def _get_hints_for_topic(conn: sqlite3.Connection, topic_id: int) -> list[Hint]:
     """topicに対するlogs_sparse判定 (素朴閾値: log<5 かつ decision>0)。"""
     row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM decisions"
-        " WHERE topic_id = ? AND retracted_at IS NULL",
+        """
+        SELECT COUNT(*) AS cnt FROM decisions d
+        JOIN relations r
+          ON r.source_type = 'decision' AND r.source_id = d.id
+         AND r.target_type = 'topic'
+         AND r.relation_type = 'belongs_to'
+         AND r.target_id = ?
+        WHERE d.retracted_at IS NULL
+        """,
         (topic_id,),
     ).fetchone()
     decision_count = row["cnt"] if row else 0
@@ -283,8 +295,15 @@ def _get_hints_for_topic(conn: sqlite3.Connection, topic_id: int) -> list[Hint]:
         return []
 
     row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM discussion_logs"
-        " WHERE topic_id = ? AND retracted_at IS NULL",
+        """
+        SELECT COUNT(*) AS cnt FROM discussion_logs dl
+        JOIN relations r
+          ON r.source_type = 'log' AND r.source_id = dl.id
+         AND r.target_type = 'topic'
+         AND r.relation_type = 'belongs_to'
+         AND r.target_id = ?
+        WHERE dl.retracted_at IS NULL
+        """,
         (topic_id,),
     ).fetchone()
     log_count = row["cnt"] if row else 0

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -11,7 +11,22 @@ from src.services.tag_service import (
 logger = logging.getLogger(__name__)
 
 VALID_ENTITY_TYPES = {"topic", "activity", "material", "decision", "log"}
-VALID_RELATION_TYPES = {"related", "depends_on", "supersedes"}
+VALID_RELATION_TYPES = {"related", "depends_on", "supersedes", "belongs_to"}
+
+# 親帰属パターン: 子→親 (decision/log/material/activity → topic) を表す relations 行は
+# 自動的に 'belongs_to' で書き込む。正規化制約により親が必ず target 側に来る
+_PARENT_CHILD_TYPES = {"activity", "material", "decision", "log"}
+
+
+def _resolve_relation_type(n_stype: str, n_ttype: str, requested: str) -> str:
+    """正規化後のペアと要求された relation_type から、実際に書き込む relation_type を決める。
+
+    親帰属パターン (子 → topic) の 'related' は自動的に 'belongs_to' に格上げする。
+    親帰属でないペアに対する 'belongs_to' の指定は呼び出し元側で弾く想定。
+    """
+    if n_ttype == "topic" and n_stype in _PARENT_CHILD_TYPES:
+        return "belongs_to"
+    return requested
 
 
 def _validate_entity_type(entity_type: str) -> dict | None:
@@ -140,8 +155,18 @@ def _add_depends_on_with_conn(conn: sqlite3.Connection, source_id: int, target_i
     return added
 
 
-def _add_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]) -> int:
-    """conn共有版: リレーションを追加する。追加件数を返す。"""
+def _add_relation_with_conn(
+    conn: sqlite3.Connection,
+    source_type: str,
+    source_id: int,
+    targets: list[dict],
+    relation_type: str = "related",
+) -> int:
+    """conn共有版: リレーションを追加する。追加件数を返す。
+
+    親帰属パターン (子 → topic) は自動的に 'belongs_to' に格上げされる。
+    それ以外は relation_type 引数の値 (default: 'related') で書き込む。
+    """
     added = 0
     for target in targets:
         target_type = target["type"]
@@ -151,9 +176,10 @@ def _add_relation_with_conn(conn: sqlite3.Connection, source_type: str, source_i
                 # 自己参照はスキップ
                 continue
             n_stype, n_sid, n_ttype, n_tid = normalized
+            rtype = _resolve_relation_type(n_stype, n_ttype, relation_type)
             conn.execute(
-                "INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
-                (n_stype, n_sid, n_ttype, n_tid),
+                "INSERT OR IGNORE INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES (?, ?, ?, ?, ?)",
+                (n_stype, n_sid, n_ttype, n_tid, rtype),
             )
             # INSERT OR IGNOREの場合、重複時はchanges()=0
             if conn.execute("SELECT changes()").fetchone()[0] > 0:
@@ -403,7 +429,7 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
                 )
             return result
         else:
-            added = _add_relation_with_conn(conn, source_type, source_id, targets)
+            added = _add_relation_with_conn(conn, source_type, source_id, targets, relation_type)
         conn.commit()
         return {"added": added}
     except ValueError as e:

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -249,6 +249,28 @@ def _validate_depends_on_constraints(source_type: str, targets: list[dict]) -> d
     return None
 
 
+def _validate_belongs_to_constraints(source_type: str, targets: list[dict]) -> dict | None:
+    """belongs_toリレーションの制約をバリデーションする。
+    親帰属パターン (子: decision/log/material/activity → 親: topic) のみ有効。
+    """
+    if source_type not in _PARENT_CHILD_TYPES:
+        return {
+            "error": {
+                "code": "INVALID_RELATION_TYPE",
+                "message": f"belongs_to is only valid for source_type in {sorted(_PARENT_CHILD_TYPES)} → 'topic'",
+            }
+        }
+    for target in targets:
+        if target["type"] != "topic":
+            return {
+                "error": {
+                    "code": "INVALID_RELATION_TYPE",
+                    "message": "belongs_to is only valid when target type is 'topic'",
+                }
+            }
+    return None
+
+
 def _validate_supersedes_constraints(source_type: str, targets: list[dict]) -> dict | None:
     """supersedesリレーションの制約をバリデーションする。decision→decisionのみ有効。"""
     if source_type != "decision":
@@ -371,9 +393,12 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
         source_type: 起点エンティティのタイプ（"topic", "activity", "material", "decision", or "log"）
         source_id: 起点エンティティのID
         targets: ターゲットリスト [{"type": "topic", "ids": [1, 2]}, ...]
-        relation_type: リレーションタイプ（"related", "depends_on", or "supersedes"）。
+        relation_type: リレーションタイプ（"related", "depends_on", "supersedes", or "belongs_to"）。
             "depends_on" はactivity同士のみ有効で、循環依存を検出した場合はエラーを返す。
             "supersedes" はdecision同士のみ有効で、循環を検出した場合はエラーを返す。
+            "belongs_to" は子 (decision/log/material/activity) → 親 (topic) の親帰属表現にのみ有効。
+            なお、"related" を渡しても親帰属パターン (子 → topic) は内部で自動的に "belongs_to"
+            に格上げされる。
 
     Returns:
         成功時: {"added": int}
@@ -401,6 +426,11 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
 
     if relation_type == "supersedes":
         err = _validate_supersedes_constraints(source_type, targets)
+        if err:
+            return err
+
+    if relation_type == "belongs_to":
+        err = _validate_belongs_to_constraints(source_type, targets)
         if err:
             return err
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -327,13 +327,15 @@ def _attach_details(results: list[dict]) -> None:
             desc_map = {r["id"]: (r["description"] or "")[:DETAILS_DESCRIPTION_MAX] for r in rows}
 
             # recent_decisions取得（各topicの最新3件）
-            # topic_idごとにまとめてクエリし、ROW_NUMBERで上位3件に絞る
+            # topicごとにまとめてクエリし、ROW_NUMBERで上位3件に絞る
             decision_rows = execute_query(
                 f"""
-                SELECT topic_id, decision, reason,
-                       ROW_NUMBER() OVER (PARTITION BY topic_id ORDER BY id DESC) AS rn
-                FROM decisions
-                WHERE topic_id IN ({placeholders})
+                SELECT r.target_id AS topic_id, d.decision, d.reason,
+                       ROW_NUMBER() OVER (PARTITION BY r.target_id ORDER BY d.id DESC) AS rn
+                FROM decisions d
+                JOIN relations r ON r.source_type='decision' AND r.source_id=d.id
+                                AND r.target_type='topic' AND r.relation_type='belongs_to'
+                WHERE r.target_id IN ({placeholders})
                 """,
                 tuple(ids),
             )
@@ -584,7 +586,10 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
         -- decision (UNION継承)
         SELECT 'decision', decision_id FROM (
             SELECT d.id AS decision_id, tt.tag_id
-            FROM decisions d JOIN topic_tags tt ON tt.topic_id = d.topic_id
+            FROM decisions d
+            JOIN relations r ON r.source_type='decision' AND r.source_id=d.id
+                            AND r.target_type='topic' AND r.relation_type='belongs_to'
+            JOIN topic_tags tt ON tt.topic_id = r.target_id
             WHERE tt.tag_id IN ({placeholders})
             UNION
             SELECT dt.decision_id, dt.tag_id
@@ -595,7 +600,10 @@ def _build_tag_filter_cte(tag_ids: list[int]) -> tuple[str, list]:
         -- log (UNION継承)
         SELECT 'log', log_id FROM (
             SELECT dl.id AS log_id, tt.tag_id
-            FROM discussion_logs dl JOIN topic_tags tt ON tt.topic_id = dl.topic_id
+            FROM discussion_logs dl
+            JOIN relations r ON r.source_type='log' AND r.source_id=dl.id
+                            AND r.target_type='topic' AND r.relation_type='belongs_to'
+            JOIN topic_tags tt ON tt.topic_id = r.target_id
             WHERE tt.tag_id IN ({placeholders})
             UNION
             SELECT lt.log_id, lt.tag_id
@@ -1004,10 +1012,12 @@ def find_similar_decisions(
             SELECT si.id, si.source_id, COALESCE(d.title, d.decision) AS title
             FROM search_index si
             JOIN decisions d ON d.id = si.source_id
+            JOIN relations r ON r.source_type='decision' AND r.source_id=d.id
+                            AND r.target_type='topic' AND r.relation_type='belongs_to'
             WHERE si.id IN ({rowid_placeholders})
               AND si.source_type = 'decision'
               AND si.source_id != ?
-              AND d.topic_id = ?
+              AND r.target_id = ?
               AND d.retracted_at IS NULL
             """,
             (*rowids, exclude_id, topic_id),
@@ -1130,13 +1140,17 @@ def _tag_like_search(ctx: SearchContext) -> list[dict]:
         )
         OR EXISTS (
             SELECT 1 FROM decisions d
-            JOIN topic_tags tt2 ON tt2.topic_id = d.topic_id
+            JOIN relations r2 ON r2.source_type='decision' AND r2.source_id=d.id
+                             AND r2.target_type='topic' AND r2.relation_type='belongs_to'
+            JOIN topic_tags tt2 ON tt2.topic_id = r2.target_id
             WHERE d.id = si.source_id AND si.source_type = 'decision'
               AND tt2.tag_id IN ({tag_placeholders})
         )
         OR EXISTS (
             SELECT 1 FROM discussion_logs dl
-            JOIN topic_tags tt3 ON tt3.topic_id = dl.topic_id
+            JOIN relations r3 ON r3.source_type='log' AND r3.source_id=dl.id
+                             AND r3.target_type='topic' AND r3.relation_type='belongs_to'
+            JOIN topic_tags tt3 ON tt3.topic_id = r3.target_id
             WHERE dl.id = si.source_id AND si.source_type = 'log'
               AND tt3.tag_id IN ({tag_placeholders})
         )
@@ -1802,7 +1816,18 @@ def get_by_id(type: str, id: int, conn=None) -> dict:
         else:
             tags = []
 
-        return {"type": type, "data": _format_row(type, row_to_dict(row), tags)}
+        data = row_to_dict(row)
+        # decision/log の親 topic は relations.belongs_to 経由で解決し data に詰める
+        # (DB カラムから物理削除済みのため、_format_row が data["topic_id"] を参照できるよう補完)
+        if type in ('decision', 'log'):
+            r = conn.execute(
+                "SELECT target_id FROM relations WHERE source_type=? AND source_id=? "
+                "AND target_type='topic' AND relation_type='belongs_to' LIMIT 1",
+                (type, id),
+            ).fetchone()
+            data["topic_id"] = r["target_id"] if r else None
+
+        return {"type": type, "data": _format_row(type, data, tags)}
 
     except Exception as e:
         return {

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -405,13 +405,16 @@ def get_effective_tags_batch(
     junction_table = f"{entity_type}_tags"
     id_column = f"{entity_type}_id"
 
+    # decision/log の親 topic は relations.belongs_to 経由で解決
     rows = conn.execute(
         f"""
         SELECT e.id AS entity_id, t.namespace, t.name
         FROM {entity_table} e
-        JOIN topic_tags tt ON tt.topic_id = e.topic_id
+        JOIN relations r ON r.source_type = ? AND r.source_id = e.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+        JOIN topic_tags tt ON tt.topic_id = r.target_id
         JOIN tags t ON t.id = tt.tag_id
-        WHERE e.topic_id = ?
+        WHERE r.target_id = ?
 
         UNION
 
@@ -419,10 +422,12 @@ def get_effective_tags_batch(
         FROM {junction_table} et
         JOIN tags t ON t.id = et.tag_id
         WHERE et.{id_column} IN (
-            SELECT id FROM {entity_table} WHERE topic_id = ?
+            SELECT r2.source_id FROM relations r2
+            WHERE r2.source_type = ? AND r2.target_type = 'topic'
+              AND r2.relation_type = 'belongs_to' AND r2.target_id = ?
         )
         """,
-        (parent_topic_id, parent_topic_id),
+        (entity_type, parent_topic_id, entity_type, parent_topic_id),
     ).fetchall()
 
     # entity_idごとにグルーピング
@@ -456,11 +461,14 @@ def get_effective_tags_batch_by_ids(
     id_column = f"{entity_type}_id"
 
     placeholders = ",".join("?" * len(entity_ids))
+    # 継承元 topic は relations.belongs_to 経由で解決
     rows = conn.execute(
         f"""
         SELECT e.id AS entity_id, t.namespace, t.name
         FROM {entity_table} e
-        JOIN topic_tags tt ON tt.topic_id = e.topic_id
+        JOIN relations r ON r.source_type = ? AND r.source_id = e.id
+                        AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+        JOIN topic_tags tt ON tt.topic_id = r.target_id
         JOIN tags t ON t.id = tt.tag_id
         WHERE e.id IN ({placeholders})
 
@@ -471,7 +479,7 @@ def get_effective_tags_batch_by_ids(
         JOIN tags t ON t.id = et.tag_id
         WHERE et.{id_column} IN ({placeholders})
         """,
-        (*entity_ids, *entity_ids),
+        (entity_type, *entity_ids, *entity_ids),
     ).fetchall()
 
     # entity_idごとにグルーピング
@@ -491,6 +499,7 @@ def get_effective_tags(conn: sqlite3.Connection, entity_type: str, entity_id: in
     junction_table = f"{entity_type}_tags"
     id_column = f"{entity_type}_id"
 
+    # 継承元 topic は relations.belongs_to 経由で解決
     rows = conn.execute(
         f"""
         SELECT DISTINCT t.namespace, t.name
@@ -498,8 +507,9 @@ def get_effective_tags(conn: sqlite3.Connection, entity_type: str, entity_id: in
         WHERE t.id IN (
             SELECT tt.tag_id
             FROM topic_tags tt
-            JOIN {entity_table} e ON e.topic_id = tt.topic_id
-            WHERE e.id = ?
+            JOIN relations r ON r.target_type = 'topic' AND r.target_id = tt.topic_id
+                            AND r.source_type = ? AND r.relation_type = 'belongs_to'
+            WHERE r.source_id = ?
 
             UNION
 
@@ -508,7 +518,7 @@ def get_effective_tags(conn: sqlite3.Connection, entity_type: str, entity_id: in
             WHERE et.{id_column} = ?
         )
         """,
-        (entity_id, entity_id),
+        (entity_type, entity_id, entity_id),
     ).fetchall()
     return format_tags(rows)
 

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -115,7 +115,7 @@ def get_timeline(
         # --- topic_ids の解決 ---
         if activity_id is not None:
             rows = conn.execute(
-                "SELECT target_id FROM relations WHERE source_type = 'activity' AND source_id = ? AND target_type = 'topic'",
+                "SELECT target_id FROM relations WHERE source_type = 'activity' AND source_id = ? AND target_type = 'topic' AND relation_type = 'belongs_to'",
                 (activity_id,),
             ).fetchall()
             topic_ids = [row["target_id"] for row in rows]
@@ -134,11 +134,21 @@ def get_timeline(
 
         if "log" in types:
             union_parts.append(
-                f"SELECT id, 'log' AS type, title, created_at, NULL AS replaces_id, NULL AS replaced_by_id FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+                f"SELECT DISTINCT l.id, 'log' AS type, l.title, l.created_at, NULL AS replaces_id, NULL AS replaced_by_id"
+                f" FROM discussion_logs l"
+                f" JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id"
+                f"                 AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'"
+                f"                 AND r.target_id IN ({placeholders})"
+                f" WHERE l.retracted_at IS NULL"
             )
             params.extend(topic_ids)
             count_parts.append(
-                f"SELECT id, created_at FROM discussion_logs WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+                f"SELECT DISTINCT l.id, l.created_at"
+                f" FROM discussion_logs l"
+                f" JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id"
+                f"                 AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'"
+                f"                 AND r.target_id IN ({placeholders})"
+                f" WHERE l.retracted_at IS NULL"
             )
             count_params.extend(topic_ids)
 
@@ -147,24 +157,33 @@ def get_timeline(
             # decision_supersedesは多対多のスキーマだが、APIレスポンスのreplaces/replaced_byは
             # {type, id}のスカラーと定義されているため、最新の1件のみ返す。
             union_parts.append(
-                f"SELECT d.id, 'decision' AS type, COALESCE(d.title, d.decision) AS title, d.created_at,"
+                f"SELECT DISTINCT d.id, 'decision' AS type, COALESCE(d.title, d.decision) AS title, d.created_at,"
                 f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaces_id,"
                 f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaced_by_id"
-                f" FROM decisions d WHERE d.topic_id IN ({placeholders}) AND d.retracted_at IS NULL"
+                f" FROM decisions d"
+                f" JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id"
+                f"                 AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'"
+                f"                 AND r.target_id IN ({placeholders})"
+                f" WHERE d.retracted_at IS NULL"
             )
             params.extend(topic_ids)
             count_parts.append(
-                f"SELECT id, created_at FROM decisions WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL"
+                f"SELECT DISTINCT d.id, d.created_at"
+                f" FROM decisions d"
+                f" JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id"
+                f"                 AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'"
+                f"                 AND r.target_id IN ({placeholders})"
+                f" WHERE d.retracted_at IS NULL"
             )
             count_params.extend(topic_ids)
 
         if "material" in types:
             union_parts.append(
-                f"SELECT DISTINCT m.id, 'material' AS type, m.title, m.created_at, NULL AS replaces_id, NULL AS replaced_by_id FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.target_id IN ({placeholders}) WHERE m.retracted_at IS NULL"
+                f"SELECT DISTINCT m.id, 'material' AS type, m.title, m.created_at, NULL AS replaces_id, NULL AS replaced_by_id FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.relation_type = 'belongs_to' AND r.target_id IN ({placeholders}) WHERE m.retracted_at IS NULL"
             )
             params.extend(topic_ids)
             count_parts.append(
-                f"SELECT DISTINCT m.id, m.created_at FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.target_id IN ({placeholders}) WHERE m.retracted_at IS NULL"
+                f"SELECT DISTINCT m.id, m.created_at FROM materials m JOIN relations r ON r.source_type = 'material' AND r.source_id = m.id AND r.target_type = 'topic' AND r.relation_type = 'belongs_to' AND r.target_id IN ({placeholders}) WHERE m.retracted_at IS NULL"
             )
             count_params.extend(topic_ids)
 

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -71,10 +71,15 @@ def count_decisions_per_topic(conn: sqlite3.Connection, topic_ids: list[int]) ->
     placeholders = ",".join("?" * len(topic_ids))
     rows = conn.execute(
         f"""
-        SELECT topic_id, COUNT(*) AS cnt
-        FROM decisions
-        WHERE topic_id IN ({placeholders}) AND retracted_at IS NULL
-        GROUP BY topic_id
+        SELECT r.target_id AS topic_id, COUNT(*) AS cnt
+        FROM decisions d
+        JOIN relations r
+          ON r.source_type = 'decision' AND r.source_id = d.id
+         AND r.target_type = 'topic'
+         AND r.relation_type = 'belongs_to'
+         AND r.target_id IN ({placeholders})
+        WHERE d.retracted_at IS NULL
+        GROUP BY r.target_id
         """,
         tuple(topic_ids),
     ).fetchall()
@@ -84,19 +89,11 @@ def count_decisions_per_topic(conn: sqlite3.Connection, topic_ids: list[int]) ->
 def count_materials_per_topic(conn: sqlite3.Connection, topic_ids: list[int]) -> dict[int, int]:
     """トピックごとに直接紐づくmaterials件数を取得する。
 
-    relations_viewを通じてtopic→materialの直接リレーション件数をカウントする。
+    material→topic の親帰属は relations.relation_type='belongs_to' で表現される
+    (正規化制約により source=material, target=topic で格納)。
+    partial index `idx_relations_belongs_to_tgt` がこの WHERE 条件でヒットする。
 
-    実装上のポイント:
-    relationsテーブルは_normalize_pairにより source_type < target_type の辞書順で
-    正規化して格納する。'material' < 'topic' のため、topic-materialペアは常に
-    source=(material), target=(topic) として保存される。
-    そのためrelationsを直接 source_type='topic' で引くと0件になる。
-    双方向ビューであるrelations_viewは逆方向UNIONを含むため、
-    source_type='topic' AND target_type='material' で正しくマッチする。
-    各ペアはビュー内で1方向にしかマッチしないため二重計上は起きない。
-
-    relation_type='related' フィルタにより、supersedes/depends_on経由の
-    リレーションは除外される。activity経由の間接リレーションも含めない。
+    activity経由の間接リレーションは含めない (それは別経路で集約)。
 
     Returns:
         {topic_id: count, ...} — materialsが0件のtopic_idはキーに含まれない
@@ -106,13 +103,13 @@ def count_materials_per_topic(conn: sqlite3.Connection, topic_ids: list[int]) ->
     placeholders = ",".join("?" * len(topic_ids))
     rows = conn.execute(
         f"""
-        SELECT source_id AS topic_id, COUNT(*) AS cnt
-        FROM relations_view
-        WHERE source_type = 'topic'
-          AND target_type = 'material'
-          AND relation_type = 'related'
-          AND source_id IN ({placeholders})
-        GROUP BY source_id
+        SELECT target_id AS topic_id, COUNT(*) AS cnt
+        FROM relations
+        WHERE source_type = 'material'
+          AND target_type = 'topic'
+          AND relation_type = 'belongs_to'
+          AND target_id IN ({placeholders})
+        GROUP BY target_id
         """,
         tuple(topic_ids),
     ).fetchall()

--- a/tests/e2e/test_snapshot.py
+++ b/tests/e2e/test_snapshot.py
@@ -57,21 +57,31 @@ def _seed_rows(db_path: str, table: str, count: int) -> None:
                     (f"topic_{i}", "desc"),
                 )
         elif table == "decisions":
-            # decisions には topic_id が必要
+            # 親 topic との紐付けは relations.belongs_to で表現する
             topic_row = conn.execute("SELECT id FROM discussion_topics LIMIT 1").fetchone()
             topic_id = topic_row[0] if topic_row else 1
             for i in range(count):
+                cur = conn.execute(
+                    "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                    (f"decision_{i}", "reason"),
+                )
                 conn.execute(
-                    "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
-                    (topic_id, f"decision_{i}", "reason"),
+                    "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                    "VALUES ('decision', ?, 'topic', ?, 'belongs_to')",
+                    (cur.lastrowid, topic_id),
                 )
         elif table == "discussion_logs":
             topic_row = conn.execute("SELECT id FROM discussion_topics LIMIT 1").fetchone()
             topic_id = topic_row[0] if topic_row else 1
             for i in range(count):
+                cur = conn.execute(
+                    "INSERT INTO discussion_logs (content) VALUES (?)",
+                    (f"log_{i}",),
+                )
                 conn.execute(
-                    "INSERT INTO discussion_logs (topic_id, content) VALUES (?, ?)",
-                    (topic_id, f"log_{i}"),
+                    "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                    "VALUES ('log', ?, 'topic', ?, 'belongs_to')",
+                    (cur.lastrowid, topic_id),
                 )
         elif table == "activities":
             for i in range(count):

--- a/tests/integration/test_relation_service.py
+++ b/tests/integration/test_relation_service.py
@@ -786,21 +786,31 @@ class TestMaterialRelations:
 
 
 def _create_decision(conn, topic_id, title="Test Decision"):
-    """テスト用decisionを作成する"""
+    """テスト用decisionを作成する。親 topic との紐付けは relations.belongs_to で表現"""
     cursor = conn.execute(
-        "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
-        (topic_id, title, f"Reason for {title}"),
+        "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+        (title, f"Reason for {title}"),
     )
-    return cursor.lastrowid
+    decision_id = cursor.lastrowid
+    conn.execute(
+        "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES ('decision', ?, 'topic', ?, 'belongs_to')",
+        (decision_id, topic_id),
+    )
+    return decision_id
 
 
 def _create_log(conn, topic_id, title="Test Log"):
-    """テスト用discussion_logを作成する"""
+    """テスト用discussion_logを作成する。親 topic との紐付けは relations.belongs_to で表現"""
     cursor = conn.execute(
-        "INSERT INTO discussion_logs (topic_id, content) VALUES (?, ?)",
-        (topic_id, f"Content for {title}"),
+        "INSERT INTO discussion_logs (content) VALUES (?)",
+        (f"Content for {title}",),
     )
-    return cursor.lastrowid
+    log_id = cursor.lastrowid
+    conn.execute(
+        "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES ('log', ?, 'topic', ?, 'belongs_to')",
+        (log_id, topic_id),
+    )
+    return log_id
 
 
 @pytest.fixture
@@ -859,7 +869,8 @@ class TestNewEntityTypeRelations:
     def test_topic_decision_related(self, entities_with_decision_log):
         """topic↔decisionのrelatedリレーションが追加できる"""
         e = entities_with_decision_log
-        result = add_relation("topic", e["t1"], [{"type": "decision", "ids": [e["d1"]]}])
+        # d1 は fixture で t1 に belongs_to 済みなので、未紐付の (t2, d1) で検証する
+        result = add_relation("topic", e["t2"], [{"type": "decision", "ids": [e["d1"]]}])
         assert "error" not in result
         assert result["added"] == 1
 
@@ -880,7 +891,8 @@ class TestNewEntityTypeRelations:
     def test_log_topic_related(self, entities_with_decision_log):
         """log→topicのrelatedリレーション（逆方向指定）が追加できる"""
         e = entities_with_decision_log
-        result = add_relation("log", e["l1"], [{"type": "topic", "ids": [e["t1"]]}])
+        # l1 は fixture で t1 に belongs_to 済みなので、未紐付の (l1, t2) で検証する
+        result = add_relation("log", e["l1"], [{"type": "topic", "ids": [e["t2"]]}])
         assert "error" not in result
         assert result["added"] == 1
 

--- a/tests/test_migrations/test_0035_drop_pinned_columns.py
+++ b/tests/test_migrations/test_0035_drop_pinned_columns.py
@@ -50,6 +50,32 @@ def db_before_0035():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
+@pytest.fixture
+def migrated_db_up_to_0035():
+    """0035までのmigrationを適用したDBを提供する。
+
+    後続 migration（0046/0047 等）で decisions.topic_id / discussion_logs.topic_id が
+    物理削除されるため、0035 直後の「topic_id NOT NULL FK が残っている」状態を
+    検証するテストはここを使う。
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        up_to_0035 = MigrationList([m for m in all_migs if m.id < "0036"])
+        with backend.lock():
+            backend.apply_migrations(up_to_0035)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
 def _apply_migration_0035(db_path: str) -> None:
     """db_pathに対してmigration 0035のみを適用する。"""
     parsed = parse_uri(f"sqlite:///{db_path}")
@@ -157,7 +183,7 @@ class TestPinnedColumnsDropped:
 class TestOtherColumnsUnaffected:
     """0035でDROPされるべきでないカラムへの影響がないことの確認"""
 
-    def test_discussion_logs_other_columns_intact(self, migrated_db):
+    def test_discussion_logs_other_columns_intact(self, migrated_db_up_to_0035):
         """0035適用後、discussion_logsのid/title/content/topic_id/retracted_atカラムが保持される"""
         conn = get_connection()
         try:
@@ -169,7 +195,7 @@ class TestOtherColumnsUnaffected:
         finally:
             conn.close()
 
-    def test_decisions_other_columns_intact(self, migrated_db):
+    def test_decisions_other_columns_intact(self, migrated_db_up_to_0035):
         """0035適用後、decisionsのid/decision/reason/topic_id/retracted_atカラムが保持される"""
         conn = get_connection()
         try:
@@ -208,7 +234,7 @@ class TestOtherColumnsUnaffected:
 class TestDataIntegrity:
     """0035適用後のデータ操作確認"""
 
-    def test_insert_discussion_log_without_pinned(self, migrated_db):
+    def test_insert_discussion_log_without_pinned(self, migrated_db_up_to_0035):
         """0035適用後、discussion_logsにpinned列なしでINSERTできる"""
         conn = get_connection()
         try:
@@ -234,7 +260,7 @@ class TestDataIntegrity:
         finally:
             conn.close()
 
-    def test_insert_decision_without_pinned(self, migrated_db):
+    def test_insert_decision_without_pinned(self, migrated_db_up_to_0035):
         """0035適用後、decisionsにpinned列なしでINSERTできる"""
         conn = get_connection()
         try:

--- a/tests/test_migrations/test_0037_add_decisions_title.py
+++ b/tests/test_migrations/test_0037_add_decisions_title.py
@@ -52,6 +52,32 @@ def db_before_0037():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
+@pytest.fixture
+def migrated_db_up_to_0037():
+    """0037までのmigrationを適用したDBを提供する。
+
+    後続 migration（0046/0047 等）で decisions.topic_id が物理削除されるため、
+    0037 直後の「title 列追加と search_index トリガが topic_id 前提で動く」状態を
+    検証するテストはここを使う。
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        up_to_0037 = MigrationList([m for m in all_migs if m.id < "0038"])
+        with backend.lock():
+            backend.apply_migrations(up_to_0037)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
 def _apply_migration_0037(db_path: str) -> None:
     """db_pathに対してmigration 0037のみを適用する。"""
     parsed = parse_uri(f"sqlite:///{db_path}")
@@ -100,7 +126,7 @@ class TestTitleColumnAdded:
         finally:
             conn.close()
 
-    def test_other_columns_intact_after_0037(self, migrated_db):
+    def test_other_columns_intact_after_0037(self, migrated_db_up_to_0037):
         """0037適用後、decisionsのid/topic_id/decision/reason/created_at/retracted_atが保持される"""
         conn = get_connection()
         try:
@@ -143,7 +169,7 @@ class TestTitleColumnAdded:
 class TestSearchIndexTitleFallback:
     """search_index投入トリガーが title優先のdisplay titleを格納する確認"""
 
-    def test_insert_decision_with_title_indexes_title(self, migrated_db):
+    def test_insert_decision_with_title_indexes_title(self, migrated_db_up_to_0037):
         """titleを指定したdecisionのsearch_index.titleがtitleになる"""
         conn = get_connection()
         try:
@@ -168,7 +194,7 @@ class TestSearchIndexTitleFallback:
         finally:
             conn.close()
 
-    def test_insert_decision_without_title_falls_back_to_decision(self, migrated_db):
+    def test_insert_decision_without_title_falls_back_to_decision(self, migrated_db_up_to_0037):
         """title未指定のdecisionのsearch_index.titleがdecision本文にfallbackする"""
         conn = get_connection()
         try:
@@ -193,7 +219,7 @@ class TestSearchIndexTitleFallback:
         finally:
             conn.close()
 
-    def test_update_decision_title_updates_search_index(self, migrated_db):
+    def test_update_decision_title_updates_search_index(self, migrated_db_up_to_0037):
         """decisionのtitleを後からUPDATEするとsearch_index.titleも追従する"""
         conn = get_connection()
         try:
@@ -222,7 +248,7 @@ class TestSearchIndexTitleFallback:
         finally:
             conn.close()
 
-    def test_fts_body_still_matches_decision_text(self, migrated_db):
+    def test_fts_body_still_matches_decision_text(self, migrated_db_up_to_0037):
         """title指定decisionでも、FTSは decision本文/reason で全文検索できる（マッチ用indexは不変）"""
         conn = get_connection()
         try:

--- a/tests/test_migrations/test_0046_relations_belongs_to_unify.py
+++ b/tests/test_migrations/test_0046_relations_belongs_to_unify.py
@@ -1,0 +1,465 @@
+"""migration 0046_relations_belongs_to_unify のテスト
+
+0046 適用前後で以下が成立することを検証する:
+
+- relations の CHECK 制約が 'related' + 'belongs_to' の両方を受け付ける
+- partial index 2 本 (idx_relations_belongs_to_tgt / idx_relations_belongs_to_src) が貼られる
+- 既存 decisions/discussion_logs の topic_id が relations.belongs_to に複製される
+- 既存 material/activity → topic の 'related' 行が 'belongs_to' に変換される
+- decisions/discussion_logs の topic_id 列が NULLABLE 化されている (0046 適用後)
+- 関連トリガー (search_index 3 本 + CASCADE 3 本) が再作成されている
+
+0047 で topic_id が物理削除されるため、本テストは「0046 までを適用した中間状態」を
+yoyo MigrationList の部分適用パターンで再現して検証する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend
+
+
+@pytest.fixture
+def db_before_0046():
+    """0045 まで適用した DB を提供する (relations CHECK は 'related' 固定の状態)。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0046 = MigrationList([m for m in all_migs if m.id < "0046"])
+        with backend.lock():
+            backend.apply_migrations(pre_0046)
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_up_to_0046():
+    """0046 まで適用した DB を提供する (0047 未適用なので topic_id 列は NULLABLE で残置)。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        up_to_0046 = MigrationList([m for m in all_migs if m.id < "0047"])
+        with backend.lock():
+            backend.apply_migrations(up_to_0046)
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_0046(db_path: str) -> None:
+    """db_before_0046 fixture を 0046 まで進める"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0046 = MigrationList([m for m in all_migs if m.id < "0047" and not m.id.startswith("0045_")])
+    with backend.lock():
+        backend.apply_migrations([m for m in all_migs if m.id.startswith("0046_")])
+
+
+class TestSchemaChanges:
+    """0046 適用後のスキーマ変更を検証"""
+
+    def test_relations_check_allows_belongs_to(self, db_up_to_0046):
+        """relations CHECK 制約が 'belongs_to' を受け付ける"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            # topic を 1 件挿入
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            # decision を 1 件挿入 (topic_id 不要)
+            conn.execute("INSERT INTO decisions (decision, reason) VALUES ('d', 'r')")
+            dec_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            # belongs_to で relations 行を INSERT — CHECK を通れば成功
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('decision', ?, 'topic', ?, 'belongs_to')",
+                (dec_id, topic_id),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT relation_type FROM relations WHERE source_id = ?",
+                (dec_id,),
+            ).fetchone()
+            assert row[0] == "belongs_to"
+        finally:
+            conn.close()
+
+    def test_relations_check_rejects_unknown_type(self, db_up_to_0046):
+        """relations CHECK 制約が 'related'/'belongs_to' 以外を拒否する"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                    "VALUES ('topic', 1, 'activity', 2, 'depends_on')"
+                )
+        finally:
+            conn.close()
+
+    def test_partial_indexes_created(self, db_up_to_0046):
+        """partial index 2 本が作成されている"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='relations' "
+                "AND name IN ('idx_relations_belongs_to_tgt', 'idx_relations_belongs_to_src')"
+            ).fetchall()
+            names = {r[0] for r in rows}
+            assert names == {"idx_relations_belongs_to_tgt", "idx_relations_belongs_to_src"}
+
+            # WHERE 句に relation_type='belongs_to' が含まれていることを sql 文字列で確認
+            for name in names:
+                sql = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE name=?", (name,)
+                ).fetchone()[0]
+                assert "WHERE relation_type" in sql and "belongs_to" in sql
+        finally:
+            conn.close()
+
+    def test_decisions_topic_id_nullable(self, db_up_to_0046):
+        """0046 適用後 decisions.topic_id が NULLABLE になっている (NULL で INSERT 可)"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            # topic_id を指定せず INSERT 成功すれば NULLABLE
+            conn.execute("INSERT INTO decisions (decision, reason) VALUES ('d', 'r')")
+            conn.commit()
+            row = conn.execute(
+                "SELECT topic_id FROM decisions ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            assert row[0] is None
+        finally:
+            conn.close()
+
+    def test_discussion_logs_topic_id_nullable(self, db_up_to_0046):
+        """0046 適用後 discussion_logs.topic_id が NULLABLE になっている"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            conn.execute("INSERT INTO discussion_logs (title, content) VALUES ('t', 'c')")
+            conn.commit()
+            row = conn.execute(
+                "SELECT topic_id FROM discussion_logs ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            assert row[0] is None
+        finally:
+            conn.close()
+
+
+class TestDataMigration:
+    """既存データが正しく relations.belongs_to に移行されることを検証"""
+
+    def test_decisions_topic_id_replicated_to_belongs_to(self, db_before_0046):
+        """0046 適用前にあった decisions.topic_id が relations.belongs_to に複製される"""
+        # まず 0045 までの状態で decision を作る
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO decisions (topic_id, decision, reason) VALUES (?, ?, ?)",
+                (topic_id, "old decision", "old reason"),
+            )
+            dec_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.commit()
+        finally:
+            conn.close()
+
+        # 0046 を適用
+        parsed = parse_uri(f"sqlite:///{db_before_0046}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        only_0046 = MigrationList([m for m in all_migs if m.id.startswith("0046_")])
+        with backend.lock():
+            backend.apply_migrations(only_0046)
+
+        # relations に belongs_to が登録されている
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            row = conn.execute(
+                "SELECT relation_type FROM relations "
+                "WHERE source_type='decision' AND source_id=? AND target_type='topic' AND target_id=?",
+                (dec_id, topic_id),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "belongs_to"
+        finally:
+            conn.close()
+
+    def test_logs_topic_id_replicated_to_belongs_to(self, db_before_0046):
+        """0046 適用前にあった discussion_logs.topic_id が relations.belongs_to に複製される"""
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO discussion_logs (topic_id, content) VALUES (?, ?)",
+                (topic_id, "old log content"),
+            )
+            log_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.commit()
+        finally:
+            conn.close()
+
+        parsed = parse_uri(f"sqlite:///{db_before_0046}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        only_0046 = MigrationList([m for m in all_migs if m.id.startswith("0046_")])
+        with backend.lock():
+            backend.apply_migrations(only_0046)
+
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            row = conn.execute(
+                "SELECT relation_type FROM relations "
+                "WHERE source_type='log' AND source_id=? AND target_type='topic' AND target_id=?",
+                (log_id, topic_id),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "belongs_to"
+        finally:
+            conn.close()
+
+    def test_material_topic_related_converted_to_belongs_to(self, db_before_0046):
+        """0046 適用前の material→topic 'related' が 'belongs_to' に変換される"""
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("INSERT INTO materials (title, content) VALUES ('m', 'c')")
+            mat_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            # material < topic で正規化、'related' で書き込み
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('material', ?, 'topic', ?, 'related')",
+                (mat_id, topic_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        parsed = parse_uri(f"sqlite:///{db_before_0046}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        only_0046 = MigrationList([m for m in all_migs if m.id.startswith("0046_")])
+        with backend.lock():
+            backend.apply_migrations(only_0046)
+
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            row = conn.execute(
+                "SELECT relation_type FROM relations "
+                "WHERE source_type='material' AND source_id=? AND target_type='topic' AND target_id=?",
+                (mat_id, topic_id),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "belongs_to"
+        finally:
+            conn.close()
+
+    def test_activity_topic_related_converted_to_belongs_to(self, db_before_0046):
+        """0046 適用前の activity→topic 'related' が 'belongs_to' に変換される"""
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES ('a', 'd', 'pending')"
+            )
+            act_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('activity', ?, 'topic', ?, 'related')",
+                (act_id, topic_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        parsed = parse_uri(f"sqlite:///{db_before_0046}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        only_0046 = MigrationList([m for m in all_migs if m.id.startswith("0046_")])
+        with backend.lock():
+            backend.apply_migrations(only_0046)
+
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            row = conn.execute(
+                "SELECT relation_type FROM relations "
+                "WHERE source_type='activity' AND source_id=? AND target_type='topic' AND target_id=?",
+                (act_id, topic_id),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "belongs_to"
+        finally:
+            conn.close()
+
+    def test_non_parent_related_rows_preserved(self, db_before_0046):
+        """activity-material や activity-activity 等の非親帰属 'related' 行は据置される"""
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES ('a1', 'd', 'pending')"
+            )
+            a1 = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES ('a2', 'd', 'pending')"
+            )
+            a2 = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("INSERT INTO materials (title, content) VALUES ('m', 'c')")
+            mat = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            # activity-activity 'related'
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('activity', ?, 'activity', ?, 'related')",
+                (min(a1, a2), max(a1, a2)),
+            )
+            # activity-material 'related'
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('activity', ?, 'material', ?, 'related')",
+                (a1, mat),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        parsed = parse_uri(f"sqlite:///{db_before_0046}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        only_0046 = MigrationList([m for m in all_migs if m.id.startswith("0046_")])
+        with backend.lock():
+            backend.apply_migrations(only_0046)
+
+        conn = sqlite3.connect(db_before_0046)
+        try:
+            # どちらも 'related' のまま (target_type != 'topic' なので変換対象外)
+            rows = conn.execute(
+                "SELECT relation_type FROM relations "
+                "WHERE (source_type='activity' AND target_type='activity') "
+                "   OR (source_type='activity' AND target_type='material')"
+            ).fetchall()
+            assert len(rows) == 2
+            assert all(r[0] == "related" for r in rows)
+        finally:
+            conn.close()
+
+
+class TestTriggersRecreated:
+    """テーブル再作成で削除されたトリガー群が再作成されていることを検証"""
+
+    def test_decisions_search_index_trigger(self, db_up_to_0046):
+        """decisions INSERT で search_index に行が入る (再作成 trigger 経由)"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            conn.execute("INSERT INTO decisions (decision, reason, title) VALUES ('d', 'r', 't')")
+            dec_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            row = conn.execute(
+                "SELECT title FROM search_index WHERE source_type='decision' AND source_id=?",
+                (dec_id,),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "t"
+        finally:
+            conn.close()
+
+    def test_decisions_cascade_trigger_relations(self, db_up_to_0046):
+        """decisions DELETE で relations が cascade される"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("INSERT INTO decisions (decision, reason) VALUES ('d', 'r')")
+            dec_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('decision', ?, 'topic', ?, 'belongs_to')",
+                (dec_id, topic_id),
+            )
+            conn.execute("DELETE FROM decisions WHERE id = ?", (dec_id,))
+            row = conn.execute(
+                "SELECT COUNT(*) FROM relations WHERE source_type='decision' AND source_id=?",
+                (dec_id,),
+            ).fetchone()
+            assert row[0] == 0
+        finally:
+            conn.close()
+
+    def test_logs_search_index_trigger(self, db_up_to_0046):
+        """discussion_logs INSERT で search_index に行が入る"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            conn.execute("INSERT INTO discussion_logs (title, content) VALUES ('lt', 'lc')")
+            log_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            row = conn.execute(
+                "SELECT title FROM search_index WHERE source_type='log' AND source_id=?",
+                (log_id,),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "lt"
+        finally:
+            conn.close()
+
+    def test_logs_cascade_trigger_relations(self, db_up_to_0046):
+        """discussion_logs DELETE で relations が cascade される"""
+        conn = sqlite3.connect(db_up_to_0046)
+        try:
+            conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
+            topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("INSERT INTO discussion_logs (content) VALUES ('lc')")
+            log_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute(
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+                "VALUES ('log', ?, 'topic', ?, 'belongs_to')",
+                (log_id, topic_id),
+            )
+            conn.execute("DELETE FROM discussion_logs WHERE id = ?", (log_id,))
+            row = conn.execute(
+                "SELECT COUNT(*) FROM relations WHERE source_type='log' AND source_id=?",
+                (log_id,),
+            ).fetchone()
+            assert row[0] == 0
+        finally:
+            conn.close()
+
+
+class TestMigration0047:
+    """0047 適用後、topic_id 列が物理削除されることを検証"""
+
+    def test_decisions_topic_id_dropped(self):
+        """0047 適用後、decisions.topic_id 列が存在しない"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            os.environ["DISCUSSION_DB_PATH"] = db_path
+            try:
+                parsed = parse_uri(f"sqlite:///{db_path}")
+                backend = _VecSQLiteBackend(parsed, default_migration_table)
+                backend.init_database()
+                all_migs = read_migrations(str(MIGRATIONS_DIR))
+                with backend.lock():
+                    backend.apply_migrations(all_migs)
+
+                conn = sqlite3.connect(db_path)
+                try:
+                    cols = [r[1] for r in conn.execute("PRAGMA table_info(decisions)").fetchall()]
+                    assert "topic_id" not in cols
+                    cols = [r[1] for r in conn.execute("PRAGMA table_info(discussion_logs)").fetchall()]
+                    assert "topic_id" not in cols
+                finally:
+                    conn.close()
+            finally:
+                if "DISCUSSION_DB_PATH" in os.environ:
+                    del os.environ["DISCUSSION_DB_PATH"]

--- a/tests/test_migrations/test_0046_relations_belongs_to_unify.py
+++ b/tests/test_migrations/test_0046_relations_belongs_to_unify.py
@@ -60,16 +60,6 @@ def db_up_to_0046():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
-def _apply_0046(db_path: str) -> None:
-    """db_before_0046 fixture を 0046 まで進める"""
-    parsed = parse_uri(f"sqlite:///{db_path}")
-    backend = _VecSQLiteBackend(parsed, default_migration_table)
-    all_migs = read_migrations(str(MIGRATIONS_DIR))
-    only_0046 = MigrationList([m for m in all_migs if m.id < "0047" and not m.id.startswith("0045_")])
-    with backend.lock():
-        backend.apply_migrations([m for m in all_migs if m.id.startswith("0046_")])
-
-
 class TestSchemaChanges:
     """0046 適用後のスキーマ変更を検証"""
 
@@ -99,13 +89,15 @@ class TestSchemaChanges:
             conn.close()
 
     def test_relations_check_rejects_unknown_type(self, db_up_to_0046):
-        """relations CHECK 制約が 'related'/'belongs_to' 以外を拒否する"""
+        """relations CHECK 制約が 'related'/'belongs_to' 以外を拒否する。
+        正規化制約 ('activity' < 'topic') はパスし、relation_type CHECK のみで失敗することを担保する。
+        """
         conn = sqlite3.connect(db_up_to_0046)
         try:
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="relation_type"):
                 conn.execute(
                     "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
-                    "VALUES ('topic', 1, 'activity', 2, 'depends_on')"
+                    "VALUES ('activity', 1, 'topic', 2, 'depends_on')"
                 )
         finally:
             conn.close()

--- a/tests/unit/test_batch_logs_decisions.py
+++ b/tests/unit/test_batch_logs_decisions.py
@@ -655,11 +655,16 @@ class TestSavepointAtomicity:
         assert len(result["errors"]) == 1
         assert result["errors"][0]["index"] == 1
 
-        # DBに2件だけ存在することを確認
+        # DBに2件だけ存在することを確認 (親 topic は relations.belongs_to 経由)
         conn = get_connection()
         try:
             rows = conn.execute(
-                "SELECT COUNT(*) FROM discussion_logs WHERE topic_id = ?",
+                """
+                SELECT COUNT(*) FROM discussion_logs l
+                JOIN relations r ON r.source_type='log' AND r.source_id=l.id
+                                AND r.target_type='topic' AND r.relation_type='belongs_to'
+                                AND r.target_id = ?
+                """,
                 (tid,),
             ).fetchone()
             assert rows[0] == 2
@@ -681,7 +686,12 @@ class TestSavepointAtomicity:
         conn = get_connection()
         try:
             rows = conn.execute(
-                "SELECT COUNT(*) FROM decisions WHERE topic_id = ?",
+                """
+                SELECT COUNT(*) FROM decisions d
+                JOIN relations r ON r.source_type='decision' AND r.source_id=d.id
+                                AND r.target_type='topic' AND r.relation_type='belongs_to'
+                                AND r.target_id = ?
+                """,
                 (tid,),
             ).fetchone()
             assert rows[0] == 2

--- a/tests/unit/test_fts5_sync_service.py
+++ b/tests/unit/test_fts5_sync_service.py
@@ -351,8 +351,8 @@ def test_runtime_sync_decision_display_title_null(temp_db):
         conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t', 'd')")
         topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         conn.execute(
-            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, NULL)",
-            (topic_id, "決定本文 uniqdectoken", "理由 uniqreasontoken"),
+            "INSERT INTO decisions (decision, reason, title) VALUES (?, ?, NULL)",
+            ("決定本文 uniqdectoken", "理由 uniqreasontoken"),
         )
         d_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -382,8 +382,8 @@ def test_runtime_sync_decision_display_title_set(temp_db):
         conn.execute("INSERT INTO discussion_topics (title, description) VALUES ('t2', 'd2')")
         topic_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         conn.execute(
-            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, ?, ?, ?)",
-            (topic_id, "本文タイトルではない", "理由本文", "短いタイトル uniqshort"),
+            "INSERT INTO decisions (decision, reason, title) VALUES (?, ?, ?)",
+            ("本文タイトルではない", "理由本文", "短いタイトル uniqshort"),
         )
         d_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -411,10 +411,9 @@ def test_runtime_sync_all_specs_after_install_all(temp_db):
         conn.execute(
             "INSERT INTO activities (title, description, status) VALUES ('act uniqA003', 'desc uniqA004', 'in_progress')"
         )
-        # log (discussion_logs requires topic_id)
+        # log (親 topic との紐付けは relations.belongs_to に移行済み、topic_id カラムは廃止)
         conn.execute(
-            "INSERT INTO discussion_logs (topic_id, title, content) VALUES (?, 'log uniqA005', 'cont uniqA006')",
-            (topic_id,),
+            "INSERT INTO discussion_logs (title, content) VALUES ('log uniqA005', 'cont uniqA006')"
         )
         # material
         conn.execute(
@@ -422,8 +421,7 @@ def test_runtime_sync_all_specs_after_install_all(temp_db):
         )
         # decision
         conn.execute(
-            "INSERT INTO decisions (topic_id, decision, reason, title) VALUES (?, 'dec uniqA009', 'rea uniqA010', NULL)",
-            (topic_id,),
+            "INSERT INTO decisions (decision, reason, title) VALUES ('dec uniqA009', 'rea uniqA010', NULL)"
         )
 
         for token in [

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -23,6 +23,58 @@ from src.services.tag_service import _injected_tags
 DEFAULT_TAGS = ["domain:test"]
 
 
+def _insert_log(conn, topic_id, content, title, created_at=None):
+    """discussion_logsに直接INSERTし、relations.belongs_toも併せて作成するヘルパー。"""
+    if created_at is not None:
+        cur = conn.execute(
+            "INSERT INTO discussion_logs (content, title, created_at) VALUES (?, ?, ?)",
+            (content, title, created_at),
+        )
+    else:
+        cur = conn.execute(
+            "INSERT INTO discussion_logs (content, title) VALUES (?, ?)",
+            (content, title),
+        )
+    log_id = cur.lastrowid
+    conn.execute(
+        "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+        "VALUES ('log', ?, 'topic', ?, 'belongs_to')",
+        (log_id, topic_id),
+    )
+    return log_id
+
+
+def _insert_decision(conn, topic_id, decision, reason, created_at=None, decision_id=None):
+    """decisionsに直接INSERTし、relations.belongs_toも併せて作成するヘルパー。"""
+    if decision_id is not None and created_at is not None:
+        cur = conn.execute(
+            "INSERT INTO decisions (id, decision, reason, created_at) VALUES (?, ?, ?, ?)",
+            (decision_id, decision, reason, created_at),
+        )
+    elif decision_id is not None:
+        cur = conn.execute(
+            "INSERT INTO decisions (id, decision, reason) VALUES (?, ?, ?)",
+            (decision_id, decision, reason),
+        )
+    elif created_at is not None:
+        cur = conn.execute(
+            "INSERT INTO decisions (decision, reason, created_at) VALUES (?, ?, ?)",
+            (decision, reason, created_at),
+        )
+    else:
+        cur = conn.execute(
+            "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+            (decision, reason),
+        )
+    did = decision_id if decision_id is not None else cur.lastrowid
+    conn.execute(
+        "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) "
+        "VALUES ('decision', ?, 'topic', ?, 'belongs_to')",
+        (did, topic_id),
+    )
+    return did
+
+
 @pytest.fixture
 def temp_db():
     """テスト用の一時的なデータベースを作成する"""
@@ -292,14 +344,8 @@ class TestPagination:
         # 異なるcreated_atを持つデータを作成
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "古いログ", "古いログ", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "新しいログ", "新しいログ", "2025-06-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "古いログ", "古いログ", "2025-01-01 00:00:00")
+            _insert_log(conn, tid, "新しいログ", "新しいログ", "2025-06-01 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -316,18 +362,9 @@ class TestPagination:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ1", "ログ1", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ2", "ログ2", "2025-03-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ3", "ログ3", "2025-06-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "ログ1", "ログ1", "2025-01-01 00:00:00")
+            _insert_log(conn, tid, "ログ2", "ログ2", "2025-03-01 00:00:00")
+            _insert_log(conn, tid, "ログ3", "ログ3", "2025-06-01 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -343,10 +380,7 @@ class TestPagination:
         conn = get_connection()
         try:
             for i in range(5):
-                conn.execute(
-                    "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                    (tid, f"ログ{i}", f"ログ{i}", f"2025-01-0{i+1} 00:00:00"),
-                )
+                _insert_log(conn, tid, f"ログ{i}", f"ログ{i}", f"2025-01-0{i+1} 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -365,14 +399,8 @@ class TestSortOrder:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "古い", "古いログ", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "新しい", "新しいログ", "2025-06-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "古い", "古いログ", "2025-01-01 00:00:00")
+            _insert_log(conn, tid, "新しい", "新しいログ", "2025-06-01 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -387,14 +415,8 @@ class TestSortOrder:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "古い", "古いログ", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "新しい", "新しいログ", "2025-06-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "古い", "古いログ", "2025-01-01 00:00:00")
+            _insert_log(conn, tid, "新しい", "新しいログ", "2025-06-01 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -419,10 +441,7 @@ class TestLimitClamping:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title) VALUES (?, ?, ?)",
-                (tid, "ログ内容", "テストログ"),
-            )
+            _insert_log(conn, tid, "ログ内容", "テストログ")
             conn.commit()
         finally:
             conn.close()
@@ -442,10 +461,7 @@ class TestTotalCount:
         conn = get_connection()
         try:
             for i in range(10):
-                conn.execute(
-                    "INSERT INTO discussion_logs (topic_id, content, title) VALUES (?, ?, ?)",
-                    (tid, f"ログ{i}", f"ログ{i}"),
-                )
+                _insert_log(conn, tid, f"ログ{i}", f"ログ{i}")
             conn.commit()
         finally:
             conn.close()
@@ -468,18 +484,9 @@ class TestTotalCount:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ1", "ログ1", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ2", "ログ2", "2025-06-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO decisions (topic_id, decision, reason, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "決定1", "理由1", "2025-03-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "ログ1", "ログ1", "2025-01-01 00:00:00")
+            _insert_log(conn, tid, "ログ2", "ログ2", "2025-06-01 00:00:00")
+            _insert_decision(conn, tid, "決定1", "理由1", "2025-03-01 00:00:00")
             conn.commit()
         finally:
             conn.close()
@@ -567,14 +574,8 @@ class TestMixedTimeline:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO discussion_logs (topic_id, content, title, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "ログ", "ログA", "2025-01-01 00:00:00"),
-            )
-            conn.execute(
-                "INSERT INTO decisions (topic_id, decision, reason, created_at) VALUES (?, ?, ?, ?)",
-                (tid, "決定B", "理由", "2025-02-01 00:00:00"),
-            )
+            _insert_log(conn, tid, "ログ", "ログA", "2025-01-01 00:00:00")
+            _insert_decision(conn, tid, "決定B", "理由", "2025-02-01 00:00:00")
             # material: relationsテーブルを直接作成（正規化: 'material' < 'topic'）
             cursor = conn.execute(
                 "INSERT INTO materials (title, content, source, created_at) VALUES (?, ?, ?, ?)",
@@ -582,7 +583,7 @@ class TestMixedTimeline:
             )
             mat_id = cursor.lastrowid
             conn.execute(
-                "INSERT INTO relations (source_type, source_id, target_type, target_id) VALUES ('material', ?, 'topic', ?)",
+                "INSERT INTO relations (source_type, source_id, target_type, target_id, relation_type) VALUES ('material', ?, 'topic', ?, 'belongs_to')",
                 (mat_id, tid),
             )
             conn.commit()
@@ -608,14 +609,8 @@ class TestSupersedes:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (1001, tid, "旧決定", "理由"),
-            )
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (1002, tid, "新決定", "理由"),
-            )
+            _insert_decision(conn, tid, "旧決定", "理由", decision_id=1001)
+            _insert_decision(conn, tid, "新決定", "理由", decision_id=1002)
             conn.execute(
                 "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
                 (1002, 1001),
@@ -641,14 +636,8 @@ class TestSupersedes:
 
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (2001, tid, "旧決定", "理由"),
-            )
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (2002, tid, "新決定", "理由"),
-            )
+            _insert_decision(conn, tid, "旧決定", "理由", decision_id=2001)
+            _insert_decision(conn, tid, "新決定", "理由", decision_id=2002)
             conn.execute(
                 "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
                 (2002, 2001),
@@ -674,14 +663,8 @@ class TestSupersedes:
         # supersedes関係のあるdecisionを作成
         conn = get_connection()
         try:
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (3001, tid, "旧決定", "理由"),
-            )
-            conn.execute(
-                "INSERT INTO decisions (id, topic_id, decision, reason) VALUES (?, ?, ?, ?)",
-                (3002, tid, "新決定", "理由"),
-            )
+            _insert_decision(conn, tid, "旧決定", "理由", decision_id=3001)
+            _insert_decision(conn, tid, "新決定", "理由", decision_id=3002)
             conn.execute(
                 "INSERT INTO decision_supersedes (source_id, target_id) VALUES (?, ?)",
                 (3002, 3001),

--- a/tests/unit/test_topic_write.py
+++ b/tests/unit/test_topic_write.py
@@ -390,15 +390,26 @@ def test_add_decision_without_tags(temp_db):
 
 
 def test_add_decision_without_topic(temp_db):
-    """topic_id=Noneで決定事項を追加するとCONSTRAINT_VIOLATIONが返る"""
+    """topic_id=Noneでもdecisionは作成できる（relations.belongs_toが登録されない）"""
     result = add_decision(
         decision="グローバルな決定事項",
         reason="サブジェクト全体に関わる",
         topic_id=None,
     )
 
-    assert "error" in result
-    assert result["error"]["code"] == "CONSTRAINT_VIOLATION"
+    assert "error" not in result
+    assert "decision_id" in result
+    # relations.belongs_to が登録されていないことを確認
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM relations WHERE source_type='decision' AND source_id=? "
+            "AND target_type='topic' AND relation_type='belongs_to'",
+            (result["decision_id"],),
+        ).fetchone()
+        assert row[0] == 0
+    finally:
+        conn.close()
 
 
 def test_add_decision_multiple(temp_db):
@@ -437,11 +448,17 @@ def _delete_topic(topic_id: int) -> None:
 
 
 def _count_decisions(topic_id: int) -> int:
-    """テスト用: 指定トピックのdecisions件数を返すヘルパー"""
+    """テスト用: 指定トピックのdecisions件数を返すヘルパー (relations.belongs_to 経由)"""
     conn = get_connection()
     try:
         cursor = conn.execute(
-            "SELECT COUNT(*) FROM decisions WHERE topic_id = ?", (topic_id,)
+            """
+            SELECT COUNT(*) FROM decisions d
+            JOIN relations r ON r.source_type='decision' AND r.source_id=d.id
+                            AND r.target_type='topic' AND r.relation_type='belongs_to'
+                            AND r.target_id = ?
+            """,
+            (topic_id,),
         )
         return cursor.fetchone()[0]
     finally:
@@ -449,11 +466,17 @@ def _count_decisions(topic_id: int) -> int:
 
 
 def _count_logs(topic_id: int) -> int:
-    """テスト用: 指定トピックのdiscussion_logs件数を返すヘルパー"""
+    """テスト用: 指定トピックのdiscussion_logs件数を返すヘルパー (relations.belongs_to 経由)"""
     conn = get_connection()
     try:
         cursor = conn.execute(
-            "SELECT COUNT(*) FROM discussion_logs WHERE topic_id = ?", (topic_id,)
+            """
+            SELECT COUNT(*) FROM discussion_logs l
+            JOIN relations r ON r.source_type='log' AND r.source_id=l.id
+                            AND r.target_type='topic' AND r.relation_type='belongs_to'
+                            AND r.target_id = ?
+            """,
+            (topic_id,),
         )
         return cursor.fetchone()[0]
     finally:


### PR DESCRIPTION
## Summary

decision/log は `topic_id NOT NULL FK`、material/activity は `relations` 経由、という親帰属表現の非対称を、全エンティティが `relations.relation_type='belongs_to'` で親 topic を表す形に統一する。

## 変更概要

### Migration

- **0046**: `relations` の CHECK 緩和 (`'related'` + `'belongs_to'`)、partial index 2 本追加 (belongs_to クエリ hot path 用)、既存 `decisions.topic_id` / `discussion_logs.topic_id` を `relations.belongs_to` に複製、material/activity → topic の `'related'` を全件 `'belongs_to'` に変換、decisions / discussion_logs テーブル再作成 (topic_id NULLABLE 化 + FK 削除)、関連トリガー再作成
- **0047**: `decisions.topic_id` / `discussion_logs.topic_id` カラムを物理削除

### サービス層

- `decision_service` / `discussion_log_service` の書き込みパスを belongs_to 一本化 (dual-write しない)。旧 NOT NULL FK 相当の「存在しない topic_id を弾く」挙動はアプリ層 validation で維持
- `relation_service._add_relation_with_conn` が親帰属パターン (子 → topic) を自動的に `belongs_to` に格上げ
- `search_service` (tag CTE / find_similar_decisions / get_by_id) / `timeline_service` / `checkin_service` / `topic_service` / `hint_service` / `tag_service` の `topic_id` 直接参照を全て `relations.belongs_to` JOIN 経由に書換 (partial index がヒットする形)

### 仕様変更

- `add_decisions` / `add_logs` で `topic_id=None` を渡しても作成可 (親 topic 不在を許容)。旧仕様 (NOT NULL FK で CONSTRAINT_VIOLATION) は撤廃
- `get_logs` の返却フィールド `topic_id` は entity_type='topic' のとき要求された topic_id を返す (activity 経路では belongs_to から取得した値、列カラム廃止のため)

### テスト

- 新規 `tests/test_migrations/test_0046_relations_belongs_to_unify.py` で CHECK 緩和 / partial index / NULLABLE 化 / データ移行 / トリガー再作成 / 0047 後の DROP COLUMN を検証
- 0035 / 0037 migration テストは部分適用 fixture (`migrated_db_up_to_NNNN`) に切替えて旧スキーマ前提を維持
- 既存テストの直接 SQL (`WHERE topic_id = ?` 等) を relations.belongs_to JOIN 経由に書換

## Test plan

- [x] `uv run pytest tests/` 全 2145 件 pass (うち新規 migration テスト 15 件)
- [x] migration 0046 を実 DB コピーに適用、データ整合性 (decision_count = belongs_to 件数等) を確認済
- [x] partial index 2 本が `WHERE relation_type='belongs_to'` でヒットする形
- [ ] CI 緑
- [ ] claude-review 対応

## 参考

- 性能試算: B 案 + partial index 2 本で `_build_tag_cte` 全体 +1.5ms (現規模) / +3.6ms (3x スケール)、条件付き許容
- 副たる関連 (decision/log → topic で FK と異なる relations 'related' 行) は据置 (主たる親 1 個 + 副は related の運用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)