### PR TITLE
feat: 内部 ID リテラルの自動変換拡張 + PreToolUse hook で漏出を block

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -50,6 +50,15 @@
             "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/pretooluse_ow_spawn_worker.py"
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/preblock_hook.py"
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/hooks/preblock_hook.py
+++ b/hooks/preblock_hook.py
@@ -1,0 +1,220 @@
+"""PreToolUse hook: tool_input に内部 ID リテラル (`[MDLAT]#NNN` または英語フルワード
+`log/decision/activity/material/topic #NNN`) が含まれていたら block する。
+
+cc-memory 開発現場以外で内部 ID 形式の文字列を外部に出すケースは想定されないため、
+tool 引数段階で機械的に止めることで AI 経由の漏出を防ぐ (scope A 方針)。
+
+cc-memory project 内 (pyproject.toml の name が cc-memory) のみで有効。
+`CC_MEMORY_LEAK_GUARD=off` 環境変数で緊急時に opt-out 可能。
+allowlist tool (cc-memory 自身の MCP / Read 系 / harness 内部 tool) は素通し。
+バックスラッシュエスケープ (`\\M#123`, `\\log #123`) は字義扱いで非 block。
+
+検出時は `permissionDecision: "deny"` + 英文 reason を返し、
+発火ログを `~/.cc-memory/logs/preblock_hook.jsonl` に append する (書き込み失敗時は silent)。
+"""
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+# プラグイン経由で `${CLAUDE_PLUGIN_ROOT}` を cwd として起動されるため、
+# 同居ソースを import path に通す。
+_PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from src.services.internal_id_patterns import (  # noqa: E402
+    RAW_CITE_CODE_PATTERN,
+    RAW_CITE_FULLWORD_PATTERN,
+)
+
+ALLOWLIST_PREFIXES: tuple[str, ...] = (
+    "mcp__plugin_claude-code-memory_cc-memory__",
+)
+
+ALLOWLIST_EXACT: frozenset[str] = frozenset(
+    {
+        "Read",
+        "Grep",
+        "Glob",
+        "WebFetch",
+        "WebSearch",
+        "TaskCreate",
+        "TaskGet",
+        "TaskUpdate",
+        "TaskList",
+        "TaskStop",
+        "TaskOutput",
+        "Skill",
+        "ToolSearch",
+        "ScheduleWakeup",
+        "EnterPlanMode",
+        "ExitPlanMode",
+        "Monitor",
+        "NotebookEdit",
+        "PushNotification",
+    }
+)
+
+LOG_PATH = pathlib.Path.home() / ".cc-memory" / "logs" / "preblock_hook.jsonl"
+
+
+def _is_allowed(tool_name: str) -> bool:
+    if tool_name in ALLOWLIST_EXACT:
+        return True
+    return any(tool_name.startswith(p) for p in ALLOWLIST_PREFIXES)
+
+
+def _scan_text_for_literals(text: str) -> list[str]:
+    """1 個の文字列に対し code + fullword 両方を検出し、マッチした raw 文字列を返す。
+
+    バックスラッシュエスケープ (`\\M#123`, `\\log #123`) は事前に取り除いた
+    擬似テキストで scan する: hook の責務は「AI が tool に渡そうとした文字列に
+    内部 ID 形式が現れたら止める」であり、エスケープ表現で書かれた箇所は
+    字義扱いとして block 対象から外す。
+    """
+    matches: list[str] = []
+    # エスケープされた箇所を空白で潰してから scan する。
+    # `\X#NNN` / `\log #NNN` 等の直後文字数は最大 16 + 1 程度なので十分な余白を取る。
+    sanitized = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "\\" and i + 1 < n:
+            # バックスラッシュとその直後 1 文字をスキップする (字義扱い)
+            sanitized.append(" ")  # boundary を保つため空白で置換
+            sanitized.append(" ")
+            i += 2
+            continue
+        sanitized.append(text[i])
+        i += 1
+    haystack = "".join(sanitized)
+    for m in RAW_CITE_CODE_PATTERN.finditer(haystack):
+        matches.append(m.group(0))
+    for m in RAW_CITE_FULLWORD_PATTERN.finditer(haystack):
+        matches.append(m.group(0))
+    return matches
+
+
+def _scan_tool_input(value) -> list[dict]:
+    """tool_input を再帰的に走査し、検出されたリテラルと jq 風 field path を返す。
+
+    Returns:
+        [{"match": "M#123", "field": "command"}, ...]
+        field は tool_input の中での出現位置 (dict キーは ".key"、list は "[i]")。
+        root に直接 string が来た場合は field は "" (空文字)。
+    """
+    matches: list[dict] = []
+
+    def walk(v, path: str) -> None:
+        if isinstance(v, str):
+            for literal in _scan_text_for_literals(v):
+                matches.append({"match": literal, "field": path})
+        elif isinstance(v, dict):
+            for k, x in v.items():
+                walk(x, f"{path}.{k}" if path else str(k))
+        elif isinstance(v, list):
+            for i, x in enumerate(v):
+                walk(x, f"{path}[{i}]")
+
+    walk(value, "")
+    return matches
+
+
+def _is_in_cc_memory_project() -> bool:
+    """cwd から上方向に pyproject.toml を探索して cc-memory project か判定する。"""
+    cwd = pathlib.Path.cwd()
+    for p in (cwd, *cwd.parents):
+        pj = p / "pyproject.toml"
+        if not pj.exists():
+            continue
+        try:
+            text = pj.read_text(encoding="utf-8")
+        except OSError:
+            return False
+        return 'name = "cc-memory"' in text or "name = 'cc-memory'" in text
+    return False
+
+
+def _log_event(record: dict) -> None:
+    """発火ログを 1 行 JSON で append する。失敗時は何もしない (block 動作は継続)。"""
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            print("{}")
+            return
+
+        event = json.loads(raw)
+        tool_name = event.get("tool_name") or ""
+        tool_input = event.get("tool_input") or {}
+
+        # opt-out: 緊急時の脱出経路
+        if os.environ.get("CC_MEMORY_LEAK_GUARD", "").lower() == "off":
+            print("{}")
+            return
+
+        # cwd 判定: cc-memory project 内のみ有効
+        if not _is_in_cc_memory_project():
+            print("{}")
+            return
+
+        # allowlist: scan 不要 tool は素通し
+        if _is_allowed(tool_name):
+            print("{}")
+            return
+
+        matches = _scan_tool_input(tool_input)
+        if not matches:
+            print("{}")
+            return
+
+        matched_literals = [m["match"] for m in matches]
+        matched_fields = sorted({m["field"] for m in matches if m["field"]})
+
+        reason = (
+            f"Internal ID literal detected in tool_input: {matched_literals}. "
+            "These IDs are cc-memory internal references and must not leak "
+            "outside the cc-memory development context. Use a natural language "
+            "reference (e.g. entity title) instead, or escape with a backslash "
+            "prefix to indicate a literal (e.g. '\\M#123', '\\log #456')."
+        )
+
+        _log_event(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool_name": tool_name,
+                "decision": "block",
+                "matches": matched_literals,
+                "tool_input_field": matched_fields,
+                "cwd": str(pathlib.Path.cwd()),
+                "session_id": event.get("session_id"),
+            }
+        )
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
+        print(json.dumps(output, ensure_ascii=False))
+
+    except Exception as e:
+        # hook 自体の不具合で全 tool を止めないため、例外時は素通し + stderr 通知
+        print(f"preblock_hook.py error: {e}", file=sys.stderr)
+        print("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/preblock_hook.py
+++ b/hooks/preblock_hook.py
@@ -16,6 +16,7 @@ import json
 import os
 import pathlib
 import sys
+import tomllib
 from datetime import datetime, timezone
 
 # プラグイン経由で `${CLAUDE_PLUGIN_ROOT}` を cwd として起動されるため、
@@ -123,17 +124,26 @@ def _scan_tool_input(value) -> list[dict]:
 
 
 def _is_in_cc_memory_project() -> bool:
-    """cwd から上方向に pyproject.toml を探索して cc-memory project か判定する。"""
+    """cwd から上方向に pyproject.toml を探索して cc-memory project か判定する。
+
+    `[project].name` を tomllib で厳密パースする。コメント行や別フィールドに
+    たまたま `name = "cc-memory"` を含むケースで誤判定しないよう、文字列の
+    部分一致ではなくパース済みの構造から取り出す。
+    """
     cwd = pathlib.Path.cwd()
     for p in (cwd, *cwd.parents):
         pj = p / "pyproject.toml"
         if not pj.exists():
             continue
         try:
-            text = pj.read_text(encoding="utf-8")
-        except OSError:
+            with pj.open("rb") as fp:
+                data = tomllib.load(fp)
+        except (OSError, tomllib.TOMLDecodeError):
             return False
-        return 'name = "cc-memory"' in text or "name = 'cc-memory'" in text
+        project = data.get("project")
+        if not isinstance(project, dict):
+            return False
+        return project.get("name") == "cc-memory"
     return False
 
 
@@ -163,13 +173,15 @@ def main() -> None:
             print("{}")
             return
 
-        # cwd 判定: cc-memory project 内のみ有効
-        if not _is_in_cc_memory_project():
+        # allowlist: scan 不要 tool は素通し
+        # cwd 判定より先に行うことで、Read/Grep/Glob 等の頻出 tool で
+        # 毎回 pyproject.toml を読み直す I/O を回避する。
+        if _is_allowed(tool_name):
             print("{}")
             return
 
-        # allowlist: scan 不要 tool は素通し
-        if _is_allowed(tool_name):
+        # cwd 判定: cc-memory project 内のみ有効
+        if not _is_in_cc_memory_project():
             print("{}")
             return
 

--- a/src/services/citations_pure.py
+++ b/src/services/citations_pure.py
@@ -14,6 +14,12 @@ import re
 import sqlite3
 from typing import Callable
 
+from src.services.internal_id_patterns import (
+    FULLWORD_TO_CODE,
+    RAW_CITE_CODE_PATTERN as _RAW_CITE_PATTERN,
+    RAW_CITE_FULLWORD_PATTERN as _RAW_CITE_FULLWORD_PATTERN,
+)
+
 logger = logging.getLogger(__name__)
 
 # 同パッケージの他モジュール (citations_service / citation_renderer) と、
@@ -83,10 +89,6 @@ OWNER_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
 
 _CITE_PATTERN = re.compile(r"\{\{cite:([MDLAT])#(\d+)\}\}")
 _CITE_LIKE_PATTERN = re.compile(r"\{\{cite:[^}]*\}\}")
-
-# 生 `X#NNN` 検出パターン。word boundary を lookbehind/lookahead で明示する
-# (前後が英数字/_/ なら識別子の一部とみなして非マッチ)。
-_RAW_CITE_PATTERN = re.compile(r"(?<![A-Za-z0-9_/])([MDLAT])#(\d+)(?![A-Za-z0-9_])")
 
 
 def extract_citations(content: str) -> list[tuple[str, int]]:
@@ -188,8 +190,11 @@ def _new_convert_counters() -> dict:
 
 
 def _count_raw_in_segment(segment: str) -> int:
-    """セグメント内の生 `X#NNN` パターン数を boundary 付きで数える。"""
-    return len(_RAW_CITE_PATTERN.findall(segment))
+    """セグメント内の生リテラルパターン数を boundary 付きで数える (code + fullword)。"""
+    return (
+        len(_RAW_CITE_PATTERN.findall(segment))
+        + len(_RAW_CITE_FULLWORD_PATTERN.findall(segment))
+    )
 
 
 def _convert_line_raw_to_cite(
@@ -261,10 +266,18 @@ def _convert_line_raw_to_cite(
                     counters["skipped_escape"] += 1
                     i = m.end()
                     continue
+            # `\log #123` 等 fullword エスケープ: バックスラッシュ直後が
+            # fullword の type 名なら全体スキップ
+            m_fw = _RAW_CITE_FULLWORD_PATTERN.match(line, i + 1)
+            if m_fw and m_fw.start() == i + 1:
+                out_parts.append(line[i : m_fw.end()])
+                counters["skipped_escape"] += 1
+                i = m_fw.end()
+                continue
             out_parts.append(ch)
             i += 1
             continue
-        # 生 `X#NNN`
+        # 生 `X#NNN` (code 形式)
         m = _RAW_CITE_PATTERN.match(line, i)
         if m:
             code = m.group(1)
@@ -278,6 +291,23 @@ def _convert_line_raw_to_cite(
             out_parts.append("{{cite:" + code + "#" + str(target_id) + "}}")
             counters["sanitized_count"] += 1
             i = m.end()
+            continue
+        # 生 fullword (`log #123` 等)。マッチしたら大文字 code に正規化して
+        # `{{cite:L#NNN}}` 形式に統一する。
+        m_fw = _RAW_CITE_FULLWORD_PATTERN.match(line, i)
+        if m_fw:
+            name = m_fw.group(1).lower()
+            code = FULLWORD_TO_CODE[name]
+            target_id = int(m_fw.group(2))
+            target_type = TYPE_CODE_TO_NAME[code]
+            if target_validator is not None and not target_validator(target_type, target_id):
+                out_parts.append(line[i : m_fw.end()])
+                counters["skipped_dangling"] += 1
+                i = m_fw.end()
+                continue
+            out_parts.append("{{cite:" + code + "#" + str(target_id) + "}}")
+            counters["sanitized_count"] += 1
+            i = m_fw.end()
             continue
         out_parts.append(ch)
         i += 1

--- a/src/services/internal_id_patterns.py
+++ b/src/services/internal_id_patterns.py
@@ -1,0 +1,39 @@
+"""内部 ID パターン (`[MDLAT]#NNN` および英語フルワード `log/decision/activity/material/topic #NNN`)
+の正規表現定数と type 名 → code mapping を集約する純粋層。
+
+`citations_pure._convert_line_raw_to_cite` (write 経路の自動変換) と PreToolUse hook
+(漏出 block) の両方からこの module を import する。DB アクセス・ファイル I/O は持たない。
+"""
+import re
+
+__all__ = [
+    "RAW_CITE_CODE_PATTERN",
+    "RAW_CITE_FULLWORD_PATTERN",
+    "FULLWORD_TO_CODE",
+]
+
+# 大文字 type code 形式 (`M#123`, `D#456`, `L#789`, `A#321`, `T#654`)。
+# 前後の word boundary は lookbehind / lookahead で明示する
+# (前が英数字 / `_` / `/` なら識別子の一部とみなして非マッチ、
+#  後ろが英数字 / `_` なら同様)。
+RAW_CITE_CODE_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_/])([MDLAT])#(\d+)(?![A-Za-z0-9_])"
+)
+
+# 英語フルワード形式 (`log #123`, `decision #456`, `activity #789`,
+# `material #321`, `topic #654`)。case-insensitive、type 名と `#` の間の
+# 空白は 0 個または 1 個のみ許容。
+RAW_CITE_FULLWORD_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_/])(log|decision|activity|material|topic) ?#(\d+)(?![A-Za-z0-9_])",
+    re.IGNORECASE,
+)
+
+# fullword 形式の type 名を大文字 code に正規化する mapping。
+# キーは小文字。`.lower()` で照会する。
+FULLWORD_TO_CODE: dict[str, str] = {
+    "log": "L",
+    "decision": "D",
+    "activity": "A",
+    "material": "M",
+    "topic": "T",
+}

