### PR TITLE
feat: check_capability guard と is_worker_session の lookup_role 置換

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -263,7 +263,7 @@ def add_topic(
     related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]。作成と同時にリレーションを張る
 
     レスポンスに類似トピック(similar_topics)が含まれる場合がある。重複トピックの防止やリレーション追加の参考にすること。"""
-    guard_service.check_worker_guard("add_topic")
+    guard_service.check_capability("add_topic")
     caller_session_id = get_caller_session_id()
     result = topic_service.add_topic(title, description, tags, related=related, caller_session_id=caller_session_id)
     if "error" not in result:
@@ -317,7 +317,7 @@ def add_decisions(items: list[dict], ctx: Context) -> dict:
         created各要素には related_decisions（同topic内の類似decision上位3件 [{id, title, distance}]）が付く。
         既存decisionとの矛盾・重複に気づくための導線。embeddingサーバー未起動時は空配列。
     """
-    guard_service.check_worker_guard("add_decisions")
+    guard_service.check_capability("add_decisions")
     caller_session_id = get_caller_session_id()
     result = decision_service.add_decisions(items, caller_session_id=caller_session_id)
     if "error" not in result:
@@ -1043,7 +1043,7 @@ def add_habit(content: str) -> dict:
     add_decisions / add_topic と同じ guard 対象。OW_ESCALATION=1 の
     orch_proxy 経路でのみ通過する。
     """
-    guard_service.check_worker_guard("add_habit")
+    guard_service.check_capability("add_habit")
     return habit_service.add_habit(content)
 
 

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -18,7 +18,7 @@ CapabilityMatrix = dict[str, dict[str, Decision]]
 CAPABILITY_MATRIX: CapabilityMatrix = {
     # ow tools (worker lifecycle / messaging)
     "ow_spawn_worker":   {"orch": False, "dispatcher": True,  "worker": False},
-    "ow_close_worker":   {"orch": False, "dispatcher": True,  "worker": "self"},
+    "ow_close_worker":   {"orch": False, "dispatcher": True,  "worker": False},
     "ow_recover":        {"orch": False, "dispatcher": True,  "worker": False},
     "ow_send":           {"orch": True,  "dispatcher": True,  "worker": True},
     "ow_status":         {"orch": True,  "dispatcher": True,  "worker": True},

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -40,18 +40,17 @@ _ESCALATION_PASS = "1"
 def is_worker_session() -> bool:
     """ow worker として起動されたセッションかを判定する。
 
