### PR TITLE
fix: heartbeat.sh hb-fail idle-timeout に uptime gate 追加

### DIFF
--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -24,8 +24,13 @@
 #                      MCP /health 連続失敗回数の閾値 (default: 5)。
 #                      これを超えると safe state の worker は self-exit する。
 #   OW_MCP_UPTIME_MIN_SEC
-#                      self-exit を発火するために必要な heartbeat プロセスの最小経過秒
-#                      (default: 300=5分)。spawn 直後の不安定期保護。
+#                      self-exit / hb-fail idle-timeout を発火するために必要な
+#                      heartbeat プロセスの最小経過秒 (default: 300=5分)。
+#                      spawn 直後の不安定期保護として、MCP /health 連続失敗による
+#                      self-exit (OW_MCP_FAIL_THRESHOLD) と relay /send 連続失敗による
+#                      hb-fail idle-timeout (OW_HB_FAIL_THRESHOLD) の両方に同閾値が
+#                      適用される。MCP cold start 対策で本変数を大きくすると、
+#                      hb-fail idle-timeout の発火タイミングも同じだけ後ろ倒しになる。
 #   OW_MCP_CONNECT_TIMEOUT
 #                      MCP /health curl の connect timeout（秒）。default: 2
 #   OW_MCP_MAX_TIME    MCP /health curl の全体タイムアウト（秒）。default: 3
@@ -33,7 +38,11 @@
 #                      "1" を渡すと self-exit を無効化（デバッグ・検証用）。
 #   OW_HB_FAIL_THRESHOLD
 #                      relay /send 連続失敗回数の閾値 (default: 5)。
-#                      これを超えると idle-timeout として worker を kill する
+#                      hb_n >= OW_HB_FAIL_THRESHOLD かつ heartbeat 経過秒 >=
+#                      OW_MCP_UPTIME_MIN_SEC の両方を満たしたときに idle-timeout
+#                      として worker を kill する。uptime gate により spawn 直後の
+#                      relay cold start や transient hang を「永続 idle」と
+#                      誤判定しない
 #                      (D#2853 機構1: relay 不通検知)。
 #   OW_DONE_TIMEOUT_SEC
 #                      PHASE=done になってから close 未受領で kill する閾値秒

