### PR TITLE
feat: workerにidle-timeout自殺機構を追加

### DIFF
--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -61,9 +61,9 @@ OW_HB_FAIL_THRESHOLD="${OW_HB_FAIL_THRESHOLD:-5}"
 OW_DONE_TIMEOUT_SEC="${OW_DONE_TIMEOUT_SEC:-600}"
 OW_DISABLE_IDLE_TIMEOUT="${OW_DISABLE_IDLE_TIMEOUT:-0}"
 
-MCP_FAIL_COUNT_FILE="/tmp/ow-mcp-fail-$$"
-HB_FAIL_COUNT_FILE="/tmp/ow-hb-fail-$$"
-DONE_SINCE_FILE="/tmp/ow-done-since-$$"
+MCP_FAIL_COUNT_FILE="${MCP_FAIL_COUNT_FILE:-/tmp/ow-mcp-fail-$$}"
+HB_FAIL_COUNT_FILE="${HB_FAIL_COUNT_FILE:-/tmp/ow-hb-fail-$$}"
+DONE_SINCE_FILE="${DONE_SINCE_FILE:-/tmp/ow-done-since-$$}"
 HEARTBEAT_STARTED_AT=$(date +%s)
 
 # B案: trap で PHASE_FILE を自殺時に掃除する。bg化された後の親 SIGHUP は
@@ -184,8 +184,15 @@ while [ -f "$PHASE_FILE" ] && parent_alive; do
             if [ ! -f "$DONE_SINCE_FILE" ]; then
                 date +%s > "$DONE_SINCE_FILE"
             fi
-            done_since=$(cat "$DONE_SINCE_FILE" 2>/dev/null || echo 0)
             done_now=$(date +%s)
+            done_since=$(cat "$DONE_SINCE_FILE" 2>/dev/null || echo 0)
+            # ゼロバイト書き込み（/tmp 容量不足等）で done_since が空文字になると
+            # 算術展開で 0 扱いされ done_elapsed が epoch 秒大になり即時誤 kill する。
+            # 空文字・非数値・非正値はいずれも「今」起点に書き直して誤発火を防ぐ。
+            if [ -z "$done_since" ] || ! [ "$done_since" -gt 0 ] 2>/dev/null; then
+                done_since=$done_now
+                echo "$done_since" > "$DONE_SINCE_FILE"
+            fi
             done_elapsed=$(( done_now - done_since ))
             if [ "$done_elapsed" -ge "$OW_DONE_TIMEOUT_SEC" ]; then
                 shutdown_for_idle_timeout "done-stall" "${done_elapsed}s in done phase (threshold ${OW_DONE_TIMEOUT_SEC}s)"
@@ -201,12 +208,14 @@ while [ -f "$PHASE_FILE" ] && parent_alive; do
     # C案: curl にタイムアウトを付与。relay hang による heartbeat 停止を防ぐ。
     # --connect-timeout: TCP 接続確立まで / --max-time: 全体（接続+送受信）。
     # 機構1 (D#2853): 送信成否で連続失敗カウンタを更新、閾値超過で worker を kill。
-    if curl -s -X POST \
+    # stdout のみ捨て stderr は残す。連続失敗 kill 発動後に curl のエラー
+    # （Failed to connect 等）を辿れないと事後調査ができないため。
+    if curl -sS -X POST \
         --connect-timeout "$OW_CURL_CONNECT_TIMEOUT" \
         --max-time "$OW_CURL_TIMEOUT" \
         -H "Content-Type: application/json" \
         -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${BODY}}" \
-        "${RELAY_URL}/send" > /dev/null 2>&1; then
+        "${RELAY_URL}/send" > /dev/null; then
         echo 0 > "$HB_FAIL_COUNT_FILE"
     else
         if [ "$OW_DISABLE_IDLE_TIMEOUT" != "1" ]; then

--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -29,6 +29,18 @@
 #   OW_MCP_MAX_TIME    MCP /health curl の全体タイムアウト（秒）。default: 3
 #   OW_DISABLE_MCP_SELF_EXIT
 #                      "1" を渡すと self-exit を無効化（デバッグ・検証用）。