-    OW_ROLE=worker (env) または session_identity.role=worker (DB) のいずれかで真。
+    lookup_role が DB → env fallback を内包しているため、その結果が worker かを返す。
+    DB 優先 (DB に session が登録済みなら DB が真実) で、env 二重チェックは行わない。
     """
     from src.services.role_service import lookup_role, get_caller_session_id
 
     session_id = get_caller_session_id()
     conn = get_connection()
     try:
-        if lookup_role(conn, session_id) == _ROLE_WORKER:
-            return True
+        return lookup_role(conn, session_id) == _ROLE_WORKER
     finally:
         conn.close()
-    return os.environ.get(_ROLE_ENV) == _ROLE_WORKER
 
 
 def current_role() -> Optional["Role"]:
@@ -163,21 +162,42 @@ def _check_self_target(
             )
         return
 
-    if tool_name == "ow_close_worker":
-        target = args.get("target_session_id") or args.get("term_ref")
-        if target is None or session_id is None:
-            raise CapabilityError(
-                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
-            )
-        if target != session_id:
-            raise CapabilityError(
-                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
-            )
-        return
-
     raise CapabilityError(
         f"self-target check is not implemented for {tool_name}"
     )
+
+
+# matrix で "self" を返す tool 名と、_check_self_target が処理する tool 名は一致しなければならない。
+# 新たに matrix に "self" エントリを追加した際、ここを更新し忘れると実行時に
+# `self-target check is not implemented for ...` で初めて発覚するため、起動時に検出するための集合。
+_SELF_TARGET_HANDLERS: frozenset[str] = frozenset({"update_material"})
+
+
+def _matrix_self_tools() -> set[str]:
+    """capability matrix で "self" decision を持つ tool 名を集める。"""
+    from src.services.capability_matrix import CAPABILITY_MATRIX
+
+    return {
+        name
+        for name, row in CAPABILITY_MATRIX.items()
+        if any(d == "self" for d in row.values())
+    }
+
+
+def assert_self_target_handlers_consistent() -> None:
+    """matrix の "self" 集合と _check_self_target が処理する集合の不一致を検出する。
+
+    起動時 or テストから呼ぶ。不一致は AssertionError として早期に顕在化させる。
+    """
+    matrix_self = _matrix_self_tools()
+    missing = matrix_self - _SELF_TARGET_HANDLERS
+    extra = _SELF_TARGET_HANDLERS - matrix_self
+    if missing or extra:
+        raise AssertionError(
+            "self-target handler set is out of sync with capability matrix: "
+            f"missing handlers for {sorted(missing)}, "
+            f"extra handlers for {sorted(extra)}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -1,22 +1,34 @@
-"""worker セッション向けの構造的ガード。
+"""role 別 capability gating の guard。
 
-ow worker として起動されたセッションが、ユーザー合意を必要とする記録系ツール
-(add_decisions / add_topic / add_habit) を直接呼び出すのを構造的に阻止する。
-worker は task に集中するため、これらの記録はユーザー合意に基づいて
-orch 経由で行う。判断を orch に仰ぐためのエスカレーション通路では
-OW_ESCALATION=1 を立てて通過させる。
+各 tool 呼び出しの冒頭で `check_capability(tool_name, args)` を呼ぶことで、
+capability_matrix に基づき role 違反を CapabilityError で拒否する。
+hide 層 (visibility_middleware) と二層構造で動作し、本 guard は
+LLM が hide をすり抜けて tool を呼んだ場合の最終防御を担う。
 
-note: add_logs は worker-sync の退場処理で必須呼び出しなのでガード対象外。
+非 ow セッション (lookup_role が None) は role 不明扱いとして通過させる。
+これは regular Claude session の従来挙動を維持するため。ow セッションは
+SessionStart hook で auto-register されるか env OW_ROLE で fallback されるため、
+role None になるのは非 ow セッションのみという前提。
 """
 import os
-from typing import Optional, TYPE_CHECKING
+import sqlite3
+from typing import Any, Optional, TYPE_CHECKING
+
+from src.db import get_connection
 
 if TYPE_CHECKING:
     from src.services.role_service import Role
 
 
-class WorkerGuardError(RuntimeError):
-    """worker セッションが直接呼び出せないツールを呼んだときに raise される。"""
+class CapabilityError(RuntimeError):
+    """capability matrix に違反する tool 呼び出しで raise される。"""
+
+
+class WorkerGuardError(CapabilityError):
+    """worker セッションが直接呼び出せないツールを呼んだときに raise される。
+
+    後方互換のため CapabilityError のサブクラスとして残す。
+    """
 
 
 _ROLE_ENV = "OW_ROLE"
@@ -28,9 +40,17 @@ _ESCALATION_PASS = "1"
 def is_worker_session() -> bool:
     """ow worker として起動されたセッションかを判定する。
 
-    ow_spawn_worker は worker 起動時に環境変数 OW_ROLE=worker を設定する。
-    エスカレーション状態 (OW_ESCALATION) はここでは見ない。
+    OW_ROLE=worker (env) または session_identity.role=worker (DB) のいずれかで真。
     """
+    from src.services.role_service import lookup_role, get_caller_session_id
+
+    session_id = get_caller_session_id()
+    conn = get_connection()
+    try:
+        if lookup_role(conn, session_id) == _ROLE_WORKER:
+            return True
+    finally:
+        conn.close()
     return os.environ.get(_ROLE_ENV) == _ROLE_WORKER
 
 
@@ -39,10 +59,8 @@ def current_role() -> Optional["Role"]:
 
     lookup_role を経由して DB → env の順で解決する。
     MCP コンテキスト外（テスト・hook など）でも安全に呼べる。
