### PR TITLE
test: TestTmuxAdapterRebalance クラスの二重定義を統合

### DIFF
--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -415,7 +415,7 @@ class TestTmuxAdapterRebalance:
 
     def test_rebalance_excludes_largest_pane_id(self, tmp_path):
         """最大 pane_id (= 物理的に最下) は resize-pane の対象外 (残り高さ自動吸収)。
-        win_h=40, N=3 → target=(40-2)/3=12。%9 は最大 pane_id なので除外。"""
+        win_h=40, N=3 → target=(40-2)/3=12（切り捨て）。%9 は最大 pane_id なので除外。"""
         result, captured = _run_adapter(
             ["spawn", "/tmp/work", "claude", "%0"],
             tmp_path,
@@ -423,11 +423,12 @@ class TestTmuxAdapterRebalance:
             window_height="40",
         )
         assert result.returncode == 0
-        resize_lines = [l for l in captured.splitlines() if "resize-pane" in l]
-        assert any("-t %5" in l for l in resize_lines)
-        assert any("-t %7" in l for l in resize_lines)
-        assert not any("-t %9" in l for l in resize_lines)
+        resize_lines = [line for line in captured.splitlines() if "resize-pane" in line]
+        assert any("-t %5" in line for line in resize_lines)
+        assert any("-t %7" in line for line in resize_lines)
+        assert not any("-t %9" in line for line in resize_lines)
         assert "-y 12" in captured
+        assert "-y 13" not in captured  # 旧式バグ (window_height/count = 40/3 = 13) の検出
 
     def test_rebalance_skipped_when_no_worker_panes(self, tmp_path):
         """`@ow-worker=1` フラグ付き pane が 0 個ならフラグなしの pane 群があっても skip。"""

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -413,6 +413,33 @@ class TestTmuxAdapterRebalance:
         assert result.returncode == 0
         assert "resize-pane" not in captured
 
+    def test_rebalance_excludes_largest_pane_id(self, tmp_path):
+        """最大 pane_id (= 物理的に最下) は resize-pane の対象外 (残り高さ自動吸収)。
+        win_h=40, N=3 → target=(40-2)/3=12。%9 は最大 pane_id なので除外。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|1\\n%7|1\\n%9|1",
+            window_height="40",
+        )
+        assert result.returncode == 0
+        resize_lines = [l for l in captured.splitlines() if "resize-pane" in l]
+        assert any("-t %5" in l for l in resize_lines)
+        assert any("-t %7" in l for l in resize_lines)
+        assert not any("-t %9" in l for l in resize_lines)
+        assert "-y 12" in captured
+
+    def test_rebalance_skipped_when_no_worker_panes(self, tmp_path):
+        """`@ow-worker=1` フラグ付き pane が 0 個ならフラグなしの pane 群があっても skip。"""
+        result, captured = _run_adapter(
+            ["spawn", "/tmp/work", "claude", "%0"],
+            tmp_path,
+            existing_worker_panes="%5|\\n%7|",
+            window_height="40",
+        )
+        assert result.returncode == 0
+        assert "resize-pane" not in captured
+
 
 class TestTmuxAdapterThinking:
     """is_thinking=1 のとき思考worker扱いで `tmux new-window` で別タブを開く (D#2601)。"""
@@ -465,70 +492,6 @@ class TestTmuxAdapterThinking:
         )
         assert result.returncode != 0
         assert "target_pane not found" in result.stderr
