### PR TITLE
feat: tmux adapter で worker pane を spawn/close 時に均等再分配

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -177,6 +177,9 @@ case "$ACTION" in
     FALLBACK_INTERVAL="${OW_CLOSE_FALLBACK_INTERVAL:-0.5}"
 
     # 1. pane の生存確認。既に不在ならそのまま closed 扱い。
+    # 注: pane が既に不在の場合 (worker が想定外に死亡 or 自己終了済み) は #{window_id}
+    # を取得できないため、残存 worker pane の縦再分配は実行できない。再分配が必要なら
+    # 呼び出し元が spawn 時に控えた window_id を close へ引き渡す必要がある。
     if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
       echo "closed"
       exit 0

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -26,6 +26,41 @@ SESSION_NAME="${OW_TMUX_SESSION:-ow-workers}"
 WORKER_MARKER_OPT="@ow-worker"
 THINKING_WINDOW_NAME="ow-worker-thinking"
 
+# worker pane (@ow-worker=1) を window 内で縦方向に均等再分配する (D#2830)。
+# 同一カラム内の縦分割を前提に、pane_id 昇順 (= 上から下) で最後を除く各 worker
+# pane の高さを window_height/N に揃える。最後の pane は残り高さを自動で吸収する。
+# orch pane (水平分割側) の幅には触らない。worker 数 0/1 や window 高さ取得失敗時は no-op。
+rebalance_worker_panes() {
+  local window_id="$1"
+  [[ -z "$window_id" ]] && return 0
+
+  local panes
+  panes=$(tmux list-panes -t "$window_id" -F "#{pane_id}|#{@ow-worker}" 2>/dev/null \
+    | awk -F'|' '$2 == "1" { print $1 }' \
+    | sort -t'%' -k2 -n)
+
+  local count
+  count=$(printf '%s\n' "$panes" | awk '/^%/ {n++} END {print n+0}')
+  [[ "$count" -lt 2 ]] && return 0
+
+  local win_h
+  win_h=$(tmux display -t "$window_id" -p "#{window_height}" 2>/dev/null || true)
+  [[ -z "$win_h" || "$win_h" -le 0 ]] && return 0
+
+  local target=$(( win_h / count ))
+  [[ "$target" -le 0 ]] && return 0
+
+  local i=0
+  local last_idx=$(( count - 1 ))
+  while IFS= read -r pane; do
+    [[ -z "$pane" ]] && continue
+    if [[ "$i" -lt "$last_idx" ]]; then
+      tmux resize-pane -t "$pane" -y "$target" 2>/dev/null || true
+    fi
+    i=$((i + 1))
+  done <<< "$panes"
+}
+
 case "$ACTION" in
   spawn)
     if [[ $# -lt 3 ]]; then
@@ -107,6 +142,8 @@ case "$ACTION" in
       # （非対応バージョン以外にも pane消失・tmux server断などが要因になりうるため、原因は断定しない）。
       tmux set-option -p -t "$PANE_ID" "$WORKER_MARKER_OPT" 1 \
         || echo "warn: tmux set-option -p @ow-worker failed (possibly tmux <1.8 or pane gone), worker marker not set" >&2
+
+      rebalance_worker_panes "$WINDOW_ID"
     else
       # フォールバック: 従来の ow-workers 別session方式
       if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
@@ -142,8 +179,9 @@ case "$ACTION" in
       exit 0
     fi
 
-    # 2. pane 内 claude の PID を取得 (SIGKILL fallback 用に先に押さえる)。
+    # 2. pane 内 claude の PID と所属 window_id を取得 (SIGKILL fallback / 再分配用に先に押さえる)。
     PANE_PID="$(tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null || true)"
+    CLOSE_WINDOW_ID="$(tmux display -t "$TERM_REF" -p "#{window_id}" 2>/dev/null || true)"
 
     # 3. tmux kill-pane で SIGHUP 経由の正常 close を試みる。
     tmux kill-pane -t "$TERM_REF" 2>/dev/null || true
@@ -152,6 +190,7 @@ case "$ACTION" in
     i=0
     while [[ $i -lt $FALLBACK_ITER ]]; do
       if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+        rebalance_worker_panes "$CLOSE_WINDOW_ID"
         echo "closed"
         exit 0
       fi
@@ -171,6 +210,7 @@ case "$ACTION" in
     final_iter=2
     while [[ $j -lt $final_iter ]]; do
       if ! tmux display -t "$TERM_REF" -p "#{pane_pid}" 2>/dev/null >/dev/null; then
+        rebalance_worker_panes "$CLOSE_WINDOW_ID"
         echo "killed"
         exit 0
       fi

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -28,7 +28,10 @@ THINKING_WINDOW_NAME="ow-worker-thinking"
 
 # worker pane (@ow-worker=1) を window 内で縦方向に均等再分配する (D#2830)。
 # 同一カラム内の縦分割を前提に、pane_id 昇順 (= 上から下) で最後を除く各 worker
-# pane の高さを window_height/N に揃える。最後の pane は残り高さを自動で吸収する。
+# pane の高さを target = (window_height - (count-1)) / count に揃える。最後の pane は
+# 残り高さを自動で吸収する。window_height は N pane 縦積みで sum(pane_height) + (N-1)
+# セパレータ行と等しいため、セパレータを引いた値を分母 count で割る必要がある (引かないと
+# 最後の pane が geometric に小さくなる)。
 # orch pane (水平分割側) の幅には触らない。worker 数 0/1 や window 高さ取得失敗時は no-op。
 rebalance_worker_panes() {
   local window_id="$1"
@@ -47,7 +50,7 @@ rebalance_worker_panes() {
   win_h=$(tmux display -t "$window_id" -p "#{window_height}" 2>/dev/null || true)
   [[ -z "$win_h" || "$win_h" -le 0 ]] && return 0
 
-  local target=$(( win_h / count ))
+  local target=$(( (win_h - (count - 1)) / count ))
   [[ "$target" -le 0 ]] && return 0
 
   local i=0

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -19,6 +19,7 @@ def _make_mock_tmux(
     target_pane_exists: bool = True,
     existing_worker_panes: str = "",
     display_switch_at_kill: int | None = None,
+    window_height: str = "12345",
 ) -> Path:
     """tmuxをモックするシェルスクリプトを作成する。
 
@@ -32,6 +33,9 @@ def _make_mock_tmux(
 
     existing_worker_panesは `tmux list-panes -F "#{pane_id}|#{@ow-worker}"` の擬似出力。
     例: "%5|1\\n%7|" を渡すと既存worker paneが1個ある状態を模擬する（"1"がworkerマーカー、空欄が非worker）。
+
+    window_height は `tmux display -p "#{window_height}"` が返す値（rebalance の高さ計算用）。
+    既定 "12345"。window_height を問わない display クエリ（pane_pid 等）は従来通り "12345" を返す。
     """
     mock_dir = tmp_path / "mock_bin"
     mock_dir.mkdir(exist_ok=True)
@@ -64,7 +68,10 @@ def _make_mock_tmux(
         f'if [ "$1" = "display" ]; then\n'
         f'  state=$(cat "{display_state_file}" 2>/dev/null || echo "1")\n'
         f'  if [ "$state" = "0" ]; then exit 1; fi\n'
-        f'  echo "12345"\n'
+        f'  case "$*" in\n'
+        f'    *window_height*) echo "{window_height}";;\n'
+        f'    *) echo "12345";;\n'
+        f'  esac\n'
         f'  exit 0\n'
         f'fi\n'
         f'if [ "$1" = "list-panes" ]; then printf "%b\\n" "{existing_worker_panes}"; fi\n'
@@ -321,6 +328,90 @@ class TestTmuxAdapterSplit:
         )
         assert result.returncode != 0
         assert "target_pane not found" in result.stderr
+
+
+class TestTmuxAdapterRebalance:
+    """rebalance_worker_panes の縦再分配ロジックのテスト。
+
+    spawn 経路（target_pane 指定 + 既存 worker あり → 垂直分割後に rebalance 実行）で
+    検証する。rebalance が参照する list-panes 出力は existing_worker_panes、window 高さは
+    window_height で直接制御し、resize-pane 呼び出しの有無と -y 引数値を assert する。
+    """
+
+    # 5 個の worker pane（@ow-worker=1）を縦積みした状態の list-panes 擬似出力
+    FIVE_WORKERS = "%1|1\\n%2|1\\n%3|1\\n%4|1\\n%5|1"
+
+    def test_rebalance_uses_separator_aware_target(self, tmp_path):
+        """win_h=40, N=5 のとき target=(40-(5-1))/5=7。先頭から (N-1)=4 個の pane が
+        `resize-pane -y 7` でリサイズされる（最後の pane は残り高さを吸収するため触らない）。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes=self.FIVE_WORKERS,
+            window_height="40",
+        )
+        assert result.returncode == 0
+        assert "-y 7" in captured
+        assert captured.count("resize-pane") == 4
+
+    def test_rebalance_formula_regression_guard(self, tmp_path):
+        """セパレータ行を無視する旧式 win_h/count=40/5=8 への退行を防ぐ。
+        正しい target は 7 なので `-y 8` が出てはならない。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes=self.FIVE_WORKERS,
+            window_height="40",
+        )
+        assert result.returncode == 0
+        assert "-y 8" not in captured
+
+    def test_rebalance_last_pane_not_resized(self, tmp_path):
+        """N 個の worker pane に対し resize-pane は (N-1) 回だけ呼ばれる（最後は吸収）。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes=self.FIVE_WORKERS,
+            window_height="60",
+        )
+        assert result.returncode == 0
+        # win_h=60, N=5 → target=(60-4)/5=11
+        assert "-y 11" in captured
+        assert captured.count("resize-pane") == 4
+
+    def test_rebalance_skipped_for_single_worker(self, tmp_path):
+        """worker pane が 1 個（count<2）のとき rebalance は no-op で resize-pane を呼ばない。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|1",
+            window_height="40",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
+
+    def test_rebalance_skipped_when_target_nonpositive(self, tmp_path):
+        """window 高さが pane 数に対して小さく target<=0 になるとき resize-pane を呼ばない。
+        win_h=3, N=5 → (3-4)/5=0（切り捨て）→ no-op。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes=self.FIVE_WORKERS,
+            window_height="3",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
+
+    def test_rebalance_skipped_when_window_height_unavailable(self, tmp_path):
+        """window_height 取得が空文字のとき rebalance は no-op（resize-pane を呼ばない）。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes=self.FIVE_WORKERS,
+            window_height="",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
 
 
 class TestTmuxAdapterThinking:

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -376,6 +376,70 @@ class TestTmuxAdapterThinking:
         assert "target_pane not found" in result.stderr
 
 
+class TestTmuxAdapterRebalance:
+    """worker pane 均等再分配 (D#2830) のテスト。
+
+    モックの `tmux display` は引数を問わず "12345" を返すため、rebalance 内の
+    `display -p "#{window_height}"` も win_h=12345 として扱われる。
+    target = (12345 - (count - 1)) / count を計算して各 worker pane に resize-pane する。
+    """
+
+    def test_no_resize_when_single_worker(self, tmp_path):
+        """既存 worker 0 + 新規 1 = 1 個のみのとき、count<2 で skip するので resize-pane は呼ばれない。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
+
+    def test_resize_called_when_multiple_workers(self, tmp_path):
+        """worker pane が 2 個以上あれば resize-pane が呼ばれる。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|1\\n%7|1",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" in captured
+
+    def test_resize_excludes_largest_pane_id(self, tmp_path):
+        """最大 pane_id (= 物理的に最下) は resize-pane の対象外 (残り高さ自動吸収)。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|1\\n%7|1\\n%9|1",
+        )
+        assert result.returncode == 0
+        resize_targets = [l for l in captured.splitlines() if "resize-pane" in l]
+        assert any("-t %5" in l for l in resize_targets)
+        assert any("-t %7" in l for l in resize_targets)
+        assert not any("-t %9" in l for l in resize_targets)
+
+    def test_resize_target_height_subtracts_separator_rows(self, tmp_path):
+        """target = (window_height - (count-1)) / count。セパレータ行を引かないと最後の pane が
+        geometric に小さくなる。window_height=12345, count=3 → target=(12345-2)/3=4114。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|1\\n%7|1\\n%9|1",
+        )
+        assert result.returncode == 0
+        assert "-y 4114" in captured
+        assert "-y 4115" not in captured  # 旧式バグ (window_height/count) の検出
+
+    def test_no_resize_when_no_worker_panes(self, tmp_path):
+        """`@ow-worker=1` の pane が 0 個ならフラグなしの空欄 pane 群があっても skip。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|\\n%7|",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
+
+
 class TestTmuxAdapterErrors:
     def test_unknown_action_exits_nonzero(self, tmp_path):
         """未知のactionはゼロ以外のexit codeとエラーメッセージを返す。"""


### PR DESCRIPTION
## 背景

worker pane の縦サイズが現状「最新 worker を半分積み」式で、worker 数 N の増加で最古 pane が幾何級数的 (1/2^N) に狭くなる。5 worker 並走時に「読めない」レベルになる、というユーザー報告。

## 変更

`scripts/ow/adapters/tmux.sh` に `rebalance_worker_panes <window_id>` 関数を追加し、以下のタイミングで呼ぶ:

- spawn 直後 (target_pane 指定の通常 worker のみ)
- close 完了直後 (closed / killed どちらでも)

ロジック: window 内の `@ow-worker=1` の pane を pane_id 昇順で列挙し、各 pane に `resize-pane -y (window_height / N)` を順次適用する。最後の pane は残り高さを自動吸収。

`select-layout even-vertical` は orch pane も均等にしてしまうので使わず、worker pane 群だけを対象にした。orch pane (左カラム) の幅は不変。

## 動作対象外 (no-op)

- 思考 worker (別 window): 同 window 内の worker pane が 1 個だけなので skip
- target_pane 未指定 (`ow-workers` 別 session フォールバック): 1 window = 1 worker で skip
- close 後に worker pane が 0 個になった場合: skip

## 実機検証 (80x40 window)

```
3 worker spawn 後:  %1=13行 / %2=13行 / %3=12行 (均等)
中間 close 後:      %1=27行 / %3=12行 (skewed)
rebalance 適用後:   %1=20行 / %3=19行 (均等)
```

orch pane (左カラム) は全フェーズで不変。

## Test plan

- [x] 既存 unit test 40 件 pass (`tests/unit/test_tmux_adapter.py`, `tests/unit/test_ow_spawn_thinking_tmux_route.py`)
- [x] 実機検証: spawn 3 連続 + 中間 close で均等再分配を確認