+#   OW_HB_FAIL_THRESHOLD
+#                      relay /send 連続失敗回数の閾値 (default: 5)。
+#                      これを超えると idle-timeout として worker を kill する
+#                      (D#2853 機構1: relay 不通検知)。
+#   OW_DONE_TIMEOUT_SEC
+#                      PHASE=done になってから close 未受領で kill する閾値秒
+#                      (default: 600=10分)。dispatcher が done 検証 + close 送信
+#                      を完了しないまま worker が滞留するのを防ぐ
+#                      (D#2853 機構2: done 後タイマー)。
+#   OW_DISABLE_IDLE_TIMEOUT
+#                      "1" を渡すと idle-timeout (機構1+機構2) を無効化
+#                      （デバッグ・検証用）。
 
 set -euo pipefail
 
@@ -45,8 +57,13 @@ OW_MCP_UPTIME_MIN_SEC="${OW_MCP_UPTIME_MIN_SEC:-300}"
 OW_MCP_CONNECT_TIMEOUT="${OW_MCP_CONNECT_TIMEOUT:-2}"
 OW_MCP_MAX_TIME="${OW_MCP_MAX_TIME:-3}"
 OW_DISABLE_MCP_SELF_EXIT="${OW_DISABLE_MCP_SELF_EXIT:-0}"
+OW_HB_FAIL_THRESHOLD="${OW_HB_FAIL_THRESHOLD:-5}"
+OW_DONE_TIMEOUT_SEC="${OW_DONE_TIMEOUT_SEC:-600}"
+OW_DISABLE_IDLE_TIMEOUT="${OW_DISABLE_IDLE_TIMEOUT:-0}"
 
 MCP_FAIL_COUNT_FILE="/tmp/ow-mcp-fail-$$"
+HB_FAIL_COUNT_FILE="/tmp/ow-hb-fail-$$"
+DONE_SINCE_FILE="/tmp/ow-done-since-$$"
 HEARTBEAT_STARTED_AT=$(date +%s)
 
 # B案: trap で PHASE_FILE を自殺時に掃除する。bg化された後の親 SIGHUP は
@@ -55,6 +72,8 @@ HEARTBEAT_STARTED_AT=$(date +%s)
 cleanup() {
     rm -f "$PHASE_FILE" 2>/dev/null || true
     rm -f "$MCP_FAIL_COUNT_FILE" 2>/dev/null || true
+    rm -f "$HB_FAIL_COUNT_FILE" 2>/dev/null || true
+    rm -f "$DONE_SINCE_FILE" 2>/dev/null || true
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -123,6 +142,32 @@ self_exit_due_to_mcp_loss() {
     exit 0
 }
 
+# idle-timeout self-shutdown (D#2853): relay に terminated(cause:idle-timeout) を
+# 通知してから worker を kill する。reason は "hb-fail" (機構1) または
+# "done-stall" (機構2) を渡す。
+shutdown_for_idle_timeout() {
+    local reason="$1"
+    local detail="$2"
+    local body
+    body=$(printf '{"v":1,"kind":"event","from":"%s","to":"dispatcher","data":{"type":"state","state":"terminated","cause":"idle-timeout","reason":"%s","detail":"%s"}}' \
+        "$HANDLE" "$reason" "$detail")
+    curl -s -X POST \
+        --connect-timeout "$OW_CURL_CONNECT_TIMEOUT" \
+        --max-time "$OW_CURL_TIMEOUT" \
+        -H "Content-Type: application/json" \
+        -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${body}}" \
+        "${RELAY_URL}/send" > /dev/null 2>&1 || true
+    if [ -n "${TMUX_PANE:-}" ]; then
+        tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+    elif [ -n "$OW_PARENT_PID" ]; then
+        echo "heartbeat.sh: idle-timeout (reason=$reason); killing OW_PARENT_PID=$OW_PARENT_PID" >&2
+        kill -TERM "$OW_PARENT_PID" 2>/dev/null || true
+    else
+        echo "heartbeat.sh: idle-timeout (reason=$reason); TMUX_PANE and OW_PARENT_PID both unset; worker process will leak" >&2
+    fi
+    exit 0
+}
+
 while [ -f "$PHASE_FILE" ] && parent_alive; do
     PHASE=$(cat "$PHASE_FILE" 2>/dev/null || echo "ready")
 