-
-
-class TestTmuxAdapterRebalance:
-    """worker pane 均等再分配 (D#2830) のテスト。
-
-    モックの `tmux display` は引数を問わず "12345" を返すため、rebalance 内の
-    `display -p "#{window_height}"` も win_h=12345 として扱われる。
-    target = (12345 - (count - 1)) / count を計算して各 worker pane に resize-pane する。
-    """
-
-    def test_no_resize_when_single_worker(self, tmp_path):
-        """既存 worker 0 + 新規 1 = 1 個のみのとき、count<2 で skip するので resize-pane は呼ばれない。"""
-        result, captured = _run_adapter(
-            ["spawn", "/tmp/work", "claude", "%0"],
-            tmp_path,
-            existing_worker_panes="",
-        )
-        assert result.returncode == 0
-        assert "resize-pane" not in captured
-
-    def test_resize_called_when_multiple_workers(self, tmp_path):
-        """worker pane が 2 個以上あれば resize-pane が呼ばれる。"""
-        result, captured = _run_adapter(
-            ["spawn", "/tmp/work", "claude", "%0"],
-            tmp_path,
-            existing_worker_panes="%5|1\\n%7|1",
-        )
-        assert result.returncode == 0
-        assert "resize-pane" in captured
-
-    def test_resize_excludes_largest_pane_id(self, tmp_path):
-        """最大 pane_id (= 物理的に最下) は resize-pane の対象外 (残り高さ自動吸収)。"""
-        result, captured = _run_adapter(
-            ["spawn", "/tmp/work", "claude", "%0"],
-            tmp_path,
-            existing_worker_panes="%5|1\\n%7|1\\n%9|1",
-        )
-        assert result.returncode == 0
-        resize_targets = [l for l in captured.splitlines() if "resize-pane" in l]
-        assert any("-t %5" in l for l in resize_targets)
-        assert any("-t %7" in l for l in resize_targets)
-        assert not any("-t %9" in l for l in resize_targets)
-
-    def test_resize_target_height_subtracts_separator_rows(self, tmp_path):
-        """target = (window_height - (count-1)) / count。セパレータ行を引かないと最後の pane が
-        geometric に小さくなる。window_height=12345, count=3 → target=(12345-2)/3=4114。"""
-        result, captured = _run_adapter(
-            ["spawn", "/tmp/work", "claude", "%0"],
-            tmp_path,
-            existing_worker_panes="%5|1\\n%7|1\\n%9|1",
-        )
-        assert result.returncode == 0
-        assert "-y 4114" in captured
-        assert "-y 4115" not in captured  # 旧式バグ (window_height/count) の検出
-
-    def test_no_resize_when_no_worker_panes(self, tmp_path):
-        """`@ow-worker=1` の pane が 0 個ならフラグなしの空欄 pane 群があっても skip。"""
-        result, captured = _run_adapter(
-            ["spawn", "/tmp/work", "claude", "%0"],
-            tmp_path,
-            existing_worker_panes="%5|\\n%7|",
-        )
-        assert result.returncode == 0
-        assert "resize-pane" not in captured
 
 
 class TestTmuxAdapterErrors:


### PR DESCRIPTION
## Summary

`tests/unit/test_tmux_adapter.py` に `TestTmuxAdapterRebalance` クラスが 2 つ定義されていた。Python は同名クラスの後勝ちで先のクラスを class dict から外すため、L333 側のクラス内テスト 6 件が pytest の収集対象から**サイレントで外れていた**。

PR #445 のマージ時に並行作業で混入した状態のまま main に入ったもの。rebalance ロジック自体は L470 側のテストでカバーされていたが、 win_h を変えながら formula を検証するテスト群 (退行ガード含む) が一切実行されない状況だった。

window_height をモック引数として制御できる L333 側の設計を残し、L470 側にのみあった 2 ケースを window_height 明示版に書き直して移植:

- `test_rebalance_excludes_largest_pane_id`: 最大 pane_id (= 物理的に最下) は resize-pane の対象外。win_h=40 N=3 → target=12 で検証。
- `test_rebalance_skipped_when_no_worker_panes`: \`@ow-worker=1\` フラグ付き pane が 0 個ならフラグなし pane 群があっても rebalance skip。

L470 側にあった他のケース (single_worker / multiple_workers / separator_rows) は L333 側と等価のため統合に含めず削除。

## Test plan

- [x] \`uv run pytest tests/unit/test_tmux_adapter.py\` → 39 passed (うち TestTmuxAdapterRebalance は 8 件、内訳: 既存 6 + 移植 2)
- [x] grep で main の \`class TestTmuxAdapterRebalance\` が 2 箇所 (L333/L470) → fix branch で 1 箇所のみ確認