-    新規コードではこちらを使う。
     """
     from src.services.role_service import lookup_role, get_caller_session_id
-    from src.db import get_connection
 
     session_id = get_caller_session_id()
     conn = get_connection()
@@ -63,12 +81,116 @@ _WORKER_GUARD_MESSAGE_TMPL = (
     "(orch_proxy 経路では OW_ESCALATION=1 で通過します)。"
 )
 
+_ROLE_VIOLATION_MESSAGE_TMPL = (
+    "{tool_name} は {role} role からは呼び出せません。"
+    "capability matrix の許可表に従い、適切な role の session から呼び出すか、"
+    "OW_ESCALATION=1 でエスカレーション通路に切り替えてください。"
+)
+
+_SELF_VIOLATION_MESSAGE_TMPL = (
+    "{tool_name} の self-target 制約に違反しています。"
+    "{role} role からは caller 自身が target の場合のみ許可されます。"
+)
+
+
+def check_capability(
+    tool_name: str,
+    args: Optional[dict[str, Any]] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """caller の role と tool_name から capability gate を判定する。
+
+    違反時に CapabilityError を raise する。
+    - role None (非 ow session): 通過 (backward compat)
+    - escalation mode (OW_ESCALATION=1): 通過 (orch_proxy 経路の通過弁)
+    - matrix 行 True: 通過
+    - matrix 行 False: CapabilityError
+    - matrix 行 "self": self-target 判定し、違反なら CapabilityError
+    """
+    from src.services import capability_matrix, role_service
+
+    session_id = role_service.get_caller_session_id()
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        role = role_service.lookup_role(conn, session_id)
+        if role is None:
+            return  # 非 ow session: 通過
+        if is_escalation_mode():
+            return  # 通過弁
+        decision = capability_matrix.is_allowed(tool_name, role)
+        if decision is True:
+            return
+        if decision == "self":
+            _check_self_target(tool_name, role, args or {}, conn, session_id)
+            return
+        # worker role の denial は WorkerGuardError 経路で raise する。
+        # WorkerGuardError は CapabilityError の subclass なので意味的整合は保たれる。
+        if role == _ROLE_WORKER:
+            raise WorkerGuardError(
+                _WORKER_GUARD_MESSAGE_TMPL.format(tool_name=tool_name)
+            )
+        raise CapabilityError(
+            _ROLE_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
+        )
+    finally:
+        if own_conn and conn is not None:
+            conn.close()
+
+
+def _check_self_target(
+    tool_name: str,
+    role: str,
+    args: dict[str, Any],
+    conn: sqlite3.Connection,
+    session_id: Optional[str],
+) -> None:
+    """"self" 扱い tool の caller_session_id 一致判定。"""
+    if tool_name == "update_material":
+        material_id = args.get("material_id")
+        if material_id is None or session_id is None:
+            raise CapabilityError(
+                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
+            )
+        row = conn.execute(
+            "SELECT caller_session_id FROM materials WHERE id = ?",
+            (material_id,),
+        ).fetchone()
+        if not row or row[0] != session_id:
+            raise CapabilityError(
+                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
+            )
+        return
+
+    if tool_name == "ow_close_worker":
+        target = args.get("target_session_id") or args.get("term_ref")
+        if target is None or session_id is None:
+            raise CapabilityError(
+                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
+            )
+        if target != session_id:
+            raise CapabilityError(
+                _SELF_VIOLATION_MESSAGE_TMPL.format(tool_name=tool_name, role=role)
+            )
+        return
+
+    raise CapabilityError(
+        f"self-target check is not implemented for {tool_name}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 既存 API: check_worker_guard は段階的置換のために残す thin wrapper。
+# 新規コードは check_capability を呼ぶ。
+# ---------------------------------------------------------------------------
+
 
 def check_worker_guard(tool_name: str) -> None:
     """worker セッションかつ非エスカレーション時に WorkerGuardError を raise する。
 
-    add_decisions / add_topic / add_habit 等、worker が直接呼んではならない
-    ツールの冒頭で呼ぶ。OW_ESCALATION=1 のときは通過する。
+    新規コードでは check_capability を使う。本 wrapper は既存 call site の
+    段階的置換のために残す。
     """
     if is_worker_session() and not is_escalation_mode():
         raise WorkerGuardError(_WORKER_GUARD_MESSAGE_TMPL.format(tool_name=tool_name))

--- a/src/services/guard_service.py
+++ b/src/services/guard_service.py
@@ -31,7 +31,6 @@ class WorkerGuardError(CapabilityError):
     """
 
 