@@ -132,17 +177,46 @@ while [ -f "$PHASE_FILE" ] && parent_alive; do
         INTERVAL="${HEARTBEAT_INTERVAL_DEFAULT:-30}"
     fi
 
+    # 機構2 (D#2853): PHASE=done が継続している秒数を計測し、閾値超過で
+    # worker を kill する。done 以外に戻ったらカウンタファイルを消してリセット。
+    if [ "$OW_DISABLE_IDLE_TIMEOUT" != "1" ]; then
+        if [ "$PHASE" = "done" ]; then
+            if [ ! -f "$DONE_SINCE_FILE" ]; then
+                date +%s > "$DONE_SINCE_FILE"
+            fi
+            done_since=$(cat "$DONE_SINCE_FILE" 2>/dev/null || echo 0)
+            done_now=$(date +%s)
+            done_elapsed=$(( done_now - done_since ))
+            if [ "$done_elapsed" -ge "$OW_DONE_TIMEOUT_SEC" ]; then
+                shutdown_for_idle_timeout "done-stall" "${done_elapsed}s in done phase (threshold ${OW_DONE_TIMEOUT_SEC}s)"
+            fi
+        else
+            rm -f "$DONE_SINCE_FILE" 2>/dev/null || true
+        fi
+    fi
+
     BODY=$(printf '{"v":1,"kind":"event","from":"%s","to":"*","data":{"type":"heartbeat","phase":"%s"}}' \
         "$HANDLE" "$PHASE")
 
     # C案: curl にタイムアウトを付与。relay hang による heartbeat 停止を防ぐ。
     # --connect-timeout: TCP 接続確立まで / --max-time: 全体（接続+送受信）。
-    curl -s -X POST \
+    # 機構1 (D#2853): 送信成否で連続失敗カウンタを更新、閾値超過で worker を kill。
+    if curl -s -X POST \
         --connect-timeout "$OW_CURL_CONNECT_TIMEOUT" \
         --max-time "$OW_CURL_TIMEOUT" \
         -H "Content-Type: application/json" \
         -d "{\"channel\":\"${CHANNEL}\",\"handle\":\"${HANDLE}\",\"body\":${BODY}}" \