--- a/scripts/ow/heartbeat.sh
+++ b/scripts/ow/heartbeat.sh
@@ -226,7 +226,12 @@ while [ -f "$PHASE_FILE" ] && parent_alive; do
         if [ "$OW_DISABLE_IDLE_TIMEOUT" != "1" ]; then
             hb_n=$(( $(cat "$HB_FAIL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
             echo "$hb_n" > "$HB_FAIL_COUNT_FILE"
-            if [ "$hb_n" -ge "$OW_HB_FAIL_THRESHOLD" ]; then
+            # spawn 直後の relay cold start や transient hang を「永続 idle」と
+            # 誤判定しないため、MCP self-exit と同じ閾値 OW_MCP_UPTIME_MIN_SEC を
+            # 再利用して uptime gate を入れる。
+            hb_now=$(date +%s)
+            hb_elapsed=$(( hb_now - HEARTBEAT_STARTED_AT ))
+            if [ "$hb_n" -ge "$OW_HB_FAIL_THRESHOLD" ] && [ "$hb_elapsed" -ge "$OW_MCP_UPTIME_MIN_SEC" ]; then
                 shutdown_for_idle_timeout "hb-fail" "${hb_n} consecutive heartbeat send failures"
             fi
         fi

--- a/skills/dispatcher/SKILL.md
+++ b/skills/dispatcher/SKILL.md
@@ -775,7 +775,7 @@ projector は relay event 受信時に push 型で cache JSON と activities tab
 | `dead` | loading 中の load 失敗 | `failed` | (触らず、`in_progress` 維持) |
 | `crashed (inferred)` | working/blocked/escalated 中の heartbeat 途絶 | `stalled` | (触らず) |
 | `crashed-during-drain (inferred)` | draining 中の heartbeat 途絶 | `stalled` | (触らず) |
-| `idle-timeout` | heartbeat.sh が relay /send 連続失敗 N=5 を検知、または PHASE=done のまま M=10分経過 (D#2853) | `stalled` | (触らず) |
+| `idle-timeout` | heartbeat.sh が relay /send 連続失敗 N=5 + heartbeat uptime>=300s を同時に検知、または PHASE=done のまま M=10分経過 (D#2853) | `stalled` | (触らず) |
 
 `idle-timeout` は worker が自身で kill する経路 (heartbeat.sh が `event:state(terminated, cause:idle-timeout)` を送信した後 tmux kill-pane / SIGTERM)。auto-close 対象軸 (D#2609) では `closed` / `cancelled` と並ぶ auto-close 対象 (pane も kill 済みで人間判断不要)。
 

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -674,6 +674,89 @@ class TestHeartbeatShSelfExit:
         assert alive, "MCP 復活後にカウンタがリセットされず self-exit してしまった"
 
 
+class TestHeartbeatShHbFailIdleTimeout:
+    """機構1: relay /send 連続失敗で hb-fail idle-timeout が発火する。
+    uptime gate (OW_MCP_UPTIME_MIN_SEC) で spawn 直後の relay cold start
+    や transient hang を「永続 idle」と誤判定しないことを検証する。"""
+
+    def _get_dead_url(self):
+        """connect refused になる URL を返す (使ってないポートを bind→close で確保)"""
+        import socket as _socket
+
+        s = _socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        return f"http://127.0.0.1:{port}"
+
+    def test_hb_fail_kill_when_uptime_above_threshold(self, tmp_phase_file):
+        """relay /send 失敗 N 回 + uptime >= 閾値 で idle-timeout 発火 → exit"""
+        url = self._get_dead_url()
+        tmp_phase_file.write_text("working")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_HB_FAIL_THRESHOLD": "2",
+            "OW_MCP_UPTIME_MIN_SEC": "0",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",
+            "OW_CURL_CONNECT_TIMEOUT": "1",
+            "OW_CURL_TIMEOUT": "1",
+        }
+        env.pop("TMUX_PANE", None)
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_HBDOWN", "w-hbdown"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            proc.wait(timeout=10)
+            exited = True
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+            exited = False
+        if tmp_phase_file.exists():
+            tmp_phase_file.unlink()
+        assert exited, (
+            "relay /send 連続失敗 + uptime gate 通過で idle-timeout が発火しなかった"
+        )
+
+    def test_no_hb_fail_kill_when_uptime_below_threshold(self, tmp_phase_file):
+        """uptime < 閾値 なら relay /send 失敗続いても idle-timeout 発火しない"""
+        url = self._get_dead_url()
+        tmp_phase_file.write_text("working")
+        env = {
+            **os.environ,
+            "RELAY_URL": url,
+            "OW_MCP_URL": url,
+            "PHASE_FILE": str(tmp_phase_file),
+            "HEARTBEAT_INTERVAL_LOADING": "0",
+            "HEARTBEAT_INTERVAL_DEFAULT": "0",
+            "OW_HB_FAIL_THRESHOLD": "1",
+            "OW_MCP_UPTIME_MIN_SEC": "9999",
+            "OW_DISABLE_MCP_SELF_EXIT": "1",
+            "OW_CURL_CONNECT_TIMEOUT": "1",
+            "OW_CURL_TIMEOUT": "1",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(SCRIPT_PATH), "CH_HBUP", "w-hbup"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.5)
+        alive = proc.poll() is None
+        tmp_phase_file.unlink()
+        proc.terminate()
+        proc.wait(timeout=3)
+        assert alive, "uptime gate 未達で hb-fail idle-timeout が誤発火した"
+
+
 class TestHeartbeatShCurlTimeout:
     """C案: curl --max-time でhang時に sleep に進める"""
 

--- a/tests/unit/test_heartbeat_sh.py
+++ b/tests/unit/test_heartbeat_sh.py
@@ -680,18 +680,25 @@ class TestHeartbeatShHbFailIdleTimeout:
     や transient hang を「永続 idle」と誤判定しないことを検証する。"""
 
     def _get_dead_url(self):
-        """connect refused になる URL を返す (使ってないポートを bind→close で確保)"""
+        """connect refused になる URL を返す。
+
+        bind→close 方式だと s.close() の直後に別プロセスが同ポートを bind して
+        curl が接続成功する TOCTOU 競合があるため、socket を bind したまま
+        listen() せず保持する。listen() を呼ばない socket への connect() は
+        OS が ECONNREFUSED を返すため、ポート占有 + 接続拒否を同時に実現できる。
+        socket オブジェクトは呼び出し側で保持してテスト終了まで close しない。
+        """
         import socket as _socket
 
         s = _socket.socket()
         s.bind(("127.0.0.1", 0))
+        # listen() を呼ばないので接続は ECONNREFUSED になる
         port = s.getsockname()[1]
-        s.close()
-        return f"http://127.0.0.1:{port}"
+        return s, f"http://127.0.0.1:{port}"
 
     def test_hb_fail_kill_when_uptime_above_threshold(self, tmp_phase_file):
         """relay /send 失敗 N 回 + uptime >= 閾値 で idle-timeout 発火 → exit"""
-        url = self._get_dead_url()
+        dead_sock, url = self._get_dead_url()
         tmp_phase_file.write_text("working")
         env = {
             **os.environ,
@@ -722,13 +729,14 @@ class TestHeartbeatShHbFailIdleTimeout:
             exited = False
         if tmp_phase_file.exists():
             tmp_phase_file.unlink()
+        dead_sock.close()
         assert exited, (
             "relay /send 連続失敗 + uptime gate 通過で idle-timeout が発火しなかった"
         )
 
     def test_no_hb_fail_kill_when_uptime_below_threshold(self, tmp_phase_file):
         """uptime < 閾値 なら relay /send 失敗続いても idle-timeout 発火しない"""
-        url = self._get_dead_url()
+        dead_sock, url = self._get_dead_url()
         tmp_phase_file.write_text("working")
         env = {
             **os.environ,
@@ -743,6 +751,10 @@ class TestHeartbeatShHbFailIdleTimeout:
             "OW_CURL_CONNECT_TIMEOUT": "1",
             "OW_CURL_TIMEOUT": "1",
         }
+        # uptime gate=9999s で shutdown_for_idle_timeout は発火しない前提だが、
+        # 万一の誤発火時にテストランナーの tmux pane が kill されないよう
+        # 防御的に TMUX_PANE を env から除去する（第1テストと対称）。
+        env.pop("TMUX_PANE", None)
         proc = subprocess.Popen(
             ["bash", str(SCRIPT_PATH), "CH_HBUP", "w-hbup"],
             env=env,
@@ -754,6 +766,7 @@ class TestHeartbeatShHbFailIdleTimeout:
         tmp_phase_file.unlink()
         proc.terminate()
         proc.wait(timeout=3)
+        dead_sock.close()
         assert alive, "uptime gate 未達で hb-fail idle-timeout が誤発火した"
 
 


### PR DESCRIPTION
## 何が変わるか

`scripts/ow/heartbeat.sh` の **hb-fail idle-timeout** (relay /send 連続失敗で worker pane を kill する機構) に **uptime gate** を追加する。

これまでは spawn 直後でも `OW_HB_FAIL_THRESHOLD=5` 回連続で relay /send が失敗するとそのまま worker pane を `tmux kill-pane` していた。MCP self-exit には `OW_MCP_UPTIME_MIN_SEC=300` の uptime gate があるのに、hb-fail だけ無防備だった。

本 PR で hb-fail にも同じ閾値 `OW_MCP_UPTIME_MIN_SEC` を再利用した uptime gate を入れる。

## なぜ要るか

実観察で「軽い idle 作業状態の worker が spawn 後 2.5〜3.75 分前後で session ごと消える」現象が再現していた。

- `OW_HB_FAIL_THRESHOLD=5` × (working interval 30s + curl `--max-time=15s`) ≈ 150〜225 秒
- 観察された「4 分前後で死ぬ」と一致

軽い作業中の worker は MCP tool / Bash tool 呼び出しが少なく、relay / MCP の一時不安定 (cold start、dev cycle 中の restart、transient hang) を「永続 idle」と誤検知する。重い作業中の worker は MCP/relay へのアクセスで暖まり続けるため通る。これは「ワーカーが少しでも idle になると 4 分で死ぬ」という非対称な挙動になり、自己 hosted な fix worker spawn の障害になっていた。

uptime gate を入れれば、spawn 直後 5 分間は relay 不通でも自殺しない。それ以降は従来通り idle worker を回収する。

## 互換性

- 既存の `OW_DISABLE_IDLE_TIMEOUT=1` で完全無効化する経路は影響なし
- `OW_MCP_UPTIME_MIN_SEC` を 0 にセットすれば即発火する旧挙動に戻せる
- 既存 22 件の heartbeat_sh ユニットテストは全て通る

## テスト計画

- [x] `tests/unit/test_heartbeat_sh.py::TestHeartbeatShHbFailIdleTimeout` 2 ケース追加
  - relay /send 連続失敗 + uptime gate 通過 → idle-timeout 発火して exit
  - relay /send 連続失敗 + uptime gate 未達 → 発火せず生存
- [x] 既存 heartbeat_sh ユニットテスト 23 件 (新規含む) all pass
- [ ] CI: claude-review / test (unit) / test (integration-e2e) all green