--- a/tests/unit/test_citations_pure.py
+++ b/tests/unit/test_citations_pure.py
@@ -302,3 +302,120 @@ class TestConvertWithValidatorAgainstDb:
         assert out == "exists {{cite:M#1}} missing M#999"
         assert counters["sanitized_count"] == 1
         assert counters["skipped_dangling"] == 1
+
+
+class TestFullwordConversion:
+    """英語フルワード形式 (log/decision/activity/material/topic + #NNN) の変換。
+
+    既存 code 形式と並行して変換され、結果は大文字 code 形式に正規化される
+    (例: `log #123` → `{{cite:L#123}}`)。
+    """
+
+    def test_lowercase_with_space(self):
+        out, counters = convert_raw_to_cite("see log #123 here")
+        assert out == "see {{cite:L#123}} here"
+        assert counters["sanitized_count"] == 1
+
+    def test_lowercase_no_space(self):
+        out, counters = convert_raw_to_cite("see log#123 here")
+        assert out == "see {{cite:L#123}} here"
+        assert counters["sanitized_count"] == 1
+
+    def test_case_insensitive(self):
+        out, counters = convert_raw_to_cite("Log #1 and LOG #2 and LoG #3")
+        assert out == "{{cite:L#1}} and {{cite:L#2}} and {{cite:L#3}}"
+        assert counters["sanitized_count"] == 3
+
+    def test_all_five_typenames(self):
+        out, _ = convert_raw_to_cite(
+            "log #1 decision #2 activity #3 material #4 topic #5"
+        )
+        assert out == (
+            "{{cite:L#1}} {{cite:D#2}} {{cite:A#3}} "
+            "{{cite:M#4}} {{cite:T#5}}"
+        )
+
+    def test_double_space_does_not_convert(self):
+        out, counters = convert_raw_to_cite("log  #1")
+        assert out == "log  #1"
+        assert counters["sanitized_count"] == 0
+
+    def test_colon_does_not_convert(self):
+        out, _ = convert_raw_to_cite("log: #1 and log:#2")
+        assert out == "log: #1 and log:#2"
+
+    def test_japanese_does_not_convert(self):
+        out, _ = convert_raw_to_cite("ログ #1 and 決定事項 #2")
+        assert out == "ログ #1 and 決定事項 #2"
+
+    def test_word_boundary_blog_not_match(self):
+        out, _ = convert_raw_to_cite("the blog #1 was published")
+        assert out == "the blog #1 was published"
+
+    def test_word_boundary_path_log_not_match(self):
+        out, _ = convert_raw_to_cite("/var/log #1 is full")
+        assert out == "/var/log #1 is full"
+
+    def test_word_boundary_trailing_alnum_not_match(self):
+        out, _ = convert_raw_to_cite("log #1abc is junk")
+        assert out == "log #1abc is junk"
+
+    def test_escape_backslash_not_converted(self):
+        out, counters = convert_raw_to_cite("see \\log #1 literal")
+        assert out == "see \\log #1 literal"
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_escape"] == 1
+
+    def test_escape_works_for_all_typenames(self):
+        out, counters = convert_raw_to_cite(
+            "\\log #1 \\decision #2 \\activity #3 \\material #4 \\topic #5"
+        )
+        assert out == (
+            "\\log #1 \\decision #2 \\activity #3 \\material #4 \\topic #5"
+        )
+        assert counters["sanitized_count"] == 0
+        assert counters["skipped_escape"] == 5
+
+    def test_codeblock_skips_fullword(self):
+        text = "before log #1\n```\nlog #2\n```\nafter log #3"
+        out, counters = convert_raw_to_cite(text)
+        assert out == (
+            "before {{cite:L#1}}\n```\nlog #2\n```\nafter {{cite:L#3}}"
+        )
+        assert counters["sanitized_count"] == 2
+        assert counters["skipped_in_codeblock"] == 1
+
+    def test_inline_backtick_skips_fullword(self):
+        out, counters = convert_raw_to_cite("convert log #1 but not `log #2` here")
+        assert out == "convert {{cite:L#1}} but not `log #2` here"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_in_codeblock"] == 1
+
+    def test_mixed_code_and_fullword(self):
+        out, counters = convert_raw_to_cite(
+            "M#1 and log #2 and D#3 and decision #4"
+        )
+        assert out == (
+            "{{cite:M#1}} and {{cite:L#2}} and "
+            "{{cite:D#3}} and {{cite:D#4}}"
+        )
+        assert counters["sanitized_count"] == 4
+
+    def test_idempotent_existing_cite_not_reconverted(self):
+        text = "{{cite:L#1}} and log #2"
+        out, _ = convert_raw_to_cite(text)
+        assert out == "{{cite:L#1}} and {{cite:L#2}}"
+        # 2 回適用しても同じ結果
+        out2, _ = convert_raw_to_cite(out)
+        assert out2 == out
+
+    def test_validator_blocks_dangling_fullword(self):
+        def validator(t: str, i: int) -> bool:
+            return t == "log" and i == 1
+
+        out, counters = convert_raw_to_cite(
+            "log #1 and log #999", target_validator=validator
+        )
+        assert out == "{{cite:L#1}} and log #999"
+        assert counters["sanitized_count"] == 1
+        assert counters["skipped_dangling"] == 1

