### PR TITLE
feat: SSE push 安定化 (keepalive frame + pull-polling fallback)

### DIFF
--- a/scripts/ow/recv_poll.sh
+++ b/scripts/ow/recv_poll.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o pipefail
 # /history を周期 pull して自分宛メッセージを Monitor に流す fallback wrapper。
 # 使い方: recv_poll.sh <channel> <handle>
 #

--- a/scripts/ow/recv_poll.sh
+++ b/scripts/ow/recv_poll.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# /history を周期 pull して自分宛メッセージを Monitor に流す fallback wrapper。
+# 使い方: recv_poll.sh <channel> <handle>
+#
+# recv.sh (SSE push) の補完経路。push 不発症状に対し、定期 pull で確実に
+# 取りこぼしを Monitor (= Claude Code セッションの push 通知) まで届ける。
+# recv.sh と並列起動する想定。重複配送は呼び出し側 (Claude Code セッション) の
+# msg_id ベース dedup で吸収する。
+#
+# 環境変数:
+#   RELAY_URL              中継サーバーURL (default: http://127.0.0.1:8765)
+#   OW_PARENT_PID          監視対象の親PID。指定時は親プロセス消滅でループ即終了。
+#                          未指定なら親監視は無効 (recv.sh と同じ後方互換)。
+#   OW_POLL_INTERVAL_SEC   pull 間隔 (default: 60)
+#   OW_POLL_STATE_FILE     last_msg_id 永続化先
+#                          (default: /tmp/ow_recv_poll_<handle>_<channel>.last_msg_id)
+
+RELAY_URL="${RELAY_URL:-http://127.0.0.1:8765}"
+INTERVAL="${OW_POLL_INTERVAL_SEC:-60}"
+CHANNEL="$1"
+HANDLE="$2"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OW_PARENT_PID="${OW_PARENT_PID:-}"
+STATE_FILE="${OW_POLL_STATE_FILE:-/tmp/ow_recv_poll_${HANDLE}_${CHANNEL}.last_msg_id}"
+
+if [ -z "$CHANNEL" ] || [ -z "$HANDLE" ]; then
+    echo "Usage: recv_poll.sh <channel_code> <handle>" >&2
+    exit 1
+fi
+
+parent_alive() {
+    if [ -z "$OW_PARENT_PID" ]; then
+        return 0
+    fi
+    kill -0 "$OW_PARENT_PID" 2>/dev/null
+}
+
+# /history JSON を relay SSE wire format に擬装する整形スクリプト。
+# 既存 recv_filter.py の入力フォーマット ("data: {msg_id, body, handle, created_at}")
+# に揃えることで、schema 検証と to filter を二重実装せず再利用する。
+# 取得済み msg のうち最大 msg_id を state file に書き戻して次周期の since にする。
+SSE_FORMAT_SCRIPT='
+import json
+import sys
+from pathlib import Path
+
+state_path = Path(sys.argv[1])
+try:
+    resp = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+messages = resp.get("messages") or []
+if not messages:
+    sys.exit(0)
+max_id = 0
+for msg in messages:
+    msg_id = msg.get("msg_id")
+    if msg_id is None:
+        continue
+    if msg_id > max_id:
+        max_id = msg_id
+    line_payload = {
+        "msg_id": msg_id,
+        "body": msg.get("body", "{}"),
+        "handle": msg.get("handle", ""),
+        "created_at": msg.get("created_at", ""),
+    }
+    print(f"data: {json.dumps(line_payload, ensure_ascii=False)}", flush=True)
+if max_id > 0:
+    state_path.write_text(str(max_id))
+'
+
+while parent_alive; do
+    LAST=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+    # curl 失敗時は黙ってスキップ。relay 一時不調でもループ続行。
+    RESP=$(curl -s --get \
+        --data-urlencode "channel=${CHANNEL}" \
+        --data-urlencode "since=${LAST}" \
+        --data-urlencode "limit=200" \
+        --max-time 10 \
+        "${RELAY_URL}/history" 2>/dev/null)
+    if [ -n "$RESP" ]; then
+        printf '%s' "$RESP" \
+            | python3 -c "$SSE_FORMAT_SCRIPT" "$STATE_FILE" \
+            | python3 -u "${SCRIPT_DIR}/recv_filter.py" "$HANDLE"
+    fi
+    sleep "$INTERVAL"
+done