-_ROLE_ENV = "OW_ROLE"
 _ROLE_WORKER = "worker"
 _ESCALATION_ENV = "OW_ESCALATION"
 _ESCALATION_PASS = "1"

--- a/tests/services/test_capability_matrix.py
+++ b/tests/services/test_capability_matrix.py
@@ -37,6 +37,10 @@ class TestHiddenToolsFor:
         assert "ow_recover" in hidden
         assert "ow_close_worker" in hidden  # decision=False for orch
 
+    def test_worker_hides_ow_close_worker(self):
+        hidden = hidden_tools_for("worker")
+        assert "ow_close_worker" in hidden  # decision=False for worker
+
     def test_worker_hides_write_admin_tools(self):
         hidden = hidden_tools_for("worker")
         assert "add_topic" in hidden
@@ -54,7 +58,6 @@ class TestHiddenToolsFor:
 
     def test_self_tools_are_not_hidden(self):
         hidden_worker = hidden_tools_for("worker")
-        assert "ow_close_worker" not in hidden_worker
         assert "update_material" not in hidden_worker
 
     def test_unknown_role_hides_everything(self):
@@ -79,8 +82,10 @@ class TestIsAllowed:
         assert is_allowed("update_activity", "worker") is False
 
     def test_self_tools_return_self_token(self):
-        assert is_allowed("ow_close_worker", "worker") == "self"
         assert is_allowed("update_material", "worker") == "self"
+
+    def test_ow_close_worker_denied_for_worker(self):
+        assert is_allowed("ow_close_worker", "worker") is False
 
     def test_unknown_tool_default_deny(self):
         assert is_allowed("nonexistent_tool", "orch") is False

--- a/tests/services/test_check_capability.py
+++ b/tests/services/test_check_capability.py
@@ -168,31 +168,26 @@ class TestSelfTargetUpdateMaterial:
         check_capability("update_material", args={"material_id": material_id})
 
 
-class TestSelfTargetOwCloseWorker:
-    """ow_close_worker の self 判定。"""
+class TestOwCloseWorkerDeniedForWorker:
+    """ow_close_worker は worker から呼べない (dispatcher 専用)。
 
-    def test_self_close_passes(self, migrated_db, monkeypatch):
-        monkeypatch.setenv("OW_ROLE", "worker")
-        with monkeypatch.context() as m:
-            m.setattr(
-                "src.services.role_service.get_caller_session_id",
-                lambda: "sess-w1",
-            )
-            check_capability(
-                "ow_close_worker", args={"target_session_id": "sess-w1"}
-            )
+    term_ref は tmux pane id 等の terminal ID であり caller_session_id とは別軸のため
+    "self" 比較が成立しない。worker は ow_close_worker を呼ばずに他経路で終了する。
+    """
 
-    def test_close_other_worker_rejected(self, migrated_db, monkeypatch):
+    def test_worker_rejected(self, migrated_db, monkeypatch):
         monkeypatch.setenv("OW_ROLE", "worker")
-        with monkeypatch.context() as m:
-            m.setattr(
-                "src.services.role_service.get_caller_session_id",
-                lambda: "sess-w1",
-            )
-            with pytest.raises(CapabilityError):
-                check_capability(
-                    "ow_close_worker", args={"target_session_id": "sess-w2"}
-                )
+        with pytest.raises(CapabilityError):
+            check_capability("ow_close_worker", args={"term_ref": "%5"})
+
+
+class TestSelfTargetHandlerConsistency:
+    """matrix の "self" 集合と _check_self_target の handler 集合が一致する。"""
+
+    def test_self_target_handlers_consistent(self):
+        from src.services.guard_service import assert_self_target_handlers_consistent
+
+        assert_self_target_handlers_consistent()
 
 
 class TestWorkerGuardWrapper:
@@ -240,3 +235,16 @@ class TestIsWorkerSession:
 
     def test_no_role_returns_false(self, migrated_db):
         assert guard_service.is_worker_session() is False
