### PR TITLE
fix: preblock hook のバックスラッシュエスケープを citations converter と一致させる

### DIFF
--- a/hooks/preblock_hook.py
+++ b/hooks/preblock_hook.py
@@ -30,6 +30,11 @@ from src.services.internal_id_patterns import (  # noqa: E402
     RAW_CITE_FULLWORD_PATTERN,
 )
 
+# converter (`_convert_line_raw_to_cite`) が `\` 直後の TYPE_CODE 判定に使う集合と
+# 揃えるためのローカル定数。converter 側は TYPE_CODE_TO_NAME のキーを参照しているが、
+# hook は citations_pure に依存しないので最小集合だけ持つ。
+_TYPE_CODES: frozenset[str] = frozenset("MDLAT")
+
 ALLOWLIST_PREFIXES: tuple[str, ...] = (
     "mcp__plugin_claude-code-memory_cc-memory__",
 )
@@ -70,27 +75,46 @@ def _is_allowed(tool_name: str) -> bool:
 def _scan_text_for_literals(text: str) -> list[str]:
     """1 個の文字列に対し code + fullword 両方を検出し、マッチした raw 文字列を返す。
 
-    バックスラッシュエスケープ (`\\M#123`, `\\log #123`) は事前に取り除いた
-    擬似テキストで scan する: hook の責務は「AI が tool に渡そうとした文字列に
-    内部 ID 形式が現れたら止める」であり、エスケープ表現で書かれた箇所は
-    字義扱いとして block 対象から外す。
+    バックスラッシュエスケープ (`\\M#123`, `\\log #123`) は字義扱いとして block 対象
+    から外す。エスケープ判定は converter (`_convert_line_raw_to_cite`) と同じ条件:
+    `\\` の直後が「TYPE_CODE 1 文字 + リテラル形式」または「fullword リテラル形式」で
+    あるときだけ、その全体をスキップする。それ以外の `\\` は単なる文字として残し、
+    後段の `\\X` (X は TYPE_CODE) が独立したリテラルとして検出される機会を保つ。
+
+    例:
+      - `\\M#1`  (`\\` 1 個): converter はエスケープ扱い → ここでも skip
+      - `\\\\M#1` (`\\` 2 個): converter は i=0 で `\\` を文字残し、i=1 の `\\M#1` を
+        エスケープ扱い → ここでも同じ判定で skip
+      - `\\hello` (`\\` の直後が TYPE_CODE でも fullword でもない): `\\` は単なる
+        文字として残し、続く `hello` を通常テキストとして scan する
     """
-    matches: list[str] = []
-    # エスケープされた箇所を空白で潰してから scan する。
-    # `\X#NNN` / `\log #NNN` 等の直後文字数は最大 16 + 1 程度なので十分な余白を取る。
-    sanitized = []
+    # converter と同じ走査経路でエスケープ済み区間を boundary 用空白に置換する。
+    # 元テキストと長さを揃え、word boundary の lookbehind/lookahead に影響を与えない。
+    sanitized: list[str] = []
     i = 0
     n = len(text)
     while i < n:
-        if text[i] == "\\" and i + 1 < n:
-            # バックスラッシュとその直後 1 文字をスキップする (字義扱い)
-            sanitized.append(" ")  # boundary を保つため空白で置換
-            sanitized.append(" ")
-            i += 2
-            continue
-        sanitized.append(text[i])
+        ch = text[i]
+        if ch == "\\" and i + 1 < n:
+            tail = text[i + 1]
+            # `\\X#NNN` (X は TYPE_CODE) のエスケープ。
+            if tail in _TYPE_CODES:
+                m = RAW_CITE_CODE_PATTERN.match(text, i + 1)
+                if m and m.start() == i + 1:
+                    sanitized.append(" " * (m.end() - i))
+                    i = m.end()
+                    continue
+            # `\\log #NNN` 等の fullword エスケープ。
+            m_fw = RAW_CITE_FULLWORD_PATTERN.match(text, i + 1)
+            if m_fw and m_fw.start() == i + 1:
+                sanitized.append(" " * (m_fw.end() - i))
+                i = m_fw.end()
+                continue
+            # 上記いずれのリテラルにも該当しない `\\X` は単なる文字。`\\` を残す。
+        sanitized.append(ch)
         i += 1
     haystack = "".join(sanitized)
+    matches: list[str] = []
     for m in RAW_CITE_CODE_PATTERN.finditer(haystack):
         matches.append(m.group(0))
     for m in RAW_CITE_FULLWORD_PATTERN.finditer(haystack):

