### PR TITLE
feat: task_file 廃止 + ready 廃止 cut-over (spawn-bundle 経路一本化)

### DIFF
--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -4,8 +4,10 @@
 # 使い方:
 #   PHASE_FILE=/tmp/ow_hb_phase_<alias> bash heartbeat.sh <channel_code> <handle> &
 #   echo "loading" > $PHASE_FILE   # loading=10s
-#   echo "ready"   > $PHASE_FILE   # ready/working/draining=30s
+#   echo "working" > $PHASE_FILE   # working/draining=30s
 #   rm $PHASE_FILE                 # ファイル削除でループ終了
+#
+# 注: ready 状態は D#2962 で廃止 (loading → working 直行)。
 #
 # 環境変数:
 #   RELAY_URL          中継サーバーURL (default: http://127.0.0.1:8765)
@@ -78,14 +80,17 @@ mcp_health_check() {
         "${OW_MCP_URL}/health" > /dev/null 2>&1
 }
 
-# self-exit の安全条件: w-* handle かつ PHASE=ready かつ uptime>=閾値。
+# self-exit の安全条件: w-* handle かつ PHASE=working かつ uptime>=閾値。
+# working 中の MCP unreachable は cc-memory ツール (add_logs/check_in 等) が呼べず
+# worker が詰まる状態のため、殺す方がコスト低い (D#2962 ready 廃止に伴い旧
+# PHASE=ready 条件から working に変更)。
 # 安全とみなせば 0、対象外なら 1 を返す。
 is_safe_for_self_exit() {
     case "$HANDLE" in
         w-*) ;;
         *) return 1 ;;
     esac
-    [ "$PHASE" = "ready" ] || return 1
+    [ "$PHASE" = "working" ] || return 1
     # `local var=$(cmd)` は local の exit code が常に 0 になり set -e をすり抜ける。
     # 宣言と代入は分ける。
     local now
@@ -124,7 +129,7 @@ self_exit_due_to_mcp_loss() {
 }
 
 while [ -f "$PHASE_FILE" ] && parent_alive; do
-    PHASE=$(cat "$PHASE_FILE" 2>/dev/null || echo "ready")
+    PHASE=$(cat "$PHASE_FILE" 2>/dev/null || echo "working")
 
     if [ "$PHASE" = "loading" ]; then
         INTERVAL="${HEARTBEAT_INTERVAL_LOADING:-10}"

--- a/scripts/ow/sentinel.py
+++ b/scripts/ow/sentinel.py
@@ -5,10 +5,10 @@ relay の /history を polling し、worker の state 遷移を追跡する。
 auto 遷移すべき state で閾値を超えた場合 ``ow_sentinel`` handle で
 stagnation event を relay に append する。
 
