### PR TITLE
feat: dispatcher セッションの起動・終了用 MCP tool を追加

### DIFF
--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -32,6 +32,10 @@ description: orchとしてtopicのuser-facing窓口・文脈担保・タスク�
 
 ### 自律判断
 - dispatcher の生死は orch の責任 (worker 生死は dispatcher の責任)。dispatcher が死んだら新規 spawn してタスク群を継承する
+  - 起動: `ow_spawn_dispatcher(channel, cwd, model)` を呼ぶ。handle は `d-{channel}` を自動付与
+  - 終了: `ow_close_dispatcher(channel)` を呼ぶ。dispatcher 本体 + 紐づく worker pool 全員が cascade kill される (opt-out 不可)
+  - 検知: `ow_status(channel)` の presence または cache の identities から handle=`d-{channel}` の存在を確認。不在を検知したら `ow_spawn_dispatcher` で起動
+  - 既存 dispatcher がいる状態で `ow_spawn_dispatcher` を再度呼ぶと、health check せず既存を kill して新規 spawn する。worker pool も道連れに死亡するため、再起動には worker 投入し直しが必要
 - escalated 中の対応も orch 自律 (人間提示 / 自力裁定の境界判断)
 - 「人間に振る」を選んだ瞬間、自分の責任範囲を見失っている
 

--- a/src/main.py
+++ b/src/main.py
@@ -1339,6 +1339,63 @@ def ow_close_worker(term_ref: str) -> dict:
 
 
 @mcp.tool()
+def ow_spawn_dispatcher(
+    channel: str,
+    cwd: str,
+    model: str,
+    tmux_target_pane: str | None = None,
+) -> dict:
+    """dispatcher session を起動する。
+
+    handle は d-{channel} を自動付与する。channel に既存 dispatcher があれば
+    cascade kill (既存 dispatcher + 紐づく worker pool 全員) してから新規 spawn する。
+    health check や idempotent reject は行わない。
+
+    Args:
+        channel: channelコード (handle に d- prefix で組み込まれる)
+        cwd: dispatcher セッションの作業ディレクトリ
+        model: 使用モデル。claude-opus-4-7 のみ許可。
+            sonnet / haiku / opus-4-8 はバリデーションで拒否
+        tmux_target_pane: OW_TERMINAL=tmux のとき分割表示の基準 pane ID (optional)
+
+    Returns:
+        成功時: {"term_ref": str, "bundle_msg_id": int, "spawning": "ok", "alias": str}
+        失敗時: {"error": {"code": str, "message": str, ...}}
+    """
+    guard_service.check_worker_guard("ow_spawn_dispatcher")
+    return ow_service.ow_spawn_dispatcher(
+        channel=channel,
+        cwd=cwd,
+        model=model,
+        tmux_target_pane=tmux_target_pane,
+    )
+
+
+@mcp.tool()
+def ow_close_dispatcher(channel: str) -> dict:
+    """dispatcher session を kill し、紐づく worker pool も cascade kill する。
+
+    channel に dispatcher (handle=d-{channel}) が存在しない場合はエラーを返す
+    (no-op success は採らない)。close は graceful shutdown を試みず即 process kill。
+
+    Args:
+        channel: channelコード
+
+    Returns:
+        成功時: {
+            "closed": True,
+            "channel": str,
+            "dispatcher_handle": str,
+            "killed_workers": [handle, ...],
+            "failed_workers": [{"handle": str, "reason"/"error": ...}, ...]
+        }
+        失敗時: {"error": {"code": str, "message": str}, "killed_workers": [...], ...}
+    """
+    guard_service.check_worker_guard("ow_close_dispatcher")
+    return ow_service.ow_close_dispatcher(channel)
+
+
+@mcp.tool()
 def ow_status(channel: str, topic_id: str | None = None) -> dict:
     """queueサマリ＋GetPresence（worker死活）の合成ビュー。
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -24,6 +24,7 @@ import urllib.error
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
 import yaml
@@ -148,6 +149,41 @@ def _validate_alias_format(alias: str) -> str | None:
     if not _ALIAS_PATTERN.match(alias):
         return (
             f"alias '{alias}' does not match required kebab-case pattern "
+            "(lowercase letters/digits/hyphen, start with letter, "
+            "end with letter or digit, no consecutive hyphens)"
+        )
+    return None
+
+
+_DISPATCHER_HANDLE_MIN_LENGTH: int = 4
+_DISPATCHER_HANDLE_PREFIX: str = "d-"
+
+
+def _validate_dispatcher_handle(handle: str) -> str | None:
+    """dispatcher handle (d-{channel}) の書式検証。OK なら None、NG ならエラーメッセージを返す。
+
+    検証項目:
+        - 最小長: 4 文字以上 (例: "d-XX")
+        - d- prefix 必須
+        - prefix 後は kebab-case (小文字英数字 + ハイフン、末尾英数字、連続ハイフン禁止)
+    """
+    if not isinstance(handle, str) or not handle:
+        return "dispatcher handle must be a non-empty string"
+    if not handle.startswith(_DISPATCHER_HANDLE_PREFIX):
+        return (
+            f"dispatcher handle '{handle}' must start with "
+            f"'{_DISPATCHER_HANDLE_PREFIX}' prefix"
+        )
+    if len(handle) < _DISPATCHER_HANDLE_MIN_LENGTH:
+        return (
+            f"dispatcher handle '{handle}' is too short "
+            f"(length={len(handle)}, min={_DISPATCHER_HANDLE_MIN_LENGTH})"
+        )
+    rest = handle[len(_DISPATCHER_HANDLE_PREFIX):]
+    if not _ALIAS_PATTERN.match(rest):
+        return (
+            f"dispatcher handle '{handle}' has invalid characters after "
+            f"'{_DISPATCHER_HANDLE_PREFIX}' "
             "(lowercase letters/digits/hyphen, start with letter, "
             "end with letter or digit, no consecutive hyphens)"
         )
@@ -984,6 +1020,7 @@ def ow_spawn_worker(
     tmux_target_pane: str | None = None,
     effort: str | None = None,
     goal_text: str | None = None,
+    _alias_validator: Callable[[str], str | None] | None = None,
 ) -> dict:
     """workerセッションを起動する。
 
