### PR TITLE
refactor: get 系 tool レスポンスから id field を廃止

### DIFF
--- a/src/services/citation_renderer.py
+++ b/src/services/citation_renderer.py
@@ -187,8 +187,8 @@ def apply_flavor_to_entity_dict(
 def _extract_entity_id(d: dict, entity_type: str, id_key: str) -> int | None:
     """response dict から整数 ID を取り出す。
 
-    apply_readable_id_inplace で `id` / `<entity>_id` が文字列化されている場合に
-    備えて `<key>_raw` フィールドにフォールバックする。"""
+    apply_readable_id_inplace で `id` / `<entity>_id` キーが削除されているため、
+    `<key>_raw` フィールドにフォールバックする。"""
     for key in (
         id_key,
         f"{entity_type}_id",

--- a/src/services/readable_id.py
+++ b/src/services/readable_id.py
@@ -1,10 +1,10 @@
-"""エンティティ ID readable 整形 helper
+"""エンティティ ID 整形 helper
 
-cc-memory の MCP tool 返却で `id` フィールドが整数として返り、AI が文脈推測なしで
-「何を指しているか」読めるよう、タイトル + (#NNN) 形式に展開する。
+cc-memory の get 系 tool 返却で、整数 `id` を `id_raw` に退避し、`id` キーを削除する。
+タイトル + (#NNN) 形式の文字列展開は廃止 (D#2966)。AI には構造化フィールド (`title` +
+`id_raw`) で渡し、内部 ID リテラルが返却ペイロードに乗らないようにする。
 
-現状は flavor="readable" のみ実装。将来 flavor="raw" / flavor="internal" を追加し、
-citation parser と接続する。
+`format_readable_id` は session_start_hook の activity 表示で参照されているため残置。
 """
 from typing import Literal, get_args
 
@@ -20,15 +20,17 @@ def format_readable_id(
     title: str | None,
     flavor: FLAVOR = "readable",
 ) -> str:
-    """エンティティ ID を readable 形式で返す。
+    """エンティティ ID を `{title} (#NNN)` 形式の文字列で返す。
 
-    現状は flavor='readable' のみ実装。'raw' / 'internal' は将来拡張用 stub。
+    現状は session_start_hook の activity 表示のみが利用する。tool レスポンス整形は
+    `apply_readable_id_inplace` で別経路 (id 削除 + id_raw 退避) に切り替わったため、
+    新規 caller を増やさないこと。
 
     Args:
         entity_type: エンティティ種別 ('topic'/'decision'/'activity'/'log'/'material')
         id_int: 元の整数 ID
-        title: エンティティのタイトル（None や空文字列の場合は ID のみ）
-        flavor: 表示形式（'readable' のみ実装済み、'raw'/'internal' は将来実装）
+        title: エンティティのタイトル (None や空文字列の場合は ID のみ)
+        flavor: 表示形式 ('readable' のみ実装済み、'raw'/'internal' は将来実装)
 
     Returns:
         flavor='readable': `{title} (#{id_int})` 形式の文字列。
@@ -62,38 +64,40 @@ def format_readable_id(
 def apply_readable_id_inplace(
     result_dict: dict,
     entity_type: ENTITY_TYPE,
-    flavor: FLAVOR = "readable",
     id_key: str = "id",
-    title_key: str = "title",
 ) -> None:
-    """`result_dict[id_key]` を readable 形式で置換する（in-place）。
+    """`result_dict[id_key]` を `{id_key}_raw` に退避し、元キーを削除する (in-place)。
 
-    元の整数 ID は `{id_key}_raw` に退避し、将来の parser / migration tool から
-    アクセス可能にする。
+    AI 側に渡るペイロードから内部 ID リテラル (`(#NNN)` 文字列) を消すために、
+    整数 `id` を `id_raw` 名で残しつつ `id` キー自体を取り除く。`title` 等の他フィールド
+    は触らない。
 
-    `id_key` が `result_dict` に存在しない場合や、すでに `{id_key}_raw` が存在する
-    場合は何もしない（冪等性確保）。
+    冪等性:
+    - `id_key` が `result_dict` に無ければ no-op
+    - `{id_key}_raw` が既に存在すれば no-op (既に処理済み)
+    - `result_dict[id_key]` が int でなければ no-op (既に文字列に整形済み等)
 
     Args:
-        result_dict: 対象の dict（in-place 更新される）
-        entity_type: エンティティ種別
-        flavor: 表示形式（'readable' のみ実装済み）
-        id_key: ID を保持するキー名（デフォルト "id"）
-        title_key: タイトルを保持するキー名（デフォルト "title"）
+        result_dict: 対象の dict (in-place 更新される)
+        entity_type: エンティティ種別 (検証のみに使用、戻り値・更新内容には影響しない)
+        id_key: ID を保持するキー名 (デフォルト "id")
     """
+    if entity_type not in _VALID_ENTITY_TYPES:
+        raise ValueError(
+            f"Invalid entity_type: {entity_type!r}. "
+            f"Must be one of {sorted(_VALID_ENTITY_TYPES)}"
+        )
+
     if id_key not in result_dict:
         return
 
-    # 冪等性: すでに整形済み（_raw に元 ID が退避されている）なら何もしない
     raw_key = f"{id_key}_raw"
     if raw_key in result_dict:
         return
 
     id_value = result_dict[id_key]
-    # 整数以外（既に整形済み文字列など）が入っている場合は触らない
     if not isinstance(id_value, int):
         return
 
-    title = result_dict.get(title_key)
     result_dict[raw_key] = id_value
-    result_dict[id_key] = format_readable_id(entity_type, id_value, title, flavor)
+    del result_dict[id_key]

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1664,8 +1664,8 @@ def _decorate(
 
     nearby_tags = _compute_nearby_tags(sliced, query_tag_ids, ctx.offset)
 
-    # readable_id 化: 各結果の id を「title (#NNN)」形式に置換し、元の id を id_raw に退避
-    # type フィールドは置換前に確定済みなのでそのまま参照する
+    # readable_id 化: 各結果の id を削除し、整数 id を id_raw に退避する
+    # type フィールドは適用前に確定済みなのでそのまま参照する
     for item in sliced:
         apply_readable_id_inplace(item, item["type"])
 

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -140,9 +140,10 @@ class TestCheckIn:
 
         assert "error" not in result
         assert len(result["materials"]) == 2
-        # カタログ形式: id, title, snippet, source, created_at（contentなし）
+        # カタログ形式: id_raw, title, snippet, source, created_at (contentなし)
         for m in result["materials"]:
-            assert "id" in m
+            assert "id_raw" in m
+            assert "id" not in m
             assert "title" in m
             assert "snippet" in m
             assert "source" in m

--- a/tests/unit/test_decision_title.py
+++ b/tests/unit/test_decision_title.py
@@ -290,7 +290,6 @@ class TestDisplayFallback:
         finally:
             conn.close()
 
-        # α化後 id は文字列なので、元 ID は id_raw で索引する
         by_id = {d["id_raw"]: d["title"] for d in decisions}
         assert by_id[with_id] == "要点X", "titleありdecisionがtitleで表示されない"
         assert by_id[without_id] == "本文Y（titleなし）", "titleなしdecisionがdecision本文にfallbackしない"
@@ -312,8 +311,8 @@ class TestDisplayFallback:
     def test_get_by_id_decision_title_fallback_when_omitted(self, topic):
         """title未指定decisionのget_by_idはdecision本文先頭50文字をfallback表示する
 
-        α化（`{title} (#NNN)` 形式）で title None だと `(#NNN)` のみになるのを防ぐため、
-        decision本文の先頭50文字をtitleにfallbackする（_get_decisions_from_topics と同じ挙動）。
+        title が None のまま返ると check-in / search の見出しに何も出ないため、
+        decision 本文の先頭50文字を title にfallbackする (_get_decisions_from_topics と同じ挙動)。
         """
         result = add_decisions([
             {"topic_id": topic["topic_id"], "decision": "本文だけのdecision", "reason": "理由"},
@@ -322,6 +321,5 @@ class TestDisplayFallback:
 
         res = get_by_id("decision", did)
         assert res["data"]["title"] == "本文だけのdecision"
-        # α化された id 文字列にも本文先頭がのる
-        assert res["data"]["id"] == f"本文だけのdecision (#{did})"
         assert res["data"]["id_raw"] == did
+        assert "id" not in res["data"]

--- a/tests/unit/test_fts5_search.py
+++ b/tests/unit/test_fts5_search.py
@@ -60,7 +60,8 @@ def test_search_response_format(temp_db):
     if result["results"]:
         item = result["results"][0]
         assert "type" in item
-        assert "id" in item
+        assert "id_raw" in item
+        assert "id" not in item
         assert "title" in item
         assert "score" in item
         assert "snippet" in item

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -893,7 +893,7 @@ def test_search_offset_skips_results(temp_db, mock_embedding_model):
     assert "error" not in result_offset
     assert len(result_all["results"]) >= 3
     # offset=2 の結果は、全体の3番目以降と一致する
-    assert result_offset["results"][0]["id"] == result_all["results"][2]["id"]
+    assert result_offset["results"][0]["id_raw"] == result_all["results"][2]["id_raw"]
 
 
 def test_search_offset_with_limit(temp_db, mock_embedding_model):
@@ -912,7 +912,7 @@ def test_search_offset_with_limit(temp_db, mock_embedding_model):
     assert "error" not in result_page
     assert len(result_page["results"]) <= 2
     if len(result_all["results"]) > 1:
-        assert result_page["results"][0]["id"] == result_all["results"][1]["id"]
+        assert result_page["results"][0]["id_raw"] == result_all["results"][1]["id_raw"]
 
 
 def test_search_offset_beyond_results(temp_db, mock_embedding_model):
@@ -944,7 +944,7 @@ def test_search_offset_zero_is_default(temp_db, mock_embedding_model):
     assert "error" not in result_zero
     assert len(result_default["results"]) == len(result_zero["results"])
     for r1, r2 in zip(result_default["results"], result_zero["results"]):
-        assert r1["id"] == r2["id"]
+        assert r1["id_raw"] == r2["id_raw"]
 
 
 def test_search_offset_negative_treated_as_zero(temp_db, mock_embedding_model):

--- a/tests/unit/test_readable_id.py
+++ b/tests/unit/test_readable_id.py
@@ -69,31 +69,25 @@ def test_format_readable_id_internal_flavor_not_implemented():
 
 
 def test_apply_readable_id_inplace_normal():
-    """通常 dict は id を readable 化し、id_raw に元 ID を退避する"""
+    """通常 dict は id を削除し、id_raw に元 ID (int) を退避する。title は触らない"""
     d = {"id": 123, "title": "T", "other": "x"}
     apply_readable_id_inplace(d, "topic")
-    assert d == {"id": "T (#123)", "id_raw": 123, "title": "T", "other": "x"}
+    assert d == {"id_raw": 123, "title": "T", "other": "x"}
 
 
-def test_apply_readable_id_inplace_missing_title():
-    """title キーが無い場合は (#NNN) のみ"""
+def test_apply_readable_id_inplace_does_not_touch_title():
+    """title フィールドは値の有無に関わらず一切変更されない"""
     d = {"id": 50}
     apply_readable_id_inplace(d, "log")
-    assert d == {"id": "(#50)", "id_raw": 50}
+    assert d == {"id_raw": 50}
 
+    d2 = {"id": 9, "title": ""}
+    apply_readable_id_inplace(d2, "material")
+    assert d2 == {"id_raw": 9, "title": ""}
 
-def test_apply_readable_id_inplace_empty_title():
-    """title が空文字列の場合は (#NNN) のみ"""
-    d = {"id": 9, "title": ""}
-    apply_readable_id_inplace(d, "material")
-    assert d == {"id": "(#9)", "id_raw": 9, "title": ""}
-
-
-def test_apply_readable_id_inplace_none_title():
-    """title が None の場合は (#NNN) のみ"""
-    d = {"id": 11, "title": None}
-    apply_readable_id_inplace(d, "decision")
-    assert d == {"id": "(#11)", "id_raw": 11, "title": None}
+    d3 = {"id": 11, "title": None}
+    apply_readable_id_inplace(d3, "decision")
+    assert d3 == {"id_raw": 11, "title": None}
 
 
 def test_apply_readable_id_inplace_missing_id_key():
@@ -103,28 +97,31 @@ def test_apply_readable_id_inplace_missing_id_key():
     assert d == {"title": "x"}
 
 
-def test_apply_readable_id_inplace_custom_keys():
-    """id_key / title_key を変更できる"""
+def test_apply_readable_id_inplace_custom_id_key():
+    """id_key を変更できる"""
     d = {"decision_id": 7, "decision_title": "D"}
-    apply_readable_id_inplace(
-        d, "decision", id_key="decision_id", title_key="decision_title"
-    )
+    apply_readable_id_inplace(d, "decision", id_key="decision_id")
     assert d == {
-        "decision_id": "D (#7)",
         "decision_id_raw": 7,
         "decision_title": "D",
     }
 
 
 def test_apply_readable_id_inplace_idempotent():
-    """すでに整形済み（id_raw が存在）の dict には何もしない"""
-    d = {"id": "T (#1)", "id_raw": 1, "title": "T"}
+    """すでに整形済み (id_raw が存在) の dict には何もしない"""
+    d = {"id_raw": 1, "title": "T"}
     apply_readable_id_inplace(d, "topic")
-    assert d == {"id": "T (#1)", "id_raw": 1, "title": "T"}
+    assert d == {"id_raw": 1, "title": "T"}
 
 
 def test_apply_readable_id_inplace_non_int_id():
-    """id が int でない（既に整形済み文字列など）場合は何もしない"""
+    """id が int でない場合 (例: 既に文字列化済み) は何もしない"""
     d = {"id": "already (#1)", "title": "x"}
     apply_readable_id_inplace(d, "topic")
     assert d == {"id": "already (#1)", "title": "x"}
+
+
+def test_apply_readable_id_inplace_invalid_entity_type():
+    """不正な entity_type は ValueError"""
+    with pytest.raises(ValueError, match="Invalid entity_type"):
+        apply_readable_id_inplace({"id": 1}, "unknown")  # type: ignore[arg-type]

--- a/tests/unit/test_readable_id_title_fallback.py
+++ b/tests/unit/test_readable_id_title_fallback.py
@@ -1,7 +1,7 @@
-"""readable_id 化時の title fallback テスト (PR #405 review fix)
+"""title fallback テスト
 
-title が None の decision / log を readable_id 化すると `(#NNN)` のみになる問題を防ぐ。
-本文先頭50文字を fallback として `{snippet} (#NNN)` 形式にする。
+title が None の decision / log を返却する際、title フィールドが None のままになる
+のを防ぐため本文先頭50文字を fallback として title に入れる挙動を検証する。
 
 対応箇所:
 - search_service._format_row (decision ブランチ) → get_by_id / get_by_ids 経由
@@ -46,7 +46,7 @@ class TestDecisionTitleFallbackInFormatRow:
     """_format_row decision ブランチで title None 時に decision 本文へ fallback する"""
 
     def test_get_by_id_uses_decision_body_when_title_none(self, topic):
-        """get_by_id(decision) は title なしのとき decision 本文先頭50文字を表示する"""
+        """get_by_id(decision) は title なしのとき decision 本文先頭50文字を title に入れる"""
         body = "これがdecision本文の中身でtitleは指定されていない"
         result = add_decisions([
             {"topic_id": topic["topic_id"], "decision": body, "reason": "理由"},
@@ -56,11 +56,9 @@ class TestDecisionTitleFallbackInFormatRow:
         res = get_by_id("decision", did)
         assert "error" not in res
         data = res["data"]
-        # title フィールドに本文 fallback が乗る
         assert data["title"] == body[:50]
-        # readable_id 化された id 文字列にも fallback タイトルが組み込まれる
-        assert data["id"] == f"{body[:50]} (#{did})"
         assert data["id_raw"] == did
+        assert "id" not in data
 
     def test_get_by_ids_uses_decision_body_when_title_none(self, topic):
         """get_by_ids(decision) も同様に本文 fallback する"""
@@ -76,7 +74,8 @@ class TestDecisionTitleFallbackInFormatRow:
         assert len(items) == 1
         data = items[0]["data"]
         assert data["title"] == body
-        assert data["id"] == f"{body} (#{did})"
+        assert data["id_raw"] == did
+        assert "id" not in data
 
     def test_get_by_id_prefers_title_when_provided(self, topic):
         """title 指定済みなら本文 fallback ではなく title が使われる"""
@@ -93,7 +92,8 @@ class TestDecisionTitleFallbackInFormatRow:
         res = get_by_id("decision", did)
         data = res["data"]
         assert data["title"] == "正しい題名"
-        assert data["id"] == f"正しい題名 (#{did})"
+        assert data["id_raw"] == did
+        assert "id" not in data
 
 
 class TestLogsCatalogTitleFallback:
@@ -113,9 +113,9 @@ class TestLogsCatalogTitleFallback:
             conn.close()
 
         assert latest_log is not None
-        log_id = latest_log["id_raw"]
         assert latest_log["title"] == content[:50]
-        assert latest_log["id"] == f"{content[:50]} (#{log_id})"
+        assert "id_raw" in latest_log
+        assert "id" not in latest_log
 
     def test_catalog_falls_back_to_content_when_title_none(self, topic):
         """catalog の各 log も title None なら content 先頭50文字に fallback"""
@@ -123,7 +123,7 @@ class TestLogsCatalogTitleFallback:
         add_logs([
             {"topic_id": tid, "content": "旧log本文1"},
             {"topic_id": tid, "content": "旧log本文2"},
-            {"topic_id": tid, "content": "最新log本文（latest側）"},
+            {"topic_id": tid, "content": "最新log本文(latest側)"},
         ])
 
         conn = get_connection()
@@ -133,13 +133,13 @@ class TestLogsCatalogTitleFallback:
             conn.close()
 
         assert latest_log is not None
-        # catalog には残り2件が新しい順に入る
         assert len(catalog) == 2
         for item in catalog:
             assert "id_raw" in item
-            # title None だと "(#NNN)" のみになる挙動を回避できているか
-            assert not item["id"].startswith("(#"), (
-                f"catalog item id should embed content fallback, got {item['id']!r}"
+            assert "id" not in item
+            # title None だと None のままになる挙動を回避できているか
+            assert item["title"] is not None and item["title"] != "", (
+                f"catalog item title should embed content fallback, got {item['title']!r}"
             )
 
     def test_latest_log_prefers_title_when_provided(self, topic):
@@ -155,6 +155,6 @@ class TestLogsCatalogTitleFallback:
             conn.close()
 
         assert latest_log is not None
-        log_id = latest_log["id_raw"]
         assert latest_log["title"] == "ログ題名"
-        assert latest_log["id"] == f"ログ題名 (#{log_id})"
+        assert "id_raw" in latest_log
+        assert "id" not in latest_log

--- a/tests/unit/test_timeline_service.py
+++ b/tests/unit/test_timeline_service.py
@@ -201,10 +201,11 @@ class TestGetTimelineByTopicId:
         assert types == {"decision", "log", "material"}
 
     def test_each_item_has_required_fields(self, topic_with_data):
-        """各アイテムがid, type, title, created_at, replaces, replaced_byを持つ"""
+        """各アイテムがid_raw, type, title, created_at, replaces, replaced_byを持つ"""
         result = get_timeline(topic_id=topic_with_data["topic_id"])
         for item in result["items"]:
-            assert "id" in item
+            assert "id_raw" in item
+            assert "id" not in item
             assert "type" in item
             assert "title" in item
             assert "created_at" in item
@@ -513,7 +514,7 @@ class TestRetractedExclusion:
 
         result = get_timeline(topic_id=tid)
         assert result["total"] == 1
-        assert all(item["id"] != retract_id for item in result["items"])
+        assert all(item["id_raw"] != retract_id for item in result["items"])
 
     def test_retracted_log_excluded(self, topic):
         """retractされたlogはタイムラインに表示されない"""
@@ -528,7 +529,7 @@ class TestRetractedExclusion:
 
         result = get_timeline(topic_id=tid)
         assert result["total"] == 1
-        assert all(item["id"] != retract_id for item in result["items"])
+        assert all(item["id_raw"] != retract_id for item in result["items"])
 
 
 class TestMaterialDedup:
@@ -560,7 +561,7 @@ class TestMaterialDedup:
         )
 
         result = get_timeline(activity_id=aid, entity_types=["material"])
-        material_ids = [item["id"] for item in result["items"]]
+        material_ids = [item["id_raw"] for item in result["items"]]
         assert len(material_ids) == 1
         assert result["total"] == 1
 


### PR DESCRIPTION
## Summary

- `apply_readable_id_inplace` を「id を `{title} (#NNN)` 文字列で置換」から「id を `id_raw` に退避して元キーを削除」に変更
- 全 get 系 tool レスポンスから `id` フィールドが消え、`id_raw` (整数) + `title` (文字列) のみ返るようになる
- AI に渡るペイロードから内部 ID リテラル `(#NNN)` が消えるので、入口側で参照記号漏出を塞げる

## なぜ変えるか

現状の `id` フィールドは実体が `\"{title} (#{NNN})\"` 形式で、`title` フィールドと `id_raw` フィールドの内容が両方乗った冗長表記になっていた。`title` と `id_raw` が別フィールドで返るなら、`id` を削っても情報損失はゼロ。一方で `(#NNN)` リテラルが毎ターン AI コンテキストに乗るのを止められる。

## 影響範囲

- helper 1 ファイル変更 (`src/services/readable_id.py`)
- 7 service callsite (topic / decision / material / search / checkin / timeline / relation / discussion_log) は helper 経由なので変更不要
- 内部 Python caller は元々 integer `id` を読んでいたので影響なし
- AI / skill 側 (~/.claude/skills, plugin cache, cc-memory/skills) に `(#NNN)` パース動線は存在しないことを grep で確認済み
- テスト 8 ファイルで `["id"]` を読んでいた assertion を `["id_raw"]` に置換

`format_readable_id` は `hooks/session_start_hook.py` の activity 表示で参照されているため残置している。

## Test plan

- [x] `tests/unit/test_readable_id.py` 単体テスト書き直し: 新挙動 (id 削除 + id_raw 退避) を検証
- [x] 既存テストの `["id"]` assertion を `["id_raw"]` または `"id" not in ...` に更新
- [x] 全テスト pass (2232 passed, 1 skipped)