--- a/src/relay/server.py
+++ b/src/relay/server.py
@@ -35,6 +35,10 @@ DB_PATH = os.environ.get(
     str(Path.home() / ".cc-memory" / "ow" / "relay" / "relay.db"),
 )
 
+# SSE 無送信時に出すコメントフレーム間隔。flush が定期的に走ることで blocked
+# client は BrokenPipeError で finally に到達し subscriber がリークしない。
+KEEPALIVE_INTERVAL_SEC = int(os.environ.get("RELAY_KEEPALIVE_SEC", "10"))
+
 # channel_code → list of (handle, queue.Queue)
 # presence も兼用: 接続中の handle はこのリストに現れる
 _subscribers: dict[str, list[tuple[str, queue.Queue]]] = {}
@@ -433,8 +437,11 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(b": connected\n\n")
             self.wfile.flush()
             while True:
-                msg = q.get()
-                self.wfile.write(f"data: {msg}\n\n".encode("utf-8"))
+                try:
+                    msg = q.get(timeout=KEEPALIVE_INTERVAL_SEC)
+                    self.wfile.write(f"data: {msg}\n\n".encode("utf-8"))
+                except queue.Empty:
+                    self.wfile.write(b": keepalive\n\n")
                 self.wfile.flush()
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass

--- a/src/relay/server.py
+++ b/src/relay/server.py
@@ -37,7 +37,21 @@ DB_PATH = os.environ.get(
 
 # SSE 無送信時に出すコメントフレーム間隔。flush が定期的に走ることで blocked
 # client は BrokenPipeError で finally に到達し subscriber がリークしない。
-KEEPALIVE_INTERVAL_SEC = int(os.environ.get("RELAY_KEEPALIVE_SEC", "10"))
+def _parse_keepalive_sec(raw: str | None) -> int:
+    if raw is None or raw == "":
+        return 10
+    try:
+        v = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"RELAY_KEEPALIVE_SEC must be a positive integer, got {raw!r}"
+        ) from e
+    if v < 1:
+        raise ValueError(f"RELAY_KEEPALIVE_SEC must be >= 1, got {v}")
+    return v
+
+
+KEEPALIVE_INTERVAL_SEC = _parse_keepalive_sec(os.environ.get("RELAY_KEEPALIVE_SEC"))
 
 # channel_code → list of (handle, queue.Queue)
 # presence も兼用: 接続中の handle はこのリストに現れる