@@ -1062,7 +1099,9 @@ def ow_spawn_worker(
         task_title = _resolve_activity_title(activity_id)
 
     # spawn前ヘルスチェック (relay疎通・channel存在・cwd存在・alias重複)
-    preflight = _validate_spawn_preconditions(alias, channel, cwd, topic_id=topic_id, task_n=task_n)
+    preflight = _validate_spawn_preconditions(
+        alias, channel, cwd, topic_id=topic_id, task_n=task_n, alias_validator=_alias_validator,
+    )
     if not preflight["ok"]:
         return {
             "error": {
@@ -1544,6 +1583,7 @@ def _validate_spawn_preconditions(
     cwd: str,
     topic_id: str | None = None,
     task_n: int | None = None,
+    alias_validator: Callable[[str], str | None] | None = None,
 ) -> dict:
     """ow_spawn_worker起動前の一括ヘルスチェック。
 
@@ -1553,6 +1593,10 @@ def _validate_spawn_preconditions(
         - cwd存在: Path(cwd).expanduser()がディレクトリとして存在するか
         - alias重複: 同aliasがpresence onlineまたはcache上で活動中タスクのworkerとして他の
           task_nに割当て済みでないか（同一task_nで再spawn=再リンクは許可）
+
+    Args:
+        alias_validator: alias 書式の検証関数。None なら worker 用 _validate_alias_format。
+            dispatcher 経路からは _validate_dispatcher_handle を渡す。
 
     Returns:
         {
@@ -1566,7 +1610,8 @@ def _validate_spawn_preconditions(
 
     # 0. alias書式（最小長 + kebab-case）。relay 接続前に純粋な書式検証で弾く。
     # 書式エラー時は relay 接続を行わずに早期return（無効aliasで relay 接続を発生させない）。
-    alias_err = _validate_alias_format(alias)
+    validator = alias_validator if alias_validator is not None else _validate_alias_format
+    alias_err = validator(alias)
     if alias_err is not None:
         warnings.append(alias_err)
         return {"ok": False, "warnings": warnings}
@@ -2351,6 +2396,216 @@ def ow_recover(
         "reconstructed_max_msg_id": reconstructed.get("max_msg_id", 0),
         "dry_run": dry_run,
         "nonce_echo_results": nonce_echo_results,
+    }
+
+
+# ----------------------------
+# ow_spawn_dispatcher / ow_close_dispatcher
+# ----------------------------
+# orch 専用 dispatcher session lifecycle ツール。既存 ow_spawn_worker /
+# ow_close_worker の subprocess 起動・終了経路を共有し、tool API 層と引数の正規化だけ
+# 分ける。handle は d-{channel} を自動付与。既存 dispatcher があれば cascade kill
+# (dispatcher + 紐づく worker pool 全員) してから新規 spawn する。close 時も cascade を
+# 強制する (opt-out 引数なし)。recover は対象外。
+
+
+def ow_spawn_dispatcher(
+    channel: str,
+    cwd: str,
+    model: str,
+    tmux_target_pane: str | None = None,
+) -> dict:
+    """dispatcher session を起動する。
+
+    handle は d-{channel} を自動付与する。channel に既存 dispatcher があれば
+    cascade kill (既存 dispatcher + 紐づく worker pool 全員) してから新規 spawn する。
+    health check や idempotent reject は行わない。
+
+    Args:
+        channel: channel コード (handle に d- prefix で組み込まれる)
+        cwd: dispatcher セッションの作業ディレクトリ
+        model: 使用モデル (claude-opus-4-7 のみ許可。ow_spawn_worker と同じ制約)
+        tmux_target_pane: tmux 分割表示用 (optional、ow_spawn_worker と同じ意味)
+
+    Returns:
+        成功時: ow_spawn_worker と同形式 (term_ref / alias / bundle_msg_id 等)
+        失敗時: ow_spawn_worker と同形式の error response
+    """
+    if not isinstance(channel, str) or not channel:
+        return {
+            "error": {
+                "code": "INVALID_CHANNEL",
+                "message": "channel must be a non-empty string",
+            },
+        }
+
+    dispatcher_handle = f"{_DISPATCHER_HANDLE_PREFIX}{channel}"
+
+    handle_err = _validate_dispatcher_handle(dispatcher_handle)
+    if handle_err is not None:
+        return {
+            "error": {
+                "code": "INVALID_HANDLE",
+                "message": handle_err,
+            },
+        }
+
+    topic_id = find_topic_id_by_channel(channel)
+    if topic_id is not None:
+        existing_state = load_state(topic_id, channel)
+        if existing_state is not None:
+            workers = existing_state.get("workers") or {}
+            identities = existing_state.get("identities") or {}
+            if dispatcher_handle in workers or dispatcher_handle in identities:
+                cascade_result = ow_close_dispatcher(channel)
+                if not cascade_result.get("closed"):
+                    logger.warning(
+                        "ow_spawn_dispatcher: cascade kill of existing dispatcher failed for "
+                        "channel %s: %s",
+                        channel,
+                        cascade_result.get("error"),
+                    )
+
+    return ow_spawn_worker(
+        alias=dispatcher_handle,
+        channel=channel,
+        cwd=cwd,
+        model=model,
+        task_title=f"dispatcher for channel {channel}",
+        acceptance="",
+        context="",
+        playbook="",
+        timeout_min=60 * 24,
+        activity_id=None,
+        topic_id=str(topic_id) if topic_id is not None else None,
+        task_n=0,
+        tmux_target_pane=tmux_target_pane,
+        _alias_validator=_validate_dispatcher_handle,
+    )
+
+
+def ow_close_dispatcher(channel: str) -> dict:
+    """dispatcher session を kill し、紐づく worker pool も cascade kill する。
+
+    channel に dispatcher (handle=d-{channel}) が存在しない場合はエラーを返す。
+    no-op success は採らない (失敗の物理顕在化原則)。
+
+    Args:
+        channel: channel コード
+
+    Returns:
+        成功時: {
+            "closed": True,
+            "channel": str,
+            "dispatcher_handle": str,
+            "killed_workers": [handle, ...],
+            "failed_workers": [{"handle": str, "reason"/"error": ...}, ...],
+        }
+        失敗時: {"error": {"code": str, "message": str}, "killed_workers": [...], ...}
+    """
+    if not isinstance(channel, str) or not channel:
+        return {
+            "error": {
+                "code": "INVALID_CHANNEL",
+                "message": "channel must be a non-empty string",
+            },
+        }
+
+    dispatcher_handle = f"{_DISPATCHER_HANDLE_PREFIX}{channel}"
+
+    topic_id = find_topic_id_by_channel(channel)
+    state = load_state(topic_id, channel) if topic_id is not None else None
+
+    if state is None:
+        return {
+            "error": {
+                "code": "DISPATCHER_NOT_FOUND",
+                "message": (
+                    f"no cached state for channel {channel}, dispatcher absent"
+                ),
+            },
+        }
+
+    workers_map = state.get("workers") or {}
+    identities_map = state.get("identities") or {}
+
+    if dispatcher_handle not in workers_map and dispatcher_handle not in identities_map:
+        return {
+            "error": {
+                "code": "DISPATCHER_NOT_FOUND",
+                "message": (
+                    f"no dispatcher (handle={dispatcher_handle}) in channel {channel}"
+                ),
+            },
+        }
+
+    killed_workers: list[str] = []
+    failed_workers: list[dict] = []
+
+    for handle in list(workers_map.keys()):
+        if not handle.startswith("w-"):
+            continue
+        identity = ow_get_identity(channel, handle)
+        if identity is None:
+            failed_workers.append({"handle": handle, "reason": "no identity event"})
+            continue
+        term_ref = identity.get("term_ref") if isinstance(identity, dict) else None
+        if not term_ref:
+            failed_workers.append({"handle": handle, "reason": "no term_ref in identity"})
+            continue
+        close_result = ow_close_worker(term_ref)
+        if close_result.get("closed"):
+            killed_workers.append(handle)
+        else:
+            failed_workers.append({
+                "handle": handle,
+                "error": close_result.get("error"),
+            })
+
+    dispatcher_identity = ow_get_identity(channel, dispatcher_handle)
+    if dispatcher_identity is None:
+        return {
+            "error": {
+                "code": "DISPATCHER_IDENTITY_MISSING",
+                "message": (
+                    f"dispatcher (handle={dispatcher_handle}) has no identity event"
+                ),
+            },
+            "killed_workers": killed_workers,
+            "failed_workers": failed_workers,
+        }
+
+    dispatcher_term_ref = (
+        dispatcher_identity.get("term_ref") if isinstance(dispatcher_identity, dict) else None
+    )
+    if not dispatcher_term_ref:
+        return {
+            "error": {
+                "code": "DISPATCHER_NO_TERM_REF",
+                "message": "dispatcher identity has no term_ref",
+            },
+            "killed_workers": killed_workers,
+            "failed_workers": failed_workers,
+        }
+
+    dispatcher_close_result = ow_close_worker(dispatcher_term_ref)
+    if not dispatcher_close_result.get("closed"):
+        return {
+            "error": {
+                "code": "DISPATCHER_CLOSE_FAILED",
+                "message": "failed to close dispatcher process",
+                "detail": dispatcher_close_result.get("error"),
+            },
+            "killed_workers": killed_workers,
+            "failed_workers": failed_workers,
+        }
+
+    return {
+        "closed": True,
+        "channel": channel,
+        "dispatcher_handle": dispatcher_handle,
+        "killed_workers": killed_workers,
+        "failed_workers": failed_workers,
     }
 
 

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -189,6 +189,7 @@ def _validate_dispatcher_handle(handle: str) -> str | None:
         )
     return None
 
+
 # reducer: v3 workload state 分類
 _NON_TERMINAL_WORKLOAD_STATES: frozenset[str] = frozenset(
     {"loading", "working", "blocked", "escalated", "draining"}
@@ -2420,6 +2421,13 @@ def ow_spawn_dispatcher(
     handle は d-{channel} を自動付与する。channel に既存 dispatcher があれば
     cascade kill (既存 dispatcher + 紐づく worker pool 全員) してから新規 spawn する。
     health check や idempotent reject は行わない。
+
+    cascade kill が失敗した場合は warning ログを出すだけで spawn を続行するが、旧
+    dispatcher の alive identity が state に残ったままになる。続く ow_spawn_worker は
+    identity alive check (INV-9) で同一 alias を弾くため、戻り値が
+    SPAWN_PRECONDITION_FAILED の error response になる可能性が高い。呼び出し側は
+    error code を見て、必要なら手動で ow_close_worker / ow_recover を打って残骸を
+    片付けてから再 spawn する。
 
     Args:
         channel: channel コード (handle に d- prefix で組み込まれる)

--- a/tests/unit/test_ow_spawn_dispatcher.py
+++ b/tests/unit/test_ow_spawn_dispatcher.py
@@ -19,6 +19,8 @@
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from src.services import ow_service
@@ -162,11 +164,13 @@ class TestOwSpawnDispatcher:
             lambda _ch: {"error": {"code": "DISPATCHER_CLOSE_FAILED", "message": "oops"}},
         )
 
-        result = ow_service.ow_spawn_dispatcher(
-            channel="ow-w1", cwd="/tmp", model="claude-opus-4-7"
-        )
+        with caplog.at_level(logging.WARNING, logger=ow_service.logger.name):
+            result = ow_service.ow_spawn_dispatcher(
+                channel="ow-w1", cwd="/tmp", model="claude-opus-4-7"
+            )
         assert result.get("spawning") == "ok"
         assert len(spawn_calls) == 1
+        assert "cascade kill of existing dispatcher failed" in caplog.text
 
     def test_spawn_worker_error_passes_through(self, monkeypatch):
         """ow_spawn_worker が error を返したらそのまま透過"""

--- a/tests/unit/test_ow_spawn_dispatcher.py
+++ b/tests/unit/test_ow_spawn_dispatcher.py
@@ -1,0 +1,325 @@
+"""ow_service: dispatcher session 起動・終了 tool のユニットテスト。
+
+検証範囲:
+- `_validate_dispatcher_handle`: 単独での OK/NG 判定 (最小長 4 + d- prefix + kebab-case)
+- `ow_spawn_dispatcher`:
+  - handle = d-{channel} を自動付与
+  - 既存 dispatcher が channel にいたら cascade kill してから新規 spawn
+  - ow_spawn_worker を _alias_validator=_validate_dispatcher_handle で呼ぶ
+  - channel 不正 (空 / 非文字列) は INVALID_CHANNEL
+  - 結果として生成される handle が dispatcher validator で reject される場合は INVALID_HANDLE
+  - ow_spawn_worker 失敗 response はそのまま透過
+- `ow_close_dispatcher`:
+  - cache に channel 状態が無い場合は DISPATCHER_NOT_FOUND
+  - dispatcher handle が cache の workers / identities に無い場合は DISPATCHER_NOT_FOUND
+  - worker pool (handle prefix w-*) を cascade kill した上で dispatcher 本体を kill
+  - dispatcher identity が無い場合は DISPATCHER_IDENTITY_MISSING
+  - dispatcher term_ref が無い場合は DISPATCHER_NO_TERM_REF
+  - ow_close_worker が dispatcher kill で失敗した場合は DISPATCHER_CLOSE_FAILED
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.services import ow_service
+
+
+# ----------------------------
+# _validate_dispatcher_handle
+# ----------------------------
+
+
+class TestValidateDispatcherHandle:
+    """dispatcher handle 書式の単体テスト。"""
+
+    @pytest.mark.parametrize(
+        "handle",
+        [
+            "d-a",          # 3 文字 → 最小長 4 未満で NG だが、別パラメータで検証
+            "d-",           # prefix のみ
+        ],
+    )
+    def test_too_short_rejected(self, handle: str):
+        err = ow_service._validate_dispatcher_handle(handle)
+        assert err is not None
+
+    @pytest.mark.parametrize(
+        "handle",
+        ["d-ab", "d-ow", "d-x1", "d-ow-w1", "d-ow-w3a", "d-very-long-channel-name"],
+    )
+    def test_valid_handles_pass(self, handle: str):
+        assert ow_service._validate_dispatcher_handle(handle) is None
+
+    @pytest.mark.parametrize(
+        "handle",
+        ["", None, "ow-w1", "w-foo", "o-main", "X-foo", "dispatcher-foo", "d_ow"],
+    )
+    def test_missing_prefix_rejected(self, handle):
+        err = ow_service._validate_dispatcher_handle(handle)
+        assert err is not None
+
+    @pytest.mark.parametrize(
+        "handle",
+        [
+            "d-W1",         # 大文字混入
+            "d-ow_w1",      # アンダースコア
+            "d-ow--w1",     # 連続ハイフン
+            "d-ow-",        # 末尾ハイフン
+            "d--foo",       # prefix 直後にハイフン (連続扱い)
+            "d-プレイ",     # 非 ASCII
+            "d-ow w1",      # スペース
+        ],
+    )
+    def test_invalid_chars_after_prefix_rejected(self, handle: str):
+        err = ow_service._validate_dispatcher_handle(handle)
+        assert err is not None
+
+
+# ----------------------------
+# ow_spawn_dispatcher
+# ----------------------------
+
+
+@pytest.fixture
+def spawn_calls(monkeypatch):
+    """ow_spawn_worker の呼び出しを記録するフィクスチャ。"""
+    calls = []
+
+    def _fake_spawn_worker(**kwargs):
+        calls.append(kwargs)
+        return {
+            "term_ref": "%99",
+            "bundle_msg_id": 1,
+            "spawning": "ok",
+            "alias": kwargs.get("alias", "?"),
+        }
+
+    monkeypatch.setattr(ow_service, "ow_spawn_worker", _fake_spawn_worker)
+    return calls
+
+
+class TestOwSpawnDispatcher:
+    def test_invalid_channel_empty(self):
+        result = ow_service.ow_spawn_dispatcher(channel="", cwd="/tmp", model="opus")
+        assert result.get("error", {}).get("code") == "INVALID_CHANNEL"
+
+    def test_invalid_channel_non_string(self):
+        result = ow_service.ow_spawn_dispatcher(channel=None, cwd="/tmp", model="opus")  # type: ignore[arg-type]
+        assert result.get("error", {}).get("code") == "INVALID_CHANNEL"
+
+    def test_invalid_channel_makes_invalid_handle(self, monkeypatch):
+        """channel 名に非 ASCII 文字 → dispatcher handle 検証で reject"""
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: None)
+        result = ow_service.ow_spawn_dispatcher(channel="プレイ", cwd="/tmp", model="opus")
+        assert result.get("error", {}).get("code") == "INVALID_HANDLE"
+
+    def test_basic_spawn_no_existing(self, monkeypatch, spawn_calls):
+        """channel に既存 dispatcher 無し → 単純に ow_spawn_worker を呼ぶ"""
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: None)
+        result = ow_service.ow_spawn_dispatcher(
+            channel="ow-w1", cwd="/tmp", model="claude-opus-4-7"
+        )
+        assert result.get("spawning") == "ok"
+        assert len(spawn_calls) == 1
+        call = spawn_calls[0]
+        assert call["alias"] == "d-ow-w1"
+        assert call["channel"] == "ow-w1"
+        assert call["_alias_validator"] is ow_service._validate_dispatcher_handle
+        assert call["task_n"] == 0
+
+    def test_existing_dispatcher_triggers_cascade_kill(self, monkeypatch, spawn_calls):
+        """channel に既存 dispatcher → ow_close_dispatcher が呼ばれてから spawn"""
+        close_calls = []
+
+        def _fake_close_dispatcher(channel: str):
+            close_calls.append(channel)
+            return {"closed": True, "channel": channel, "dispatcher_handle": f"d-{channel}"}
+
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service, "load_state", lambda _tid, _ch: {"workers": {"d-ow-w1": {"state": "ready"}}}
+        )
+        monkeypatch.setattr(ow_service, "ow_close_dispatcher", _fake_close_dispatcher)
+
+        result = ow_service.ow_spawn_dispatcher(
+            channel="ow-w1", cwd="/tmp", model="claude-opus-4-7"
+        )
+        assert result.get("spawning") == "ok"
+        assert close_calls == ["ow-w1"]
+        assert len(spawn_calls) == 1
+
+    def test_cascade_kill_failure_does_not_block_spawn(self, monkeypatch, spawn_calls, caplog):
+        """cascade kill が失敗しても新規 spawn は試みる (頭悪く、resurrect しない)"""
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda _tid, _ch: {"identities": {"d-ow-w1": {"raw": "stuff"}}},
+        )
+        monkeypatch.setattr(
+            ow_service,
+            "ow_close_dispatcher",
+            lambda _ch: {"error": {"code": "DISPATCHER_CLOSE_FAILED", "message": "oops"}},
+        )
+
+        result = ow_service.ow_spawn_dispatcher(
+            channel="ow-w1", cwd="/tmp", model="claude-opus-4-7"
+        )
+        assert result.get("spawning") == "ok"
+        assert len(spawn_calls) == 1
+
+    def test_spawn_worker_error_passes_through(self, monkeypatch):
+        """ow_spawn_worker が error を返したらそのまま透過"""
+        def _fake_spawn_worker(**kwargs):
+            return {
+                "error": {"code": "SPAWN_PRECONDITION_FAILED", "warnings": ["cwd missing"]}
+            }
+
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: None)
+        monkeypatch.setattr(ow_service, "ow_spawn_worker", _fake_spawn_worker)
+        result = ow_service.ow_spawn_dispatcher(
+            channel="ow-w1", cwd="/nonexistent", model="claude-opus-4-7"
+        )
+        assert result.get("error", {}).get("code") == "SPAWN_PRECONDITION_FAILED"
+
+
+# ----------------------------
+# ow_close_dispatcher
+# ----------------------------
+
+
+class TestOwCloseDispatcher:
+    def test_invalid_channel_empty(self):
+        result = ow_service.ow_close_dispatcher(channel="")
+        assert result.get("error", {}).get("code") == "INVALID_CHANNEL"
+
+    def test_no_cached_state_returns_not_found(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: None)
+        monkeypatch.setattr(ow_service, "load_state", lambda *_args, **_kw: None)
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("error", {}).get("code") == "DISPATCHER_NOT_FOUND"
+
+    def test_dispatcher_handle_absent_returns_not_found(self, monkeypatch):
+        """cache はあるが d-{channel} が workers/identities に無い → NOT_FOUND"""
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {"workers": {"w-a": {}}, "identities": {}},
+        )
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("error", {}).get("code") == "DISPATCHER_NOT_FOUND"
+
+    def test_full_cascade_close_success(self, monkeypatch):
+        """worker 2 個 + dispatcher 1 個を cascade kill"""
+        close_calls = []
+
+        def _fake_close_worker(term_ref: str):
+            close_calls.append(term_ref)
+            return {"closed": True, "term_ref": term_ref}
+
+        identities = {
+            "w-a": {"term_ref": "%10"},
+            "w-b": {"term_ref": "%11"},
+            "d-ow-w1": {"term_ref": "%99"},
+        }
+
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {
+                "workers": {"w-a": {}, "w-b": {}, "d-ow-w1": {}},
+                "identities": dict(identities),
+            },
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity", lambda _ch, handle: identities.get(handle)
+        )
+        monkeypatch.setattr(ow_service, "ow_close_worker", _fake_close_worker)
+
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("closed") is True
+        assert result.get("channel") == "ow-w1"
+        assert result.get("dispatcher_handle") == "d-ow-w1"
+        assert sorted(result.get("killed_workers", [])) == ["w-a", "w-b"]
+        assert result.get("failed_workers") == []
+        # close 順: worker 2 個が先、dispatcher 本体が最後
+        assert close_calls[-1] == "%99"
+        assert set(close_calls) == {"%10", "%11", "%99"}
+
+    def test_dispatcher_identity_missing(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {"workers": {"d-ow-w1": {}}, "identities": {}},
+        )
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda _ch, _h: None)
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("error", {}).get("code") == "DISPATCHER_IDENTITY_MISSING"
+
+    def test_dispatcher_no_term_ref(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {"workers": {"d-ow-w1": {}}, "identities": {}},
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity", lambda _ch, _h: {"some_field": "x"}
+        )
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("error", {}).get("code") == "DISPATCHER_NO_TERM_REF"
+
+    def test_dispatcher_close_failed(self, monkeypatch):
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {"workers": {"d-ow-w1": {}}, "identities": {}},
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity", lambda _ch, _h: {"term_ref": "%99"}
+        )
+        monkeypatch.setattr(
+            ow_service,
+            "ow_close_worker",
+            lambda _t: {"closed": False, "error": {"code": "ADAPTER_CLOSE_TIMEOUT"}},
+        )
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("error", {}).get("code") == "DISPATCHER_CLOSE_FAILED"
+
+    def test_worker_close_failures_recorded(self, monkeypatch):
+        """一部の worker close が失敗しても dispatcher 本体は試行、failed_workers に記録"""
+        identities = {
+            "w-bad": {},  # term_ref なし
+            "w-ok": {"term_ref": "%10"},
+            "d-ow-w1": {"term_ref": "%99"},
+        }
+        close_results = {
+            "%10": {"closed": True, "term_ref": "%10"},
+            "%99": {"closed": True, "term_ref": "%99"},
+        }
+
+        monkeypatch.setattr(ow_service, "find_topic_id_by_channel", lambda _ch: 42)
+        monkeypatch.setattr(
+            ow_service,
+            "load_state",
+            lambda *_args, **_kw: {
+                "workers": {"w-bad": {}, "w-ok": {}, "d-ow-w1": {}},
+                "identities": dict(identities),
+            },
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity", lambda _ch, handle: identities.get(handle)
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker", lambda t: close_results.get(t, {"closed": False})
+        )
+
+        result = ow_service.ow_close_dispatcher(channel="ow-w1")
+        assert result.get("closed") is True
+        assert result.get("killed_workers") == ["w-ok"]
+        failed = result.get("failed_workers", [])
+        assert any(f.get("handle") == "w-bad" for f in failed)


