### PR TITLE
fix: preblock hook で claude-code-memory を許可リストに追加

### DIFF
--- a/hooks/preblock_hook.py
+++ b/hooks/preblock_hook.py
@@ -4,7 +4,7 @@
 cc-memory 開発現場以外で内部 ID 形式の文字列を外部に出すケースは想定されないため、
 tool 引数段階で機械的に止めることで AI 経由の漏出を防ぐ (scope A 方針)。
 
-cc-memory project 内 (pyproject.toml の name が cc-memory) のみで有効。
+cc-memory project 内 (pyproject.toml の `[project].name` が `_PROJECT_NAMES` のいずれかに一致) のみで有効。
 `CC_MEMORY_LEAK_GUARD=off` 環境変数で緊急時に opt-out 可能。
 allowlist tool (cc-memory 自身の MCP / Read 系 / harness 内部 tool) は素通し。
 バックスラッシュエスケープ (`\\M#123`, `\\log #123`) は字義扱いで非 block。
@@ -63,7 +63,7 @@ LOG_PATH = pathlib.Path.home() / ".cc-memory" / "logs" / "preblock_hook.jsonl"
 # pyproject.toml `[project].name` がこのいずれかに一致したら cc-memory project と判定する。
 # 実プロジェクトの name は "claude-code-memory" だが、過去ドキュメントや一部 fixture が
 # "cc-memory" 表記を持つので両方を受け入れる。
-_PROJECT_NAMES = ("cc-memory", "claude-code-memory")
+_PROJECT_NAMES: tuple[str, ...] = ("cc-memory", "claude-code-memory")
 
 
 def _is_allowed(tool_name: str) -> bool:
@@ -131,9 +131,10 @@ def _scan_tool_input(value) -> list[dict]:
 def _is_in_cc_memory_project() -> bool:
     """cwd から上方向に pyproject.toml を探索して cc-memory project か判定する。
 
-    `[project].name` を tomllib で厳密パースする。コメント行や別フィールドに
-    たまたま `name = "cc-memory"` を含むケースで誤判定しないよう、文字列の
-    部分一致ではなくパース済みの構造から取り出す。
+    `[project].name` を tomllib で厳密パースし、`_PROJECT_NAMES` のいずれかに
+    一致するケースを cc-memory project とみなす。コメント行や別フィールドに
+    たまたま許容値を含むケースで誤判定しないよう、文字列の部分一致ではなく
+    パース済みの構造から取り出す。
     """
     cwd = pathlib.Path.cwd()
     for p in (cwd, *cwd.parents):

--- a/hooks/preblock_hook.py
+++ b/hooks/preblock_hook.py
@@ -60,6 +60,11 @@ ALLOWLIST_EXACT: frozenset[str] = frozenset(
 
 LOG_PATH = pathlib.Path.home() / ".cc-memory" / "logs" / "preblock_hook.jsonl"
 
+# pyproject.toml `[project].name` がこのいずれかに一致したら cc-memory project と判定する。
+# 実プロジェクトの name は "claude-code-memory" だが、過去ドキュメントや一部 fixture が
+# "cc-memory" 表記を持つので両方を受け入れる。
+_PROJECT_NAMES = ("cc-memory", "claude-code-memory")
+
 
 def _is_allowed(tool_name: str) -> bool:
     if tool_name in ALLOWLIST_EXACT:
@@ -143,7 +148,7 @@ def _is_in_cc_memory_project() -> bool:
         project = data.get("project")
         if not isinstance(project, dict):
             return False
-        return project.get("name") == "cc-memory"
+        return project.get("name") in _PROJECT_NAMES
     return False
 
 

--- a/tests/unit/test_preblock_hook.py
+++ b/tests/unit/test_preblock_hook.py
@@ -200,6 +200,14 @@ class TestIsInCcMemoryProject:
         monkeypatch.chdir(tmp_path)
         assert preblock_hook._is_in_cc_memory_project() is True
 
+    def test_pyproject_with_claude_code_memory_literal_string(self, tmp_path, monkeypatch):
+        # claude-code-memory も literal string (single quotes) で受理される
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'claude-code-memory'\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is True
+
     def test_pyproject_with_other_name(self, tmp_path, monkeypatch):
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "other-project"\n'

--- a/tests/unit/test_preblock_hook.py
+++ b/tests/unit/test_preblock_hook.py
@@ -183,6 +183,15 @@ class TestIsInCcMemoryProject:
         monkeypatch.chdir(tmp_path)
         assert preblock_hook._is_in_cc_memory_project() is True
 
+    def test_pyproject_with_claude_code_memory_name(self, tmp_path, monkeypatch):
+        # 実プロジェクトの pyproject.toml は name = "claude-code-memory" なので
+        # こちらも cc-memory project として受理されること
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "claude-code-memory"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        assert preblock_hook._is_in_cc_memory_project() is True
+
     def test_pyproject_with_literal_string(self, tmp_path, monkeypatch):
         # TOML literal string (single quotes) も同様に受理される
         (tmp_path / "pyproject.toml").write_text(


### PR DESCRIPTION
## 何が変わるか

`hooks/preblock_hook.py` の `_is_in_cc_memory_project` が `("cc-memory", "claude-code-memory")` の両方を `[project].name` の許可値として受け入れるようにする。

## なぜ要るか

実プロジェクトの `pyproject.toml` の `[project].name` は `claude-code-memory` で、`_is_in_cc_memory_project` の判定 (`name == "cc-memory"`) では一度も True にならない。結果として PreToolUse hook の内部 ID 漏出 block が本番で一度も発火していなかった。test 上は fixture で `cc-memory` を書くので pass するが、本番の security 機構は素通しの状態。

## テスト

- 新規 `test_pyproject_with_claude_code_memory_name` で `claude-code-memory` が True を返すことを確認
- 既存テスト (`test_pyproject_with_cc_memory_name` 等) は破壊なし、70 件 pass

## 関連

#451 (内部 ID 漏出 block の本体実装) の作業中に発見した pre-existing バグ。