### PR TITLE
feat: capability_matrix と role 別 visibility middleware

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -233,6 +233,10 @@ def _apply_flavor_to_snippets(items: list[dict], flavor: str) -> None:
 # MCPサーバーを作成
 mcp = FastMCP("cc-memory", instructions=build_instructions())
 
+# role 別の tools/list 可視性を制御する middleware を登録する
+from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+mcp.add_middleware(CapabilityVisibilityMiddleware())
+
 # サーバー起動時刻（/health で uptime 算出に使用）
 _SERVER_STARTED_AT = datetime.now(timezone.utc)
 

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ from src.services.tag_service import search_tags as _search_tags, update_tag as 
 from src.services.tag_analysis_service import analyze_tags as _analyze_tags
 from src.services import citation_renderer
 from src.services.role_service import get_caller_session_id
+from src.services.visibility_middleware import CapabilityVisibilityMiddleware
 from src.db import get_connection
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -234,7 +235,6 @@ def _apply_flavor_to_snippets(items: list[dict], flavor: str) -> None:
 mcp = FastMCP("cc-memory", instructions=build_instructions())
 
 # role 別の tools/list 可視性を制御する middleware を登録する
-from src.services.visibility_middleware import CapabilityVisibilityMiddleware
 mcp.add_middleware(CapabilityVisibilityMiddleware())
 
 # サーバー起動時刻（/health で uptime 算出に使用）

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -1,10 +1,13 @@
 """role 別 tool capability matrix。
 
-各 tool が orch / dispatcher / worker のどの role から呼び出せるかを表現する。
+各 tool が orch / dispatcher / worker / user のどの role から呼び出せるかを表現する。
 matrix の値:
   - True: 許可
   - False: 拒否 (hide 候補)
   - "self": 条件付き許可 (caller_session_id 比較は呼び出し側 guard が行う、tools/list には表示)
+
+user role は MCP tool 呼び出し主体にならない想定 (人間操作面は orch session を介する)
+ため全 tool を False (hide) としている。
 
 判定経路は role_service.lookup_role に集約。
 """