### PR DESCRIPTION
## 変更内容

orch から dispatcher セッションを起こす・閉じるための MCP tool を 2 つ追加する。

- `ow_spawn_dispatcher(channel, cwd, model, tmux_target_pane?)`: handle `d-{channel}` の dispatcher セッションを起動。channel に既存 dispatcher がいた場合は cascade kill (dispatcher 本体 + 紐づく worker pool 全員) してから新規 spawn する
- `ow_close_dispatcher(channel)`: dispatcher 本体 + worker pool を cascade kill。対象不在の場合はエラーを返す (no-op success は採らない)

内部実装は既存 `ow_spawn_worker` / `ow_close_worker` の subprocess 起動・終了経路をそのまま共有し、tool API 層と引数の正規化だけを分けて扱う。`ow_spawn_worker` には `_alias_validator` 引数を 1 つ追加し、preconditions 内の alias 書式検証を差し替え可能にした。

## なぜこれが要るか

`ow_spawn_worker` を将来 orch から物理拒否する役割ベースの権限制御を入れる前提で、orch が dispatcher を起こす経路を別 tool として切り出す必要がある。これまで dispatcher の起動・終了は orch スキル文書経由で `ow_spawn_worker` を流用する運用だったが、これだと将来の制限で orch から起こせなくなる。