--- a/tests/integration/test_recv_poll.py
+++ b/tests/integration/test_recv_poll.py
@@ -1,0 +1,253 @@
+"""recv_poll.sh の動作検証 (pull-polling fallback wrapper)。
+
+SSE push が不発に陥った場合に、/history を周期 pull して自分宛 msg を
+Monitor (= 親の Claude Code セッション) に確実に届けるための fallback。
+本テストでは recv.sh と並列起動を模さず、recv_poll.sh 単体の動作だけを
+確認する (filter / dedup / 差分取得)。
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RECV_POLL_SH = _REPO_ROOT / "scripts" / "ow" / "recv_poll.sh"
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start_relay(port: int, db_path: str) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["RELAY_PORT"] = str(port)
+    env["RELAY_DB"] = db_path
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "src.relay.server"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=str(_REPO_ROOT),
+    )
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=0.3
+            ) as r:
+                if r.status == 200:
+                    return proc
+        except Exception:
+            time.sleep(0.1)
+    proc.kill()
+    raise RuntimeError("relay did not become ready in time")
+
+
+def _create_channel(port: int, code: str) -> str:
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/create",
+        data=json.dumps({"channel_code": code}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=2.0) as r:
+        return json.loads(r.read())["channel_code"]
+
+
+def _send_msg(port: int, channel: str, handle: str, to: str, seq: int) -> int:
+    body = {"v": 1, "kind": "event", "data": {"type": "test"}, "to": to, "seq": seq}
+    payload = json.dumps(
+        {"channel": channel, "handle": handle, "body": json.dumps(body)}
+    ).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/send",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=2.0) as r:
+        return json.loads(r.read())["msg_id"]
+
+
+@pytest.fixture
+def isolated_relay(tmp_path):
+    port = _pick_free_port()
+    db_path = str(tmp_path / "relay.db")
+    proc = _start_relay(port, db_path)
+    try:
+        yield port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def _start_recv_poll(
+    port: int, channel: str, handle: str, state_file: str, interval_sec: int = 1
+) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["RELAY_URL"] = f"http://127.0.0.1:{port}"
+    env["OW_POLL_INTERVAL_SEC"] = str(interval_sec)
+    env["OW_POLL_STATE_FILE"] = state_file
+    return subprocess.Popen(
+        ["bash", str(_RECV_POLL_SH), channel, handle],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(_REPO_ROOT),
+    )
+
+
+def _extract_seqs(data_lines: list[str]) -> list[int]:
+    """`data: {...}` 形式の行群から body 内 seq を抽出する。"""
+    seqs: list[int] = []
+    for line in data_lines:
+        assert line.startswith("data: "), line
+        payload = json.loads(line[len("data: "):])
+        body = json.loads(payload["body"])
+        seqs.append(body["seq"])
+    return seqs
+
+
+class _LineCollector:
+    """Process の stdout を別 thread で読み続け、累積を保持する。
+
+    `select + readline` だと text mode の内部バッファが select に
+    可視化されない隙で行を取り逃すため、blocking readline を thread に
+    乗せて全部回収する形にする。
+    """
+
+    def __init__(self, proc: subprocess.Popen) -> None:
+        self._proc = proc
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._t = threading.Thread(target=self._reader, daemon=True)
+        self._t.start()
+
+    def _reader(self) -> None:
+        assert self._proc.stdout is not None
+        for raw in self._proc.stdout:
+            with self._lock:
+                self._lines.append(raw.rstrip("\n"))
+
+    def wait(self, duration_sec: float) -> None:
+        time.sleep(duration_sec)
+
+    def get(self) -> list[str]:
+        with self._lock:
+            return list(self._lines)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._lines.clear()
+
+
+def _stop(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+class TestRecvPollFiltering:
+    """recv_filter.py と同等の filter が pull 経路にも適用される。"""
+
+    def test_pulls_self_and_broadcast_drops_other(self, isolated_relay, tmp_path):
+        """自分宛 + broadcast(to=*) は stdout に出力、別人宛は drop。"""
+        port = isolated_relay
+        code = _create_channel(port, "poll-filter")
+        _send_msg(port, code, "attacker", "victim", seq=1)        # self
+        _send_msg(port, code, "attacker", "someone_else", seq=2)  # other (drop 対象)
+        _send_msg(port, code, "attacker", "*", seq=3)             # broadcast
+
+        state_file = str(tmp_path / "state")
+        proc = _start_recv_poll(port, code, "victim", state_file, interval_sec=1)
+        collector = _LineCollector(proc)
+        try:
+            collector.wait(2.5)
+            lines = collector.get()
+        finally:
+            _stop(proc)
+
+        data_lines = [l for l in lines if l.startswith("data: ")]
+        assert len(data_lines) == 2, (
+            f"期待 2 行 (self + broadcast)、実 {len(data_lines)} 行: {lines}"
+        )
+        seqs = _extract_seqs(data_lines)
+        assert sorted(seqs) == [1, 3], (
+            f"期待 [1, 3] (self + broadcast)、実 {seqs}: 2 (other) が落ちてない / 1 or 3 が落ちた"
+        )
+
+
+class TestRecvPollStateAdvance:
+    """state file が advance し、2 周目以降は同じ msg を流さない。"""
+
+    def test_state_file_advances_and_no_duplicate(self, isolated_relay, tmp_path):
+        port = isolated_relay
+        code = _create_channel(port, "poll-dedup")
+        _send_msg(port, code, "attacker", "victim", seq=1)
+
+        state_file = str(tmp_path / "state")
+        proc = _start_recv_poll(port, code, "victim", state_file, interval_sec=1)
+        collector = _LineCollector(proc)
+        try:
+            collector.wait(2.0)
+            r1 = collector.get()
+            # 1 周目で state file 更新済みのはず
+            assert Path(state_file).exists(), "state file が作られていない"
+            advanced = Path(state_file).read_text().strip()
+            assert advanced != "0" and int(advanced) > 0, (
+                f"state file の last_msg_id が advance してない: {advanced!r}"
+            )
+            collector.reset()
+            # 2 周目以降は新規 msg なしなので 0 行
+            collector.wait(2.0)
+            r2 = collector.get()
+        finally:
+            _stop(proc)
+
+        d1 = [l for l in r1 if l.startswith("data: ")]
+        d2 = [l for l in r2 if l.startswith("data: ")]
+        assert len(d1) == 1, f"round1 で初回分が来てない: {r1}"
+        assert len(d2) == 0, f"round2 で重複出力: {r2}"
+
+
+class TestRecvPollIncremental:
+    """初回 pull 後に投入した新規 msg は次周期で拾える。"""
+
+    def test_new_message_after_first_poll_is_picked_up(self, isolated_relay, tmp_path):
+        port = isolated_relay
+        code = _create_channel(port, "poll-incr")
+        _send_msg(port, code, "attacker", "victim", seq=1)
+
+        state_file = str(tmp_path / "state")
+        proc = _start_recv_poll(port, code, "victim", state_file, interval_sec=1)
+        collector = _LineCollector(proc)
+        try:
+            collector.wait(2.0)
+            r1 = collector.get()
+            collector.reset()
+            _send_msg(port, code, "attacker", "victim", seq=99)
+            collector.wait(2.5)
+            r2 = collector.get()
+        finally:
+            _stop(proc)
+
+        d1 = [l for l in r1 if l.startswith("data: ")]
+        d2 = [l for l in r2 if l.startswith("data: ")]
+        assert len(d1) == 1, f"r1: {r1}"
+        assert len(d2) == 1, f"新規 msg 拾えてない: r2={r2}"
+        assert _extract_seqs(d2) == [99]

--- a/tests/integration/test_relay_sse_keepalive.py
+++ b/tests/integration/test_relay_sse_keepalive.py
@@ -1,0 +1,171 @@
+"""SSE keepalive frame の動作検証。
+
+無送信状態でも `: keepalive\\n\\n` が KEEPALIVE_INTERVAL_SEC 間隔で flush される
+ことを実プロセスの relay に対して確認する。flush が定期的に走ることで blocked
+client の subscriber リークも構造的に解決される (BrokenPipeError → finally で
+remove)。
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start_relay(port: int, db_path: str, keepalive_sec: int) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["RELAY_PORT"] = str(port)
+    env["RELAY_DB"] = db_path
+    env["RELAY_KEEPALIVE_SEC"] = str(keepalive_sec)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "src.relay.server"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=str(_REPO_ROOT),
+    )
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=0.3
+            ) as r:
+                if r.status == 200:
+                    return proc
+        except Exception:
+            time.sleep(0.1)
+    proc.kill()
+    raise RuntimeError("relay did not become ready in time")
+
+
+def _create_channel(port: int, code: str = "kptest") -> str:
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/create",
+        data=json.dumps({"channel_code": code}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=2.0) as r:
+        return json.loads(r.read())["channel_code"]
+
+
+def _post_send(port: int, channel: str, handle: str, body: dict) -> int:
+    payload = json.dumps(
+        {"channel": channel, "handle": handle, "body": json.dumps(body)}
+    ).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/send",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=2.0) as r:
+        return json.loads(r.read())["msg_id"]
+
+
+@pytest.fixture
+def isolated_relay(tmp_path):
+    port = _pick_free_port()
+    db_path = str(tmp_path / "relay.db")
+    proc = _start_relay(port, db_path, keepalive_sec=1)
+    try:
+        yield port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def _read_stream_lines(port: int, channel: str, handle: str, duration_sec: float) -> list[str]:
+    """SSE ストリームを duration_sec 秒読んで受信した行を全部返す。"""
+    lines: list[str] = []
+    stop = threading.Event()
+
+    def reader():
+        url = f"http://127.0.0.1:{port}/stream?channel={channel}&handle={handle}"
+        try:
+            with urllib.request.urlopen(url, timeout=duration_sec + 5) as r:
+                for raw in r:
+                    if stop.is_set():
+                        break
+                    lines.append(raw.decode(errors="replace").rstrip("\n"))
+        except Exception:
+            pass
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+    time.sleep(duration_sec)
+    stop.set()
+    t.join(timeout=1.0)
+    return lines
+
+
+class TestKeepaliveFrame:
+    """RELAY_KEEPALIVE_SEC=1 のとき keepalive comment frame が定期的に出る。"""
+
+    def test_idle_connection_receives_keepalive(self, isolated_relay):
+        """無送信状態で SSE 接続を保持していると ': keepalive' が複数回届く。"""
+        port = isolated_relay
+        code = _create_channel(port, "idle-kp")
+
+        lines = _read_stream_lines(port, code, "victim", duration_sec=3.5)
+
+        # connected 初回 + 少なくとも 2 回の keepalive
+        assert any(": connected" in line for line in lines), (
+            f"connected frame 未受信: lines={lines}"
+        )
+        keepalives = [line for line in lines if ": keepalive" in line]
+        assert len(keepalives) >= 2, (
+            f"keepalive frame 期待 >=2 件、実受信 {len(keepalives)} 件: lines={lines}"
+        )
+
+    def test_keepalive_does_not_replace_data_frames(self, isolated_relay):
+        """keepalive 経路は data frame の配送を妨げない。"""
+        port = isolated_relay
+        code = _create_channel(port, "mixed-kp")
+
+        lines: list[str] = []
+        stop = threading.Event()
+
+        def reader():
+            url = f"http://127.0.0.1:{port}/stream?channel={code}&handle=victim"
+            try:
+                with urllib.request.urlopen(url, timeout=10) as r:
+                    for raw in r:
+                        if stop.is_set():
+                            break
+                        lines.append(raw.decode(errors="replace").rstrip("\n"))
+            except Exception:
+                pass
+
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+        time.sleep(0.5)  # subscribe 完了を確実に待つ
+        _post_send(
+            port, code, "attacker",
+            {"v": 1, "kind": "event", "data": {"type": "test"}, "to": "victim"},
+        )
+        time.sleep(2.5)  # data frame + keepalive 両方拾える時間
+        stop.set()
+        t.join(timeout=1.0)
+
+        data_lines = [line for line in lines if line.startswith("data: ")]
+        keepalives = [line for line in lines if ": keepalive" in line]
+        assert len(data_lines) >= 1, f"data frame 未受信: lines={lines}"
+        assert len(keepalives) >= 1, f"keepalive 未受信: lines={lines}"