@@ -17,54 +20,54 @@ CapabilityMatrix = dict[str, dict[str, Decision]]
 
 CAPABILITY_MATRIX: CapabilityMatrix = {
     # ow tools (worker lifecycle / messaging)
-    "ow_spawn_worker":   {"orch": False, "dispatcher": True,  "worker": False},
-    "ow_close_worker":   {"orch": False, "dispatcher": True,  "worker": "self"},
-    "ow_recover":        {"orch": False, "dispatcher": True,  "worker": False},
-    "ow_send":           {"orch": True,  "dispatcher": True,  "worker": True},
-    "ow_status":         {"orch": True,  "dispatcher": True,  "worker": True},
-    "ow_history":        {"orch": True,  "dispatcher": True,  "worker": True},
-    "ow_spawn_dispatcher": {"orch": True,  "dispatcher": False, "worker": False},
-    "ow_close_dispatcher": {"orch": True,  "dispatcher": False, "worker": False},
+    "ow_spawn_worker":   {"orch": False, "dispatcher": True,  "worker": False, "user": False},
+    "ow_close_worker":   {"orch": False, "dispatcher": True,  "worker": "self", "user": False},
+    "ow_recover":        {"orch": False, "dispatcher": True,  "worker": False, "user": False},
+    "ow_send":           {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "ow_status":         {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "ow_history":        {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "ow_spawn_dispatcher": {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "ow_close_dispatcher": {"orch": True,  "dispatcher": False, "worker": False, "user": False},
 
     # 書き込み
-    "add_topic":         {"orch": True,  "dispatcher": False, "worker": False},
-    "add_activity":      {"orch": True,  "dispatcher": False, "worker": False},
-    "add_decisions":     {"orch": True,  "dispatcher": False, "worker": False},
-    "add_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
-    "add_material":      {"orch": True,  "dispatcher": False, "worker": True},
-    "add_relation":      {"orch": True,  "dispatcher": False, "worker": False},
-    "add_pin":           {"orch": True,  "dispatcher": False, "worker": False},
-    "add_habit":         {"orch": True,  "dispatcher": False, "worker": False},
+    "add_topic":         {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "add_activity":      {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "add_decisions":     {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "add_logs":          {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "add_material":      {"orch": True,  "dispatcher": False, "worker": True,  "user": False},
+    "add_relation":      {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "add_pin":           {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "add_habit":         {"orch": True,  "dispatcher": False, "worker": False, "user": False},
 
     # 更新
-    "update_activity":   {"orch": True,  "dispatcher": False, "worker": False},
-    "update_material":   {"orch": True,  "dispatcher": False, "worker": "self"},
-    "update_habit":      {"orch": True,  "dispatcher": False, "worker": False},
-    "update_tag":        {"orch": True,  "dispatcher": False, "worker": False},
+    "update_activity":   {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "update_material":   {"orch": True,  "dispatcher": False, "worker": "self", "user": False},
+    "update_habit":      {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "update_tag":        {"orch": True,  "dispatcher": False, "worker": False, "user": False},
 
     # 削除・取消
-    "retract":           {"orch": True,  "dispatcher": False, "worker": False},
-    "remove_pin":        {"orch": True,  "dispatcher": False, "worker": False},
-    "remove_relation":   {"orch": True,  "dispatcher": False, "worker": False},
+    "retract":           {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "remove_pin":        {"orch": True,  "dispatcher": False, "worker": False, "user": False},
+    "remove_relation":   {"orch": True,  "dispatcher": False, "worker": False, "user": False},
 
     # 読み出し
-    "search":            {"orch": True,  "dispatcher": True,  "worker": True},
-    "search_tags":       {"orch": True,  "dispatcher": True,  "worker": True},
-    "analyze_tags":      {"orch": True,  "dispatcher": True,  "worker": True},
-    "check_in":          {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_activities":    {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_decisions":     {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_topics":        {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_material":      {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_habits":        {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_map":           {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_timeline":      {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_by_ids":        {"orch": True,  "dispatcher": True,  "worker": True},
-    "get_config":        {"orch": True,  "dispatcher": True,  "worker": True},
+    "search":            {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "search_tags":       {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "analyze_tags":      {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "check_in":          {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_activities":    {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_decisions":     {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_logs":          {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_topics":        {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_material":      {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_habits":        {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_map":           {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_timeline":      {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_by_ids":        {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
+    "get_config":        {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
 
     # その他
-    "roll_dice":         {"orch": True,  "dispatcher": True,  "worker": True},
+    "roll_dice":         {"orch": True,  "dispatcher": True,  "worker": True,  "user": False},
 }
 
 

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -1,0 +1,93 @@
+"""role 別 tool capability matrix。
+
+各 tool が orch / dispatcher / worker のどの role から呼び出せるかを表現する。
+matrix の値:
+  - True: 許可
+  - False: 拒否 (hide 候補)
+  - "self": 条件付き許可 (caller_session_id 比較は呼び出し側 guard が行う、tools/list には表示)
+
+判定経路は role_service.lookup_role に集約。
+"""
+from typing import Literal
+
+Role = Literal["orch", "dispatcher", "worker", "user"]
+Decision = bool | Literal["self"]
+CapabilityMatrix = dict[str, dict[str, Decision]]
+
+
+CAPABILITY_MATRIX: CapabilityMatrix = {
+    # ow tools (worker lifecycle / messaging)
+    "ow_spawn_worker":   {"orch": False, "dispatcher": True,  "worker": False},
+    "ow_close_worker":   {"orch": False, "dispatcher": True,  "worker": "self"},
+    "ow_recover":        {"orch": False, "dispatcher": True,  "worker": False},
+    "ow_send":           {"orch": True,  "dispatcher": True,  "worker": True},
+    "ow_status":         {"orch": True,  "dispatcher": True,  "worker": True},
+    "ow_history":        {"orch": True,  "dispatcher": True,  "worker": True},
+    "ow_spawn_dispatcher": {"orch": True,  "dispatcher": False, "worker": False},
+    "ow_close_dispatcher": {"orch": True,  "dispatcher": False, "worker": False},
+
+    # 書き込み
+    "add_topic":         {"orch": True,  "dispatcher": False, "worker": False},
+    "add_activity":      {"orch": True,  "dispatcher": False, "worker": False},
+    "add_decisions":     {"orch": True,  "dispatcher": False, "worker": False},
+    "add_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
+    "add_material":      {"orch": True,  "dispatcher": False, "worker": True},
+    "add_relation":      {"orch": True,  "dispatcher": False, "worker": False},
+    "add_pin":           {"orch": True,  "dispatcher": False, "worker": False},
+    "add_habit":         {"orch": True,  "dispatcher": False, "worker": False},
+
+    # 更新
+    "update_activity":   {"orch": True,  "dispatcher": False, "worker": False},
+    "update_material":   {"orch": True,  "dispatcher": False, "worker": "self"},
+    "update_habit":      {"orch": True,  "dispatcher": False, "worker": False},
+    "update_tag":        {"orch": True,  "dispatcher": False, "worker": False},
+
+    # 削除・取消
+    "retract":           {"orch": True,  "dispatcher": False, "worker": False},
+    "remove_pin":        {"orch": True,  "dispatcher": False, "worker": False},
+    "remove_relation":   {"orch": True,  "dispatcher": False, "worker": False},
+
+    # 読み出し
+    "search":            {"orch": True,  "dispatcher": True,  "worker": True},
+    "search_tags":       {"orch": True,  "dispatcher": True,  "worker": True},
+    "analyze_tags":      {"orch": True,  "dispatcher": True,  "worker": True},
+    "check_in":          {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_activities":    {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_decisions":     {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_topics":        {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_material":      {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_habits":        {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_map":           {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_timeline":      {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_by_ids":        {"orch": True,  "dispatcher": True,  "worker": True},
+    "get_config":        {"orch": True,  "dispatcher": True,  "worker": True},
+
+    # その他
+    "roll_dice":         {"orch": True,  "dispatcher": True,  "worker": True},
+}
+
+
+def hidden_tools_for(role: str) -> set[str]:
+    """role に対して tools/list から hide すべき tool 名集合。
+
+    decision が False の tool のみ hide する。"self" は表示する (guard 層で判定)。
+    matrix に role 自体が無いケース (=未定義 role) では全 tool を hide。
+    """
+    hidden: set[str] = set()
+    for name, matrix in CAPABILITY_MATRIX.items():
+        decision = matrix.get(role)
+        if decision is False or decision is None:
+            hidden.add(name)
+    return hidden
+
+
+def is_allowed(tool_name: str, role: str) -> Decision:
+    """capability matrix から (tool, role) の decision を返す。
+
+    matrix に無い tool は False (default deny)。
+    """
+    matrix_row = CAPABILITY_MATRIX.get(tool_name)
+    if matrix_row is None:
+        return False
+    return matrix_row.get(role, False)

--- a/src/services/visibility_middleware.py
+++ b/src/services/visibility_middleware.py
@@ -2,8 +2,8 @@
 
 initialize 時にセッションの role を解決し、その role から見える tool 集合だけ
 tools/list に出るよう FastMCP の session-level visibility rules を設定する。
-判定ロジック自体は guard_service.check_capability (PR-d) が担当する二層構造の
-hide 側を担う。
+本 middleware は二層構造の hide 側のみを担い、実際の呼び出し可否判定 (reject) は
+別途 guard 層が担当する。
 """
 from __future__ import annotations
 

--- a/src/services/visibility_middleware.py
+++ b/src/services/visibility_middleware.py
@@ -1,0 +1,70 @@
+"""capability matrix に基づく role 別 visibility の middleware。
+
+initialize 時にセッションの role を解決し、その role から見える tool 集合だけ
+tools/list に出るよう FastMCP の session-level visibility rules を設定する。
+判定ロジック自体は guard_service.check_capability (PR-d) が担当する二層構造の
+hide 側を担う。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types as mt
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
+from fastmcp.server.transforms.visibility import disable_components
+
+from src.db import get_connection
+from src.services import capability_matrix, role_service
+
+
+class CapabilityVisibilityMiddleware(Middleware):
+    """role に応じて tools/list から見えない tool を hide する middleware。
+
+    on_initialize で session role を解決し、その role の hidden set を
+    session-level visibility rule として登録する。role 未解決 (grace period)
+    の場合は何も hide しない (guard 層で reject されるため見えても問題ない)。
+    """
+
+    async def on_initialize(
+        self,
+        context: MiddlewareContext[mt.InitializeRequest],
+        call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None],
+    ) -> mt.InitializeResult | None:
+        result = await call_next(context)
+        fastmcp_ctx = context.fastmcp_context
+        if fastmcp_ctx is None:
+            return result
+
+        session_id = self._safe_session_id(fastmcp_ctx)
+        role = self._resolve_role(session_id)
+        if role is None:
+            return result
+
+        hidden = capability_matrix.hidden_tools_for(role)
+        if not hidden:
+            return result
+
+        await disable_components(
+            fastmcp_ctx,
+            names=hidden,
+            components={"tool"},
+        )
+        return result
+
+    @staticmethod
+    def _safe_session_id(fastmcp_ctx: Any) -> str | None:
+        try:
+            return fastmcp_ctx.session_id
+        except RuntimeError:
+            return None
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def _resolve_role(session_id: str | None) -> str | None:
+        conn = get_connection()
+        try:
+            return role_service.lookup_role(conn, session_id)
+        finally:
+            conn.close()

--- a/tests/services/test_capability_matrix.py
+++ b/tests/services/test_capability_matrix.py
@@ -15,7 +15,7 @@ from src.services.capability_matrix import (
 class TestMatrixCoverage:
     """matrix が想定 role を全行で扱っていることを保証する。"""
 
-    @pytest.mark.parametrize("role", ["orch", "dispatcher", "worker"])
+    @pytest.mark.parametrize("role", ["orch", "dispatcher", "worker", "user"])
     def test_every_tool_has_decision_for_role(self, role):
         for tool_name, matrix_row in CAPABILITY_MATRIX.items():
             assert role in matrix_row, (
@@ -61,6 +61,12 @@ class TestHiddenToolsFor:
         hidden = hidden_tools_for("nobody")
         assert hidden == set(CAPABILITY_MATRIX.keys())
 
+    def test_user_role_hides_everything(self):
+        # user role は MCP tool 呼び出し主体にならない想定で、matrix 上は
+        # 全 tool が False。hidden_tools_for は全 tool を返す。
+        hidden = hidden_tools_for("user")
+        assert hidden == set(CAPABILITY_MATRIX.keys())
+
     def test_read_tools_visible_to_all(self):
         for role in ("orch", "dispatcher", "worker"):
             hidden = hidden_tools_for(role)
@@ -87,3 +93,8 @@ class TestIsAllowed:
 
     def test_unknown_role_default_deny(self):
         assert is_allowed("search", "nobody") is False
+
+    def test_user_role_default_deny(self):
+        # user role は matrix 上では全 tool に対して False。
+        assert is_allowed("search", "user") is False
+        assert is_allowed("add_decisions", "user") is False

--- a/tests/services/test_capability_matrix.py
+++ b/tests/services/test_capability_matrix.py
@@ -1,0 +1,89 @@
+"""capability_matrix の unit test。
+
+CAPABILITY_MATRIX が想定通り (orch/dispatcher/worker × 全 tool) を網羅していること、
+hidden_tools_for / is_allowed の判定が matrix の値と一致することを検証する。
+"""
+import pytest
+
+from src.services.capability_matrix import (
+    CAPABILITY_MATRIX,
+    hidden_tools_for,
+    is_allowed,
+)
+
+
+class TestMatrixCoverage:
+    """matrix が想定 role を全行で扱っていることを保証する。"""
+
+    @pytest.mark.parametrize("role", ["orch", "dispatcher", "worker"])
+    def test_every_tool_has_decision_for_role(self, role):
+        for tool_name, matrix_row in CAPABILITY_MATRIX.items():
+            assert role in matrix_row, (
+                f"tool {tool_name!r} has no entry for role {role!r}"
+            )
+
+    def test_no_unknown_decision_values(self):
+        for tool_name, matrix_row in CAPABILITY_MATRIX.items():
+            for role, decision in matrix_row.items():
+                assert decision in (True, False, "self"), (
+                    f"unexpected decision {decision!r} for {tool_name}/{role}"
+                )
+
+
+class TestHiddenToolsFor:
+    def test_orch_hides_dispatcher_only_tools(self):
+        hidden = hidden_tools_for("orch")
+        assert "ow_spawn_worker" in hidden
+        assert "ow_recover" in hidden
+        assert "ow_close_worker" in hidden  # decision=False for orch
+
+    def test_worker_hides_write_admin_tools(self):
+        hidden = hidden_tools_for("worker")
+        assert "add_topic" in hidden
+        assert "add_decisions" in hidden
+        assert "add_relation" in hidden
+        assert "update_activity" in hidden
+        assert "retract" in hidden
+
+    def test_dispatcher_hides_almost_all_write_tools(self):
+        hidden = hidden_tools_for("dispatcher")
+        assert "add_topic" in hidden
+        assert "add_decisions" in hidden
+        assert "add_material" in hidden
+        assert "update_activity" in hidden
+
+    def test_self_tools_are_not_hidden(self):
+        hidden_worker = hidden_tools_for("worker")
+        assert "ow_close_worker" not in hidden_worker
+        assert "update_material" not in hidden_worker
+
+    def test_unknown_role_hides_everything(self):
+        hidden = hidden_tools_for("nobody")
+        assert hidden == set(CAPABILITY_MATRIX.keys())
+
+    def test_read_tools_visible_to_all(self):
+        for role in ("orch", "dispatcher", "worker"):
+            hidden = hidden_tools_for(role)
+            assert "search" not in hidden
+            assert "get_decisions" not in hidden
+            assert "check_in" not in hidden
+
+
+class TestIsAllowed:
+    def test_orch_allowed_for_writes(self):
+        assert is_allowed("add_decisions", "orch") is True
+        assert is_allowed("add_topic", "orch") is True
+
+    def test_worker_denied_for_admin_writes(self):
+        assert is_allowed("add_decisions", "worker") is False
+        assert is_allowed("update_activity", "worker") is False
+
+    def test_self_tools_return_self_token(self):
+        assert is_allowed("ow_close_worker", "worker") == "self"
+        assert is_allowed("update_material", "worker") == "self"
+
+    def test_unknown_tool_default_deny(self):
+        assert is_allowed("nonexistent_tool", "orch") is False
+
+    def test_unknown_role_default_deny(self):
+        assert is_allowed("search", "nobody") is False

--- a/tests/services/test_visibility_middleware.py
+++ b/tests/services/test_visibility_middleware.py
@@ -1,0 +1,153 @@
+"""CapabilityVisibilityMiddleware の unit test。
+
+on_initialize で resolve した role に応じて disable_components が呼ばれ、
+hidden_tools_for と同じ tool 集合が渡ることを検証する。
+"""
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    """全 migration を適用済みのテスト用 DB を提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture(autouse=True)
+def clear_ow_role(monkeypatch):
+    monkeypatch.delenv("OW_ROLE", raising=False)
+
+
+def _make_mw_context(session_id: str | None = "sess-1"):
+    fastmcp_ctx = MagicMock()
+    if session_id is None:
+        type(fastmcp_ctx).session_id = property(
+            fget=lambda self: (_ for _ in ()).throw(RuntimeError("no session"))
+        )
+    else:
+        fastmcp_ctx.session_id = session_id
+    mw_context = MagicMock()
+    mw_context.fastmcp_context = fastmcp_ctx
+    return mw_context, fastmcp_ctx
+
+
+@pytest.mark.asyncio
+async def test_hides_orch_disallowed_tools_when_role_is_orch(migrated_db):
+    from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+    from src.services.capability_matrix import hidden_tools_for
+
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO session_identity (session_id, role) VALUES (?, ?)",
+            ("sess-orch", "orch"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    middleware = CapabilityVisibilityMiddleware()
+    mw_context, _ = _make_mw_context("sess-orch")
+    call_next = AsyncMock(return_value="initialize-result")
+
+    with patch(
+        "src.services.visibility_middleware.disable_components",
+        new=AsyncMock(),
+    ) as mock_disable:
+        result = await middleware.on_initialize(mw_context, call_next)
+
+    assert result == "initialize-result"
+    mock_disable.assert_called_once()
+    call_kwargs = mock_disable.call_args.kwargs
+    assert call_kwargs["names"] == hidden_tools_for("orch")
+    assert call_kwargs["components"] == {"tool"}
+
+
+@pytest.mark.asyncio
+async def test_does_nothing_when_role_is_unresolved(migrated_db):
+    from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+
+    middleware = CapabilityVisibilityMiddleware()
+    mw_context, _ = _make_mw_context("sess-unknown")
+    call_next = AsyncMock(return_value="initialize-result")
+
+    with patch(
+        "src.services.visibility_middleware.disable_components",
+        new=AsyncMock(),
+    ) as mock_disable:
+        result = await middleware.on_initialize(mw_context, call_next)
+
+    assert result == "initialize-result"
+    mock_disable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_env_ow_role(migrated_db, monkeypatch):
+    from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+    from src.services.capability_matrix import hidden_tools_for
+
+    monkeypatch.setenv("OW_ROLE", "worker")
+    middleware = CapabilityVisibilityMiddleware()
+    mw_context, _ = _make_mw_context("sess-no-db-row")
+    call_next = AsyncMock(return_value="initialize-result")
+
+    with patch(
+        "src.services.visibility_middleware.disable_components",
+        new=AsyncMock(),
+    ) as mock_disable:
+        await middleware.on_initialize(mw_context, call_next)
+
+    mock_disable.assert_called_once()
+    assert mock_disable.call_args.kwargs["names"] == hidden_tools_for("worker")
+
+
+@pytest.mark.asyncio
+async def test_no_fastmcp_context_skips_hiding(migrated_db):
+    from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+
+    middleware = CapabilityVisibilityMiddleware()
+    mw_context = MagicMock()
+    mw_context.fastmcp_context = None
+    call_next = AsyncMock(return_value="initialize-result")
+
+    with patch(
+        "src.services.visibility_middleware.disable_components",
+        new=AsyncMock(),
+    ) as mock_disable:
+        result = await middleware.on_initialize(mw_context, call_next)
+
+    assert result == "initialize-result"
+    mock_disable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_id_runtime_error_uses_env_fallback(migrated_db, monkeypatch):
+    from src.services.visibility_middleware import CapabilityVisibilityMiddleware
+    from src.services.capability_matrix import hidden_tools_for
+
+    monkeypatch.setenv("OW_ROLE", "dispatcher")
+    middleware = CapabilityVisibilityMiddleware()
+    mw_context, _ = _make_mw_context(None)  # session_id raises RuntimeError
+    call_next = AsyncMock(return_value="initialize-result")
+
+    with patch(
+        "src.services.visibility_middleware.disable_components",
+        new=AsyncMock(),
+    ) as mock_disable:
+        await middleware.on_initialize(mw_context, call_next)
+
+    mock_disable.assert_called_once()
+    assert mock_disable.call_args.kwargs["names"] == hidden_tools_for("dispatcher")


### PR DESCRIPTION
## Summary

role 別に tools/list を絞り込む二層構造のうち、hide 層を導入する。capability matrix を data として定義し、FastMCP の session-level visibility rules で role に応じた tool を非表示にする。

## 振る舞い変更

### capability_matrix.py (新規)

全 cc-memory tool に対して orch / dispatcher / worker からの許可を `True` / `False` / `"self"` で表現する。`hidden_tools_for(role)` は `False` の tool 集合を返す。`"self"` 扱いの tool (`ow_close_worker` / `update_material`) は表示し、tool 内 guard 側で判定する。

### CapabilityVisibilityMiddleware (新規)

`on_initialize` で session の role を `role_service.lookup_role` で解決し、解決できれば `disable_components` で role に応じた tool を hide する。grace period (役割未解決) では何もしない (guard 層が reject するため見えても安全)。

`disable_components` は `notifications/tools/list_changed` を自動送信するため、role 確定タイミングで LLM 側の tools/list は再取得される。

### main.py への middleware 登録

`mcp = FastMCP(...)` の直後に `mcp.add_middleware(CapabilityVisibilityMiddleware())` を追加する。

## なぜ

役割違反の tool 呼び出しを「LLM に見せない」一次防御を導入するため。可視性を制限することで、LLM が「呼べる前提」で誤った tool を計画してしまう事故を構造的に減らす。実際の呼び出し拒否は後続 PR の guard 層が担う。

## Test plan

- [x] `tests/services/test_capability_matrix.py` を新規追加 (matrix 整合性、hidden_tools_for / is_allowed 判定、self / read-only の例外パス、未知 role の deny)
- [x] `tests/services/test_visibility_middleware.py` を新規追加 (orch role での disable_components 呼び出し、grace period 時の no-op、env OW_ROLE fallback、fastmcp_context None の安全性)
- [x] 既存テスト 2288 件 pass 維持