### PR TITLE
docs: worker / dispatcher SKILL.md に上長 done envelope 報告完了の enforcement を追加

### DIFF
--- a/skills/dispatcher/SKILL.md
+++ b/skills/dispatcher/SKILL.md
@@ -190,7 +190,7 @@ dispatcher が worker を spawn する際 (`ow_spawn_worker` 経由 / `command:a
 
 具体的に worker に渡す要件 (pack 構築時に context に明文化する):
 
-- `event:state(done)` の `summary` には「保存済 material id / log id + 1-2 行の成果文」を必ず含める
+- `event:state(done)` の `summary` には「保存済 material id + 1-2 行の成果文」を必ず含める (log id は done 送信時点ではまだ worker-sync で確定していないため summary に載せない)
 - 成果が PR の場合は `summary` 末尾に PR URL を 1 件添える (dispatcher が diff 確認に直接アクセスできるため)
 - 「Goal achieved」recap 表示だけで終了とせず、必ず `event:state(done)` 送信 + `command:close` 受領 + draining → terminated の正規退場プロトコルを踏む
 

--- a/skills/dispatcher/SKILL.md
+++ b/skills/dispatcher/SKILL.md
@@ -184,6 +184,18 @@ context_pack:
 - minor dispatch は log として記録 (`intent:dispatch-log` タグ)
 - audit log として後追い可能、次回 pack 改善ヒント蓄積に活用
 
+### dispatcher 必須責務: 上長 done envelope 報告完了の enforcement
+
+dispatcher が worker を spawn する際 (`ow_spawn_worker` 経由 / `command:assign` 経由いずれも)、worker 側 acceptance + context に **「dispatcher が `event:state(done)` envelope を受領するまで terminated に向かわない」** を必ず含める。pack 個別の AC が material 保存・PR 作成までで止まる場合でも、上長報告まで含めて初めて「完了」と見なす規律にする。
+
+具体的に worker に渡す要件 (pack 構築時に context に明文化する):
+
+- `event:state(done)` の `summary` には「保存済 material id / log id + 1-2 行の成果文」を必ず含める
+- 成果が PR の場合は `summary` 末尾に PR URL を 1 件添える (dispatcher が diff 確認に直接アクセスできるため)
+- 「Goal achieved」recap 表示だけで終了とせず、必ず `event:state(done)` 送信 + `command:close` 受領 + draining → terminated の正規退場プロトコルを踏む
+
+これは worker SKILL.md §完了→done / §禁止事項 と整合する。worker 側でも明文化されているが、dispatcher は pack 構築時に context に「本規約を踏むこと」を含め、二重で担保する (規約だけでは「Goal achieved」recap で省略される観察事例があるため)。
+
 ### tacit_knowledge は pack に含めない
 
 user の趣味・嗜好レベルは CLAUDE.md / glossary / 自明で伝わるべき。orch 判断前提・曖昧事項は re-query / 事前確認で処理。pack に tacit_knowledge セクションは置かない。
@@ -836,6 +848,14 @@ ready 状態は D#2962 で廃止されたため、stagnation 監視対象から�
 5. dispatcher は `event:state(terminated, cause:closed)` 受信後に `ow_close_worker(term_ref)` でセッションをクローズ
 6. terminated が来なければ閉じずに orch に notify する
 
+### done envelope 未受領のまま terminated を観測したら異常扱い
+
+worker が `event:state(done)` envelope を送らずに `event:state(terminated)` に向かう、または heartbeat 途絶で stalled 経由で実質的に terminated に至る経路は **規約違反**。dispatcher は以下を実施する:
+
+- 該当 worker の成果 (worktree diff / cc-memory log・material) を pull で能動回収する
+- worker 死亡原因と「done envelope 省略」の事実を `intent:dispatch-log` で記録し、orch に `escalate` (reason_class: `high_uncertainty` or `pack_violation`) で異常報告 push する
+- 次回 pack 構築時に context へ「done envelope 報告完了の enforcement」明記が抜けていなかったか自己点検する (§dispatcher 必須責務: 上長 done envelope 報告完了の enforcement 参照)
+
 ## 受信処理 (SSE はベル、真実源は /history)
 
 1. SSE (Monitor 監視) は起床信号専用。届いた data 行の中身は処理に使わない
@@ -884,3 +904,5 @@ Monitor recv.sh --me dispatcher (persistent)
 - failed 設定および強制クローズの自律判断は禁止
 - 本格的なコード理解・テスト解析・PR レビューを SA で済ませるのは禁止 (worker spawn する)
 - 「着手待ち」を残すのは禁止 (§visibility 着手待ち禁止規律)
+- worker に渡す context_pack / acceptance に「上長 done envelope 報告完了」要件が欠落した状態で spawn するのは禁止 (§dispatcher 必須責務 参照)
+- worker が done envelope 未送信のまま terminated に向かった事象を観察したのに orch に異常報告しないのは禁止 (§クローズハンドシェイク 参照)

--- a/skills/worker-sync/SKILL.md
+++ b/skills/worker-sync/SKILL.md
@@ -39,8 +39,8 @@ worker-sync は `cmd:close` 受信を前提として呼ばれる。`cmd:close` �
 
 具体チェック:
 
-1. `ow_history(channel=<channel_code>, since=0)` で自分が `from` の `data.type=state` envelope を pull
-2. `event:state(done)` (= `data.state == "done"`) が **無い** または `cmd:close` 受信より新しくない場合は abort
+1. `ow_history(channel=<channel_code>, since=<spawn-bundle msg_id>)` で自分が `from` の `data.type=state` envelope を pull (since には worker SKILL.md Step 7 で取得した spawn-bundle envelope の msg_id を使い、過去セッションで同 alias が再利用された際の取り違えを避ける)
+2. abort 条件: `event:state(done)` (= `data.state == "done"`) が **無い**、または唯一の done envelope の msg_id が `cmd:close` 受信時の msg_id より **新しい** (= cmd:close より後に送られた異常順序) 場合
 3. abort 時の挙動: worker-sync の以降のステップを実行せず、`event:state(working, phase="recovery-from-skip", note="done envelope was not sent before drain; resuming work to send done envelope")` を上長に送り、worker SKILL.md §完了 → done に戻る
 
 この guard は「Goal achieved」recap で done envelope を省略して退場処理に直行する経路 (worker SKILL.md §完了 → done で禁止された動き) を、worker-sync 側でも最後にトラップするための fail-safe。本 guard が発火する状況は本来あってはならず、発火そのものを `intent:dispatch-log` 相当の log にも残してから revert する。

--- a/skills/worker-sync/SKILL.md
+++ b/skills/worker-sync/SKILL.md
@@ -31,6 +31,20 @@ workerは記録ストア上をorchフローとして走るため、知識層へ�
 このスキルは `worker` スキルの退場処理から、`cmd:close` 受信後・`state:closed` 送信前に呼ばれる。
 task fileの `topic_id` / `activity_id` を記録の紐づけ先に使う。
 
+### 0. fail-safe: done envelope 送信済みチェック (terminated 直前 guard)
+
+worker-sync は `cmd:close` 受信を前提として呼ばれる。`cmd:close` は dispatcher が `event:state(done)` を受領し検証 OK と判定した時のみ送る規約 (dispatcher SKILL.md §クローズハンドシェイク)。逆に言えば、worker-sync が呼ばれた時点で worker は **必ず `event:state(done)` を送信済み** のはず。
+
+呼び出し経路バグや worker 側 SKILL 解釈ズレで「done 未送信なのに worker-sync に到達」した場合は、本スキルを即中止して worker SKILL.md §完了 → done に戻り `event:state(done)` を送信してから `cmd:close` 受領を再度待ち直す。
+
+具体チェック:
+
+1. `ow_history(channel=<channel_code>, since=0)` で自分が `from` の `data.type=state` envelope を pull
+2. `event:state(done)` (= `data.state == "done"`) が **無い** または `cmd:close` 受信より新しくない場合は abort
+3. abort 時の挙動: worker-sync の以降のステップを実行せず、`event:state(working, phase="recovery-from-skip", note="done envelope was not sent before drain; resuming work to send done envelope")` を上長に送り、worker SKILL.md §完了 → done に戻る
+
+この guard は「Goal achieved」recap で done envelope を省略して退場処理に直行する経路 (worker SKILL.md §完了 → done で禁止された動き) を、worker-sync 側でも最後にトラップするための fail-safe。本 guard が発火する状況は本来あってはならず、発火そのものを `intent:dispatch-log` 相当の log にも残してから revert する。
+
 ### 1. log記録（必須） — add_logs
 
 セッション中の作業経緯を **1件のログ** として記録する。`state:done` のsummaryより詳細に残す。次に来るセッション（同一workerの再spawnや、orchによる別worker割り当て）が経緯を引き継げることが目的。
@@ -71,3 +85,4 @@ workerは決定事項を **直接記録しない**。`state:done` の `decision_
 - topic・activityを新規作成しない
 - decisionを直接記録しない（エスカレーション例外を除く）
 - 棚卸し・remember・ふりかえりをしない
+- `event:state(done)` 送信済みチェック (Step 0) を skip しない。done 未送信で worker-sync を実行して terminated に向かうと、上長は worker 死亡と区別がつかず成果検証不能になる (本 guard の存在理由)

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -269,16 +269,27 @@ orchが人間へのエスカレーションを指示したら、以下の**エ�
 
 ## 完了 → done
 
-作業が完了したら:
+worker は claude CLI の `/goal` 自走モードで goal_text を満たした時点で recap を表示する習性があるが、recap 表示は **正規退場ではない**。recap で止まったまま idle に落ちると、上長 (dispatcher / orch) に `event:state(done)` envelope が届かず、上長から見ると「成果は不可視 / 検証不能 / 自分で pull せざるを得ない」状態になる。
+
+「Goal achieved (= acceptance を満たしたと自己判定)」と「正規退場」は別物。両者を直結させず、必ず以下を踏む:
+
 1. acceptanceを満たしていることを確認し、証拠（evidence: テスト結果・PR URL等）を揃える
 2. worker専用の記録規律（§記録規律）に従い、material保存・decision_proposalsの準備を済ませる
-3. `event:state(done)` を送信する:
+3. `event:state(done)` を**必ず**送信する:
    ```json
    {"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>",
-    "data":{"type":"state", "state":"done", "summary":"<作業内容の要約>", "evidence":"<acceptanceを満たす証拠>", "synced":true, "materials":[<material_id...>], "decision_proposals":[{"decision":"...","reason":"..."}]}}
+    "data":{"type":"state", "state":"done",
+            "summary":"M#<id> / L#<id>: <1-2 行で成果>",
+            "evidence":"<acceptanceを満たす証拠>",
+            "synced":true,
+            "materials":[<material_id...>],
+            "decision_proposals":[{"decision":"...","reason":"..."}]}}
    ```
-   - `synced:true` は「material保存済み・decision_proposals添付済みでorchが検証可能な状態」を意味する。最終作業経緯ログの確定はcmd:close時の退場処理で行う
-4. orchからの応答を待つ（§完了後の待機）
+   - `summary` は **「保存済 material id / log id の列挙」+「1-2 行の成果文」** の両方を必ず含める。dispatcher / orch が SSE notification の truncated body (約 200 文字) でも成果と紐付き先を即時判定できるよう、id を `summary` 先頭に置いて truncation で落ちないようにする
+   - `summary` に載せる id は `materials[]` の中身と整合させる (引き合い検証フィールド)
+   - 成果が PR の場合は `summary` 末尾に PR URL を 1 件添える (dispatcher が diff 確認に直接アクセスできるように)
+   - `synced:true` は「material保存済み・decision_proposals添付済みで上長が検証可能な状態」を意味する。最終作業経緯ログの確定はcmd:close時の退場処理で行う
+4. done envelope 送信後は `command:close` 受領まで待機する（§完了後の待機）。recap が表示されても、`event:state(done)` を送らず terminated に向かう動きは禁止 (§禁止事項)
 
 ## 完了後の待機
 
@@ -427,4 +438,6 @@ orchから `kind:command, data.type:ping` が届いたら、現在の state を 
 - decisionを直接記録しない（エスカレーション例外を除く。原則decision_proposalsでorchに提案）
 - `event:state(terminated)` 送信後にツールを呼ばない
 - done送信後、closeを受けるまで新しい作業を始めない・cc-memoryへ追記しない（退場処理を除く）
+- **`event:state(done)` envelope を送信せずに `event:state(terminated)` に向かわない**: 「Goal achieved」recap だけで作業終了と判断せず、必ず `event:state(done)` → `command:close` 受領 → 退場処理 (draining → terminated) の正規プロトコルを踏む。recap 表示だけで idle に落ちると上長は worker 死亡と区別がつかず成果検証不能になる (本規約の存在理由)
+- **done envelope の summary に material id / log id を省略しない**: SSE notification truncation 対策。`materials[]` 列挙だけで済まさず、`summary` 先頭にも id を埋め込む
 - **AskUserQuestion 禁止**: worker は人間に直接質問しない。質問は `event:state(blocked)` envelope で orch 経由。AskUserQuestion ツールは ow_spawn_worker の settings injection で deny されているが、明示的に守ること

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -279,15 +279,16 @@ worker は claude CLI の `/goal` 自走モードで goal_text を満たした�
    ```json
    {"v":1, "kind":"event", "from":"<alias>", "to":"dispatcher", "task":"T<task_n>",
     "data":{"type":"state", "state":"done",
-            "summary":"M#<id> / L#<id>: <1-2 行で成果>",
+            "summary":"M#<id>: <1-2 行で成果>",
             "evidence":"<acceptanceを満たす証拠>",
             "synced":true,
             "materials":[<material_id...>],
             "decision_proposals":[{"decision":"...","reason":"..."}]}}
    ```
-   - `summary` は **「保存済 material id / log id の列挙」+「1-2 行の成果文」** の両方を必ず含める。dispatcher / orch が SSE notification の truncated body (約 200 文字) でも成果と紐付き先を即時判定できるよう、id を `summary` 先頭に置いて truncation で落ちないようにする
+   - `summary` は **「保存済 material id の列挙」+「1-2 行の成果文」** の両方を必ず含める。dispatcher / orch が SSE notification の truncated body (約 200 文字) でも成果と紐付き先を即時判定できるよう、material id を `summary` 先頭に置いて truncation で落ちないようにする
    - `summary` に載せる id は `materials[]` の中身と整合させる (引き合い検証フィールド)
    - 成果が PR の場合は `summary` 末尾に PR URL を 1 件添える (dispatcher が diff 確認に直接アクセスできるように)
+   - **log id は載せない**: 最終作業経緯 log は `cmd:close` 受信後の退場処理 (worker-sync) で確定するため、done envelope 送信時点ではまだ id が存在しない。log は退場処理で記録され、dispatcher は activity 経由で逆引きできる
    - `synced:true` は「material保存済み・decision_proposals添付済みで上長が検証可能な状態」を意味する。最終作業経緯ログの確定はcmd:close時の退場処理で行う
 4. done envelope 送信後は `command:close` 受領まで待機する（§完了後の待機）。recap が表示されても、`event:state(done)` を送らず terminated に向かう動きは禁止 (§禁止事項)
 
@@ -439,5 +440,5 @@ orchから `kind:command, data.type:ping` が届いたら、現在の state を 
 - `event:state(terminated)` 送信後にツールを呼ばない
 - done送信後、closeを受けるまで新しい作業を始めない・cc-memoryへ追記しない（退場処理を除く）
 - **`event:state(done)` envelope を送信せずに `event:state(terminated)` に向かわない**: 「Goal achieved」recap だけで作業終了と判断せず、必ず `event:state(done)` → `command:close` 受領 → 退場処理 (draining → terminated) の正規プロトコルを踏む。recap 表示だけで idle に落ちると上長は worker 死亡と区別がつかず成果検証不能になる (本規約の存在理由)
-- **done envelope の summary に material id / log id を省略しない**: SSE notification truncation 対策。`materials[]` 列挙だけで済まさず、`summary` 先頭にも id を埋め込む
+- **done envelope の summary に material id を省略しない**: SSE notification truncation 対策。`materials[]` 列挙だけで済まさず、`summary` 先頭にも material id を埋め込む (log id は done 送信時点ではまだ確定していないので summary には載せない)
 - **AskUserQuestion 禁止**: worker は人間に直接質問しない。質問は `event:state(blocked)` envelope で orch 経由。AskUserQuestion ツールは ow_spawn_worker の settings injection で deny されているが、明示的に守ること


### PR DESCRIPTION
## 背景

worker が claude CLI の `/goal` 自走モードで「Goal achieved」recap を表示後、上長 (dispatcher / orch) に `event:state(done)` envelope を送らずに idle に落ちる症状を観察した。worker session 内には material 保存・ログ記録などの成果が残っているが、上長から見ると worker 死亡と区別がつかず、能動 pull しないと成果検証ができない。

原因の中心は SKILL レベルでの規約欠落:

- worker 側で「Goal achieved 判定 = 終了」と直結する書きぶりになっており、done envelope 送信を経由する正規退場プロトコルが明文化されていなかった
- dispatcher 側で worker spawn 時の context_pack に「上長報告まで含めて完了」と書き入れる責務が無く、AC が「material 保存まで」で止まる pack を構築できてしまった
- worker-sync 側に terminated 直前 guard が無く、done 未送信のまま退場処理に到達できた

過渡期は dispatcher が運用カバーするが、本 PR で SKILL レベルの機構として固める。

## 変更内容

### `skills/worker/SKILL.md`

- §完了 → done: 「Goal achieved」recap が正規退場ではないことを明文化。done envelope を必ず送信し、`summary` には保存済 material id / log id + 1-2 行の成果文 + (該当時) PR URL を含める規約を追加
- 禁止事項: 「done envelope を送らずに terminated に向かわない」「summary に id を省略しない」を明示

### `skills/dispatcher/SKILL.md`

- §stop-conditions に「dispatcher 必須責務: 上長 done envelope 報告完了の enforcement」を新設。worker spawn 時 acceptance + context にこの要件を必ず含める
- §クローズハンドシェイク に「done envelope 未受領のまま terminated を観測したら異常扱い」セクション追加。成果の能動回収、orch への escalate (reason_class: `high_uncertainty` or `pack_violation`)、次回 pack 構築時の自己点検をルール化
- 禁止事項: enforcement 欠落 spawn の禁止、異常観測時の orch 異常報告省略の禁止を追加

### `skills/worker-sync/SKILL.md`

- Step 0 (fail-safe): 退場処理に到達した時点で `event:state(done)` 送信済みかを確認するチェックを追加。未送信なら worker §完了 → done に戻り送信を完了させる経路
- 禁止事項: Step 0 skip の禁止

## なぜ要るのか

`/goal` 自走モードは goal_text を満たすと recap を出して止まる。AC が「material 保存」「PR 作成」で完結する書き方になっていると、worker は recap の時点で「もう何もすることがない」と判定し、上長に明示報告を送らずに idle 化する。SKILL.md レベルで「Goal achieved ≠ 正規退場」「上長報告まで含めて完了」と明文化することで、recap 経由のリーク経路を物理化された規約として塞ぐ。

加えて、SSE notification の body は約 200 文字で truncate されるため、`summary` 先頭に material id / log id を埋め込まないと上長が initial 判定で done を見落とす既知症状にも対処する。

## 互換性

既存進行中 worker の起動時 SKILL スナップショットは変わらない (worker 起動時に SKILL.md を pull する設計ではない)。本変更は新規 spawn 以降の worker に反映される。dispatcher 側の責務追加も、すでに稼働中の dispatcher セッションには影響しない (次回起動時に新 SKILL.md を読み込む)。

## テスト計画

- [ ] SKILL.md 修正が claude-review で構文・整合性チェックを通過すること
- [ ] worker SKILL.md §完了 → done の手順番号付けが崩れていないこと
- [ ] dispatcher SKILL.md の新セクションが §stop-conditions の流れに自然に挿入されていること
- [ ] worker-sync の Step 0 が既存 Step 1-4 の番号と整合していること