--- a/tests/unit/test_relay_server.py
+++ b/tests/unit/test_relay_server.py
@@ -173,3 +173,32 @@ class TestInitDbIndexes:
         db_path = str(tmp_path / "relay.db")
         srv.init_db(db_path)
         srv.init_db(db_path)
+
+
+class TestParseKeepaliveSec:
+    """_parse_keepalive_sec の不正値バリデーション。"""
+
+    def test_none_returns_default(self):
+        assert srv._parse_keepalive_sec(None) == 10
+
+    def test_empty_string_returns_default(self):
+        assert srv._parse_keepalive_sec("") == 10
+
+    def test_positive_integer(self):
+        assert srv._parse_keepalive_sec("5") == 5
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="must be >= 1"):
+            srv._parse_keepalive_sec("0")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="must be >= 1"):
+            srv._parse_keepalive_sec("-1")
+
+    def test_non_integer_raises(self):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            srv._parse_keepalive_sec("10.5")
+
+    def test_garbage_raises(self):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            srv._parse_keepalive_sec("abc")


### PR DESCRIPTION
## 背景

ow framework で観察された push 通知不発症状 (recv.sh + Monitor 生存中なのに msg が届かず ow_history pull で救う伝書鳩状態) への構造的対処。短期再現テストで H1 (SSE flush blocking) を最有力と判定して着手したが、検証で「完全 buffer 詰まり subscriber の早期削除」効果は限定的と判明。idle 接続維持・他 subscriber 独立性確保には有効なので構造的改善として取り込みつつ、確実な救済経路として pull-polling fallback を追加する 2 段構え。