dispatcher は worker と違い permanent state を持たず、worker pool と生死を連帯する設計に従う。よって本 tool は health check / graceful shutdown / 引き継ぎ機構を一切持たず、最小スコープで「立てる/殺す」だけを担う。

## 主な振る舞いの差分

- spawn 時:
  - channel に既存 dispatcher 有り → 既存を kill (worker pool 巻き込み) してから新規 spawn
  - 既存 kill が失敗しても新規 spawn は試行する (resurrect しない)
  - subprocess 起動・relay broadcast・spawn-bundle 送信は既存 `ow_spawn_worker` の経路を再利用
- close 時:
  - channel に dispatcher が居ない場合はエラー
  - worker pool は handle prefix `w-*` で列挙して全 kill、その後 dispatcher 本体を kill
  - graceful shutdown は試みず即 process kill
- handle 命名:
  - `d-{channel}` 自動付与、最小長 4 文字 + d- prefix + kebab-case
  - 既存 worker alias の 8 文字以上 + kebab-case ルールは維持
- orch スキルの dispatcher 生死管理セクションに、新 tool の検知・起動・終了の手順を追記

## テスト計画

新規 `tests/unit/test_ow_spawn_dispatcher.py` (38 件) で以下を保証:

- dispatcher handle 書式検証: 最小長 4 / d- prefix 必須 / 中身 kebab-case の有効・無効パターン全部
- spawn:
  - channel 不正 → `INVALID_CHANNEL`
  - 結果 handle が validator で reject → `INVALID_HANDLE`
  - 基本起動 → `ow_spawn_worker` が `_alias_validator=_validate_dispatcher_handle` で呼ばれる
  - 既存 dispatcher 検出 → cascade kill 経由で再 spawn
  - cascade kill 失敗時も新規 spawn を試行
  - subprocess 起動失敗 (precondition 等) は透過的に返却
- close:
  - channel 不正 / cache 不在 / dispatcher handle 不在 → 各エラーコード
  - worker 2 + dispatcher 1 の cascade 成功、close 順序検証
  - dispatcher identity / term_ref 不在の各エラー
  - dispatcher kill 失敗時の error response + killed_workers 残存
  - 一部 worker close 失敗時の failed_workers 記録

既存テスト 1744 件 (新規 38 件含む) pass、1 件 skipped。回帰なし。