### PR TITLE
feat: idle worker が MCP 接続喪失で self-exit する仕組みを追加

### DIFF
--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -17,6 +17,15 @@
 #                      heartbeat 停止を防ぐ。default: 15
 #   OW_CURL_CONNECT_TIMEOUT
 #                      curl の connect timeout（秒）。default: 5
+#   OW_MCP_URL         MCP server /health のURL (default: http://127.0.0.1:52837)
+#   OW_MCP_FAIL_THRESHOLD
+#                      MCP /health 連続失敗回数の閾値 (default: 5)。
+#                      これを超えると safe state の worker は self-exit する。
+#   OW_MCP_UPTIME_MIN_SEC
+#                      self-exit を発火するために必要な heartbeat プロセスの最小経過秒
+#                      (default: 300=5分)。spawn 直後の不安定期保護。
+#   OW_DISABLE_MCP_SELF_EXIT
+#                      "1" を渡すと self-exit を無効化（デバッグ・検証用）。
 
 set -euo pipefail
 
@@ -27,12 +36,20 @@ PHASE_FILE="${PHASE_FILE:-/tmp/ow_hb_phase_$$}"
 OW_PARENT_PID="${OW_PARENT_PID:-}"
 OW_CURL_TIMEOUT="${OW_CURL_TIMEOUT:-15}"
 OW_CURL_CONNECT_TIMEOUT="${OW_CURL_CONNECT_TIMEOUT:-5}"
+OW_MCP_URL="${OW_MCP_URL:-http://127.0.0.1:52837}"
+OW_MCP_FAIL_THRESHOLD="${OW_MCP_FAIL_THRESHOLD:-5}"
+OW_MCP_UPTIME_MIN_SEC="${OW_MCP_UPTIME_MIN_SEC:-300}"
+OW_DISABLE_MCP_SELF_EXIT="${OW_DISABLE_MCP_SELF_EXIT:-0}"
+
+MCP_FAIL_COUNT_FILE="/tmp/ow-mcp-fail-$$"
+HEARTBEAT_STARTED_AT=$(date +%s)
 
 # B案: trap で PHASE_FILE を自殺時に掃除する。bg化された後の親 SIGHUP は
 # macOS デフォルトで届かないため A案(PPID watchdog) の補助にすぎないが、
 # claude が正常 exit するときの SIGTERM や、bash の自発的 EXIT には反応する。
 cleanup() {
     rm -f "$PHASE_FILE" 2>/dev/null || true
+    rm -f "$MCP_FAIL_COUNT_FILE" 2>/dev/null || true
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -46,6 +63,44 @@ parent_alive() {
         return 0  # 未指定なら無効（後方互換）
     fi
     kill -0 "$OW_PARENT_PID" 2>/dev/null
+}
+
+# MCP /health の死活確認。成功=0 / 失敗=1。
+mcp_health_check() {
+    curl -sf --connect-timeout 2 --max-time 3 "${OW_MCP_URL}/health" > /dev/null 2>&1
+}
+
+# self-exit の安全条件: w-* handle かつ PHASE=ready かつ uptime>=閾値。
+# 安全とみなせば 0、対象外なら 1 を返す。
+is_safe_for_self_exit() {
+    case "$HANDLE" in
+        w-*) ;;
+        *) return 1 ;;
+    esac
+    [ "$PHASE" = "ready" ] || return 1
+    local now=$(date +%s)
+    local elapsed=$(( now - HEARTBEAT_STARTED_AT ))
+    [ "$elapsed" -ge "$OW_MCP_UPTIME_MIN_SEC" ] || return 1
+    return 0
+}
+
+# self-exit: relay に通知してから tmux pane を kill する。
+# relay が死んでいる場合は通知失敗を許容して kill のみ進める。
+self_exit_due_to_mcp_loss() {
+    local fail_count="$1"
+    local body
+    body=$(printf '{"v":1,"kind":"event","from":"%s","to":"*","data":{"type":"self-exit","reason":"mcp-loss","fail_count":%d}}' \
+        "$HANDLE" "$fail_count")
+    curl -s -X POST \
+        --connect-timeout "$OW_CURL_CONNECT_TIMEOUT" \
+        --max-time "$OW_CURL_TIMEOUT" \
+        -H "Content-Type: application/json" \
+        -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${body}}" \
+        "${RELAY_URL}/send" > /dev/null 2>&1 || true
+    if [ -n "${TMUX_PANE:-}" ]; then
+        tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+    fi
+    exit 0
 }
 
 while [ -f "$PHASE_FILE" ] && parent_alive; do