-        "${RELAY_URL}/send" > /dev/null || true
+        "${RELAY_URL}/send" > /dev/null 2>&1; then
+        echo 0 > "$HB_FAIL_COUNT_FILE"
+    else
+        if [ "$OW_DISABLE_IDLE_TIMEOUT" != "1" ]; then
+            hb_n=$(( $(cat "$HB_FAIL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+            echo "$hb_n" > "$HB_FAIL_COUNT_FILE"
+            if [ "$hb_n" -ge "$OW_HB_FAIL_THRESHOLD" ]; then
+                shutdown_for_idle_timeout "hb-fail" "${hb_n} consecutive heartbeat send failures"
+            fi
+        fi
+    fi
 
     # MCP /health チェックと self-exit 判定。
     # OW_DISABLE_MCP_SELF_EXIT=1 で無効化可能。

--- a/skills/dispatcher/SKILL.md
+++ b/skills/dispatcher/SKILL.md
@@ -764,6 +764,9 @@ projector は relay event 受信時に push 型で cache JSON と activities tab
 | `dead` | loading 中の load 失敗 | `failed` | (触らず、`in_progress` 維持) |
 | `crashed (inferred)` | ready/working/blocked/escalated 中の heartbeat 途絶 | `stalled` | (触らず) |
 | `crashed-during-drain (inferred)` | draining 中の heartbeat 途絶 | `stalled` | (触らず) |
+| `idle-timeout` | heartbeat.sh が relay /send 連続失敗 N=5 を検知、または PHASE=done のまま M=10分経過 (D#2853) | `stalled` | (触らず) |
+
+`idle-timeout` は worker が自身で kill する経路 (heartbeat.sh が `event:state(terminated, cause:idle-timeout)` を送信した後 tmux kill-pane / SIGTERM)。auto-close 対象軸 (D#2609) では `closed` / `cancelled` と並ぶ auto-close 対象 (pane も kill 済みで人間判断不要)。
 
 **自動 failed および自動クローズはしない**: heartbeat 途絶 (crashed 推論) は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明とはならない。activities.status の `failed` 化は projector が触らず、人間判断に残す。
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -337,6 +337,7 @@ kill タイミングは relay POST の**完了後**で固定する。送信前�
 | `dead` | ❌ 対象外 | 起動失敗。人間判断ステージに残す |
 | `crashed` | ❌ 対象外 | reducer 推論のみで本 step を実行する worker は存在しない |
 | `crashed-during-drain` | ❌ 対象外 | 同上 |
+| `idle-timeout` | ✅ 対象 (bash 側で kill 済み) | heartbeat.sh が自分で event 送信 + pane kill する (D#2853 機構1/2)。worker AI が SKILL を踏まなくても確実に退場する仕組みなので、本 Step 6 が worker AI 側で発火する経路は通常存在しない |
 
 起動環境（環境変数）別の経路:
 

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -745,3 +745,136 @@ class TestHeartbeatShCurlTimeout:
             f"curl --max-time が機能していない (試行 {len(server.received)} 件、"
             f"timeout 1s なら 4秒で 2件以上届くはず)"
         )
+
+
+class TestHeartbeatShDoneTimeout:
+    """機構2 (D#2853): PHASE=done 継続で done-stall idle-timeout が発火する。
+    DONE_SINCE_FILE 環境変数で since 記録ファイルを注入してタイマー起点を制御する。"""
+
+    def test_empty_done_since_file_does_not_false_kill(self, mock_relay, tmp_path):
+        """DONE_SINCE_FILE がゼロバイト（/tmp 容量不足等）でも即時誤 kill しない。
+
+        空文字は算術展開で 0 扱いされ done_elapsed が epoch 秒大になり
+        即時 kill されうるが、ガードが「今」起点に書き直して誤発火を防ぐ。"""
+        server, relay_url = mock_relay
+        phase_file = tmp_path / "ow_hb_phase_done_empty"
+        phase_file.write_text("done")
+        done_since_file = tmp_path / "ow_done_since_empty"
+        done_since_file.write_text("")  # ゼロバイト
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(phase_file),
+            "DONE_SINCE_FILE": str(done_since_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0.2",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0.2",
+            "OW_DONE_TIMEOUT_SEC": "5",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",  # MCP self-exit を切り idle-timeout のみ検証
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_DONE_EMPTY", "w-done-empty"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # 閾値 5s 未満の 1.5s 経過後も生存しているはず（ガードで起点が「今」に補正）
+        time.sleep(1.5)
+        alive = proc.poll() is None
+
+        phase_file.unlink(missing_ok=True)
+        proc.terminate()
+        proc.wait(timeout=3)
+        if done_since_file.exists():
+            done_since_file.unlink()
+
+        # ガードが効いていれば done_since が「今」に書き直されているはず（空のままではない）
+        assert alive, "空 DONE_SINCE_FILE で done-stall が即時誤発火し worker が kill された"
+
+    def test_done_stall_kills_when_threshold_exceeded(self, mock_relay, tmp_path):
+        """DONE_SINCE_FILE が閾値超過の過去 timestamp なら done-stall で kill + 通知。"""
+        server, relay_url = mock_relay
+        phase_file = tmp_path / "ow_hb_phase_done_stall"
+        phase_file.write_text("done")
+        done_since_file = tmp_path / "ow_done_since_stall"
+        # 十分過去の epoch（done に入ってから長時間経過した状態を模擬）
+        done_since_file.write_text("1000000000")
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(phase_file),
+            "DONE_SINCE_FILE": str(done_since_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0.2",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0.2",
+            "OW_DONE_TIMEOUT_SEC": "5",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",
+        }
+        env.pop("TMUX_PANE", None)  # kill-pane は noop 化（テスト環境）
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_DONE_STALL", "w-done-stall"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            proc.wait(timeout=5)
+            exited = True
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+            exited = False
+
+        terminated_events = [
+            r for r in server.received
+            if r.get("body", {}).get("data", {}).get("state") == "terminated"
+        ]
+
+        phase_file.unlink(missing_ok=True)
+        if done_since_file.exists():
+            done_since_file.unlink()
+
+        assert exited, "done-stall 閾値超過で worker が exit しなかった"
+        assert len(terminated_events) >= 1, "terminated(idle-timeout) が relay に届いていない"
+        data = terminated_events[0]["body"]["data"]
+        assert data["cause"] == "idle-timeout"
+        assert data["reason"] == "done-stall"
+
+    def test_disable_idle_timeout_skips_done_stall(self, mock_relay, tmp_path):
+        """OW_DISABLE_IDLE_TIMEOUT=1 なら done-stall 閾値超過でも kill しない。"""
+        server, relay_url = mock_relay
+        phase_file = tmp_path / "ow_hb_phase_done_dis"
+        phase_file.write_text("done")
+        done_since_file = tmp_path / "ow_done_since_dis"
+        done_since_file.write_text("1000000000")  # 閾値を確実に超える過去
+
+        env = {
+            **os.environ,
+            "RELAY_URL": relay_url,
+            "PHASE_FILE": str(phase_file),
+            "DONE_SINCE_FILE": str(done_since_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0.2",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0.2",
+            "OW_DONE_TIMEOUT_SEC": "5",
+            "OW_DISABLE_IDLE_TIMEOUT": "1",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",
+        }
+
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_DONE_DIS", "w-done-dis"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.5)
+        alive = proc.poll() is None
+
+        phase_file.unlink(missing_ok=True)
+        proc.terminate()
+        proc.wait(timeout=3)
+        if done_since_file.exists():
+            done_since_file.unlink()
+
+        assert alive, "OW_DISABLE_IDLE_TIMEOUT=1 でも done-stall kill が発火した"


### PR DESCRIPTION
## Summary

heartbeat.sh に二重防御の自殺ロジックを足し、SKILL.md の遵守やタブを閉じる人手に頼らず worker が確実に退場するようにする。

- **機構 1**: relay `/send` 連続失敗が `OW_HB_FAIL_THRESHOLD` (default 5) を超えたら自殺。relay 不通検知。
- **機構 2**: `PHASE=done` のまま `OW_DONE_TIMEOUT_SEC` (default 600s = 10分) 経過で自殺。dispatcher の close 送信が遅れた / 来ない場合の滞留対策。

いずれも自殺前に `event:state(terminated, cause:idle-timeout)` を relay へ通知してから `tmux kill-pane` または親 PID へ `SIGTERM` を送る。既存の MCP `/health` self-exit とは独立した経路で、同じ heartbeat.sh 内に共存する。

dispatcher / worker SKILL の cause lineup / auto-close 対応表にも `idle-timeout` を追記。

## env

- `OW_HB_FAIL_THRESHOLD` (default 5)
- `OW_DONE_TIMEOUT_SEC` (default 600)
- `OW_DISABLE_IDLE_TIMEOUT` (debug 抑止)

## Test plan

- [x] `bash -n` / `shellcheck` pass
- [x] 機構 1 発火: `PHASE=ready`、偽 relay、threshold=2 → 連続失敗で `event:state(terminated, cause:idle-timeout, reason:hb-fail)` 送信 → 自殺
- [x] 機構 2 発火: `PHASE=done`、timeout=2s → 経過後 `reason:done-stall` で同じく自殺
- [x] `OW_DISABLE_IDLE_TIMEOUT=1` で機構 1/2 抑止 (5秒経過しても生存)
- [ ] 実環境 worker spawn での経路確認 (relay を実際に落として SIGTERM が届くか)
- [ ] dispatcher 側で cause:idle-timeout を受けた時の projector 反映観察 (task_status=stalled に倒れる想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)