### PR TITLE
ow_send で正常終了 worker の pane を自動 kill

### DIFF
--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -810,7 +810,17 @@ def ow_send(
             )
         else:
             try:
-                ow_close_worker(term_ref)
+                close_result = ow_close_worker(term_ref)
+                if close_result.get("closed") is False:
+                    logger.warning(
+                        "auto-close: tmux kill failed for term_ref=%s on channel=%s handle=%s, result=%s",
+                        term_ref, channel, handle, close_result,
+                    )
+                elif close_result.get("manual"):
+                    logger.warning(
+                        "auto-close: manual term_ref=%s on channel=%s handle=%s requires operator action: %s",
+                        term_ref, channel, handle, close_result.get("message"),
+                    )
             except Exception as exc:
                 logger.warning(
                     "auto-close failed for term_ref=%s on channel=%s handle=%s: %s",

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -707,6 +707,49 @@ def _maybe_inject_term_ref(body: dict) -> dict:
     return new_body
 
 
+def _resolve_term_ref(channel: str, handle: str) -> str | None:
+    """(channel, handle) から term_ref を引き当てる。
+
+    cache の identity_events に格納された event:identity.data.term_ref を
+    優先で返す。cache miss / identity 未送信 / term_ref フィールド欠落の
+    いずれでも None を返す (handler 側で warn log のみ、tool error にしない)。
+    """
+    try:
+        identity = ow_get_identity(channel, handle)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "_resolve_term_ref: ow_get_identity raised for channel=%s handle=%s: %s",
+            channel, handle, exc,
+        )
+        return None
+    if not isinstance(identity, dict):
+        return None
+    term_ref = identity.get("term_ref")
+    if not isinstance(term_ref, str) or not term_ref:
+        return None
+    return term_ref
+
+
+def _is_terminated_close_event(body: dict) -> bool:
+    """ow_send body が auto-close 対象の terminated event か判定する。
+
+    判定条件: kind==event AND data.type==state AND data.state==terminated
+    AND data.cause in {"closed", "cancelled"}。dead / crashed / 他 state は対象外。
+    """
+    if not isinstance(body, dict):
+        return False
+    if body.get("kind") != "event":
+        return False
+    data = body.get("data")
+    if not isinstance(data, dict):
+        return False
+    if data.get("type") != "state":
+        return False
+    if data.get("state") != "terminated":
+        return False
+    return data.get("cause") in ("closed", "cancelled")
+
+
 def ow_send(
     channel: str,
     handle: str,
@@ -719,6 +762,12 @@ def ow_send(
     bodyはow固有JSONを格納するdict（relay schemaは無改修）。
     4xx即失敗、5xx/接続断のみ3回指数バックオフ。
     channel未存在（404）の場合はensure_channelで自動作成してから再送する。
+
+    auto-close 副作用: body が event:state(terminated, cause:closed|cancelled) の
+    場合、relay POST 成功直後に ow_close_worker(term_ref) を同期発火する。
+    冪等性は adapter (tmux kill-pane) 側で吸収する。
+    term_ref 解決失敗 / kill 失敗時は warn log のみで tool error には伝播
+    させない (relay POST は成功しているため呼び出し側には成功を返す)。
 
     Args:
         channel: channelコード
@@ -748,6 +797,25 @@ def ow_send(
         logger.info("ow_send: channel %s not found, attempting ensure_channel", channel)
         if ensure_channel(channel):
             result = _relay_request("POST", "/send", payload)
+
+    # auto-close: terminated(closed|cancelled) を観測したら term_ref を引き当てて
+    # ow_close_worker を同期発火する。relay POST が成功した場合のみ (msg_id 取得)
+    # 副作用を起こす。失敗時は warn のみで tool error には伝播させない。
+    if "msg_id" in result and _is_terminated_close_event(body):
+        term_ref = _resolve_term_ref(channel, handle)
+        if term_ref is None:
+            logger.warning(
+                "auto-close skipped: term_ref not found for handle=%s on channel=%s",
+                handle, channel,
+            )
+        else:
+            try:
+                ow_close_worker(term_ref)
+            except Exception as exc:
+                logger.warning(
+                    "auto-close failed for term_ref=%s on channel=%s handle=%s: %s",
+                    term_ref, channel, handle, exc,
+                )
 
     return result
 

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -586,6 +586,53 @@ class TestOwSendAutoClose:
         assert "error" not in result
         assert any("auto-close failed" in rec.message for rec in caplog.records)
 
+    def test_close_worker_returns_closed_false_warns(self, monkeypatch, stub_relay_success, caplog):
+        """ow_close_worker が {"closed": False} を返した場合 warn log が出る"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda _term_ref: {"closed": False, "error": "tmux kill failed"},
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        with caplog.at_level("WARNING", logger="src.services.ow_service"):
+            result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert result.get("msg_id") == 123
+        assert "error" not in result
+        assert any(
+            "auto-close: tmux kill failed" in rec.message for rec in caplog.records
+        )
+
+    def test_close_worker_returns_manual_warns(self, monkeypatch, stub_relay_success, caplog):
+        """ow_close_worker が {"manual": True} を返した場合 warn log が出る"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda _term_ref: {
+                "manual": True,
+                "message": "manual: prefix detected, operator action required",
+            },
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        with caplog.at_level("WARNING", logger="src.services.ow_service"):
+            result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert result.get("msg_id") == 123
+        assert "error" not in result
+        assert any(
+            "auto-close: manual" in rec.message for rec in caplog.records
+        )
+
     def test_relay_post_failure_does_not_trigger_close(self, monkeypatch):
         """relay POST 失敗 (msg_id 未取得) では ow_close_worker は呼ばれない"""
 

--- a/tests/unit/test_ow_send.py
+++ b/tests/unit/test_ow_send.py
@@ -394,3 +394,221 @@ class TestOwStatusEnsure:
 
         assert "error" in result
         assert result["error"]["code"] == "RELAY_UNAVAILABLE"
+
+
+class TestOwSendAutoClose:
+    """ow_send: event:state(terminated, cause:closed|cancelled) 観測時に
+    ow_close_worker を同期発火する副作用。"""
+
+    @pytest.fixture
+    def stub_relay_success(self, monkeypatch):
+        """relay POST 成功 (msg_id 返却) を固定で返す stub。"""
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps({"msg_id": 123}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+
+    def test_terminated_cause_closed_triggers_close_worker(self, monkeypatch, stub_relay_success):
+        """cause=closed → ow_close_worker(term_ref) が同期呼び出しされる"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42", "session_id": "s1"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref) or {"closed": True, "killed": False, "term_ref": term_ref},
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert result.get("msg_id") == 123
+        assert called == ["%42"]
+
+    def test_terminated_cause_cancelled_triggers_close_worker(self, monkeypatch, stub_relay_success):
+        """cause=cancelled でも呼ばれる"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%99"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref) or {"closed": True, "killed": False, "term_ref": term_ref},
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "cancelled"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert called == ["%99"]
+
+    def test_terminated_cause_dead_does_not_trigger(self, monkeypatch, stub_relay_success):
+        """cause=dead では呼ばれない"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "dead"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert called == []
+
+    def test_terminated_cause_crashed_does_not_trigger(self, monkeypatch, stub_relay_success):
+        """cause=crashed では呼ばれない"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "crashed"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert called == []
+
+    def test_state_draining_does_not_trigger(self, monkeypatch, stub_relay_success):
+        """state=draining (terminated 以外) では呼ばれない"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "draining"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert called == []
+
+    def test_command_kind_does_not_trigger(self, monkeypatch, stub_relay_success):
+        """kind=command では呼ばれない (event 以外)"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        # kind=command で data に terminated っぽい中身を入れても発火しない
+        body = {"v": 1, "kind": "command", "from": "orch", "to": "w-a",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="orch", body=body)
+
+        assert called == []
+
+    def test_term_ref_cache_miss_logs_warning_no_op(self, monkeypatch, stub_relay_success, caplog):
+        """term_ref が引き当てられないとき: warn log のみ、ow_close_worker は呼ばれない"""
+        monkeypatch.setattr(ow_service, "ow_get_identity", lambda ch, h: None)
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        with caplog.at_level("WARNING", logger="src.services.ow_service"):
+            result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert result.get("msg_id") == 123
+        assert called == []
+        assert any("auto-close skipped" in rec.message for rec in caplog.records)
+
+    def test_duplicate_terminated_calls_close_worker_each_time(self, monkeypatch, stub_relay_success):
+        """同 term_ref で 2 回 ow_send (terminated) → handler は 2 回とも ow_close_worker を呼ぶ。
+        adapter 側冪等性に乗る設計のため handler 内フラグは持たない。"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%77"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref) or {"closed": True, "killed": False, "term_ref": term_ref},
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+        ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert called == ["%77", "%77"]
+
+    def test_close_worker_exception_does_not_propagate(self, monkeypatch, stub_relay_success, caplog):
+        """ow_close_worker が例外を投げても ow_send は msg_id を成功返却し warn log のみ残す"""
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+
+        def _raising(_term_ref):
+            raise RuntimeError("adapter boom")
+
+        monkeypatch.setattr(ow_service, "ow_close_worker", _raising)
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        with caplog.at_level("WARNING", logger="src.services.ow_service"):
+            result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert result.get("msg_id") == 123
+        assert "error" not in result
+        assert any("auto-close failed" in rec.message for rec in caplog.records)
+
+    def test_relay_post_failure_does_not_trigger_close(self, monkeypatch):
+        """relay POST 失敗 (msg_id 未取得) では ow_close_worker は呼ばれない"""
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=400, msg="bad request", hdrs={}, fp=None
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ow_service, "RELAY_URL", "http://127.0.0.1:8765")
+        monkeypatch.setattr(
+            ow_service, "ow_get_identity",
+            lambda ch, h: {"term_ref": "%42"},
+        )
+        called: list = []
+        monkeypatch.setattr(
+            ow_service, "ow_close_worker",
+            lambda term_ref: called.append(term_ref),
+        )
+
+        body = {"v": 1, "kind": "event", "from": "w-a", "to": "*",
+                "data": {"type": "state", "state": "terminated", "cause": "closed"}}
+        result = ow_service.ow_send(channel="AbCdEfGh", handle="w-a", body=body)
+
+        assert "error" in result
+        assert called == []


### PR DESCRIPTION
## 概要

worker が `event:state(terminated, cause:closed|cancelled)` を `ow_send` で送ったとき、cc-memory MCP server 側で自動的に対応 worker の pane を kill する仕組みを追加する。

## 振る舞いの変化

**Before**: worker SKILL.md の auto-close 手順 (`tmux kill-pane` を worker 自身が実行) に kill 発火を依存していた。worker LLM が SKILL を読み落とすと kill が発火せず pane が leak していた。

**After**: `ow_send` MCP tool handler が relay POST 成功直後に envelope を判定し、cause が `closed` または `cancelled` なら `ow_close_worker(term_ref)` を同期発火する。kill 発火が server-side のコードで保証され、worker LLM の SKILL 遵守に依存しない。

## なぜ要るのか

worker auto-close を worker LLM の SKILL 読解任せにしていたため、SKILL を読み落とした worker は pane を leak していた。kill 保証をシステム側に持ち込むことで、LLM 任意の脱出を撲滅する。

## 設計判断

- 副作用は handler 内で同期発火する (return より kill が先、worker session は ow_send の戻り値を受け取らずに死ぬ)
- cause 別判定: `closed` / `cancelled` は kill 対象、`dead` / `crashed` / `crashed-during-drain` は対象外 (再現可能な正常終了のみシステム kill する)
- 冪等性は adapter (`tmux kill-pane` の \`2>/dev/null || true\`) に任せる。handler 内に発火済みフラグや msg_id store は実装しない (二重発火しても adapter で no-op に落ちる)
- `ow_close_worker` 失敗は warn log のみで tool error には伝播しない (worker は kill されてしまうので、ow_send の戻り値を受け取ることはなく、tool error を伝える意味がない)

## テスト計画

新規追加テスト 10 件、いずれも \`tests/unit/test_ow_send.py\` の \`TestOwSendAutoClose\` クラス。検証項目:

- terminated cause=closed で \`ow_close_worker\` が呼ばれる
- terminated cause=cancelled で呼ばれる
- terminated cause=dead / crashed / crashed-during-drain で呼ばれない
- state=draining 等 terminated 以外で呼ばれない
- kind=command (event 以外) で呼ばれない
- term_ref 解決失敗で no-op + warn log のみ
- 同 term_ref で 2 回 ow_send (terminated) → 2 回とも発火 (冪等性は adapter 任せ)
- \`ow_close_worker\` 失敗時に ow_send は成功扱い (tool error にしない)
- relay POST 失敗時は副作用発火しない (POST 成功時のみフック)
- envelope が dict でない / data フィールド欠落でも安全に no-op

既存テスト破壊なし (\`tests/unit/\` 全体維持確認済み)。

## 関連する後続作業

worker SKILL.md の auto-close 手順削除と dispatcher SKILL.md の terminated 受信後 \`ow_close_worker\` 手動指示の撤去は、本 PR マージ後に別 PR で対応する。本 PR はシステム kill 経路を立ち上げるところまでで、SKILL 側の記述清掃は順序的に後行させる方が安全。

## Known follow-up

\`ow_close_worker\` は \`tmux kill-pane\` の TimeoutExpired / CalledProcessError を内部で吸収して \`{\"closed\": False}\` を返す実装になっている。本 PR の auto-close ブロックは Python の例外しか try/except していないため、kill 漏れがあった場合に warn log が出ない。後続の改善で \`{\"closed\": False}\` ケースも warn 出力対象に拡張する想定。