### PR TITLE
fix: tmux adapter spawn 経路に pane 生存検証を追加

### DIFF
--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -64,6 +64,36 @@ rebalance_worker_panes() {
   done <<< "$panes"
 }
 
+# spawn 直後の pane が生存しているか短時間遅延後に検証する。
+# tmux は new-window / split-window コマンドを受理した瞬間に pane_id を払い出すため、
+# bash -c で走る worker_cmd が即時失敗して pane が消滅しても adapter は exit 0 を返してしまう
+# (silent failure)。本関数で短時間 sleep してから pane の存在 + プロセス生存を両方検証する。
+# tmux 側の pane structure cleanup は process exit より少し遅れるため、pane が見えても中身が
+# zombie/reap 済のケースがある。pane_pid を取得して kill -0 で生存確認する二段検査で確実に捕まえる。
+# OW_PANE_SURVIVAL_DELAY 環境変数で sleep 時間を調整可能 (default: 1.0 秒)。
+# 1.0s は claude startup が完了する前のタイミングだが、claude 起動失敗時の bash プロセス即死は
+# bash の exec 前か直後で起きるためこの幅で十分捕まえられる。
+# OW_SKIP_PANE_SURVIVAL_CHECK=1 で本検査全体を skip (テスト用、本番 spawn では設定しない)。
+verify_pane_alive() {
+  local pane_id="$1"
+  if [[ "${OW_SKIP_PANE_SURVIVAL_CHECK:-0}" == "1" ]]; then
+    return 0
+  fi
+  local delay="${OW_PANE_SURVIVAL_DELAY:-1.0}"
+  sleep "$delay"
+  local pane_pid
+  pane_pid=$(tmux display -t "$pane_id" -p "#{pane_pid}" 2>/dev/null || true)
+  if [[ -z "$pane_pid" ]]; then
+    echo "adapter_error: pane $pane_id missing within ${delay}s of spawn (pane cleanup done, worker_cmd failed)" >&2
+    return 1
+  fi
+  if ! kill -0 "$pane_pid" 2>/dev/null; then
+    echo "adapter_error: pane $pane_id process pid=$pane_pid not alive within ${delay}s of spawn (worker_cmd terminated immediately)" >&2
+    return 1
+  fi
+  return 0
+}
+
 case "$ACTION" in
   spawn)
     if [[ $# -lt 3 ]]; then
@@ -103,12 +133,14 @@ case "$ACTION" in
         fi
         PANE_ID=$(tmux new-window -t "$SESSION_ID" -n "$THINKING_WINDOW_NAME" -d -P -F "#{pane_id}" -- \
           bash -c "$SHELL_CMD")
+        verify_pane_alive "$PANE_ID" || exit 1
       else
         if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
           tmux new-session -d -s "$SESSION_NAME" -n "ow-base"
         fi
         PANE_ID=$(tmux new-window -t "$SESSION_NAME" -n "$THINKING_WINDOW_NAME" -P -F "#{pane_id}" -- \
           bash -c "$SHELL_CMD")
+        verify_pane_alive "$PANE_ID" || exit 1
       fi
       tmux set-option -p -t "$PANE_ID" "$WORKER_MARKER_OPT" 1 \
         || echo "warn: tmux set-option -p @ow-worker failed (possibly tmux <1.8 or pane gone), worker marker not set" >&2
@@ -138,6 +170,7 @@ case "$ACTION" in
         PANE_ID=$(tmux split-window -v -d -t "$EXISTING_WORKER" -P -F "#{pane_id}" -- \
           bash -c "$SHELL_CMD")
       fi
+      verify_pane_alive "$PANE_ID" || exit 1
 
       # pane user option で識別用マーカーを設定（claudeの escape sequence では上書き不可）。
       # set-option -p は pane-local オプション、@<name> カスタムオプションは tmux 1.8+ 対応。
@@ -155,6 +188,7 @@ case "$ACTION" in
 
       PANE_ID=$(tmux new-window -t "$SESSION_NAME" -n "ow-worker" -P -F "#{pane_id}" -- \
         bash -c "$SHELL_CMD")
+      verify_pane_alive "$PANE_ID" || exit 1
     fi
 
     echo "$PANE_ID"

--- a/scripts/ow/adapters/tmux.sh
+++ b/scripts/ow/adapters/tmux.sh
@@ -80,7 +80,10 @@ verify_pane_alive() {
     return 0
   fi
   local delay="${OW_PANE_SURVIVAL_DELAY:-1.0}"
-  sleep "$delay"
+  if ! sleep "$delay" 2>/dev/null; then
+    echo "adapter_error: invalid OW_PANE_SURVIVAL_DELAY: $delay (sleep failed)" >&2
+    return 1
+  fi
   local pane_pid
   pane_pid=$(tmux display -t "$pane_id" -p "#{pane_pid}" 2>/dev/null || true)
   if [[ -z "$pane_pid" ]]; then
@@ -89,6 +92,7 @@ verify_pane_alive() {
   fi
   if ! kill -0 "$pane_pid" 2>/dev/null; then
     echo "adapter_error: pane $pane_id process pid=$pane_pid not alive within ${delay}s of spawn (worker_cmd terminated immediately)" >&2
+    tmux kill-pane -t "$pane_id" 2>/dev/null || true
     return 1
   fi
   return 0

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -20,6 +20,7 @@ def _make_mock_tmux(
     existing_worker_panes: str = "",
     display_switch_at_kill: int | None = None,
     window_height: str = "12345",
+    pane_pid: str | None = None,
 ) -> Path:
     """tmuxをモックするシェルスクリプトを作成する。
 
@@ -35,7 +36,12 @@ def _make_mock_tmux(
     例: "%5|1\\n%7|" を渡すと既存worker paneが1個ある状態を模擬する（"1"がworkerマーカー、空欄が非worker）。
 
     window_height は `tmux display -p "#{window_height}"` が返す値（rebalance の高さ計算用）。
-    既定 "12345"。window_height を問わない display クエリ（pane_pid 等）は従来通り "12345" を返す。
+    既定 "12345"。
+
+    pane_pid は `tmux display -p "#{pane_pid}"` が返す値（spawn 後の verify_pane_alive と
+    close 時の SIGKILL fallback 用）。None 時は "12345" を返す（close 時の SIGKILL fallback で
+    存在しない PID に対して kill -KILL されても 2>/dev/null || true で吸収される）。silent failure
+    検出テストでは OW_SKIP_PANE_SURVIVAL_CHECK=0 + pane_pid 指定で verify_pane_alive を有効化する。
     """
     mock_dir = tmp_path / "mock_bin"
     mock_dir.mkdir(exist_ok=True)
@@ -48,6 +54,7 @@ def _make_mock_tmux(
     display_state_file.write_text("1" if target_pane_exists else "0")
     kill_counter_file.write_text("0")
     switch_at = "" if display_switch_at_kill is None else str(display_switch_at_kill)
+    pane_pid_val = pane_pid if pane_pid is not None else "12345"
 
     mock.write_text(
         f'#!/usr/bin/env bash\n'
@@ -70,6 +77,7 @@ def _make_mock_tmux(
         f'  if [ "$state" = "0" ]; then exit 1; fi\n'
         f'  case "$*" in\n'
         f'    *window_height*) echo "{window_height}";;\n'
+        f'    *pane_pid*) echo "{pane_pid_val}";;\n'
         f'    *) echo "12345";;\n'
         f'  esac\n'
         f'  exit 0\n'
@@ -98,6 +106,9 @@ def _run_adapter(
 
     env = os.environ.copy()
     env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+    # 既存テストでは verify_pane_alive を skip (mock pane_pid を kill -0 / SIGKILL fallback の
+    # 対象にしないため)。silent failure 検出テストでは extra_env で上書き解除する。
+    env.setdefault("OW_SKIP_PANE_SURVIVAL_CHECK", "1")
     if extra_env:
         env.update(extra_env)
 
@@ -519,3 +530,85 @@ class TestTmuxAdapterErrors:
         result, _ = _run_adapter(["close"], tmp_path)
         assert result.returncode != 0
         assert "Usage" in result.stderr
+
+
+class TestTmuxAdapterPaneSurvival:
+    """spawn 直後の pane 生存検証 (verify_pane_alive) のテスト。
+
+    tmux は new-window / split-window を受理した瞬間に pane_id を払い出すため、
+    bash -c で走る worker_cmd が即時失敗して pane が消滅しても adapter は exit 0 で
+    pane_id を返してしまう (silent failure)。spawn 直後に pane の存在 + プロセス生存を
+    両方検証することで silent failure を adapter 層で検出する。
+    """
+
+    # silent failure 検出テストでは skip を解除 + delay=0 で高速化
+    CHECK_ON_ENV = {"OW_SKIP_PANE_SURVIVAL_CHECK": "0", "OW_PANE_SURVIVAL_DELAY": "0"}
+
+    def test_spawn_succeeds_when_pane_pid_alive(self, tmp_path):
+        """spawn 直後の pane_pid 取得 + kill -0 成功 → exit 0。
+
+        テストプロセス自身の PID を pane_pid に渡せば kill -0 が成功し verify_pane_alive が
+        return 0 を返す。
+        """
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "claude"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            pane_pid=str(os.getpid()),
+        )
+        assert result.returncode == 0
+        assert MOCK_PANE_ID in result.stdout
+
+    def test_spawn_detects_dead_process(self, tmp_path):
+        """spawn 直後の pane_pid に対する kill -0 が失敗するとき exit 1 + adapter_error。
+
+        worker_cmd が exec 失敗で bash プロセスが即死し、pane structure は cleanup 遅延で
+        残るが中身の process は zombie/reap 済になるケース。silent failure の典型パターン。
+        """
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "exec /usr/bin/true"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            pane_pid="999999999",
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+        assert "not alive" in result.stderr
+
+    def test_spawn_detects_pane_missing(self, tmp_path):
+        """spawn 直後に display が pane_pid を空で返すケース (pane cleanup 完了) を検出。
+
+        worker_cmd が即時失敗して pane も即消滅し、tmux 側の cleanup も完了している
+        さらに severe な silent failure。
+        """
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "exec /usr/bin/true"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            pane_pid="",
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+        assert "missing" in result.stderr
+
+    def test_spawn_with_target_pane_also_checks_survival(self, tmp_path):
+        """split-window 経路 (target_pane 指定) でも survival check が機能する。"""
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "exec /usr/bin/true", "%0"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            pane_pid="999999999",
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+
+    def test_spawn_thinking_worker_also_checks_survival(self, tmp_path):
+        """思考worker (is_thinking=1) 経路でも survival check が機能する。"""
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "exec /usr/bin/true", "%0", "1"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            pane_pid="999999999",
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr

--- a/tests/unit/test_tmux_adapter.py
+++ b/tests/unit/test_tmux_adapter.py
@@ -576,10 +576,11 @@ class TestTmuxAdapterPaneSurvival:
         assert "not alive" in result.stderr
 
     def test_spawn_detects_pane_missing(self, tmp_path):
-        """spawn 直後に display が pane_pid を空で返すケース (pane cleanup 完了) を検出。
+        """display が exit 0 で空文字列を返すエッジケースを検出 (pane_pid 空)。
 
         worker_cmd が即時失敗して pane も即消滅し、tmux 側の cleanup も完了している
-        さらに severe な silent failure。
+        さらに severe な silent failure。display 自身が exit 1 を返す典型ケースは
+        test_spawn_detects_pane_missing_via_display_exit_1 でカバー。
         """
         result, _ = _run_adapter(
             ["spawn", "/tmp/work", "exec /usr/bin/true"],
@@ -590,6 +591,77 @@ class TestTmuxAdapterPaneSurvival:
         assert result.returncode == 1
         assert "adapter_error" in result.stderr
         assert "missing" in result.stderr
+
+    def test_spawn_detects_pane_missing_via_display_exit_1(self, tmp_path):
+        """pane 消滅時に tmux display 自体が exit 1 を返す典型ケースを検出。
+
+        実 tmux 挙動: pane が存在しない pane_id を指定すると display は exit 1 を返す
+        (空文字列 exit 0 ではない)。adapter 側は `2>/dev/null || true` で吸収するため
+        最終的に pane_pid="" の missing ブランチに入る。本テストでは
+        target_pane_exists=False で display 一律 exit 1 を模擬し、実 tmux と同じ
+        失敗経路で missing 検出が機能することを保証する。
+        """
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "exec /usr/bin/true"],
+            tmp_path,
+            extra_env=self.CHECK_ON_ENV,
+            target_pane_exists=False,
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+        assert "missing" in result.stderr
+
+    def test_spawn_kills_orphan_pane_on_dead_process(self, tmp_path):
+        """kill -0 失敗時に tmux kill-pane で orphan pane を後始末する。
+
+        verify_pane_alive が dead process を検知して return 1 する際、サーバーは
+        PANE_ID を知らないまま spawn が失敗し、`remain-on-exit on` の tmux 環境では
+        pane structure が zombie として残る。verify_pane_alive 側で kill-pane を
+        呼んで後始末していることを capture で確認する。
+        """
+        capture_file = tmp_path / "tmux_args.txt"
+        capture_file.write_text("")
+        mock_dir = _make_mock_tmux(
+            tmp_path,
+            capture_file=capture_file,
+            pane_pid="999999999",
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = str(mock_dir) + ":" + env["PATH"]
+        env["OW_SKIP_PANE_SURVIVAL_CHECK"] = "0"
+        env["OW_PANE_SURVIVAL_DELAY"] = "0"
+
+        result = subprocess.run(
+            [str(ADAPTER), "spawn", "/tmp/work", "exec /usr/bin/true"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        captured = capture_file.read_text()
+
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+        assert "not alive" in result.stderr
+        # kill -0 失敗ブランチで kill-pane が呼ばれている (orphan pane の後始末)
+        assert "kill-pane" in captured
+        assert MOCK_PANE_ID in captured
+
+    def test_spawn_invalid_survival_delay_returns_adapter_error(self, tmp_path):
+        """OW_PANE_SURVIVAL_DELAY が不正値のとき adapter_error prefix 付きで失敗する。
+
+        set -euo pipefail 配下で sleep が失敗するとスクリプトが中断し、サーバー側で
+        エラー分類が困難になる。verify_pane_alive 側で sleep 失敗を明示的に拾って
+        adapter_error: prefix で stderr に出すことを保証する。
+        """
+        result, _ = _run_adapter(
+            ["spawn", "/tmp/work", "claude"],
+            tmp_path,
+            extra_env={"OW_SKIP_PANE_SURVIVAL_CHECK": "0", "OW_PANE_SURVIVAL_DELAY": "abc"},
+        )
+        assert result.returncode == 1
+        assert "adapter_error" in result.stderr
+        assert "OW_PANE_SURVIVAL_DELAY" in result.stderr
 
     def test_spawn_with_target_pane_also_checks_survival(self, tmp_path):
         """split-window 経路 (target_pane 指定) でも survival check が機能する。"""


### PR DESCRIPTION
## Summary

ow_spawn_worker が `{spawning:ok, term_ref:%N}` を返却しつつ実 pane が即消滅する silent failure (phantom term_ref) を adapter 層で検出する。

### before/after の挙動差

- before: worker_cmd が exec 失敗で即死しても adapter は exit 0 で pane_id を返す。server は spawning:ok を返却し、orch は phantom term_ref を抱えたまま loading state で詰まる。
- after: spawn 直後に pane の存在 + プロセス生存を検証し、失敗時は adapter が exit 1 + stderr に adapter_error を出力。server 側で subprocess.CalledProcessError 経路に倒れ manual fallback として観測可能になる。

### なぜ要るのか

ow_spawn_worker silent failure は orch / dispatcher が phantom worker を抱えて loading state で停滞する観測可能性ゼロのバグの根本因。adapter 層に検証ゲートを置くことで「pane 作成成功 ≠ worker プロセス生存」のギャップを埋める。

### 実装ポイント

- spawn 各経路 (思考worker / 通常worker split-window / フォールバック new-window) で pane_id 払い出し直後に verify_pane_alive を実行
- verify_pane_alive は短時間 sleep 後に (a) tmux display で pane_pid が取得できるか (b) kill -0 で pane プロセスが生存しているか の二段検査
- OW_PANE_SURVIVAL_DELAY (default 1.0s) で sleep 時間を環境変数調整可能
- OW_SKIP_PANE_SURVIVAL_CHECK=1 でテスト時 skip 可能

### スコープ外

server 側で event:heartbeat(alive) 受信を待つ二段目の検証 (修正方針 v0 §4-b) は async 化の議論が要るため別 activity で扱う。本 PR は adapter 層の silent failure 可視化に限定。

## Test plan

新規追加テストの検証項目:

- [x] spawn 直後の pane_pid 取得 + kill -0 成功 → exit 0
- [x] kill -0 失敗 (pane_pid に存在しない PID) → exit 1 + stderr "not alive"
- [x] display で pane_pid が空応答 (pane cleanup 完了) → exit 1 + stderr "missing"
- [x] split-window 経路 (target_pane 指定) でも survival check が機能
- [x] 思考worker (is_thinking=1) 経路でも survival check が機能

既存テスト群への影響:

- [x] tmux adapter テスト 44 件 pass (既存 39 件は OW_SKIP_PANE_SURVIVAL_CHECK=1 default で影響なし)
- [x] test_ow_spawn_thinking_tmux_route テスト 9 件 pass

実機検証:

- [x] `bash scripts/ow/adapters/tmux.sh spawn /tmp 'exec /usr/bin/true' "" 0` → exit 1 + stderr adapter_error 出力を確認
- [x] `bash scripts/ow/adapters/tmux.sh spawn /tmp 'exec sleep 30' "" 0` → exit 0 + pane 生存を確認