--- a/tests/unit/test_internal_id_patterns.py
+++ b/tests/unit/test_internal_id_patterns.py
@@ -1,0 +1,216 @@
+"""internal_id_patterns module の単体テスト。
+
+code パターン / fullword パターン / 境界 / case 揺れ / エスケープ尊重前提を
+finditer ベースで網羅する。本 module は pure regex 定数 + mapping のため、
+ロジック側 (citations_pure._convert_line_raw_to_cite / preblock_hook._scan_tool_input)
+での挙動は別ファイルで検証する。
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.services.internal_id_patterns import (
+    FULLWORD_TO_CODE,
+    RAW_CITE_CODE_PATTERN,
+    RAW_CITE_FULLWORD_PATTERN,
+)
+
+
+def _code_matches(text: str) -> list[str]:
+    return [m.group(0) for m in RAW_CITE_CODE_PATTERN.finditer(text)]
+
+
+def _fullword_matches(text: str) -> list[str]:
+    return [m.group(0) for m in RAW_CITE_FULLWORD_PATTERN.finditer(text)]
+
+
+class TestRawCiteCodePattern:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("M#123", ["M#123"]),
+            ("D#456", ["D#456"]),
+            ("L#789", ["L#789"]),
+            ("A#321", ["A#321"]),
+            ("T#654", ["T#654"]),
+            ("see M#1 and D#2 and L#3", ["M#1", "D#2", "L#3"]),
+            ("(M#10) [D#20] {L#30}", ["M#10", "D#20", "L#30"]),
+        ],
+    )
+    def test_canonical_code_forms_match(self, text: str, expected: list[str]) -> None:
+        assert _code_matches(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "m#123",
+            "d#456",
+            "l#789",
+            "a#321",
+            "t#654",
+            "Md#1",
+            "DL#1",
+            "X#999",
+            "Z#1",
+        ],
+    )
+    def test_non_canonical_codes_do_not_match(self, text: str) -> None:
+        assert _code_matches(text) == []
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "aM#123",
+            "x_M#123",
+            "path/M#123",
+            "fooM#123",
+        ],
+    )
+    def test_leading_word_char_blocks_match(self, text: str) -> None:
+        assert _code_matches(text) == []
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "M#123abc",
+            "M#123_suffix",
+        ],
+    )
+    def test_trailing_word_char_blocks_match(self, text: str) -> None:
+        assert _code_matches(text) == []
+
+    def test_boundary_with_punctuation_allows_match(self) -> None:
+        # 句読点・括弧・空白で囲まれている場合はマッチする
+        assert _code_matches("see (M#10) and M#20, plus M#30.") == [
+            "M#10",
+            "M#20",
+            "M#30",
+        ]
+
+
+class TestRawCiteFullwordPattern:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("log #1", ["log #1"]),
+            ("decision #2", ["decision #2"]),
+            ("activity #3", ["activity #3"]),
+            ("material #4", ["material #4"]),
+            ("topic #5", ["topic #5"]),
+        ],
+    )
+    def test_canonical_fullword_lowercase_with_space(
+        self, text: str, expected: list[str]
+    ) -> None:
+        assert _fullword_matches(text) == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("log#1", ["log#1"]),
+            ("decision#2", ["decision#2"]),
+            ("activity#3", ["activity#3"]),
+            ("material#4", ["material#4"]),
+            ("topic#5", ["topic#5"]),
+        ],
+    )
+    def test_canonical_fullword_lowercase_no_space(
+        self, text: str, expected: list[str]
+    ) -> None:
+        assert _fullword_matches(text) == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("Log #1", ["Log #1"]),
+            ("LOG #1", ["LOG #1"]),
+            ("LoG #1", ["LoG #1"]),
+            ("DECISION #2", ["DECISION #2"]),
+            ("Activity #3", ["Activity #3"]),
+        ],
+    )
+    def test_case_insensitive(self, text: str, expected: list[str]) -> None:
+        assert _fullword_matches(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "log  #1",
+            "log\t#1",
+            "log: #1",
+            "log:#1",
+        ],
+    )
+    def test_excluded_separators(self, text: str) -> None:
+        assert _fullword_matches(text) == []
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "blog #1",
+            "Xlog #2",
+            "analog #3",
+            "path/log #4",
+            "_log #5",
+        ],
+    )
+    def test_leading_word_char_blocks_match(self, text: str) -> None:
+        assert _fullword_matches(text) == []
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "log #123abc",
+            "log #1_suffix",
+        ],
+    )
+    def test_trailing_word_char_blocks_match(self, text: str) -> None:
+        assert _fullword_matches(text) == []
+
+    def test_unknown_typename_does_not_match(self) -> None:
+        assert _fullword_matches("comment #1") == []
+        assert _fullword_matches("issue #99") == []
+        assert _fullword_matches("note #5") == []
+
+    def test_short_alias_does_not_match(self) -> None:
+        # スコープ確定で略称は対象外
+        assert _fullword_matches("act #1") == []
+        assert _fullword_matches("mat #2") == []
+        assert _fullword_matches("dec #3") == []
+
+    def test_japanese_does_not_match(self) -> None:
+        # スコープ確定で日本語表記は対象外
+        assert _fullword_matches("ログ #1") == []
+        assert _fullword_matches("決定事項 #2") == []
+        assert _fullword_matches("アクティビティ #3") == []
+
+    def test_multiple_in_one_string(self) -> None:
+        assert _fullword_matches("see log #1 and decision #2") == [
+            "log #1",
+            "decision #2",
+        ]
+
+    def test_mixed_case_and_separator(self) -> None:
+        assert _fullword_matches("Log#1 and LOG #2 and log#3") == [
+            "Log#1",
+            "LOG #2",
+            "log#3",
+        ]
+
+
+class TestFullwordToCode:
+    def test_mapping_covers_all_five_types(self) -> None:
+        assert set(FULLWORD_TO_CODE.keys()) == {
+            "log",
+            "decision",
+            "activity",
+            "material",
+            "topic",
+        }
+
+    def test_mapping_values(self) -> None:
+        assert FULLWORD_TO_CODE["log"] == "L"
+        assert FULLWORD_TO_CODE["decision"] == "D"
+        assert FULLWORD_TO_CODE["activity"] == "A"
+        assert FULLWORD_TO_CODE["material"] == "M"
+        assert FULLWORD_TO_CODE["topic"] == "T"

--- a/tests/unit/test_preblock_hook.py
+++ b/tests/unit/test_preblock_hook.py
@@ -177,17 +177,55 @@ class TestIsAllowed:
 
 class TestIsInCcMemoryProject:
     def test_pyproject_with_cc_memory_name(self, tmp_path, monkeypatch):
-        (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "cc-memory"\n'
+        )
         monkeypatch.chdir(tmp_path)
         assert preblock_hook._is_in_cc_memory_project() is True
 
-    def test_pyproject_with_single_quotes(self, tmp_path, monkeypatch):
-        (tmp_path / "pyproject.toml").write_text("name = 'cc-memory'\n")
+    def test_pyproject_with_literal_string(self, tmp_path, monkeypatch):
+        # TOML literal string (single quotes) も同様に受理される
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'cc-memory'\n"
+        )
         monkeypatch.chdir(tmp_path)
         assert preblock_hook._is_in_cc_memory_project() is True
 
     def test_pyproject_with_other_name(self, tmp_path, monkeypatch):
-        (tmp_path / "pyproject.toml").write_text('name = "other-project"\n')
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "other-project"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is False
+
+    def test_pyproject_with_name_only_in_comment(self, tmp_path, monkeypatch):
+        # コメント行に `name = "cc-memory"` があっても [project].name は別ならば False
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n# name = "cc-memory"\nname = "other-project"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is False
+
+    def test_pyproject_with_name_in_other_table(self, tmp_path, monkeypatch):
+        # 別 table の name が "cc-memory" でも [project].name でなければ False
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "other-project"\n\n'
+            '[tool.foo]\nname = "cc-memory"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is False
+
+    def test_pyproject_without_project_table(self, tmp_path, monkeypatch):
+        # [project] table が無ければ False (defensive)
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.foo]\nname = "cc-memory"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is False
+
+    def test_pyproject_invalid_toml(self, tmp_path, monkeypatch):
+        # 壊れた TOML はパース失敗 → False
+        (tmp_path / "pyproject.toml").write_text("this is = = not toml [[[\n")
         monkeypatch.chdir(tmp_path)
         assert preblock_hook._is_in_cc_memory_project() is False
 
@@ -203,7 +241,9 @@ class TestIsInCcMemoryProject:
         assert result is False
 
     def test_pyproject_found_in_parent(self, tmp_path, monkeypatch):
-        (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "cc-memory"\n'
+        )
         subdir = tmp_path / "src" / "deep" / "path"
         subdir.mkdir(parents=True)
         monkeypatch.chdir(subdir)
@@ -232,7 +272,9 @@ def _run_main_with_event(event: dict, capsys) -> dict:
 @pytest.fixture
 def cc_memory_cwd(tmp_path, monkeypatch):
     """cc-memory project 内っぽい cwd を用意する fixture。"""
-    (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "cc-memory"\n'
+    )
     monkeypatch.chdir(tmp_path)
     # opt-out 環境変数は明示的に消しておく
     monkeypatch.delenv("CC_MEMORY_LEAK_GUARD", raising=False)
@@ -326,6 +368,28 @@ class TestMainBlockFlow:
         )
         assert out == {}
 
+    def test_allowlist_skips_project_check_io(
+        self, capsys, cc_memory_cwd, monkeypatch
+    ):
+        # allowlist tool では _is_in_cc_memory_project が呼ばれないこと
+        # (頻出 tool で pyproject.toml の読み直しを避ける最適化)
+        call_count = {"n": 0}
+
+        def _spy() -> bool:
+            call_count["n"] += 1
+            return True
+
+        monkeypatch.setattr(preblock_hook, "_is_in_cc_memory_project", _spy)
+        _run_main_with_event(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/tmp/x.md"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert call_count["n"] == 0
+
     def test_opt_out_env_var_passes_through(
         self, capsys, cc_memory_cwd, monkeypatch
     ):
@@ -370,7 +434,9 @@ class TestMainBlockFlow:
     def test_non_cc_memory_project_passes_through(
         self, capsys, tmp_path, monkeypatch
     ):
-        (tmp_path / "pyproject.toml").write_text('name = "other-project"\n')
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "other-project"\n'
+        )
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("CC_MEMORY_LEAK_GUARD", raising=False)
         out = _run_main_with_event(

--- a/tests/unit/test_preblock_hook.py
+++ b/tests/unit/test_preblock_hook.py
@@ -1,0 +1,458 @@
+"""preblock_hook.py の単体テスト。
+
+PreToolUse hook の入出力 (stdin から event JSON 受領、stdout に
+permissionDecision JSON 出力 or 空 dict 出力) と、各補助関数の挙動を検証する。
+
+検証対象:
+- _scan_text_for_literals: 1 文字列内の code / fullword 検出、エスケープ無視
+- _scan_tool_input: dict / list 再帰スキャン、field path 保持
+- _is_allowed: allowlist 判定 (prefix / exact match)
+- _is_in_cc_memory_project: pyproject.toml 上方向探索
+- main: stdin event → block / pass 判定の総合フロー
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# hooks ディレクトリを sys.path に通して直接 import 可能にする
+_HOOKS_DIR = Path(__file__).resolve().parents[2] / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import preblock_hook  # type: ignore  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _scan_text_for_literals
+# ---------------------------------------------------------------------------
+
+
+class TestScanTextForLiterals:
+    def test_code_form_detected(self):
+        assert preblock_hook._scan_text_for_literals("see M#1") == ["M#1"]
+
+    def test_fullword_form_detected(self):
+        assert preblock_hook._scan_text_for_literals("see log #1") == ["log #1"]
+
+    def test_case_insensitive_fullword(self):
+        assert preblock_hook._scan_text_for_literals("LOG #1 Log #2") == [
+            "LOG #1",
+            "Log #2",
+        ]
+
+    def test_mixed_code_and_fullword(self):
+        result = preblock_hook._scan_text_for_literals("M#1 and log #2")
+        assert "M#1" in result
+        assert "log #2" in result
+
+    def test_lowercase_code_not_matched(self):
+        assert preblock_hook._scan_text_for_literals("m#1 is junk") == []
+
+    def test_escape_code_not_matched(self):
+        assert preblock_hook._scan_text_for_literals("\\M#1 is literal") == []
+
+    def test_escape_fullword_not_matched(self):
+        assert preblock_hook._scan_text_for_literals("\\log #1 is literal") == []
+
+    def test_word_boundary_blog_not_match(self):
+        assert preblock_hook._scan_text_for_literals("blog #1 was published") == []
+
+    def test_word_boundary_trailing_alnum_not_match(self):
+        assert preblock_hook._scan_text_for_literals("M#1abc is junk") == []
+
+    def test_empty_string(self):
+        assert preblock_hook._scan_text_for_literals("") == []
+
+
+# ---------------------------------------------------------------------------
+# _scan_tool_input
+# ---------------------------------------------------------------------------
+
+
+class TestScanToolInput:
+    def test_top_level_string_value(self):
+        # root は dict 想定だが string 単独でも walk は耐える
+        result = preblock_hook._scan_tool_input({"command": "echo M#1"})
+        assert result == [{"match": "M#1", "field": "command"}]
+
+    def test_nested_dict(self):
+        result = preblock_hook._scan_tool_input(
+            {"outer": {"inner": "see log #1"}}
+        )
+        assert result == [{"match": "log #1", "field": "outer.inner"}]
+
+    def test_list_value(self):
+        result = preblock_hook._scan_tool_input(
+            {"args": ["echo M#1", "echo D#2"]}
+        )
+        assert {"match": "M#1", "field": "args[0]"} in result
+        assert {"match": "D#2", "field": "args[1]"} in result
+
+    def test_multiple_matches_in_one_field(self):
+        result = preblock_hook._scan_tool_input(
+            {"command": "echo M#1 and D#2"}
+        )
+        fields = {(r["match"], r["field"]) for r in result}
+        assert ("M#1", "command") in fields
+        assert ("D#2", "command") in fields
+
+    def test_no_match_returns_empty(self):
+        assert preblock_hook._scan_tool_input({"command": "echo hello"}) == []
+
+    def test_non_string_values_ignored(self):
+        result = preblock_hook._scan_tool_input(
+            {"timeout": 30, "force": True, "tags": None}
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _is_allowed
+# ---------------------------------------------------------------------------
+
+
+class TestIsAllowed:
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "Read",
+            "Grep",
+            "Glob",
+            "WebFetch",
+            "WebSearch",
+            "TaskCreate",
+            "TaskGet",
+            "TaskUpdate",
+            "TaskList",
+            "TaskStop",
+            "TaskOutput",
+            "Skill",
+            "ToolSearch",
+            "ScheduleWakeup",
+            "EnterPlanMode",
+            "ExitPlanMode",
+            "Monitor",
+            "NotebookEdit",
+            "PushNotification",
+        ],
+    )
+    def test_exact_match_allowed(self, tool_name):
+        assert preblock_hook._is_allowed(tool_name) is True
+
+    def test_cc_memory_mcp_prefix_allowed(self):
+        assert preblock_hook._is_allowed(
+            "mcp__plugin_claude-code-memory_cc-memory__search"
+        )
+        assert preblock_hook._is_allowed(
+            "mcp__plugin_claude-code-memory_cc-memory__add_logs"
+        )
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "Bash",
+            "Edit",
+            "Write",
+            "MultiEdit",
+            "Agent",
+            "SendMessage",
+            "TodoWrite",
+            "mcp__other_namespace__something",
+        ],
+    )
+    def test_block_target_not_allowed(self, tool_name):
+        assert preblock_hook._is_allowed(tool_name) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_in_cc_memory_project
+# ---------------------------------------------------------------------------
+
+
+class TestIsInCcMemoryProject:
+    def test_pyproject_with_cc_memory_name(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is True
+
+    def test_pyproject_with_single_quotes(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text("name = 'cc-memory'\n")
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is True
+
+    def test_pyproject_with_other_name(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text('name = "other-project"\n')
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is False
+
+    def test_no_pyproject_in_tree(self, tmp_path, monkeypatch):
+        # tmp_path 配下に pyproject.toml がない
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+        # tmp_path 上にも pyproject.toml がないことを保証するため、
+        # macOS / Linux の / までさかのぼると別の pyproject に当たる可能性があるが、
+        # その場合は cc-memory ではないという結果になる (False) のでテスト目的的は OK
+        result = preblock_hook._is_in_cc_memory_project()
+        assert result is False
+
+    def test_pyproject_found_in_parent(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+        subdir = tmp_path / "src" / "deep" / "path"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+        assert preblock_hook._is_in_cc_memory_project() is True
+
+
+# ---------------------------------------------------------------------------
+# main フロー (block 判定 + log 記録)
+# ---------------------------------------------------------------------------
+
+
+def _run_main_with_event(event: dict, capsys) -> dict:
+    """stdin に event を流して main() を呼び、stdout 出力を dict として返す。"""
+    sys.stdin = io.StringIO(json.dumps(event))
+    try:
+        preblock_hook.main()
+    finally:
+        sys.stdin = sys.__stdin__
+    captured = capsys.readouterr()
+    text = captured.out.strip()
+    if not text or text == "{}":
+        return {}
+    return json.loads(text)
+
+
+@pytest.fixture
+def cc_memory_cwd(tmp_path, monkeypatch):
+    """cc-memory project 内っぽい cwd を用意する fixture。"""
+    (tmp_path / "pyproject.toml").write_text('name = "cc-memory"\n')
+    monkeypatch.chdir(tmp_path)
+    # opt-out 環境変数は明示的に消しておく
+    monkeypatch.delenv("CC_MEMORY_LEAK_GUARD", raising=False)
+    # log path を tmp 配下に逃がして home 汚染を防ぐ
+    log_path = tmp_path / "log" / "preblock_hook.jsonl"
+    monkeypatch.setattr(preblock_hook, "LOG_PATH", log_path)
+    return tmp_path, log_path
+
+
+class TestMainBlockFlow:
+    def test_empty_stdin_passes_through(self, capsys, cc_memory_cwd):
+        sys.stdin = io.StringIO("")
+        try:
+            preblock_hook.main()
+        finally:
+            sys.stdin = sys.__stdin__
+        assert capsys.readouterr().out.strip() == "{}"
+
+    def test_clean_input_passes_through(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo hello"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_code_literal_in_bash_blocks(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#123 hello"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        spec = out["hookSpecificOutput"]
+        assert spec["hookEventName"] == "PreToolUse"
+        assert spec["permissionDecision"] == "deny"
+        assert "M#123" in spec["permissionDecisionReason"]
+
+    def test_fullword_literal_in_write_blocks(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/tmp/x.md",
+                    "content": "see log #45 in docs",
+                },
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        spec = out["hookSpecificOutput"]
+        assert spec["permissionDecision"] == "deny"
+        assert "log #45" in spec["permissionDecisionReason"]
+
+    def test_escape_not_blocked(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo \\M#123 literal"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_allowlist_tool_passes_through(self, capsys, cc_memory_cwd):
+        # cc-memory MCP は scan されない
+        out = _run_main_with_event(
+            {
+                "tool_name": "mcp__plugin_claude-code-memory_cc-memory__search",
+                "tool_input": {"keyword": "D#123"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_allowlist_read_passes_through(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/tmp/M#1.md"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_opt_out_env_var_passes_through(
+        self, capsys, cc_memory_cwd, monkeypatch
+    ):
+        monkeypatch.setenv("CC_MEMORY_LEAK_GUARD", "off")
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1 leak"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_opt_out_case_insensitive(self, capsys, cc_memory_cwd, monkeypatch):
+        monkeypatch.setenv("CC_MEMORY_LEAK_GUARD", "OFF")
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1 leak"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_opt_out_other_values_do_not_skip(
+        self, capsys, cc_memory_cwd, monkeypatch
+    ):
+        # "on" / "1" / "true" などは opt-out ではない
+        monkeypatch.setenv("CC_MEMORY_LEAK_GUARD", "on")
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1 leak"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_non_cc_memory_project_passes_through(
+        self, capsys, tmp_path, monkeypatch
+    ):
+        (tmp_path / "pyproject.toml").write_text('name = "other-project"\n')
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CC_MEMORY_LEAK_GUARD", raising=False)
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1 leak"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+
+class TestLogEventFields:
+    def test_log_written_with_required_fields(self, capsys, cc_memory_cwd):
+        _, log_path = cc_memory_cwd
+        _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#123 and log #45"},
+                "session_id": "session-xyz",
+            },
+            capsys,
+        )
+        assert log_path.exists()
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["tool_name"] == "Bash"
+        assert rec["decision"] == "block"
+        assert "M#123" in rec["matches"]
+        assert "log #45" in rec["matches"]
+        assert rec["tool_input_field"] == ["command"]
+        assert rec["cwd"] == str(cc_memory_cwd[0])
+        assert rec["session_id"] == "session-xyz"
+        assert "timestamp" in rec
+
+    def test_log_field_for_nested_dict(self, capsys, cc_memory_cwd):
+        _, log_path = cc_memory_cwd
+        _run_main_with_event(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/tmp/x.md",
+                    "content": "see log #1 here",
+                },
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        rec = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+        assert "content" in rec["tool_input_field"]
+
+    def test_no_log_when_clean(self, capsys, cc_memory_cwd):
+        _, log_path = cc_memory_cwd
+        _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo hello"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert not log_path.exists()
+
+    def test_log_write_failure_is_silent(
+        self, capsys, cc_memory_cwd, monkeypatch
+    ):
+        # LOG_PATH の親に書き込み権限がない状況を疑似的に再現するため、
+        # _log_event 内の open を強制的に失敗させる
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(preblock_hook.pathlib.Path, "mkdir", boom)
+
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        # block 動作は継続している
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
## Summary

cc-memory の内部 ID 参照について、以下 2 つの仕組みを 1 つの正規表現定数群で支える共有 module を新設する。

- 自動変換側: 既存 `convert_raw_to_cite` の変換対象に英語フルワード形式 (`log #123`, `decision #456`, `activity #789`, `material #321`, `topic #654`) を追加。大文字小文字揺れと空白 0-1 を吸収し、変換結果は大文字 code 形式 (`{{cite:L#123}}`) に正規化する。既存の大文字 code 形式 (`[MDLAT]#NNN`) は触らず、振る舞いは完全維持。
- block 側: PreToolUse hook を新設し、tool 入力に内部 ID リテラルが含まれた呼び出しは `permissionDecision: "deny"` で止める。block 時は検出箇所 (jq 風 field path) を `~/.cc-memory/logs/preblock_hook.jsonl` に append する。書き込み失敗時は silent (block 動作は止めない)。

両側が同じ正規表現を使うことで「自動変換は通すが block はすり抜ける」「block はするが自動変換しない」といった乖離が原理的に起きない構造にした。

### スコープと安全弁

- hook 有効範囲は cwd の `pyproject.toml` を上方向探索し `name = "cc-memory"` が見つかった場合のみ。それ以外のプロジェクトでは何もしない。
- `CC_MEMORY_LEAK_GUARD=off` (case-insensitive) で全プロジェクト共通の opt-out を提供。誤 block で作業が止まった場合の緊急退避用。
- allowlist (cc-memory MCP 全 / Read・Grep・Glob・WebFetch・WebSearch / Task系・Skill・ToolSearch・ScheduleWakeup・PlanMode 系・Monitor・NotebookEdit・PushNotification) は scan 対象外で素通し。
- バックスラッシュエスケープ (`\M#123`, `\log #123`) は字義表現として block 対象から除外。README やドキュメントで内部 ID 形式の例を示したい場面の escape hatch。

### スコープ外 (本 PR では触らない)

- 既存 transcript sanitize hook、bulk migration、citation_event_log の write 経路統合
- 日本語表記 (「ログ #123」「決定事項 #456」等) と略称 (`act #1`, `mat #2`) の変換対応

## Test plan

新規ユニットテスト (合計 173 ケース、本 PR 領域) の検証項目:

- 正規表現定数 (`tests/unit/test_internal_id_patterns.py`)
  - 大文字 code 形式の 5 種 (M/D/L/A/T) の canonical match
  - 小文字単独 (`m#123` 等) は非マッチ維持
  - 英語フルワード 5 種の canonical match (空白 0/1、大文字小文字揺れ)
  - 空白 2 個・タブ・コロン (`log: #1`) は非マッチ
  - 略称 (`act #1`)・日本語表記 (`ログ #1`)・未知 type 名 (`comment #1`) は非マッチ
  - word boundary: `blog #1`, `path/log #1`, `log #1abc` などは非マッチ
  - FULLWORD_TO_CODE mapping の網羅性 (5 種すべて)
- 自動変換 (`tests/unit/test_citations_pure.py` 追加分)
  - フルワード変換結果は大文字 code 形式に正規化される
  - code + フルワード混在テキストの両方を変換
  - フェンスコードブロック / インラインバッククォート内のフルワードはスキップ
  - `\log #123` 等のバックスラッシュエスケープは非変換 (skipped_escape にカウント)
  - 既存 `{{cite:X#NNN}}` は再変換されない (冪等)
  - validator が False を返した dangling target は非変換
- PreToolUse hook (`tests/unit/test_preblock_hook.py`)
  - allowlist tool は scan されず素通し (prefix match + exact match の両方)
  - block 対象 tool (Bash / Edit / Write / 外部 MCP 等) は scan されて block 判定
  - block 時の reason は英文で検出リテラルを含む
  - cwd 判定: `pyproject.toml` の `name = "cc-memory"` 一致時のみ有効化、シングルクオート表記も許容
  - opt-out: `CC_MEMORY_LEAK_GUARD=off` / `OFF` で全プロジェクト共通の素通し、`on` / `1` 等は opt-out 扱いにならない
  - エスケープ表現 (`\M#1`, `\log #1`) は scan 対象外
  - 発火ログのフィールド網羅: timestamp / tool_name / decision="block" / matches / tool_input_field / cwd / session_id
  - 発火ログ書き込みが OSError で失敗しても block 動作は継続
  - 入力 stdin が空 / clean な tool input / dict 再帰 / list 要素 の各ケース

### 既存テスト

- 既存 `tests/unit/test_citations_pure.py` の振る舞いは不変 (内部 `_RAW_CITE_PATTERN` を新 module から alias import するだけで、ロジック側は code 形式のフローを保つ)
- 全体回帰: `uv run pytest --ignore=tests/e2e` で 2341 passed / 1 skipped を確認 (新規含む)

### 実機 block の確認方法 (PR マージ後の手動検証)

本 PR では hook を `hooks/hooks.json` に登録するため、マージ + プラグインキャッシュ更新 + MCP サーバ再起動を経て初めて有効化される。実機検証は次の手順で行う:

1. cc-memory リポジトリ内で `Bash` 経由 `echo M#999` を実行 → block されること
2. 同じく `Bash` 経由 `echo hello` を実行 → 素通しすること
3. cc-memory 以外のリポジトリで `Bash` 経由 `echo M#999` を実行 → 素通しすること
4. `CC_MEMORY_LEAK_GUARD=off Bash` 経由 `echo M#999` → 素通しすること
5. `~/.cc-memory/logs/preblock_hook.jsonl` に block 1 件が記録されていること