-- 監視対象: state=ready (60秒で working/terminated に遷移すべき),
-  state=draining (90秒で terminated に遷移すべき)
-- loading→ready は対象外 (heartbeat 継続中の長時間 loading は許容、
+- 監視対象: state=draining (90秒で terminated に遷移すべき)
+- loading→working は対象外 (heartbeat 継続中の長時間 loading は許容、
   巨大 context warm-up を誤検知するため)
+- ready 状態は D#2962 で廃止 (loading→working 直行) のため監視対象から除外
 - 既存 watchdog (heartbeat 途絶検知) とは責務分離して併走する
   (watchdog=死活、stagnation=詰まり)
 
@@ -31,8 +31,8 @@ from typing import Optional
 SENTINEL_HANDLE = "ow_sentinel"
 
 # state -> 閾値秒。loading は意図的に含めない (D#2752 仕様)。
+# ready 状態は D#2962 で廃止されたため監視対象から除外。
 DEFAULT_THRESHOLDS: dict[str, int] = {
-    "ready": 60,
     "draining": 90,
 }
 

--- a/skills/dispatcher/SKILL.md
+++ b/skills/dispatcher/SKILL.md
@@ -383,7 +383,7 @@ escalate_count_in_pack: <数>                  # §escalation ガイドライン
 
 ### 層 1: 機械的検知 (既存機構を event 化)
 
-- D#2752 stagnation detector (`ow_sentinel`) が ready→working / draining→terminated の遅延を検知
+- D#2752 stagnation detector (`ow_sentinel`) が draining→terminated の遅延を検知 (ready→working は D#2962 で廃止)
 - `scripts/ow/heartbeat.sh` 等の watchdog が heartbeat 途絶を検知
 - 既存 `ow_recover` が ghost_active を検知
 - これらの event を dispatcher が SSE subscribe する
@@ -398,7 +398,7 @@ sentinel event 受信時に dispatcher が以下を順に実行する:
 
 1. `command:ping` で alive 確認
 2. 状態把握 (worker 状態問い合わせ or tmux capture-pane 相当)
-3. 復帰可能 → 指示送信 (明示 `command:assign`、blocked 解除支援)
+3. 復帰可能 → 指示送信 (`command:answer` で軌道修正、blocked 解除支援)
 4. 復帰不能 → close + reassign (新 worker spawn、同 worktree + WIP commit 渡して継続)
 5. 構造的に詰まり (acceptance 矛盾 / 依存待ち / 新 decision 必要) → orch escalate
 
@@ -528,7 +528,7 @@ dispatcher が参照する情報は 4 層に分かれる:
   - **派生 1 = cache JSON** (ow_service 内部の派生キャッシュ、projector 自動再生成)
   - **派生 2 = activity.status** (projector が cause → status マッピングに従い自動更新)
 - **dispatcher concern 原則**: dispatcher が直接触ってよい操作は以下のみ:
-  - (a) worker への命令送信 (`ow_send` で `command:assign|close|cancel|answer|ping`)
+  - (a) worker への命令送信 (`ow_send` で `command:close|cancel|answer|ping`)
   - (b) 状態取得 API (`ow_status` / `ow_get_identity` / `ow_get_presence` / `ow_get_workload_state` / `ow_list_identities` / `ow_recover` / `ow_recover_candidates` / `ow_history`)
   - (c) worker 起動・終了 (`ow_spawn_worker` / `ow_close_worker`)
   - (d) orch から受領した `command:relay-spawn` / `relay-close` / `relay-cancel` / `relay-query` の受信処理
@@ -591,7 +591,7 @@ orch がタスク管理判断 (どの worker を spawn するか、どの worker
 
 | data.type | data 内容 | 補足 |
 |---|---|---|
-| `relay-spawn` | `{semantic_role, activity_id, topic_id, cwd, model（必須）, context_pack（必須）}` | dispatcher は worker を spawn し `command:assign` 送出 |
+| `relay-spawn` | `{semantic_role, activity_id, topic_id, cwd, model（必須）, context_pack（必須）}` | dispatcher は `ow_spawn_worker` で worker を起動し、spawn-bundle envelope を relay に書き込む (D#2952) |
 | `relay-close` | `{target_semantic, reason}` | dispatcher は対応 worker に `command:close` 送出 |
 | `relay-cancel` | `{target_semantic, reason}` | dispatcher は対応 worker に `command:cancel` 送出 |
 | `relay-query` | `{target_semantic, query_type}` | dispatcher は drill-down 結果を返す (§progress-report user 質問駆動 lookup) |
@@ -658,7 +658,7 @@ projector はこの event を受信して `cache.workers[target_handle].task_sta
 
 ### workload state
 
-worker の workload state machine は worker SKILL.md と整合 (loading → ready → working → [blocked → escalated → working] → done → draining → terminated)。watchdog / projector マッピングは旧 orch SKILL.md と同じものを dispatcher が引き継ぐ。
+worker の workload state machine は worker SKILL.md と整合 (loading → working → [blocked → escalated → working] → done → draining → terminated)。ready 状態は廃止 (D#2962)、loading → working 直行。watchdog / projector マッピングは旧 orch SKILL.md と同じものを dispatcher が引き継ぐ。
 
 ### identity (event:identity)
 
@@ -734,7 +734,6 @@ projector は relay event 受信時に push 型で cache JSON と activities tab
 |---|---|---|
 | `event:state(spawning, target_handle=h)` (dispatcher broadcast) | workers[h]={state:"loading", task_status:"spawning", assigned_at, acceptance, model, cwd} | (触らず) |
 | `event:state(loading)` (worker) | state=loading, task_status=spawning, latest_msg_id, latest_at | (触らず) |
-| `event:state(ready)` (worker) | state=ready, task_status=spawning | (触らず) |
 | `event:state(working)` (worker) | state=working, task_status=working | activity.status=in_progress (まだなら) |
 | `event:state(blocked)` (worker) | state=blocked | (触らず) |
 | `event:state(escalated)` (worker) | state=escalated, task_status=escalated | (触らず) |
@@ -762,7 +761,7 @@ projector は relay event 受信時に push 型で cache JSON と activities tab
 | `closed` | command:close 受領 → 正常退出 | `done` (acceptance満たし & synced済み) | `completed` |
 | `cancelled` | command:cancel 受領 → 退出 | `cancelled` | `completed` + [cancelled] 追記 |
 | `dead` | loading 中の load 失敗 | `failed` | (触らず、`in_progress` 維持) |
-| `crashed (inferred)` | ready/working/blocked/escalated 中の heartbeat 途絶 | `stalled` | (触らず) |
+| `crashed (inferred)` | working/blocked/escalated 中の heartbeat 途絶 | `stalled` | (触らず) |
 | `crashed-during-drain (inferred)` | draining 中の heartbeat 途絶 | `stalled` | (触らず) |
 
 **自動 failed および自動クローズはしない**: heartbeat 途絶 (crashed 推論) は worker が長時間ツール実行中の場合にも発生しうるため、確実な異常証明とはならない。activities.status の `failed` 化は projector が触らず、人間判断に残す。
@@ -776,7 +775,7 @@ projector は relay event 受信時に push 型で cache JSON と activities tab
 | 現在の workload state | heartbeat 周期 | タイムアウト閾値 (周期×3) |
 |---|---|---|
 | `loading` | 10 秒 | **30 秒** |
-| `ready` / `working` / `blocked` / `draining` | 30 秒 | **90 秒** |
+| `working` / `blocked` / `draining` | 30 秒 | **90 秒** |
 | `escalated` | 監視対象外 | — |
 
 dispatcher は `ow_get_workload_state(channel, handle)` で現在の state を参照し、対応する閾値を選んで判定する。
@@ -799,27 +798,27 @@ watchdog が「死活 (heartbeat 途絶)」を見るのに対し、stagnation de
 
 | 観測 state | 期待される遷移 | 閾値 | 検出する詰まり |
 |---|---|---|---|
-| `ready` | `working` (auto-assign 成功) | **60 秒** | auto-assign 不発 |
 | `draining` | `terminated` | **90 秒** | close ハンドシェイク失敗 / worker-sync 詰まり |
+
+ready 状態は D#2962 で廃止されたため、stagnation 監視対象からも除外 (旧: ready→working 60 秒検出は廃止)。
 
 **sentinel envelope 形式**:
 
 ```json
 {"v":1, "kind":"event", "from":"ow_sentinel", "to":"dispatcher", "task":"T<n>",
  "data":{"type":"stagnation", "target_handle":"<alias>",
-         "target_state":"ready|draining", "elapsed_sec":<int>, "threshold_sec":<int>}}
+         "target_state":"draining", "elapsed_sec":<int>, "threshold_sec":<int>}}
 ```
 
 注: 過渡期は sentinel が `to:"orch"` で送信するケースが残り、relay 側 recv_filter で吸収される (sentinel.py の `to` 統一は別 PR)。
 
 **dispatcher 側受信時の対処**:
 
-- `target_state="ready"` → auto-assign 不発の疑い。`command:assign` を明示送信、または worker 側 SKILL 不発の調査
 - `target_state="draining"` → close ハンドシェイク失敗の疑い。`command:close` 再送、または `ow_recover` で stalled_close 候補を確認
 
 ## モデル選択 (プロトコル制約のみ)
 
-`command:assign` envelope では `model` が必須フィールド。値の選び方は合算版 playbook (`skills/orch/playbook.md` §モデル選択) に従う (リポ別調整があれば特化版で上書き)。具体的な model ID 列挙は playbook に一元化する (本 SKILL では二重管理しない)。
+`ow_spawn_worker` 引数の `model` は必須フィールド。値の選び方は合算版 playbook (`skills/orch/playbook.md` §モデル選択) に従う (リポ別調整があれば特化版で上書き)。具体的な model ID 列挙は playbook に一元化する (本 SKILL では二重管理しない)。
 
 ## 思考 worker (effort 指定) の spawn
 

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -13,9 +13,8 @@ owフレームワークのworkerとして動作する。orchからの指示を�
 
 | state | 意味 |
 |-------|------|
-| `loading` | 起動中・コンテキスト読み込み中 |
-| `ready` | 起動完了・assign待ち |
-| `working` | assign受諾・作業中 |
+| `loading` | 起動中・spawn-bundle pull / context load 中 |
+| `working` | 作業中 (loading → working 直行、ready 状態は廃止) |
 | `blocked` | 判断要請中（orch回答待ち） |
 | `escalated` | 人間へのエスカレーション中 |
 | `done` | 作業完了・orch検証待ち |
@@ -40,48 +39,108 @@ dispatcher (旧 orch handle) からworkerへ届くメッセージは `kind:comma
 
 ## 起動シーケンス
 
-### 1. task fileを読み込む
+worker は ow_spawn_worker (`OW_ROLE=worker` 経由) で起動される。起動 prompt は `/goal <goal_text>。workerスキルに従って check_in からぜんぶやって。` の形式で、claude CLI ネイティブの `/goal` 自走モードでゴール完了 (`event:state(done)`) まで動き続ける。
 
-orchのbootstrapプロンプトで渡されたパス（`.md`）を読む。task fileはYAML frontmatter（起動パラメータ）＋本文（タスク内容）のマークダウン形式。
+### 1. env 読み込み
 
-frontmatterから取得するパラメータ:
-- `channel` (channel_code), `alias`, `task` (task_n), `cwd`, `model`, `timeout_min`, `activity_id`, `topic_id`
+以下の環境変数から worker bootstrap 識別子を取得する:
 
-本文から取得する情報:
-- タイトル（H1）, `## Acceptance`, `## Context`, `## Playbook`
-- `## Thinking worker` セクションが存在する場合は「思考worker」モード (深い議論・設計検討・調査向け; D#2599)。frontmatter にも `effort: <値>` (`high`/`xhigh`/`max`/`ultrathink`) が入る。マーカー直下に thinking トリガー語 (正規綴り) が埋め込まれており、worker セッション全体が長考モードで動作する。実装ではなく議論・設計・調査が役割範囲なので、コード変更には踏み込まない (related: `intent:thinking` notes)。
+- `OW_CHANNEL`: 自分が参加する channel code
+- `OW_ALIAS`: 自分の handle (alias)
+- `OW_TASK_N`: タスク番号 (Tn)
 
-**task fileが存在しない / 読めない場合の処理（起動失敗）:**
-```
-可能ならば: event:identity（最小bundle + terminated_at + cause:"dead"）を送信
-           → event:state(terminated, cause:"dead") を送信
-不可能な場合: event:state(terminated, cause:"dead") のみ送信
-→ 終了
-```
+これらが未設定 / 空のいずれかなら起動失敗扱い。relay 接続できないため envelope 送信もできず、exit code 非ゼロで即終了する。
 
-### 2. heartbeatループ起動
+### 2. heartbeat ループ起動
 
 `scripts/ow/heartbeat.sh` をバックグラウンドで起動し、`PHASE_FILE`（`/tmp/ow_hb_phase_<alias>`）を `loading` に設定する:
 
 ```bash
-PHASE_FILE="/tmp/ow_hb_phase_<alias>"
+PHASE_FILE="/tmp/ow_hb_phase_$OW_ALIAS"
 echo "loading" > "$PHASE_FILE"
-PHASE_FILE="$PHASE_FILE" bash ~/workspace/cc-memory/scripts/ow/heartbeat.sh <channel_code> <alias> &
+PHASE_FILE="$PHASE_FILE" bash ~/workspace/cc-memory/scripts/ow/heartbeat.sh "$OW_CHANNEL" "$OW_ALIAS" &
 ```
 
-heartbeatループは `PHASE_FILE` の内容を読んで送信間隔を決定する:
+heartbeat ループは `PHASE_FILE` の内容を読んで送信間隔を決定する:
 - `loading` → 10秒間隔
-- それ以外 → 30秒間隔
+- それ以外 (`working` / `draining` 等) → 30秒間隔
 
 ### 3. event:heartbeat(alive) を即時送信
 
-ow_sendで1回だけ送信:
+ow_send で1回だけ送信:
 
 ```json
 {"v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>", "data":{"type":"heartbeat", "phase":"alive"}}
 ```
 
-### 4. event:identity を送信
+### 4. event:identity を送信（最小フィールド）
+
+bundle 受信前のため bundle 由来の `task_title` / `activity_id` / `topic_id` は null で送る。Step 9 で bundle 受信後にフル identity を再送する。
+
+```json
+{
+  "v":1, "kind":"event", "from":"<alias>", "to":"*", "task":"T<task_n>",
+  "data":{
+    "type":"identity",
+    "role":"worker",
+    "handle":"<alias>",
+    "channel_code":"<channel_code>",
+    "topic_id": null,
+    "started_at":"<UTC ISO8601>",
+    "alias":"<alias>",
+    "activity_id": null,
+    "model":"<model>",
+    "cwd":"<cwd>",
+    "session_id":"<session_id>"
+  }
+}
+```
+
+identity から **除外する属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。`term_ref` は SessionStart hook が env (`TMUX_PANE`) から `~/.cc-memory/ow/term_refs/<session_id>.json` にキャッシュし、`ow_send` が identity event 送信時に session_id ベースで自動補完する（手動で payload に乗せる必要なし）。
+
+### 5. event:state(loading) を送信
+
+```json
+{"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>", "data":{"type":"state", "state":"loading"}}
+```
+
+### 6. Monitor 起動
+
+- `Monitor recv.sh <channel_code> <alias> (persistent)`
+- `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
+
+### 7. spawn-bundle pull
+
+`ow_history(channel=OW_CHANNEL, since=0)` で channel 全 messages を pull する。pull 結果から以下の条件をすべて満たす envelope を filter する:
+
+- `body.to == OW_ALIAS` または `body.to == "*"`
+- `body.task == "T<OW_TASK_N>"`
+- `body.data.type == "spawn-bundle"`
+
+複数該当する場合は msg_id 最大の 1 件を採用する。bundle data から以下を取得する:
+
+- `task_title`: タスクのタイトル
+- `acceptance`: 完了条件
+- `context`: タスクコンテキスト (思考 worker の場合、末尾に `ultrathink` マーカーセクションが含まれる)
+- `playbook`: プレイブック抜粋
+- `activity_id`: アクティビティID
+- `topic_id`: トピックID
+- `effort`: 思考 worker effort (None または `high`/`xhigh`/`max`/`ultrathink`)
+- `goal_text`: `/goal` 起動 prompt に埋められた短文 (claude が起動時点で自走モードのトリガーに使用済み、本文 context として参照可)
+
+**失敗時挙動:**
+
+- **relay 接続失敗** (HTTP error / curl timeout): 1 秒待ち + 最大 3 回 retry
+- 3 回連続失敗 → `event:state(terminated, cause:"dead", note:"relay unreachable at bundle pull")` を送信して終了
+- **bundle 不在** (pull 成功だが該当 envelope なし): retry しない。spawn 設計上、bundle 送信「後」に worker 起動が固定されているため、bundle 不在 = spawn 側バグ。`event:state(terminated, cause:"dead", note:"spawn-bundle not found in channel")` で即終了
+
+### 8. check_in
+
+bundle から取得した activity_id で `check_in(activity_id)` を実行し、アクティビティの関連情報を取得する。activity_id が null の場合は check_in をスキップする (任意作業 worker の例外運用)。
+
+### 9. event:identity 再送（フルフィールド）
+
+bundle 由来フィールドを含めて identity を再 append する。reducer は最新を採用するため、Step 4 の最小 identity は上書きされる。
 
 ```json
 {
@@ -92,49 +151,31 @@ ow_sendで1回だけ送信:
     "handle":"<alias>",
     "channel_code":"<channel_code>",
     "topic_id":"<topic_id>",
-    "started_at":"<UTC ISO8601>",
+    "started_at":"<起動時と同じ値>",
     "alias":"<alias>",
     "activity_id":<activity_id>,
     "model":"<model>",
     "cwd":"<cwd>",
-    "session_id":"<session_id>"
+    "session_id":"<session_id>",
+    "task_title":"<bundle data.task_title>"
   }
 }
 ```
 
-identity から **除外する属性**: `task_n`（activity_id から逆引き可能）、`user`（relay 非参加者）。`term_ref` は SessionStart hook が env (`TMUX_PANE`) から `~/.cc-memory/ow/term_refs/<session_id>.json` にキャッシュし、`ow_send` が identity event 送信時に session_id ベースで自動補完する（手動で payload に乗せる必要なし）。設計詳細は設計書 v3 §6.3.1 参照。
+### 10. event:state(working, phase="briefing") を送信
 
-### 5. event:state(loading) を送信
-
-```json
-{"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>", "data":{"type":"state", "state":"loading"}}
-```
-
-### 6. context load（Monitorとcheck_in）
-
-- Monitorを起動: `Monitor recv.sh <channel_code> <alias> (persistent)`
-  - `recv.sh` は `~/workspace/cc-memory/scripts/ow/recv.sh` にある
-- `check_in(activity_id)` でアクティビティの関連情報を取得する
-
-### 7. event:state(ready) を送信
-
-context load完了後、PHASE_FILEを `ready` に更新してからstateを宣言:
+context load 完了で working 状態に直行する。ready 状態は廃止 (D#2962)。PHASE_FILE を `working` に更新してから state を宣言する:
 
 ```bash
-echo "ready" > /tmp/ow_hb_phase_<alias>
+echo "working" > /tmp/ow_hb_phase_<alias>
 ```
 
 ```json
-{"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>", "data":{"type":"state", "state":"ready", "session_id":"<session_id>", "alias":"<alias>", "cwd":"<cwd>"}}
+{"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>",
+ "data":{"type":"state", "state":"working", "phase":"briefing", "note":"bundle pulled, context loaded"}}
 ```
 
-### 8. ow_historyでpull補完
-
-```
-ow_history(channel=<channel_code>, since=<ready_msg_id>)
-```
-
-orchがready受信後にすぐ送ったcmd:assignをSSE接続前に取りこぼす場合があるため、自分でpullして補完する。
+その後、§作業中（working） に進む。dispatcher / orch から軌道修正が必要な場合は `command:answer` で差し戻される (旧 `command:assign` 経路は廃止)。
 
 ## alias 命名ガイドライン
 
@@ -144,17 +185,6 @@ aliasは**連番（w-a, w-b）ではなく任意の単語**を推奨する。orc
 - 例（role寄り）: `designer-1`, `implementer-2`, `reviewer-3`
 
 理由: 連番は並行worker数が増えると識別性が低い。固有名のほうがorchの認知負荷が下がる。
-
-## cmd:assign の受信 → working
-
-orchから `kind:command, data.type:assign` が届いたら:
-
-1. 内容を確認し、`event:state(working)` を送信する:
-   ```json
-   {"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>", "data":{"type":"state", "state":"working", "phase":"starting", "note":"assign received, beginning work"}}
-   ```
-2. PHASE_FILEが `ready` になっていることを確認（なっていなければ更新）
-3. タスクの作業を開始する
 
 ## 作業中（working）
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -843,6 +843,7 @@ def _build_spawn_bundle_data(
     acceptance_clean = _sanitize_task_body_field(acceptance, "acceptance")
     context_clean = _sanitize_task_body_field(context, "context")
     playbook_clean = _sanitize_task_body_field(playbook, "playbook")
+    goal_text_clean = _sanitize_task_body_field(goal_text, "goal_text") if goal_text else ""
 
     if effort:
         thinking_section = (
@@ -863,7 +864,7 @@ def _build_spawn_bundle_data(
         "activity_id": activity_id,
         "topic_id": topic_id,
         "effort": effort,
-        "goal_text": goal_text or task_title_clean,
+        "goal_text": goal_text_clean or task_title_clean,
     }
     return data
 
@@ -1171,7 +1172,7 @@ def ow_spawn_worker(
     # 起動 prompt は `/goal <goal_text>` で worker をゴール完了まで自走モードにする (D#2962)。
     # worker は起動後 env から識別子を読んで relay 接続、spawn-bundle を pull、check_in、
     # working 状態に直行する (ready 状態は廃止)。
-    goal_for_prompt = goal_text or task_title or alias
+    goal_for_prompt = bundle_data["goal_text"] or alias
     prompt_text = f"/goal {goal_for_prompt}。workerスキルに従って check_in からぜんぶやって。"
 
     # OW_PARENT_PID=$$ + exec claude で「shell PID → claude PID」の継承を行い、

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -110,9 +110,9 @@ def _normalize_and_validate_model(model: str) -> tuple[str, str | None]:
 
 
 # 思考worker (thinking worker) の effort enum。Claude のreasoning effort と対応する4段。
-# None = 通常 worker。値が指定された場合は task_file 本文に思考トリガー語マーカー (正規綴り
-# `ultrathink`) が埋め込まれ、OW_TERMINAL=tmux では split-pane ではなく new-window で
-# 別タブに開かれる。
+# None = 通常 worker。値が指定された場合は spawn-bundle envelope の data.effort と本文
+# context に思考トリガー語マーカー (正規綴り `ultrathink`) が含まれ、OW_TERMINAL=tmux
+# では split-pane ではなく new-window で別タブに開かれる。
 THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathink"})
 
 # orch 側コード/skill/ドキュメントから sentinel 綴り `ultratink` を渡せるよう、最大段の
@@ -124,8 +124,9 @@ _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
 # worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字、
 # 連続ハイフン禁止）かつ最小長 8 文字以上。短すぎる alias は名前衝突や視認性低下を招き、
 # queue/relay 識別子として再利用しづらいため一律で拒否する。
-# alias の上限長は意図的に設けない（task_file / queue / relay messages に埋め込まれるが、
-# 物理上限はファイルシステム側に委ねる。orch 運用上は kebab-case の自然な命名で十分短く収まる）。
+# alias の上限長は意図的に設けない（relay messages の handle / spawn-bundle envelope の
+# `to` フィールドに埋め込まれるが、物理上限は relay 側に委ねる。orch 運用上は
+# kebab-case の自然な命名で十分短く収まる）。
 _ALIAS_MIN_LENGTH: int = 8
 _ALIAS_PATTERN: re.Pattern[str] = re.compile(r"^[a-z]([a-z0-9]|-(?!-))*[a-z0-9]$")
 
@@ -154,7 +155,7 @@ def _validate_alias_format(alias: str) -> str | None:
 
 # reducer: v3 workload state 分類
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
-    {"loading", "ready", "working", "blocked", "escalated", "draining"}
+    {"loading", "working", "blocked", "escalated", "draining"}
 )
 # heartbeat タイムアウト閾値（周期×3）。
 # キーは workload_state または heartbeat body の phase。両者は worker 側で同期される
@@ -162,7 +163,7 @@ _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
 _HEARTBEAT_TIMEOUT_SECS: dict[str, float] = {
     "loading": 30.0,  # 10s × 3
 }
-_HEARTBEAT_TIMEOUT_DEFAULT: float = 90.0  # 30s × 3（ready/working/draining共通）
+_HEARTBEAT_TIMEOUT_DEFAULT: float = 90.0  # 30s × 3（working/draining共通）
 
 
 # ----------------------------
@@ -801,130 +802,70 @@ _MCP_RESERVED_TAG_RE = re.compile(
 
 
 def _sanitize_task_body_field(value: str, field_name: str = "") -> str:
-    """task_file本文フィールド（acceptance/context等）からMCP予約XMLタグを除去する。
+    """spawn-bundle envelope の本文フィールド（acceptance/context等）からMCP予約XMLタグを除去する。
 
     orchがtool callの引数としてフィールド値を渡すとき、XML構文ミスでタグ残骸
     （例: </parameter>, <invoke name="..."> 等）が混入することがある。
-    workerがtask_fileとして読むとき、これらがMCPプロトコルの一部として
+    workerが spawn-bundle として読むとき、これらがMCPプロトコルの一部として
     誤解釈される恐れがあるため、既知の予約タグは除去する。
     """
     cleaned, count = _MCP_RESERVED_TAG_RE.subn("", value)
     if count:
         logger.warning(
-            "_write_task_file: %sフィールドにMCP予約XMLタグが%d件混入していました（除去済み）",
+            "_build_spawn_bundle: %sフィールドにMCP予約XMLタグが%d件混入していました（除去済み）",
             field_name or "unknown",
             count,
         )
     return cleaned
 
 
-def _slugify_task_title(title: str, max_len: int = 40) -> str:
-    """task fileのファイル名に使うslugをタイトルから生成する。
-
-    「main — detail」構造のタイトルはmain部分のみを採用し、
-    空白・パス上危険な文字（/ \\ | : # ? * < > " ' 改行等）を `-` に畳む。
-    日本語はそのまま残す（日本語話者がファイル名から内容を即把握できるようにするため）。
-    連続する `-` は1つに畳み、max_len文字で切り詰める。空文字列なら "" を返す。
-    """
-    if not title:
-        return ""
-    # 「main — detail」構造ならmain部分のみを使う
-    for sep in (" — ", " – ", " - ", "—", "–"):
-        if sep in title:
-            title = title.split(sep, 1)[0]
-            break
-    slug = re.sub(r"""[\s/\\|:#?*<>"']+""", "-", title.strip())
-    slug = re.sub(r"-+", "-", slug).strip("-")
-    if len(slug) > max_len:
-        slug = slug[:max_len].rstrip("-")
-    return slug
-
-
-def _write_task_file(
-    task_dir: Path,
+def _build_spawn_bundle_data(
     task_n: int,
-    alias: str,
-    channel: str,
-    cwd: str,
-    model: str,
     task_title: str,
     acceptance: str,
     context: str,
     playbook: str,
-    timeout_min: int,
     activity_id: int | None,
     topic_id: str | None,
-    effort: str | None = None,
-) -> Path:
-    """task fileをマークダウン（YAML frontmatter + 本文）で書き出す。
+    effort: str | None,
+    goal_text: str | None,
+) -> dict:
+    """spawn-bundle envelope の data フィールドを組み立てる。
 
-    機械可読フィールド（task/alias/channel/cwd/model等）はfrontmatterに、
-    人間可読な内容（タイトル・acceptance・context・playbook）は本文に置く。
-    workerはfrontmatterから起動パラメータを、本文からタスク内容を読み取る。
+    本文フィールド (task_title/acceptance/context/playbook) は MCP 予約 XML タグを
+    除去してから格納する。effort が指定された場合は本文 context の末尾に思考worker
+    マーカーセクションを差し込み、正規綴り `ultrathink` トリガー語を埋め込む。
 
-    ファイル名は `t<topic_id>-T<n>-<title-slug>.md`。topic prefixでtopic間の名前衝突を、
-    title slugで人間がファイルを開かずに内容を把握できることを担保する。
-    topic_idが未指定の場合は `T<n>-<title-slug>.md`、slugが空なら接尾辞を省く。
-
-    effort が指定された場合 (THINKING_EFFORTS の値) は思考workerとして扱い、本文冒頭
-    （タイトル直後）に思考workerマーカーセクションを挿入する。マーカーには正規綴り
-    `ultrathink` （claude の extended thinking トリガー語）を埋め込む。frontmatterにも
-    `effort: <値>` を残す。
-
-    Note: ドキュメント・skill・チャット文中で本トリガー語に言及する場合は、orch
-    セッション側で extended thinking モードが暴発しないよう sentinel `ultratink`
-    （意図的タイポ）を使う運用とする。worker 埋め込みの実体は正規綴り `ultrathink`。
+    goal_text は `/goal` 起動コマンドに埋める短文。omit (None) 時は task_title を
+    フォールバックに使う。
     """
-    base = f"t{topic_id}-T{task_n}" if (topic_id is not None and str(topic_id)) else f"T{task_n}"
-    slug = _slugify_task_title(task_title)
-    name = f"{base}-{slug}" if slug else base
-    task_file = task_dir / f"{name}.md"
-    task_file.parent.mkdir(parents=True, exist_ok=True)
-
-    fm_data = {
-        "v": 1,
-        "task": f"T{task_n}",
-        "alias": alias,
-        "channel": channel,
-        "cwd": cwd,
-        "model": model,
-        "permission_mode": "auto",
-        "timeout_min": timeout_min,
-        "activity_id": activity_id,
-        "topic_id": topic_id,
-    }
-    if effort:
-        fm_data["effort"] = effort
-    fm_yaml = yaml.safe_dump(fm_data, default_flow_style=False, allow_unicode=True, sort_keys=False)
-
+    task_title_clean = _sanitize_task_body_field(task_title, "task_title")
     acceptance_clean = _sanitize_task_body_field(acceptance, "acceptance")
     context_clean = _sanitize_task_body_field(context, "context")
     playbook_clean = _sanitize_task_body_field(playbook, "playbook")
 
-    body_lines = [f"# {fm_data['task']}: {task_title}".rstrip()]
     if effort:
-        body_lines += [
-            "",
-            "## Thinking worker",
-            "",
-            "ultrathink",
-            "",
+        thinking_section = (
+            "\n\n## Thinking worker\n\n"
+            "ultrathink\n\n"
             f"このタスクは思考worker (effort: {effort}) 扱い。実装ではなく深い議論・"
             "設計検討・調査を行う。上記キーワード `ultrathink` は claude の extended "
-            "thinking モードトリガー語。worker セッションは長考モードで動作する。",
-        ]
-    if acceptance_clean:
-        body_lines += ["", "## Acceptance", "", acceptance_clean]
-    if context_clean:
-        body_lines += ["", "## Context", "", context_clean]
-    if playbook_clean:
-        body_lines += ["", "## Playbook", "", playbook_clean]
-    body = "\n".join(body_lines) + "\n"
+            "thinking モードトリガー語。worker セッションは長考モードで動作する。"
+        )
+        context_clean = (context_clean + thinking_section) if context_clean else thinking_section.lstrip("\n")
 
-    content = f"---\n{fm_yaml}---\n\n{body}"
-    task_file.write_text(content, encoding="utf-8")
-
-    return task_file
+    data = {
+        "type": "spawn-bundle",
+        "task_title": task_title_clean,
+        "acceptance": acceptance_clean,
+        "context": context_clean,
+        "playbook": playbook_clean,
+        "activity_id": activity_id,
+        "topic_id": topic_id,
+        "effort": effort,
+        "goal_text": goal_text or task_title_clean,
+    }
+    return data
 
 
 def _get_adapter_path(terminal: str) -> Path | None:
@@ -1041,11 +982,12 @@ def ow_spawn_worker(
     task_n: int = 1,
     tmux_target_pane: str | None = None,
     effort: str | None = None,
+    goal_text: str | None = None,
 ) -> dict:
     """workerセッションを起動する。
 
-    処理順: spawn前ヘルスチェック → relay へ spawning event broadcast → task file書き出し
-        → アダプタ呼び出し → 安定ID返却
+    処理順: spawn前ヘルスチェック → relay へ spawning event broadcast →
+        event:spawn-bundle を relay に送信 → アダプタ呼び出し → 安定ID返却
 
     permission_modeは常にautoに固定される。
 
@@ -1071,15 +1013,18 @@ def ow_spawn_worker(
             参照できない。
         effort: 思考worker（深い議論・設計検討・調査向けworker）として起動するなら
             THINKING_EFFORTS の値 (`"high"` / `"xhigh"` / `"max"` / `"ultrathink"`) のい
-            ずれかを指定する。指定時は task_file 本文に正規綴り `ultrathink` マーカー
-            セクションが挿入され、frontmatter にも `effort: <値>` が残る。OW_TERMINAL=
-            tmux のときは split-pane ではなく `tmux new-window` で別タブに開く。role は
-            worker のまま（新role不要）。対応activityには `intent:thinking` タグを別途
-            付与すること。None（デフォルト）は通常 worker。
+            ずれかを指定する。指定時は spawn-bundle data.effort に値が入り、data.context
+            末尾に正規綴り `ultrathink` マーカーセクションが差し込まれる。OW_TERMINAL=tmux
+            のときは split-pane ではなく `tmux new-window` で別タブに開く。role は worker
+            のまま。対応activityには `intent:thinking` タグを別途付与すること。
+            None（デフォルト）は通常 worker。
+        goal_text: claude CLI 起動 prompt の `/goal` コマンドに埋めるテキスト。None または
+            空のときは task_title をフォールバックに使う。`/goal` ネイティブ機能で worker
+            はゴール完了 (state:done) まで自走モードで動く。
 
     Returns:
-        {"term_ref": str, "task_file": str, "spawning": "ok"}
-        manualフォールバック時: {"command": str, "manual": True, "task_file": str}
+        {"term_ref": str, "bundle_msg_id": int, "spawning": "ok", "alias": str}
+        manualフォールバック時: {"command": str, "manual": True, "bundle_msg_id": int, "alias": str}
         spawn前検証失敗時: {"error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": [...]}}
         effort不正値時: {"error": {"code": "INVALID_EFFORT", "message": ...}}
     """
@@ -1110,8 +1055,8 @@ def ow_spawn_worker(
 
     # task_title未指定 かつ activity_id指定時は activities.title を自動解決する。
     # 呼び出し側（orch等）に task_title を毎回詰めさせず、activity名と一貫させる。
-    # この task_title は task file frontmatter / ファイル名スラッグ / worker_cmd の
-    # --name（セッション表示名）すべてに伝播する。
+    # この task_title は spawn-bundle envelope の data.task_title / worker_cmd の
+    # --name（セッション表示名） / goal_text 未指定時のフォールバックに伝播する。
     if not task_title and activity_id is not None:
         task_title = _resolve_activity_title(activity_id)
 
@@ -1130,8 +1075,6 @@ def ow_spawn_worker(
     # Claude Code CLI の permission deny を使って worker セッションから AskUserQuestion を
     # 構造的に遮断する。既存設定があればマージ。
     _ensure_worker_askuser_deny(cwd)
-
-    task_dir = _OW_ORCH_DIR / "tasks"
 
     # relay へ spawning broadcast (孤児 worker 対策の真実源化、SKILL.md §通信プロトコル orch→broadcast)。
     # projector は本 event を受信して cache.workers[alias].task_status="spawning" を書き、
@@ -1171,23 +1114,49 @@ def ow_spawn_worker(
             },
         }
 
-    # task fileを書き出す
-    task_file = _write_task_file(
-        task_dir=task_dir,
+    # event:spawn-bundle を relay に送信する (D#2952 / D#2953)。
+    # worker は起動後に env から OW_CHANNEL / OW_ALIAS / OW_TASK_N を読み、relay に接続して
+    # ow_history(since=0) で自分宛 spawn-bundle を pull する。task_title / acceptance /
+    # context / playbook / activity_id / topic_id / effort / goal_text を bundle data に含める。
+    # claude プロセス起動「前」に send する順序保証必須 (worker が history pull する時点で
+    # bundle が messages テーブルに存在している必要があるため)。
+    bundle_data = _build_spawn_bundle_data(
         task_n=task_n,
-        alias=alias,
-        channel=channel,
-        cwd=cwd,
-        model=model,
         task_title=task_title,
         acceptance=acceptance,
         context=context,
         playbook=playbook,
-        timeout_min=timeout_min,
         activity_id=activity_id,
         topic_id=topic_id,
         effort=effort,
+        goal_text=goal_text,
     )
+    bundle_body = {
+        "v": 1,
+        "kind": "event",
+        "from": "orch",
+        "to": alias,
+        "task": f"T{task_n}",
+        "data": bundle_data,
+    }
+    bundle_result = ow_send(channel=channel, handle="orch", body=bundle_body)
+    if "error" in bundle_result:
+        err_detail = bundle_result.get("error")
+        logger.error(
+            "ow_spawn_worker: failed to send event:spawn-bundle for %s: %s — aborting spawn",
+            alias,
+            err_detail,
+        )
+        return {
+            "error": {
+                "code": "SPAWN_PRECONDITION_FAILED",
+                "message": "relay send of event:spawn-bundle failed; spawn aborted",
+                "warnings": [
+                    f"relay send event:spawn-bundle failed for {alias}: {err_detail}"
+                ],
+            },
+        }
+    bundle_msg_id = bundle_result.get("msg_id")
 
     # アダプタ起動
     # OW_TERMINAL 未設定時は "tmux" にフォールバックする (原則 tmux 運用)。
@@ -1195,19 +1164,22 @@ def ow_spawn_worker(
     terminal = os.environ.get("OW_TERMINAL", "tmux")
     adapter_path = _get_adapter_path(terminal) if terminal != "manual" else None
 
-    # --add-dir は commander.js の variadic option (`<directories...>`) で、空白区切り形式
-    # (`--add-dir DIR PROMPT`) だと続く positional prompt を dir として吸収する。
-    # `=` 形式 (`--add-dir=DIR`) は単一値として確定的にパースされ、複数指定は
-    # `--add-dir=DIR1 --add-dir=DIR2` の append 形で渡せる。後続 prompt の吸収リスクが
-    # 構造的に発生しないため、`--` separator なしで positional が確実に届く。
     # --name はセッション表示名（プロンプトボックス・/resume picker・端末タイトル）。
     # workerはtask_titleをActivity名としてそのまま渡し、orch側で見分けやすくする。
     session_name = task_title or alias
+
+    # 起動 prompt は `/goal <goal_text>` で worker をゴール完了まで自走モードにする (D#2962)。
+    # worker は起動後 env から識別子を読んで relay 接続、spawn-bundle を pull、check_in、
+    # working 状態に直行する (ready 状態は廃止)。
+    goal_for_prompt = goal_text or task_title or alias
+    prompt_text = f"/goal {goal_for_prompt}。workerスキルに従って check_in からぜんぶやって。"
+
     # OW_PARENT_PID=$$ + exec claude で「shell PID → claude PID」の継承を行い、
     # claude プロセスに OW_PARENT_PID 環境変数として自身の PID を埋め込む。
     # claude の子（Bash tool / Monitor で起動される recv.sh / heartbeat.sh）はこの env を
     # 継承するため、claude 本体死亡時に watchdog が自動 exit する。
-    # worker SKILL.md 依存ゼロ（A案 + ow_service spawn 経路で完結）。
+    # OW_CHANNEL / OW_ALIAS / OW_TASK_N は worker bootstrap 識別子 (D#2952 / D#2953)。
+    # worker SKILL.md は env からこれらを読んで relay に接続し、spawn-bundle を pull する。
     #
     # 注: `$$` はこの Python 文字列ではエスケープされず、tmux.sh の `eval` 実行時
     # （base64 経由で運搬された後）に「その bash プロセスの PID」へ展開される。
@@ -1216,11 +1188,10 @@ def ow_spawn_worker(
     worker_cmd = (
         f'OW_PARENT_PID=$$ '
         f'OW_ROLE=worker OW_ALIAS={shlex.quote(alias)} OW_CHANNEL={shlex.quote(channel)} '
-        f'OW_TASK_FILE={shlex.quote(str(task_file))} '
+        f'OW_TASK_N={shlex.quote(str(task_n))} '
         f'exec claude --model {shlex.quote(model)} --permission-mode auto '
         f'--name {shlex.quote(session_name)} '
-        f'--add-dir={shlex.quote(str(task_file.parent))} '
-        f'{shlex.quote(f"workerスキルに従って作業を開始して。task: {task_file}")}'
+        f'{shlex.quote(prompt_text)}'
     )
 
     if adapter_path is None:
@@ -1238,7 +1209,7 @@ def ow_spawn_worker(
         return {
             "command": worker_cmd,
             "manual": True,
-            "task_file": str(task_file),
+            "bundle_msg_id": bundle_msg_id,
             "alias": alias,
             "adapter_error": adapter_error,
         }
@@ -1271,7 +1242,7 @@ def ow_spawn_worker(
         return {
             "command": worker_cmd,
             "manual": True,
-            "task_file": str(task_file),
+            "bundle_msg_id": bundle_msg_id,
             "alias": alias,
             "adapter_error": "adapter spawn timed out",
         }
@@ -1280,14 +1251,14 @@ def ow_spawn_worker(
         return {
             "command": worker_cmd,
             "manual": True,
-            "task_file": str(task_file),
+            "bundle_msg_id": bundle_msg_id,
             "alias": alias,
             "adapter_error": e.stderr,
         }
 
     return {
         "term_ref": term_ref,
-        "task_file": str(task_file),
+        "bundle_msg_id": bundle_msg_id,
         "spawning": "ok",
         "alias": alias,
     }
@@ -1516,7 +1487,7 @@ def _get_presence(channel: str) -> list[str]:
 
 # cache.workers[alias].state における「workerが活動中」と分類する workload state。
 # spawning は workload state ではなく task_status のため別カテゴリで扱う。
-_ACTIVE_WORKLOAD_STATES: frozenset[str] = frozenset({"ready", "working", "blocked", "escalated", "draining"})
+_ACTIVE_WORKLOAD_STATES: frozenset[str] = frozenset({"working", "blocked", "escalated", "draining"})
 
 # cache.workers[alias].task_status における「workerが活動中」と分類する状態。
 # spawning を含めることで、cache に spawning entry が残っている alias への重複 spawn を
@@ -1532,9 +1503,9 @@ _TERMINATED_IDENTITY_CAUSES: frozenset[str] = frozenset({"closed", "cancelled", 
 
 # projector: worker からの event:state(state) を受信したときに cache.workers[alias].task_status へ
 # マップする規則。設計書 v3 §5 と SKILL.md §projector マッピング表 に対応。
+# ready 状態は D#2962 で廃止 (loading から working へ直行)。
 _STATE_TO_TASK_STATUS: dict[str, str] = {
     "loading": "spawning",
-    "ready": "spawning",
     "working": "working",
     "blocked": "working",
     "escalated": "escalated",
@@ -1551,14 +1522,13 @@ _CAUSE_TO_TASK_STATUS: dict[str, str] = {
 
 # relay 最新 state 宣言 → cache task_status の suggested 反映マップ。
 # presence offline & cache active の ghost_active ケースで使う。
-# 終端 state (done/closed/cancelled/failed) はそのまま反映、非終端 (ready/working等) は
+# 終端 state (done/closed/cancelled/failed) はそのまま反映、非終端 (working等) は
 # presence offline = 異常終了とみなして "stalled" に倒す（手動介入を促す）。
 _RELAY_STATE_TO_TASK_STATUS: dict[str, str] = {
     "done": "done",
     "closed": "done",   # 旧プロトコル互換 (現行 worker は terminated/cause=closed で送るため state="closed" は通常来ない)
     "failed": "failed",
     "cancelled": "cancelled",
-    "ready": "stalled",
     "working": "stalled",
     "blocked": "stalled",
     "escalated": "stalled",
@@ -2678,7 +2648,7 @@ def _latest_events_by_type(
 def ow_get_identity(channel: str, handle: str) -> dict | None:
     """指定 handle の最新 identity bundle を返す。crash 推論を含む。
 
-    crash 推論: 最新の event:state が terminal でない（loading/ready/working/blocked/
+    crash 推論: 最新の event:state が terminal でない（loading/working/blocked/
                escalated/draining）かつ最後の event:heartbeat 受信時刻から閾値超過 →
                メモリ上で inferred_cause を付与（DB 不変）。
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pytest
 
-_OW_ENV_KEYS = ("OW_ROLE", "OW_ALIAS", "OW_CHANNEL", "OW_TASK_N", "OW_TASK_FILE")
+_OW_ENV_KEYS = ("OW_ROLE", "OW_ALIAS", "OW_CHANNEL", "OW_TASK_N")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pytest
 
-_OW_ENV_KEYS = ("OW_ROLE", "OW_ALIAS", "OW_CHANNEL", "OW_TASK_FILE")
+_OW_ENV_KEYS = ("OW_ROLE", "OW_ALIAS", "OW_CHANNEL", "OW_TASK_N", "OW_TASK_FILE")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -136,10 +136,10 @@ class TestHeartbeatShEnvelope:
         assert data.get("type") == "heartbeat"
         assert data.get("phase") == "loading"
 
-    def test_sends_v3_envelope_with_ready_phase(self, mock_relay, tmp_phase_file):
-        """ready フェーズで v3 envelope の phase フィールドが ready になる"""
+    def test_sends_v3_envelope_with_working_phase(self, mock_relay, tmp_phase_file):
+        """working フェーズで v3 envelope の phase フィールドが working になる"""
         server, relay_url = mock_relay
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
 
         env = {
             **os.environ,
@@ -166,7 +166,7 @@ class TestHeartbeatShEnvelope:
 
         assert len(server.received) >= 1
         body = server.received[0].get("body", {})
-        assert body.get("data", {}).get("phase") == "ready"
+        assert body.get("data", {}).get("phase") == "working"
 
     def test_channel_and_handle_in_request(self, mock_relay, tmp_phase_file):
         """channel と handle が relay /send リクエストに含まれる"""
@@ -243,7 +243,7 @@ class TestHeartbeatShLoopControl:
         assert exited, "PHASE_FILE 削除後にスクリプトが終了しなかった"
 
     def test_interval_switches_with_phase(self, mock_relay, tmp_phase_file):
-        """PHASE_FILE を loading → ready に変更すると interval が変わる"""
+        """PHASE_FILE を loading → working に変更すると interval が変わる"""
         server, relay_url = mock_relay
         tmp_phase_file.write_text("loading")
 
@@ -272,23 +272,23 @@ class TestHeartbeatShLoopControl:
             f"loading フェーズのメッセージが届かなかった (deadline 3.0s 内に 0 件)"
         )
 
-        # ready フェーズに切り替え
-        tmp_phase_file.write_text("ready")
+        # working フェーズに切り替え
+        tmp_phase_file.write_text("working")
 
         deadline = time.time() + 6.0
         while len(server.received) < loading_count + 1 and time.time() < deadline:
             time.sleep(0.05)
 
-        # ready フェーズのメッセージが届いているはず
+        # working フェーズのメッセージが届いているはず
         tmp_phase_file.unlink()
         proc.terminate()
         proc.wait(timeout=3)
 
-        ready_msgs = [
+        working_msgs = [
             m for m in server.received
-            if m.get("body", {}).get("data", {}).get("phase") == "ready"
+            if m.get("body", {}).get("data", {}).get("phase") == "working"
         ]
-        assert len(ready_msgs) >= 1
+        assert len(working_msgs) >= 1
 
 
 class TestHeartbeatShParentWatchdog:
@@ -297,7 +297,7 @@ class TestHeartbeatShParentWatchdog:
     def test_exits_when_parent_dies(self, mock_relay, tmp_phase_file):
         """OW_PARENT_PID で指定された親 PID が消えたら loop が終了する"""
         server, relay_url = mock_relay
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
 
         # ダミー親 process を sleep で起動
         parent = subprocess.Popen(["sleep", "30"])
@@ -379,7 +379,7 @@ class TestHeartbeatShTrap:
         """SIGTERM 受信で PHASE_FILE が削除される（trap cleanup）"""
         server, relay_url = mock_relay
         phase_file = tmp_path / "ow_hb_phase_trap_test"
-        phase_file.write_text("ready")
+        phase_file.write_text("working")
 
         env = {
             **os.environ,
@@ -458,7 +458,7 @@ class TestHeartbeatShSelfExit:
     def test_no_self_exit_when_mcp_alive(self, tmp_phase_file):
         """MCP /health が ok を返している間は self-exit しない"""
         server, url = self._start_health_relay(health_alive=True)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -485,9 +485,9 @@ class TestHeartbeatShSelfExit:
         assert alive, "MCP /health 応答中に self-exit してしまった"
 
     def test_self_exit_when_mcp_down_and_safe(self, tmp_phase_file):
-        """w-* handle + PHASE=ready + uptime >= 閾値 + MCP 失敗 N回 で self-exit"""
+        """w-* handle + PHASE=working + uptime >= 閾値 + MCP 失敗 N回 で self-exit"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -528,7 +528,7 @@ class TestHeartbeatShSelfExit:
     def test_no_self_exit_when_uptime_below_threshold(self, tmp_phase_file):
         """uptime が閾値未満なら MCP 失敗続いても self-exit しない"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -556,7 +556,7 @@ class TestHeartbeatShSelfExit:
     def test_no_self_exit_for_non_w_handle(self, tmp_phase_file):
         """handle が w-* 以外なら self-exit 対象外（orch / dispatcher 保護）"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -581,10 +581,10 @@ class TestHeartbeatShSelfExit:
         server.shutdown()
         assert alive, "orch handle が self-exit してしまった"
 
-    def test_no_self_exit_for_non_ready_phase(self, tmp_phase_file):
-        """PHASE != ready なら self-exit 対象外（working/draining 保護）"""
+    def test_no_self_exit_for_non_working_phase(self, tmp_phase_file):
+        """PHASE != working なら self-exit 対象外（loading/draining 保護）"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("working")
+        tmp_phase_file.write_text("loading")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -607,12 +607,12 @@ class TestHeartbeatShSelfExit:
         proc.terminate()
         proc.wait(timeout=3)
         server.shutdown()
-        assert alive, "PHASE=working で self-exit してしまった"
+        assert alive, "PHASE=loading で self-exit してしまった"
 
     def test_disable_flag_skips_self_exit(self, tmp_phase_file):
         """OW_DISABLE_MCP_SELF_EXIT=1 で self-exit を完全無効化できる"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -641,7 +641,7 @@ class TestHeartbeatShSelfExit:
     def test_recovery_resets_fail_counter(self, tmp_phase_file):
         """MCP が復活したらカウンタが 0 リセットされる（復帰後 N 回未満なら exit しない）"""
         server, url = self._start_health_relay(health_alive=False)
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": url,
@@ -707,7 +707,7 @@ class TestHeartbeatShCurlTimeout:
         port = server.server_address[1]
         relay_url = f"http://127.0.0.1:{port}"
 
-        tmp_phase_file.write_text("ready")
+        tmp_phase_file.write_text("working")
         env = {
             **os.environ,
             "RELAY_URL": relay_url,

--- a/tests/unit/test_ow_sentinel.py
+++ b/tests/unit/test_ow_sentinel.py
@@ -1,13 +1,12 @@
 """scripts/ow/sentinel.py の純粋ロジックを検証する unit test。
 
-ow stagnation detector Phase A (案B orch 側 watcher) の SentinelState が
-M#388 + D#2752 の仕様通りに動作することを確認する:
+ow stagnation detector の SentinelState が仕様通りに動作することを確認する:
 
-- ready→working は 60秒、draining→terminated は 90秒で stagnation 発火
+- draining→terminated は 90秒で stagnation 発火 (ready 監視は D#2962 で廃止)
 - 同一 (handle, state) は 1回だけ通知 (重複抑止)
-- state 遷移 (entry 差し替え) で再武装、二度目以降の ready 滞留でも再発火
+- state 遷移 (entry 差し替え) で再武装、二度目以降の滞留でも再発火
 - identity (terminated_at) で watch 解除
-- loading は監視対象外
+- loading / blocked / escalated は監視対象外
 - 複数 handle は独立して追跡される
 """
 
@@ -57,30 +56,6 @@ def _identity_msg(handle: str, *, terminated_at: str | None = None) -> dict:
     }
 
 
-def test_ready_60sec_triggers_stagnation():
-    s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready", task="T1"), now=0.0)
-
-    assert s.scan(59.0) == []
-
-    envelopes = s.scan(60.0)
-    assert len(envelopes) == 1
-    env = envelopes[0]
-    assert env["from"] == SENTINEL_HANDLE
-    assert env["to"] == "orch"
-    assert env["kind"] == "event"
-    assert env["v"] == 1
-    assert env["task"] == "T1"
-    data = env["data"]
-    assert data == {
-        "type": "stagnation",
-        "target_handle": "w-a",
-        "target_state": "ready",
-        "elapsed_sec": 60,
-        "threshold_sec": 60,
-    }
-
-
 def test_draining_90sec_triggers_stagnation():
     s = SentinelState()
     s.observe_event(_state_msg("w-b", "draining"), now=0.0)
@@ -97,41 +72,71 @@ def test_draining_90sec_triggers_stagnation():
     assert "task" not in env
 
 
+def test_draining_with_task_includes_task_field():
+    """task 付き state 遷移は envelope に task キーを含める。"""
+    s = SentinelState()
+    s.observe_event(_state_msg("w-a", "draining", task="T1"), now=0.0)
+
+    assert s.scan(89.0) == []
+
+    envelopes = s.scan(90.0)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env["from"] == SENTINEL_HANDLE
+    assert env["to"] == "orch"
+    assert env["kind"] == "event"
+    assert env["v"] == 1
+    assert env["task"] == "T1"
+    data = env["data"]
+    assert data == {
+        "type": "stagnation",
+        "target_handle": "w-a",
+        "target_state": "draining",
+        "elapsed_sec": 90,
+        "threshold_sec": 90,
+    }
+
+
 def test_duplicate_suppression_for_same_state():
     """同一 (handle, state) で mark_emitted 後は scan を何度呼んでも返らない。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
 
-    first = s.scan(60.0)
+    first = s.scan(90.0)
     assert len(first) == 1
     # 送信成功を mark
-    s.mark_emitted("w-a", "ready")
+    s.mark_emitted("w-a", "draining")
 
     # さらに時間が経っても再発火しない
-    assert s.scan(120.0) == []
+    assert s.scan(150.0) == []
     assert s.scan(600.0) == []
 
 
 def test_scan_returns_envelope_again_when_not_marked_emitted():
     """送信失敗で mark_emitted を呼ばないと次回 scan で再度返る (retry)。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
 
-    first = s.scan(60.0)
+    first = s.scan(90.0)
     assert len(first) == 1
     # mark_emitted を呼ばない (= 送信失敗を模擬)
-    second = s.scan(65.0)
+    second = s.scan(95.0)
     assert len(second) == 1
     assert second[0]["data"]["target_handle"] == "w-a"
 
     # ようやく成功 → 以降は出ない
-    s.mark_emitted("w-a", "ready")
-    assert s.scan(70.0) == []
+    s.mark_emitted("w-a", "draining")
+    assert s.scan(100.0) == []
 
 
 def test_mark_emitted_ignores_state_mismatch_after_rearm():
-    """mark_emitted は古い state の確定が新 watch entry に影響しないこと。"""
-    s = SentinelState()
+    """mark_emitted は古い state の確定が新 watch entry に影響しないこと。
+
+    既定の監視対象は draining 単独だが、本ケースは再武装後に古い state の
+    mark を無視するガード (entry.state != state) を検証する目的で、複数監視
+    state を custom thresholds で与える。
+    """
+    s = SentinelState(thresholds={"ready": 60, "draining": 90})
     s.observe_event(_state_msg("w-a", "ready"), now=0.0)
     assert len(s.scan(60.0)) == 1
     # ready の mark を立てる前に state 遷移して draining に再武装
@@ -146,28 +151,28 @@ def test_mark_emitted_ignores_state_mismatch_after_rearm():
 
 def test_mark_emitted_for_unknown_handle_is_noop():
     s = SentinelState()
-    s.mark_emitted("nonexistent", "ready")  # 例外を出さない
+    s.mark_emitted("nonexistent", "draining")  # 例外を出さない
     assert s.watches == {}
 
 
-def test_rearm_after_state_transition_back_to_ready():
-    """ready→working で watch 解除、再度 ready に戻ったら 60秒で再発火する。"""
+def test_rearm_after_state_transition_back_to_draining():
+    """draining→working で watch 解除、再度 draining に戻ったら 90秒で再発火する。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
-    assert len(s.scan(60.0)) == 1
-    s.mark_emitted("w-a", "ready")
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
+    assert len(s.scan(90.0)) == 1
+    s.mark_emitted("w-a", "draining")
 
-    # ready → working: 監視対象外なので watch 解除
-    s.observe_event(_state_msg("w-a", "working"), now=70.0)
-    assert s.scan(200.0) == []
+    # draining → working: 監視対象外なので watch 解除
+    s.observe_event(_state_msg("w-a", "working"), now=100.0)
+    assert s.scan(300.0) == []
 
-    # working → ready: 新規 watch entry (emitted=False)
-    s.observe_event(_state_msg("w-a", "ready"), now=300.0)
-    assert s.scan(359.0) == []
+    # working → draining: 新規 watch entry (emitted=False)
+    s.observe_event(_state_msg("w-a", "draining"), now=400.0)
+    assert s.scan(489.0) == []
 
-    envelopes = s.scan(360.0)
+    envelopes = s.scan(490.0)
     assert len(envelopes) == 1
-    assert envelopes[0]["data"]["target_state"] == "ready"
+    assert envelopes[0]["data"]["target_state"] == "draining"
     assert envelopes[0]["data"]["target_handle"] == "w-a"
 
 
@@ -183,15 +188,15 @@ def test_terminated_identity_clears_watch():
 def test_identity_without_terminated_does_not_clear_watch():
     """spawn 時の identity (terminated_at 無し) は watch を解除しない。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
     s.observe_event(_identity_msg("w-a"), now=10.0)
 
-    envelopes = s.scan(60.0)
+    envelopes = s.scan(90.0)
     assert len(envelopes) == 1
 
 
 def test_loading_state_is_not_monitored():
-    """loading→ready は仕様により監視対象外 (D#2752)。"""
+    """loading→working は仕様により監視対象外 (D#2752)。"""
     s = SentinelState()
     s.observe_event(_state_msg("w-a", "loading"), now=0.0)
 
@@ -211,36 +216,36 @@ def test_blocked_and_escalated_states_are_not_monitored():
 
 def test_multiple_handles_tracked_independently():
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
-    s.observe_event(_state_msg("w-b", "draining"), now=10.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
+    s.observe_event(_state_msg("w-b", "draining"), now=30.0)
 
-    # t=70: w-a だけ閾値到達 (60秒経過)、w-b はまだ 60秒
-    envelopes_70 = s.scan(70.0)
-    assert len(envelopes_70) == 1
-    assert envelopes_70[0]["data"]["target_handle"] == "w-a"
-    s.mark_emitted("w-a", "ready")
+    # t=90: w-a だけ閾値到達 (90秒経過)、w-b はまだ 60秒
+    envelopes_90 = s.scan(90.0)
+    assert len(envelopes_90) == 1
+    assert envelopes_90[0]["data"]["target_handle"] == "w-a"
+    s.mark_emitted("w-a", "draining")
 
-    # t=100: w-b も 90秒経過で発火
-    envelopes_100 = s.scan(100.0)
-    assert len(envelopes_100) == 1
-    assert envelopes_100[0]["data"]["target_handle"] == "w-b"
-    assert envelopes_100[0]["data"]["target_state"] == "draining"
+    # t=120: w-b も 90秒経過で発火
+    envelopes_120 = s.scan(120.0)
+    assert len(envelopes_120) == 1
+    assert envelopes_120[0]["data"]["target_handle"] == "w-b"
+    assert envelopes_120[0]["data"]["target_state"] == "draining"
 
 
-def test_working_event_after_ready_within_threshold_clears_watch():
-    """ready 受信後すぐ working が来た正常ケースは発火しない。"""
+def test_working_event_after_draining_within_threshold_clears_watch():
+    """draining 受信後すぐ working が来たケースは発火しない。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
     s.observe_event(_state_msg("w-a", "working"), now=5.0)
 
-    assert s.scan(60.0) == []
+    assert s.scan(90.0) == []
     assert s.scan(120.0) == []
 
 
 def test_observe_event_ignores_non_state_non_identity_types():
     """heartbeat 等は watch に影響しない。"""
     s = SentinelState()
-    s.observe_event(_state_msg("w-a", "ready"), now=0.0)
+    s.observe_event(_state_msg("w-a", "draining"), now=0.0)
     # heartbeat はスキップ
     s.observe_event(
         {
@@ -251,13 +256,13 @@ def test_observe_event_ignores_non_state_non_identity_types():
                 "kind": "event",
                 "from": "w-a",
                 "to": "*",
-                "data": {"type": "heartbeat", "phase": "ready"},
+                "data": {"type": "heartbeat", "phase": "working"},
             },
         },
         now=30.0,
     )
 
-    envelopes = s.scan(60.0)
+    envelopes = s.scan(90.0)
     assert len(envelopes) == 1
 
 
@@ -276,7 +281,7 @@ def test_observe_event_coerces_json_string_body_internally():
         {
             "msg_id": 1,
             "handle": "w-a",
-            "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"ready"}}',
+            "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"draining"}}',
         },
         now=0.0,
     )
@@ -294,7 +299,7 @@ def test_observe_event_uses_handle_fallback_when_from_missing():
                 "v": 1,
                 "kind": "event",
                 "to": "orch",
-                "data": {"type": "state", "state": "ready"},
+                "data": {"type": "state", "state": "draining"},
             },
         },
         now=0.0,
@@ -321,11 +326,11 @@ def test_coerce_message_body_parses_json_string():
     raw = {
         "msg_id": 1,
         "handle": "w-a",
-        "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"ready"}}',
+        "body": '{"v":1,"from":"w-a","data":{"type":"state","state":"draining"}}',
     }
     coerced = _coerce_message_body(raw)
     assert isinstance(coerced["body"], dict)
-    assert coerced["body"]["data"]["state"] == "ready"
+    assert coerced["body"]["data"]["state"] == "draining"
     # 元 dict は破壊しない
     assert isinstance(raw["body"], str)
 
@@ -334,7 +339,7 @@ def test_coerce_message_body_passes_through_dict_body():
     raw = {
         "msg_id": 1,
         "handle": "w-a",
-        "body": {"v": 1, "from": "w-a", "data": {"type": "state", "state": "ready"}},
+        "body": {"v": 1, "from": "w-a", "data": {"type": "state", "state": "draining"}},
     }
     coerced = _coerce_message_body(raw)
     assert coerced is raw or coerced["body"] is raw["body"]

--- a/tests/unit/test_ow_spawn_bundle.py
+++ b/tests/unit/test_ow_spawn_bundle.py
@@ -1,0 +1,179 @@
+"""ow_spawn_worker: spawn-bundle envelope 送信処理と worker_cmd 組み立てのテスト。
+
+D#2952 / D#2953 / D#2962 で確定した cut-over 仕様を検証する:
+- event:spawn-bundle envelope が relay に送信されること (to=alias 直送)
+- worker_cmd に env (OW_CHANNEL / OW_ALIAS / OW_TASK_N) が注入されること
+- worker_cmd の prompt が `/goal ...` 形式であること
+- worker_cmd に `--add-dir` が含まれないこと
+- spawn-bundle 送信失敗時に SPAWN_PRECONDITION_FAILED で abort すること
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.services import ow_service
+
+
+@pytest.fixture
+def _stub_spawn_environment(monkeypatch):
+    """ow_spawn_worker の依存をすべて mock し、relay 送信 body を捕捉する。
+
+    yield された list に ow_send で送信された body dict が順次 append される。
+    """
+    sent_bodies: list[dict] = []
+
+    def _capture_ow_send(channel, handle, body, needs_reply=False, in_reply_to=None):
+        sent_bodies.append(body)
+        return {"msg_id": len(sent_bodies)}
+
+    monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+    monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+    monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+    monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+    monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
+    monkeypatch.setattr(ow_service, "ow_send", _capture_ow_send)
+    # adapter 経路を抑制するため manual fallback に倒す
+    monkeypatch.setenv("OW_TERMINAL", "manual")
+
+    return sent_bodies
+
+
+class TestSpawnBundleEnvelope:
+    def test_spawn_sends_spawn_bundle_after_spawning(
+        self, _stub_spawn_environment, tmp_path: Path
+    ):
+        """ow_spawn_worker は spawning broadcast に続いて event:spawn-bundle を送る"""
+        result = ow_service.ow_spawn_worker(
+            alias="w-bundle01",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="バンドル送信テスト",
+            acceptance="acceptance本文",
+            context="context本文",
+            playbook="playbook本文",
+            task_n=42,
+            activity_id=1234,
+            topic_id=567,
+        )
+        # manual fallback でも spawn-bundle までは送られる
+        assert "bundle_msg_id" in result
+        assert "command" in result  # manual fallback の command 返却
+
+        # 1 件目: spawning broadcast
+        spawning = _stub_spawn_environment[0]
+        assert spawning["data"]["type"] == "state"
+        assert spawning["data"]["state"] == "spawning"
+        assert spawning["to"] == "*"
+        # 2 件目: spawn-bundle envelope
+        bundle = _stub_spawn_environment[1]
+        assert bundle["kind"] == "event"
+        assert bundle["to"] == "w-bundle01"  # 直送
+        assert bundle["task"] == "T42"
+        assert bundle["data"]["type"] == "spawn-bundle"
+        assert bundle["data"]["task_title"] == "バンドル送信テスト"
+        assert bundle["data"]["acceptance"] == "acceptance本文"
+        assert bundle["data"]["context"] == "context本文"
+        assert bundle["data"]["playbook"] == "playbook本文"
+        assert bundle["data"]["activity_id"] == 1234
+        assert bundle["data"]["topic_id"] == 567
+        # goal_text omit 時は task_title をフォールバック
+        assert bundle["data"]["goal_text"] == "バンドル送信テスト"
+
+    def test_spawn_passes_explicit_goal_text(
+        self, _stub_spawn_environment, tmp_path: Path
+    ):
+        """goal_text を明示すると envelope と worker_cmd の両方に反映される"""
+        result = ow_service.ow_spawn_worker(
+            alias="w-bundle02",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="タイトル",
+            acceptance="",
+            context="",
+            playbook="",
+            task_n=7,
+            goal_text="明示ゴール本文",
+        )
+        bundle = _stub_spawn_environment[1]
+        assert bundle["data"]["goal_text"] == "明示ゴール本文"
+        # worker_cmd の prompt にも /goal 経由で含まれる
+        assert "/goal 明示ゴール本文" in result["command"]
+
+
+class TestSpawnBundleSendFailure:
+    def test_bundle_send_failure_aborts_spawn(self, monkeypatch, tmp_path: Path):
+        """event:spawn-bundle 送信失敗時は SPAWN_PRECONDITION_FAILED で即 return する"""
+        call_log: list[str] = []
+
+        def _ow_send(channel, handle, body, needs_reply=False, in_reply_to=None):
+            data_type = body.get("data", {}).get("type")
+            state = body.get("data", {}).get("state")
+            if data_type == "state" and state == "spawning":
+                call_log.append("spawning")
+                return {"msg_id": 1}
+            if data_type == "spawn-bundle":
+                call_log.append("spawn-bundle")
+                return {"error": {"code": 500, "message": "relay down"}}
+            return {"msg_id": 999}
+
+        monkeypatch.setattr(ow_service, "ensure_relay_server", lambda: True)
+        monkeypatch.setattr(ow_service, "ensure_channel", lambda ch: True)
+        monkeypatch.setattr(ow_service, "_get_presence", lambda ch: [])
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        monkeypatch.setattr(ow_service, "_ensure_worker_askuser_deny", lambda c: None)
+        monkeypatch.setattr(ow_service, "ow_send", _ow_send)
+        monkeypatch.setenv("OW_TERMINAL", "manual")
+
+        result = ow_service.ow_spawn_worker(
+            alias="w-failure1",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="失敗テスト",
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "SPAWN_PRECONDITION_FAILED"
+        assert any("spawn-bundle" in w for w in result["error"]["warnings"])
+        # spawning + spawn-bundle の 2 回呼ばれて停止 (adapter には到達しない)
+        assert call_log == ["spawning", "spawn-bundle"]
+
+
+class TestWorkerCmdComposition:
+    def test_worker_cmd_includes_env_identifiers(
+        self, _stub_spawn_environment, tmp_path: Path
+    ):
+        """worker_cmd に OW_CHANNEL / OW_ALIAS / OW_TASK_N が含まれる (OW_TASK_FILE は無い)"""
+        result = ow_service.ow_spawn_worker(
+            alias="w-envinj01",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="env注入テスト",
+            task_n=99,
+        )
+        cmd = result["command"]
+        assert "OW_CHANNEL=" in cmd
+        assert "OW_ALIAS=" in cmd
+        assert "OW_TASK_N=" in cmd
+        assert "OW_TASK_FILE=" not in cmd
+
+    def test_worker_cmd_uses_goal_prompt_and_no_add_dir(
+        self, _stub_spawn_environment, tmp_path: Path
+    ):
+        """worker_cmd の prompt は `/goal ...` 形式、`--add-dir` は含まれない"""
+        result = ow_service.ow_spawn_worker(
+            alias="w-promptest",
+            channel="ChAbCdEf",
+            cwd=str(tmp_path),
+            model="claude-opus-4-7",
+            task_title="プロンプトテスト",
+        )
+        cmd = result["command"]
+        assert "/goal " in cmd
+        assert "check_in" in cmd
+        assert "--add-dir" not in cmd
+        # 旧フォーマット (task: <path>) が含まれていない
+        assert "task: /" not in cmd

--- a/tests/unit/test_ow_task_file_sanitize.py
+++ b/tests/unit/test_ow_task_file_sanitize.py
@@ -175,6 +175,38 @@ class TestBuildSpawnBundleData:
         )
         assert data["goal_text"] == "明示ゴール"
 
+    def test_goal_text_with_mcp_tags_sanitized(self):
+        """goal_text に MCP タグが混入しても bundle data から除去される"""
+        data = ow_service._build_spawn_bundle_data(
+            task_n=1,
+            task_title="タイトル",
+            acceptance="",
+            context="",
+            playbook="",
+            activity_id=None,
+            topic_id=None,
+            effort=None,
+            goal_text='ゴール達成</parameter><invoke name="foo">',
+        )
+        assert "</parameter>" not in data["goal_text"]
+        assert "<invoke" not in data["goal_text"]
+        assert data["goal_text"] == "ゴール達成"
+
+    def test_goal_text_empty_after_sanitize_falls_back_to_title(self):
+        """サニタイズ後に goal_text が空になった場合は task_title をフォールバックに使う"""
+        data = ow_service._build_spawn_bundle_data(
+            task_n=1,
+            task_title="サニタイズタイトル",
+            acceptance="",
+            context="",
+            playbook="",
+            activity_id=None,
+            topic_id=None,
+            effort=None,
+            goal_text="</parameter>",
+        )
+        assert data["goal_text"] == "サニタイズタイトル"
+
     def test_effort_injects_thinking_marker(self):
         """effort 指定時は context 末尾に思考worker マーカー (`ultrathink`) が差し込まれる"""
         data = ow_service._build_spawn_bundle_data(

--- a/tests/unit/test_ow_task_file_sanitize.py
+++ b/tests/unit/test_ow_task_file_sanitize.py
@@ -1,6 +1,9 @@
-"""_write_task_file / _sanitize_task_body_field のサニタイズ動作テスト"""
-from pathlib import Path
+"""_build_spawn_bundle_data / _sanitize_task_body_field のサニタイズ動作テスト
 
+旧 _write_task_file は D#2955 で廃止された (task_file 経路の代わりに
+event:spawn-bundle envelope を relay に送る、D#2952)。本テストは spawn-bundle
+data フィールドが MCP 予約 XML タグから保護されていることを検証する。
+"""
 import pytest
 
 from src.services import ow_service
@@ -76,93 +79,116 @@ class TestSanitizeTaskBodyField:
         assert ow_service._sanitize_task_body_field("", "acceptance") == ""
 
 
-class TestWriteTaskFileSanitize:
-    def test_acceptance_with_mcp_tags_written_clean(self, tmp_path: Path):
-        """acceptanceにMCPタグが混入してもtask_fileのAcceptanceセクションにタグが残らない"""
-        task_file = ow_service._write_task_file(
-            task_dir=tmp_path,
+class TestBuildSpawnBundleData:
+    def test_acceptance_with_mcp_tags_sanitized(self):
+        """acceptance に MCP タグが混入しても bundle data から除去される"""
+        data = ow_service._build_spawn_bundle_data(
             task_n=99,
-            alias="w-test",
-            channel="testchan",
-            cwd="/tmp",
-            model="claude-opus-4-7",
-
             task_title="サニタイズテスト",
             acceptance="テスト全通過</parameter>",
             context="",
             playbook="",
-            timeout_min=30,
             activity_id=None,
             topic_id=None,
+            effort=None,
+            goal_text=None,
         )
-        content = task_file.read_text(encoding="utf-8")
-        assert "</parameter>" not in content
-        assert "テスト全通過" in content
-        assert "## Acceptance" in content
+        assert data["type"] == "spawn-bundle"
+        assert "</parameter>" not in data["acceptance"]
+        assert data["acceptance"] == "テスト全通過"
 
-    def test_context_with_invoke_tags_written_clean(self, tmp_path: Path):
-        """contextに<invoke>タグが混入してもtask_fileのContextセクションにタグが残らない"""
-        task_file = ow_service._write_task_file(
-            task_dir=tmp_path,
+    def test_context_with_invoke_tags_sanitized(self):
+        """context に <invoke> タグが混入しても bundle data から除去される"""
+        data = ow_service._build_spawn_bundle_data(
             task_n=99,
-            alias="w-test",
-            channel="testchan",
-            cwd="/tmp",
-            model="claude-opus-4-7",
-
             task_title="サニタイズテスト",
             acceptance="",
             context='<invoke name="foo">背景情報</invoke>',
             playbook="",
-            timeout_min=30,
             activity_id=None,
             topic_id=None,
+            effort=None,
+            goal_text=None,
         )
-        content = task_file.read_text(encoding="utf-8")
-        assert "<invoke" not in content
-        assert "</invoke>" not in content
-        assert "背景情報" in content
-        assert "## Context" in content
+        assert "<invoke" not in data["context"]
+        assert "</invoke>" not in data["context"]
+        assert data["context"] == "背景情報"
 
-    def test_acceptance_empty_after_sanitize_omits_section(self, tmp_path: Path):
-        """サニタイズ後にacceptanceが空になった場合はAcceptanceセクション自体を出力しない"""
-        task_file = ow_service._write_task_file(
-            task_dir=tmp_path,
+    def test_acceptance_empty_after_sanitize(self):
+        """サニタイズ後に acceptance が空になった場合 bundle data には空文字列が入る"""
+        data = ow_service._build_spawn_bundle_data(
             task_n=99,
-            alias="w-test",
-            channel="testchan",
-            cwd="/tmp",
-            model="claude-opus-4-7",
-
             task_title="サニタイズテスト",
             acceptance="</parameter>",
             context="",
             playbook="",
-            timeout_min=30,
             activity_id=None,
             topic_id=None,
+            effort=None,
+            goal_text=None,
         )
-        content = task_file.read_text(encoding="utf-8")
-        assert "## Acceptance" not in content
+        assert data["acceptance"] == ""
 
-    def test_clean_input_acceptance_preserved(self, tmp_path: Path):
-        """タグを含まないacceptanceはそのまま書き出される"""
-        task_file = ow_service._write_task_file(
-            task_dir=tmp_path,
+    def test_clean_input_preserved(self):
+        """タグを含まない acceptance/context はそのまま bundle data に入る"""
+        data = ow_service._build_spawn_bundle_data(
             task_n=1,
-            alias="w-a",
-            channel="chan",
-            cwd="/tmp",
-            model="claude-opus-4-7",
-
             task_title="クリーンテスト",
             acceptance="PRを作成してCIが通ること",
             context="背景情報",
             playbook="",
-            timeout_min=60,
             activity_id=None,
             topic_id=None,
+            effort=None,
+            goal_text=None,
         )
-        content = task_file.read_text(encoding="utf-8")
-        assert "PRを作成してCIが通ること" in content
-        assert "背景情報" in content
+        assert data["acceptance"] == "PRを作成してCIが通ること"
+        assert data["context"] == "背景情報"
+
+    def test_goal_text_fallback_to_task_title(self):
+        """goal_text 未指定時は task_title をフォールバックに使う"""
+        data = ow_service._build_spawn_bundle_data(
+            task_n=1,
+            task_title="フォールバックテスト",
+            acceptance="",
+            context="",
+            playbook="",
+            activity_id=None,
+            topic_id=None,
+            effort=None,
+            goal_text=None,
+        )
+        assert data["goal_text"] == "フォールバックテスト"
+
+    def test_goal_text_explicit(self):
+        """goal_text 明示時はそのまま使う"""
+        data = ow_service._build_spawn_bundle_data(
+            task_n=1,
+            task_title="タイトル",
+            acceptance="",
+            context="",
+            playbook="",
+            activity_id=None,
+            topic_id=None,
+            effort=None,
+            goal_text="明示ゴール",
+        )
+        assert data["goal_text"] == "明示ゴール"
+
+    def test_effort_injects_thinking_marker(self):
+        """effort 指定時は context 末尾に思考worker マーカー (`ultrathink`) が差し込まれる"""
+        data = ow_service._build_spawn_bundle_data(
+            task_n=1,
+            task_title="思考タスク",
+            acceptance="",
+            context="既存コンテキスト",
+            playbook="",
+            activity_id=None,
+            topic_id=None,
+            effort="ultrathink",
+            goal_text=None,
+        )
+        assert "既存コンテキスト" in data["context"]
+        assert "ultrathink" in data["context"]
+        assert "## Thinking worker" in data["context"]
+        assert data["effort"] == "ultrathink"


### PR DESCRIPTION
## 概要

worker bootstrap の伝達経路を **task_file (file-based)** から **`event:spawn-bundle` envelope (relay 経由)** に切り替える cut-over PR。worker workload-state からも `ready` を廃止し、`loading` から `working` へ直行する構造に変更。

worker 起動は claude CLI ネイティブの `/goal` 自走モードを使い、worker は env で受領した識別子 (`OW_CHANNEL` / `OW_ALIAS` / `OW_TASK_N`) で relay 接続 → `ow_history` で bundle pull → check_in → working、までを完走する。

## 主な変更

- `src/services/ow_service.py`
  - `_write_task_file` / `_slugify_task_title` 削除、`_build_spawn_bundle_data` 新設
  - `ow_spawn_worker`:
    - 引数に `goal_text: Optional[str] = None` 追加
    - claude 起動「前」に `event:spawn-bundle` を `to=w-<alias>` で relay 送信
    - 起動 prompt を `/goal <goal_text>。workerスキルに従って check_in からぜんぶやって。` 形式に
    - `--add-dir` 引数を削除 (task_file 廃止に伴い不要)
    - env 注入: `OW_CHANNEL` / `OW_ALIAS` / `OW_TASK_N` を追加、`OW_TASK_FILE` を削除
  - `_NON_TERMINAL_WORKLOAD_STATES` / `_ACTIVE_WORKLOAD_STATES` / `_STATE_TO_TASK_STATUS` / `_RELAY_STATE_TO_TASK_STATUS` から `ready` を削除
- `skills/worker/SKILL.md`
  - 起動シーケンス全面書き換え (Step 1 env 読み → Step 7 bundle pull → Step 9 identity 再送 → Step 10 working/briefing 直送)
  - 状態一覧から `ready` 行削除、`cmd:assign の受信 → working` セクション削除
- `skills/dispatcher/SKILL.md`
  - ready/auto-assign 関連の stagnation 監視・命令送信ロジックを削除
  - projector マッピング表から `ready` 行を削除
  - `command:assign` の文言を `ow_spawn_worker` 経路に書き換え
- `scripts/ow/sentinel.py`: `DEFAULT_THRESHOLDS` から `"ready": 60` を削除
- `scripts/ow/heartbeat.sh`
  - コメントを `loading | working/draining` の二値運用に更新
  - self-exit 安全条件を `PHASE=ready` から `PHASE=working` に変更 (working 中の MCP unreachable は cc-memory ツールが呼べず worker 実質詰まるため殺すのが妥当)
- `tests/`
  - `conftest.py`: `_OW_ENV_KEYS` に `OW_TASK_N` 追加
  - `test_ow_task_file_sanitize.py`: `TestWriteTaskFileSanitize` を `TestBuildSpawnBundleData` に書き換え、`goal_text` / `effort` のテストも追加
  - **新規** `test_ow_spawn_bundle.py`: spawn-bundle envelope 送信 / 送信失敗時 abort / worker_cmd の env 注入 + `/goal` prompt + `--add-dir` 不在 を検証

glossary `M#417` (`glossary:ow`) は本 PR と同時に `update_material` 済み: `workload-state` 用語の state 列挙から `ready` を削除、新規用語 `spawn-bundle` を追加、yaml header の terms リストも更新。

## supersede 関係

- D#2470 (task file 形式を JSON→マークダウン、material 化) — task_file 概念自体が廃止のため supersede
- D#2474 (task file frontmatter 形式) — 同上
- D#2609 (auto-close/auto-assign worker 完結) の **auto-assign 部分** — supersede (auto-close 部分は D#2857 / D#2906 で別途固まっているため維持)

## マージ前 / マージ後の手順

- マージ前: 動いている in-flight worker session (旧経路 task_file で起動済み) は事前に close する。マージ後も生きている旧 worker は heartbeat 自然死 or `ow_close_worker` で殺す。worker SKILL.md 改訂は新規 session のみ反映 (Claude Code は SKILL.md を起動時に load するため、既存 session は旧版で動き続ける)。
- マージ後: `~/.cc-memory/ow/orch/tasks/` 配下の既存 task_file ファイル群を `rm` で cleanup。本 PR は CLAUDE.md / CLAUDE.local.md の post-merge 手順 (`rm -rf ~/.claude/plugins/cache/...`, MCP server 再起動) も併用。

## テスト

```
tests/unit/test_ow_spawn_bundle.py .....                                 [  5%]
tests/unit/test_ow_task_file_sanitize.py ..................              [ 23%]
tests/unit/test_ow_spawn_alias_and_settings.py .....................     [ 50%]
tests/unit/test_ow_spawn_thinking_tmux_route.py .........                [ 79%]
tests/unit/test_ow_spawn_manual_fallback_observability.py ........       [ 87%]
tests/unit/test_pretooluse_ow_spawn_worker.py ............               [100%]

============================== 96 passed in 0.18s ==============================
```