@@ -68,6 +123,20 @@ while [ -f "$PHASE_FILE" ] && parent_alive; do
         -H "Content-Type: application/json" \
         -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${BODY}}" \
         "${RELAY_URL}/send" > /dev/null || true
+
+    # MCP /health チェックと self-exit 判定。
+    # OW_DISABLE_MCP_SELF_EXIT=1 で無効化可能。
+    if [ "$OW_DISABLE_MCP_SELF_EXIT" != "1" ]; then
+        if mcp_health_check; then
+            echo 0 > "$MCP_FAIL_COUNT_FILE"
+        else
+            n=$(( $(cat "$MCP_FAIL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+            echo "$n" > "$MCP_FAIL_COUNT_FILE"
+            if [ "$n" -ge "$OW_MCP_FAIL_THRESHOLD" ] && is_safe_for_self_exit; then
+                self_exit_due_to_mcp_loss "$n"
+            fi
+        fi
+    fi
 
     sleep "$INTERVAL"
 done

--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -24,6 +24,9 @@
 #   OW_MCP_UPTIME_MIN_SEC
 #                      self-exit を発火するために必要な heartbeat プロセスの最小経過秒
 #                      (default: 300=5分)。spawn 直後の不安定期保護。
+#   OW_MCP_CONNECT_TIMEOUT
+#                      MCP /health curl の connect timeout（秒）。default: 2
+#   OW_MCP_MAX_TIME    MCP /health curl の全体タイムアウト（秒）。default: 3
 #   OW_DISABLE_MCP_SELF_EXIT
 #                      "1" を渡すと self-exit を無効化（デバッグ・検証用）。
 
@@ -39,6 +42,8 @@ OW_CURL_CONNECT_TIMEOUT="${OW_CURL_CONNECT_TIMEOUT:-5}"
 OW_MCP_URL="${OW_MCP_URL:-http://127.0.0.1:52837}"
 OW_MCP_FAIL_THRESHOLD="${OW_MCP_FAIL_THRESHOLD:-5}"
 OW_MCP_UPTIME_MIN_SEC="${OW_MCP_UPTIME_MIN_SEC:-300}"
+OW_MCP_CONNECT_TIMEOUT="${OW_MCP_CONNECT_TIMEOUT:-2}"
+OW_MCP_MAX_TIME="${OW_MCP_MAX_TIME:-3}"
 OW_DISABLE_MCP_SELF_EXIT="${OW_DISABLE_MCP_SELF_EXIT:-0}"
 
 MCP_FAIL_COUNT_FILE="/tmp/ow-mcp-fail-$$"
@@ -67,7 +72,10 @@ parent_alive() {
 
 # MCP /health の死活確認。成功=0 / 失敗=1。
 mcp_health_check() {
-    curl -sf --connect-timeout 2 --max-time 3 "${OW_MCP_URL}/health" > /dev/null 2>&1
+    curl -sf \
+        --connect-timeout "$OW_MCP_CONNECT_TIMEOUT" \
+        --max-time "$OW_MCP_MAX_TIME" \
+        "${OW_MCP_URL}/health" > /dev/null 2>&1
 }
 
 # self-exit の安全条件: w-* handle かつ PHASE=ready かつ uptime>=閾値。
@@ -78,8 +86,12 @@ is_safe_for_self_exit() {
         *) return 1 ;;
     esac
     [ "$PHASE" = "ready" ] || return 1
-    local now=$(date +%s)
-    local elapsed=$(( now - HEARTBEAT_STARTED_AT ))
+    # `local var=$(cmd)` は local の exit code が常に 0 になり set -e をすり抜ける。
+    # 宣言と代入は分ける。
+    local now
+    now=$(date +%s)
+    local elapsed
+    elapsed=$(( now - HEARTBEAT_STARTED_AT ))
     [ "$elapsed" -ge "$OW_MCP_UPTIME_MIN_SEC" ] || return 1
     return 0
 }
@@ -99,6 +111,14 @@ self_exit_due_to_mcp_loss() {
         "${RELAY_URL}/send" > /dev/null 2>&1 || true
     if [ -n "${TMUX_PANE:-}" ]; then
         tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+    elif [ -n "$OW_PARENT_PID" ]; then
+        # tmux pane が不明な場合は worker (claude) 本体を親PID経由で kill する。
+        # 主目的「累積メモリ解放」は worker プロセス終了で達成されるため、ここを抜くと
+        # heartbeat.sh だけ消えて worker が居残り、PR の意図を満たさなくなる。
+        echo "heartbeat.sh: TMUX_PANE unset; killing OW_PARENT_PID=$OW_PARENT_PID" >&2
+        kill -TERM "$OW_PARENT_PID" 2>/dev/null || true
+    else
+        echo "heartbeat.sh: TMUX_PANE and OW_PARENT_PID both unset; worker process will leak" >&2
     fi
     exit 0
 }

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import random
+from datetime import datetime, timezone
 from pathlib import Path
 from fastmcp import FastMCP, Context
 from fastmcp.server.dependencies import get_context
@@ -230,6 +231,9 @@ def _apply_flavor_to_snippets(items: list[dict], flavor: str) -> None:
 
 # MCPサーバーを作成
 mcp = FastMCP("cc-memory", instructions=build_instructions())
+
+# サーバー起動時刻（/health で uptime 算出に使用）
+_SERVER_STARTED_AT = datetime.now(timezone.utc)
 
 # セッション管理（HTTPモードで使用）
 _session_manager = None
@@ -1410,6 +1414,18 @@ def ow_recover(
         dry_run,
         pending_spawn_stalled_threshold_min=pending_spawn_stalled_threshold_min,
     )
+
+
+# ヘルスチェックエンドポイント（worker self-exit on MCP loss 用）
+@mcp.custom_route("/health", methods=["GET"])
+async def health(_request: Request) -> JSONResponse:
+    now = datetime.now(timezone.utc)
+    return JSONResponse({
+        "status": "ok",
+        "pid": os.getpid(),
+        "started_at": _SERVER_STARTED_AT.isoformat(),
+        "uptime_sec": int((now - _SERVER_STARTED_AT).total_seconds()),
+    })
 
 
 # セッションエンドポイント（HTTPモード用カスタムルート）

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -1,0 +1,52 @@
+"""MCP server /health エンドポイントのユニットテスト
+
+worker self-exit on MCP loss のための death judgement に使われる。
+"""
+
+import json
+import asyncio
+
+import pytest
+from starlette.requests import Request
+
+from src.main import health
+
+
+@pytest.fixture
+def fake_request():
+    """最低限の Starlette Request スタブ。/health は body も query も使わない"""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/health",
+        "headers": [],
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+class TestHealthEndpoint:
+    def test_returns_status_ok(self, fake_request):
+        response = asyncio.run(health(fake_request))
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["status"] == "ok"
+
+    def test_includes_pid(self, fake_request):
+        import os
+        response = asyncio.run(health(fake_request))
+        body = json.loads(response.body)
+        assert body["pid"] == os.getpid()
+
+    def test_includes_started_at_iso(self, fake_request):
+        from datetime import datetime
+        response = asyncio.run(health(fake_request))
+        body = json.loads(response.body)
+        # ISO 8601 としてパース可能であること
+        datetime.fromisoformat(body["started_at"])
+
+    def test_includes_nonneg_uptime(self, fake_request):
+        response = asyncio.run(health(fake_request))
+        body = json.loads(response.body)
+        assert isinstance(body["uptime_sec"], int)
+        assert body["uptime_sec"] >= 0

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -658,8 +658,11 @@ class TestHeartbeatShSelfExit:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        # 1回失敗した段階で MCP 復活
-        time.sleep(0.1)
+        # 1〜2 周期失敗した段階で MCP 復活。
+        # 0.1s だと CI のスケジューラ次第で最初のループの curl 中にも当たり、
+        # 失敗回数が 0/1/2 でブレうる。0.5s 待てば最低 1 回は必ず失敗を経由する。
+        # OW_MCP_FAIL_THRESHOLD=3 なので 2 回程度の揺れは許容される。
+        time.sleep(0.5)
         server.health_alive = True
         # 0.3 * 4 周期分待つ。カウンタが 0 にリセットされて self-exit しないことを確認
         time.sleep(1.5)

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -410,6 +410,267 @@ class TestHeartbeatShTrap:
         assert not phase_file.exists(), "trap EXIT で PHASE_FILE が削除されなかった"
 
 
+class TestHeartbeatShSelfExit:
+    """MCP /health 連続失敗時に safe state の worker が self-exit する"""
+
+    @staticmethod
+    def _start_health_relay(health_alive=True):
+        """relay と MCP /health を兼ねるスタブ。/send と /health を両方受ける。"""
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/health":
+                    if self.server.health_alive:
+                        self.send_response(200)
+                        self.end_headers()
+                        self.wfile.write(b'{"status":"ok"}')
+                    else:
+                        self.send_response(503)
+                        self.end_headers()
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                try:
+                    data = json.loads(body)
+                except json.JSONDecodeError:
+                    data = {}
+                self.server.received.append(data)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{"msg_id": 1}')
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        server.received = []
+        server.health_alive = health_alive
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        return server, f"http://127.0.0.1:{port}"
+
+    def test_no_self_exit_when_mcp_alive(self, tmp_phase_file):
+        """MCP /health が ok を返している間は self-exit しない"""
+        server, url = self._start_health_relay(health_alive=True)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_OK", "w-ok"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.0)
+        # まだ生きているはず
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        server.shutdown()
+        assert alive, "MCP /health 応答中に self-exit してしまった"
+
+    def test_self_exit_when_mcp_down_and_safe(self, tmp_phase_file):
+        """w-* handle + PHASE=ready + uptime >= 閾値 + MCP 失敗 N回 で self-exit"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "2",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+        }
+        env.pop("TMUX_PANE", None)  # kill-pane は noop 化（テスト環境）
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_DOWN", "w-down"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # 失敗 2回 → self-exit するはず
+        try:
+            proc.wait(timeout=10)
+            exited = True
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+            exited = False
+        # relay に event:self-exit が届いているか
+        self_exit_events = [
+            r for r in server.received
+            if r.get("body", {}).get("data", {}).get("type") == "self-exit"
+        ]
+        if tmp_phase_file.exists():
+            tmp_phase_file.unlink()
+        server.shutdown()
+        assert exited, "MCP down + safe state で self-exit しなかった"
+        assert len(self_exit_events) >= 1, "event:self-exit が relay に届いていない"
+        assert self_exit_events[0]["body"]["data"]["reason"] == "mcp-loss"
+
+    def test_no_self_exit_when_uptime_below_threshold(self, tmp_phase_file):
+        """uptime が閾値未満なら MCP 失敗続いても self-exit しない"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "9999",  # 事実上発火させない
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_UP", "w-up"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.0)
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        server.shutdown()
+        assert alive, "uptime 閾値未満で self-exit してしまった"
+
+    def test_no_self_exit_for_non_w_handle(self, tmp_phase_file):
+        """handle が w-* 以外なら self-exit 対象外（orch / dispatcher 保護）"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_ORCH", "orch"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.0)
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        server.shutdown()
+        assert alive, "orch handle が self-exit してしまった"
+
+    def test_no_self_exit_for_non_ready_phase(self, tmp_phase_file):
+        """PHASE != ready なら self-exit 対象外（working/draining 保護）"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("working")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_W", "w-busy"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.0)
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        server.shutdown()
+        assert alive, "PHASE=working で self-exit してしまった"
+
+    def test_disable_flag_skips_self_exit(self, tmp_phase_file):
+        """OW_DISABLE_MCP_SELF_EXIT=1 で self-exit を完全無効化できる"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_MCP_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_DIS", "w-dis"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.0)
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        server.shutdown()
+        assert alive, "OW_DISABLE_MCP_SELF_EXIT=1 でも self-exit してしまった"
+
+    def test_recovery_resets_fail_counter(self, tmp_phase_file):
+        """MCP が復活したらカウンタが 0 リセットされる（復帰後 N 回未満なら exit しない）"""
+        server, url = self._start_health_relay(health_alive=False)
+        tmp_phase_file.write_text("ready")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0.3",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0.3",
+            "OW_MCP_FAIL_THRESHOLD": "3",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_REC", "w-rec"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # 1回失敗した段階で MCP 復活
+        time.sleep(0.1)
+        server.health_alive = True
+        # 0.3 * 4 周期分待つ。カウンタが 0 にリセットされて self-exit しないことを確認
+        time.sleep(1.5)
+        alive = proc.poll() is None
+        proc.terminate()
+        proc.wait(timeout=3)
+        tmp_phase_file.unlink(missing_ok=True)
+        server.shutdown()
+        assert alive, "MCP 復活後にカウンタがリセットされず self-exit してしまった"
+
+
 class TestHeartbeatShCurlTimeout:
     """C案: curl --max-time でhang時に sleep に進める"""
 


### PR DESCRIPTION
## Summary

cc-memory MCP server (port 52837) が落ちた状態が継続すると、MCP に依存している worker (claude セッション、1個 120-443MB) が生き残り累積する問題への対策。dev cycle で MCP 再起動を繰り返すと数 GB 単位でメモリを食う状況だった。

「cc-memory shutdown を能動的に検知して連動 kill」ではなく、「worker 側が自分で MCP 喪失を観察して safe な状態のときだけ self-exit」する受動アプローチを採用。新規概念を増やさず既存の auto-close 系思想を拡張する形。

## 変更内容

### MCP server に GET /health 追加 (`src/main.py`)

- FastMCP の `@mcp.custom_route("/health", methods=["GET"])` で軽量エンドポイントを追加
- レスポンス: `{\"status\":\"ok\", \"pid\":..., \"started_at\":..., \"uptime_sec\":...}` (relay の /health 形式に揃え)

### heartbeat.sh に self-exit ロジック追加 (`scripts/ow/heartbeat.sh`)

既存の heartbeat ループ内で MCP /health を 30 秒毎に curl チェックする。連続失敗カウンタを `/tmp/ow-mcp-fail-<pid>` に保持し、health 成功で 0 リセット。

**self-exit 発火条件 (全部 AND):**
- MCP /health が連続 5 回失敗 (= 150 秒、`OW_MCP_FAIL_THRESHOLD` で変更可)
- handle が `w-*` (worker のみ。`o-*` / `d-*` は対象外)
- PHASE が `ready` (working / loading / draining 中の worker は触らない)
- heartbeat プロセス起動から 5 分以上経過 (`OW_MCP_UPTIME_MIN_SEC` で変更可、起動直後不安定期保護)

発火時は relay へ `event:self-exit` (reason=mcp-loss, fail_count) を送ってから `tmux kill-pane` で自死。

検証用 `OW_DISABLE_MCP_SELF_EXIT=1` で完全無効化可能。

### テスト

- `tests/unit/test_heartbeat_sh.py` に `TestHeartbeatShSelfExit` 追加 (7 ケース)
  - MCP 生存中は exit しない
  - safe 条件成立で exit する (event:self-exit が relay に届くことも検証)
  - uptime 不足で exit しない
  - 非 `w-*` handle で exit しない
  - 非 `ready` phase で exit しない
  - `OW_DISABLE_MCP_SELF_EXIT=1` で exit しない
  - MCP 復活時にカウンタがリセットされる
- `tests/unit/test_health_endpoint.py` 新設で `/health` レスポンス検証

## 設計判断

### 過激回避

通常 cc-memory restart は数秒〜30秒で復活するため N=5 (150秒) で誤発火しない。working 中の worker は触らない設計で、作業ロストを構造的に防いでいる。MCP 復帰直後の一時切断には grace period が自動的に効く (復帰すればカウンタが 0 リセット)。

### worker-sync は諦める

MCP 死中の self-exit のため `add_logs` / `add_material` は呼べない。発火する状態 (PHASE=ready、何も抱えてない) は記録すべき経緯がほぼ無いので諦めて relay 通知だけ送る。dispatcher は presence 消失と event:self-exit で気付ける。

### Out of scope

- working 中に MCP 死に詰まった worker の救済 (人間 / dispatcher の手動 close ルートに残す)
- 手動起動 (`tmux new -s NAME` + `claude` 手入力) のゾンビ zsh 問題 (`.zshrc` wrapper で別途対処)

## Test plan

- [x] `uv run pytest tests/unit/test_health_endpoint.py tests/unit/test_heartbeat_sh.py` 緑 (22 件)
- [x] `uv run pytest tests/unit/` フル緑 (1603 passed, 1 skipped) regression なし
- [ ] 実機: cc-memory restart して worker (state=ready) が ~150秒で self-exit すること
- [ ] 実機: cc-memory を 10 秒以内に再起動して worker が exit しないこと (restart 耐性)
- [ ] 実機: state=working の worker は触られないこと