+
+    def test_db_orch_with_stale_env_worker_returns_false(
+        self, migrated_db, monkeypatch
+    ):
+        """DB が orch を返すなら env に worker が残っていても False (DB > env)。"""
+        _register("sess-o1", "orch")
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-o1",
+            )
+            assert guard_service.is_worker_session() is False

--- a/tests/services/test_check_capability.py
+++ b/tests/services/test_check_capability.py
@@ -1,0 +1,242 @@
+"""check_capability の挙動を検証する unit test。
+
+role/matrix/escalation/self-target/grace period の各分岐を網羅する。
+fixture は test_role_service.py と同じ migrated_db パターン。
+"""
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services import guard_service
+from src.services.guard_service import (
+    CapabilityError,
+    WorkerGuardError,
+    check_capability,
+)
+from src.services.tag_service import _injected_tags
+
+
+@pytest.fixture
+def migrated_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture(autouse=True)
+def clear_ow_env(monkeypatch):
+    monkeypatch.delenv("OW_ROLE", raising=False)
+    monkeypatch.delenv("OW_ESCALATION", raising=False)
+
+
+def _register(session_id: str, role: str) -> None:
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO session_identity (session_id, role) VALUES (?, ?)",
+            (session_id, role),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestRolePassThrough:
+    """非 ow セッション (role None) は通過する。"""
+
+    def test_no_role_passes_through(self, migrated_db, monkeypatch):
+        check_capability("add_decisions")
+
+
+class TestEnvFallback:
+    """env OW_ROLE 経由で role が解決され matrix が適用される。"""
+
+    def test_env_worker_rejects_admin_write(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(CapabilityError):
+            check_capability("add_decisions")
+
+    def test_env_orch_allowed_for_admin_write(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        check_capability("add_decisions")
+
+    def test_env_dispatcher_rejected_for_admin_write(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "dispatcher")
+        with pytest.raises(CapabilityError):
+            check_capability("add_decisions")
+
+
+class TestEscalationPassValve:
+    """OW_ESCALATION=1 のとき role 違反でも通過する。"""
+
+    def test_escalation_overrides_worker_block(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        check_capability("add_decisions")
+
+
+class TestMatrixDenial:
+    """matrix の False / 未登録 tool は CapabilityError を返す。"""
+
+    def test_orch_blocked_from_spawn_worker(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        with pytest.raises(CapabilityError) as exc:
+            check_capability("ow_spawn_worker")
+        assert "orch" in str(exc.value)
+
+    def test_worker_blocked_from_update_activity(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(CapabilityError):
+            check_capability("update_activity")
+
+    def test_unknown_tool_default_deny(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        with pytest.raises(CapabilityError):
+            check_capability("nonexistent_tool")
+
+
+class TestSelfTargetUpdateMaterial:
+    """update_material の self 判定。"""
+
+    def test_self_owned_material_passes(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, source, caller_session_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("t", "c", "s", "sess-w1"),
+            )
+            material_id = cursor.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-w1",
+            )
+            check_capability("update_material", args={"material_id": material_id})
+
+    def test_others_material_rejected(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, source, caller_session_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("t", "c", "s", "sess-other"),
+            )
+            material_id = cursor.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-w1",
+            )
+            with pytest.raises(CapabilityError) as exc:
+                check_capability(
+                    "update_material", args={"material_id": material_id}
+                )
+            assert "self-target" in str(exc.value)
+
+    def test_orch_can_update_anyones_material(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO materials (title, content, source, caller_session_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("t", "c", "s", "sess-other"),
+            )
+            material_id = cursor.lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        check_capability("update_material", args={"material_id": material_id})
+
+
+class TestSelfTargetOwCloseWorker:
+    """ow_close_worker の self 判定。"""
+
+    def test_self_close_passes(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-w1",
+            )
+            check_capability(
+                "ow_close_worker", args={"target_session_id": "sess-w1"}
+            )
+
+    def test_close_other_worker_rejected(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-w1",
+            )
+            with pytest.raises(CapabilityError):
+                check_capability(
+                    "ow_close_worker", args={"target_session_id": "sess-w2"}
+                )
+
+
+class TestWorkerGuardWrapper:
+    """check_worker_guard 旧 API の wrapper 動作 (後方互換)。"""
+
+    def test_worker_env_blocks(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        with pytest.raises(WorkerGuardError):
+            guard_service.check_worker_guard("add_topic")
+
+    def test_escalation_passes(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        monkeypatch.setenv("OW_ESCALATION", "1")
+        guard_service.check_worker_guard("add_topic")
+
+    def test_orch_env_passes(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        guard_service.check_worker_guard("add_topic")
+
+
+class TestIsWorkerSession:
+    """is_worker_session が lookup_role 経由 (DB) + env fallback で動く。"""
+
+    def test_db_role_worker_returns_true(self, migrated_db, monkeypatch):
+        _register("sess-w1", "worker")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-w1",
+            )
+            assert guard_service.is_worker_session() is True
+
+    def test_db_role_orch_returns_false(self, migrated_db, monkeypatch):
+        _register("sess-o1", "orch")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "src.services.role_service.get_caller_session_id",
+                lambda: "sess-o1",
+            )
+            assert guard_service.is_worker_session() is False
+
+    def test_env_worker_returns_true(self, migrated_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "worker")
+        assert guard_service.is_worker_session() is True
+
+    def test_no_role_returns_false(self, migrated_db):
+        assert guard_service.is_worker_session() is False


### PR DESCRIPTION
## Summary

役割違反の tool 呼び出しを実行時に拒否する error 層を導入する。visibility middleware (hide 層) がすり抜けられた場合の最終防御として、`check_capability` が capability matrix と caller の role を照合する。`is_worker_session` の判定経路を env 直読みから `lookup_role` 経由 (DB + env fallback) に切り替える。

## 振る舞い変更

### check_capability (新規)

`guard_service.check_capability(tool_name, args=None, conn=None)` を新設する。判定フロー:

- caller role が None (非 ow session): 通過 (regular Claude session の従来挙動を維持)
- `OW_ESCALATION=1` がセットされている: 通過 (orch_proxy 経路の通過弁)
- matrix の decision が `True`: 通過
- decision が `"self"`: caller の session_id と target の caller_session_id を比較し、一致しなければ拒否
- decision が `False`: 拒否
  - worker role からの違反は `WorkerGuardError` (CapabilityError サブクラス) を投げ、orch 経由の記録案内メッセージを返す
  - 他 role からの違反は `CapabilityError` を投げ、matrix を案内するメッセージを返す

### self-target 判定

- `update_material`: `materials.caller_session_id` と caller session_id が一致する場合のみ通過
- `ow_close_worker`: `target_session_id` 引数が caller session_id と一致する場合のみ通過

### is_worker_session の判定経路

env 直読みから `lookup_role` ベースに置換する。`session_identity.role = "worker"` (DB) または `OW_ROLE=worker` (env) のいずれかで真。session_identity への auto-register 経路と env 経路の両方が cutover 期間中も整合する。

### main.py の置換

既存 `guard_service.check_worker_guard(...)` 3 箇所 (`add_topic` / `add_decisions` / `add_habit`) を `guard_service.check_capability(...)` に置換する。

### 後方互換

`WorkerGuardError` / `check_worker_guard` は thin wrapper として残す。`WorkerGuardError` は `CapabilityError` のサブクラスにし、worker role の violation 時に従来通り raise されるため既存の `pytest.raises(WorkerGuardError)` テストはそのまま通る。

## なぜ

hide 層は LLM に対する一次防御だが、tool 名を直接指定して呼び出すケースに対する最終防御が必要。matrix を guard と visibility の両層で参照する二層構造により、防御の漏れを構造的に潰す。`is_worker_session` 置換は、SessionStart hook で session_identity への auto-register が成立した worker session を env 設定無しで識別できるようにするため。

## Test plan

- [x] `tests/services/test_check_capability.py` を新規追加 (unit + integration 20 test): role pass-through / env fallback / escalation / matrix denial / self-target (update_material と ow_close_worker) / WorkerGuardError 互換 wrapper / is_worker_session の DB+env 経路
- [x] 既存 `tests/integration/test_worker_guard_tools.py` (14 test) と `tests/unit/test_guard_service.py` (19 test) は無修正で pass
- [x] 既存テスト 2308 件 pass 維持