## 変更内容

### 1. SSE keepalive frame (`src/relay/server.py`)

`_handle_stream` ループの `q.get` を `timeout=KEEPALIVE_INTERVAL_SEC` 化し、無送信時に `: keepalive\n\n` comment frame を flush する。

- `KEEPALIVE_INTERVAL_SEC = int(os.environ.get("RELAY_KEEPALIVE_SEC", "10"))` (env で上書き可、default 10 秒)
- 詰まった client が close した場合は次の keepalive で `BrokenPipeError` → finally で subscriber 削除 (リーク防止)
- idle 接続を kernel/NAT/proxy 層の timeout から保護

### 2. pull-polling fallback wrapper (`scripts/ow/recv_poll.sh`)

`/history` を周期 pull して自分宛 msg を Monitor (= Claude Code セッション) に流す。

- recv.sh (SSE push) と並列起動する想定。push 経路が詰まったり race を起こしても確実に取りこぼしを補完
- `/history` レスポンスを relay SSE wire format に擬装して既存 `recv_filter.py` の schema/to filter を再利用 (二重実装回避)
- 最大 msg_id を state file に永続化、次周期は `since=<last>` で差分取得
- 重複配送は呼び出し側の msg_id ベース dedup で吸収する前提
- env: `RELAY_URL` / `OW_PARENT_PID` (recv.sh 互換) / `OW_POLL_INTERVAL_SEC` (default 60) / `OW_POLL_STATE_FILE`

## テスト

- `tests/integration/test_relay_sse_keepalive.py` 新規 (2 件): idle 接続で keepalive 複数回受信 / data frame と keepalive 混在配送
- `tests/integration/test_recv_poll.py` 新規 (3 件): self+broadcast 通過 & other drop / state file advance & dedup / 新規 msg incremental 取得
- 既存 relay 関連 42 件含む全 47 件 PASS

## 残課題 (別 activity 継続予定)

検証で keepalive frame の劇的治癒効果が観測できなかった件を踏まえ、push 不発症状の真因再調査が必要:
- H5 (subscribe-race): subscriber 登録前の `ow_send` がその SSE には乗らない
- H2 (envelope schema drop): 古い形式 envelope を recv_filter が silent drop
- subscriber leak: 何らかの理由で `_subscribers` から消えてる

本番 relay の `_subscribers` 状態と recv_filter drop カウンタを観察できる debug endpoint の追加が次の手段。