--- a/tests/unit/test_preblock_hook.py
+++ b/tests/unit/test_preblock_hook.py
@@ -60,6 +60,22 @@ class TestScanTextForLiterals:
     def test_escape_fullword_not_matched(self):
         assert preblock_hook._scan_text_for_literals("\\log #1 is literal") == []
 
+    def test_double_backslash_code_not_matched(self):
+        # `\\M#1` (`\` 2 個) は converter で i=1 のエスケープが効き全体スキップになるため、
+        # hook も block しないでなければ UX が converter と食い違う。
+        assert preblock_hook._scan_text_for_literals("\\\\M#1 is literal") == []
+
+    def test_double_backslash_fullword_not_matched(self):
+        # `\\log #1` (`\` 2 個) も同様。
+        assert preblock_hook._scan_text_for_literals("\\\\log #1 is literal") == []
+
+    def test_single_backslash_then_unrelated_char_does_not_consume_following_literal(self):
+        # converter は `\` 直後が TYPE_CODE / fullword のリテラル形でない限り
+        # `\` を単なる文字として残す。hook も同様で、後続の `M#1` を盲目的に
+        # 食わずに通常リテラルとして検出する。
+        result = preblock_hook._scan_text_for_literals("\\x M#1")
+        assert result == ["M#1"]
+
     def test_word_boundary_blog_not_match(self):
         assert preblock_hook._scan_text_for_literals("blog #1 was published") == []
 
@@ -344,6 +360,43 @@ class TestMainBlockFlow:
             capsys,
         )
         assert out == {}
+
+    def test_double_backslash_code_not_blocked(self, capsys, cc_memory_cwd):
+        # `\\M#1` (`\` 2 個) は converter ではエスケープ扱いで sanitize されるため、
+        # hook 側も block してはいけない (UX 整合)。
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo \\\\M#1 literal"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_double_backslash_fullword_not_blocked(self, capsys, cc_memory_cwd):
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo \\\\log #1 literal"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out == {}
+
+    def test_plain_literal_still_blocks_regression(self, capsys, cc_memory_cwd):
+        # backslash なしの素の `M#1` は引き続き block する (regression 防止)。
+        out = _run_main_with_event(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo M#1 leak"},
+                "session_id": "s1",
+            },
+            capsys,
+        )
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "M#1" in out["hookSpecificOutput"]["permissionDecisionReason"]
 
     def test_allowlist_tool_passes_through(self, capsys, cc_memory_cwd):
         # cc-memory MCP は scan されない


### PR DESCRIPTION
## 何が変わるか

`hooks/preblock_hook.py:_scan_text_for_literals` のバックスラッシュエスケープ判定を `src/services/citations_pure.py:_convert_line_raw_to_cite` と同じ条件に揃える。

| 入力 | converter | hook (修正前) | hook (修正後) |
|---|---|---|---|
| `\M#1` (`\` 1 個) | エスケープ (skip) | block しない | block しない |
| `\\M#1` (`\` 2 個) | i=1 のエスケープが効き全体スキップ | **block** | block しない |
| `\\log #1` (`\` 2 個) | 同上、全体スキップ | **block** | block しない |
| `M#1` (`\` なし) | block (リテラル) | block | block |

## なぜ要るか

converter で「外向き表現として有効なエスケープ」と判定したものを hook が block すると、書き手から見ると「エスケープしたものを書いたのに hook が止めてしまう」UX 矛盾になる。security 上は hook が止める方が安全側だが、converter が認めるエスケープ表現は hook も認めるべき。

修正は hook 側を converter 側に揃える方向で行う:

- `\` の直後が TYPE_CODE (M/D/L/A/T) で始まるリテラル形式 (例: `\M#123`)、または fullword 形式 (例: `\log #45`) の先頭であるときだけ、その全体を skip
- それ以外の `\` は単なる文字として残し、続くテキストを通常 scan する

## テスト

新規 6 件追加:
- `\\M#1` (2 個 `\`) が block されない
- `\\log #1` (2 個 `\`) が block されない
- `\x M#1` のように `\` 直後が TYPE_CODE / fullword でない場合、後続の `M#1` が独立リテラルとして検出される (regression 防止)
- main flow 側でも上記 2 件が block されない
- 素の `M#1` (`\` なし) は引き続き block されること (regression 防止)

`tests/unit/test_preblock_hook.py` 75 件 pass。

## 関連

#451 (内部 ID 漏出 block の本体実装) の bot review で観察された非対称への対応。