### PR TITLE
feat: 発話中の内部識別子出現を観測し次ターンにリマインダー注入

### DIFF
--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -56,6 +56,25 @@ class HookState:
         """ファイル削除（missing_ok=True）"""
         self._delete(self._path("block_count"))
 
+    # --- id_leak_count ---
+
+    def get_id_leak_count(self) -> int:
+        """assistant 発話に出現した cc-memory 内部 ID リテラル件数の累積。
+        未設定 -> 0。MessageDisplay hook が観測時に increment し、
+        UserPromptSubmit hook が次ターンで参照して system-reminder を注入
+        した後に reset する想定。"""
+        return self._read_int(self._path("id_leak_count"), 0)
+
+    def increment_id_leak_count(self, by: int = 1) -> int:
+        """count を by 加算して書き込み、新しい値を返す"""
+        new_val = self.get_id_leak_count() + by
+        self._write(self._path("id_leak_count"), str(new_val))
+        return new_val
+
+    def reset_id_leak_count(self) -> None:
+        """ファイル削除（missing_ok=True）"""
+        self._delete(self._path("id_leak_count"))
+
     # --- transcript_offset ---
 
     def get_transcript_offset(self) -> int:

--- a/hooks/message_display_id_titles.py
+++ b/hooks/message_display_id_titles.py
@@ -27,6 +27,7 @@ _PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent
 if str(_PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_ROOT))
 
+from hooks.hook_state import HookState  # noqa: E402
 from src.services.internal_id_patterns import FULLWORD_TO_CODE  # noqa: E402
 
 # code 形式と fullword 形式を 1 つの regex にまとめる。2 段階 sub にすると
@@ -147,9 +148,27 @@ def main() -> None:
     except Exception:
         sys.exit(0)
 
+    # 環境変数による HookState BASE_DIR オーバーライド (テスト用)
+    if os.environ.get("HOOK_STATE_DIR"):
+        HookState.BASE_DIR = pathlib.Path(os.environ["HOOK_STATE_DIR"])
+
     message = payload.get("delta") or payload.get("assistant_message")
     if not isinstance(message, str) or not message:
         sys.exit(0)
+
+    # 観測副作用: assistant 発話に含まれる cc-memory 内部 ID リテラル件数を
+    # session 単位 state に蓄積する。UserPromptSubmit hook が次ターンに
+    # この値を参照して system-reminder を注入する。DB アクセスより前に
+    # 実行するため DB 不在でも観測は有効。
+    session_id = payload.get("session_id", "")
+    if session_id:
+        try:
+            matches = _COMBINED_PATTERN.findall(message)
+            if matches:
+                HookState(session_id).increment_id_leak_count(len(matches))
+        except Exception:
+            # 観測失敗で本体の補完表示動作を止めない
+            pass
 
     db_path = _db_path()
     if not pathlib.Path(db_path).exists():

--- a/hooks/user_prompt_submit_hook.py
+++ b/hooks/user_prompt_submit_hook.py
@@ -5,9 +5,11 @@
 2. session_idが空/null → 空JSON出力して終了
 3. events.jsonl全読み
 4. 未消費のnudgeイベント判定 → system-reminder注入
-5. 何もなし → 空JSON出力
+5. id_leak_count > 0 → 内部 ID 漏出 system-reminder 注入 + count reset
+6. 何もなし → 空JSON出力
 
 Stop hookでnudge判定とevents.jsonl追記を行い、本hookで消費して注入する。
+MessageDisplay hookが内部IDリテラル件数をid_leak_countに蓄積し、本hookで参照する。
 注入タイミングが「ユーザーの次の発言時」になるため、文面もその文脈に合わせている。
 """
 import json
@@ -47,6 +49,14 @@ _RECORD_NUDGE_MESSAGE = (
     "直近の応答で記録ツール（add_logs/add_decisions/add_topic）が呼ばれていません。"
     "ユーザーの今回の発言に応答する前に、これまでの議論で残すべき事項がないか振り返ってください。"
     "該当があれば応答冒頭で記録してから本題に入ってください。"
+    "</system-reminder>"
+)
+
+_ID_LEAK_NUDGE_MESSAGE = (
+    "<system-reminder>"
+    "Your previous response included internal IDs (e.g., `A#xxx`, `M#xxx`, `log #xxx`). "
+    "Before responding to the user, revisit your reference style and switch to descriptive "
+    "natural language; the user cannot resolve raw IDs."
     "</system-reminder>"
 )
 
@@ -94,11 +104,7 @@ def main() -> None:
         state = HookState(session_id)
         events = state.read_events()
 
-        if not events:
-            print("{}")
-            return
-
-        # 4. 未消費のnudgeイベント判定
+        # 4. 未消費のnudgeイベント判定（events空なら for loop は即抜ける）
         # 最新のnudgeイベントを探す（consumed=Trueでないもの）
         for e in reversed(events):
             if e.get("e") != "nudge":
@@ -119,7 +125,17 @@ def main() -> None:
             print(json.dumps(_make_hook_output(message), ensure_ascii=False))
             return
 
-        # 5. 何もなし
+        # 5. id_leak count チェック（既存 nudge を消費せず loop 抜けた場合のみ）
+        # MessageDisplay hook が観測した内部 ID 漏出件数 > 0 ならリマインダー注入。
+        # 既存 nudge と同 turn に立っていた場合は既存 nudge を優先し id_leak は
+        # 次ターンに繰り越す (count は reset しない)。1 turn に 1 リマインダー
+        # で認知負荷を抑える方針。
+        if state.get_id_leak_count() > 0:
+            state.reset_id_leak_count()
+            print(json.dumps(_make_hook_output(_ID_LEAK_NUDGE_MESSAGE), ensure_ascii=False))
+            return
+
+        # 6. 何もなし
         print("{}")
 
     except Exception as e:

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -196,6 +196,67 @@ class TestEmptySessionId:
         assert json.loads(result.stdout) == {}
 
 
+class TestIdLeakNudge:
+    """id_leak_count > 0 → 英語 system-reminder 注入 + count reset"""
+
+    def _set_id_leak_count(self, count: int) -> None:
+        state = HookState(_SESSION_ID)
+        for _ in range(count):
+            state.increment_id_leak_count()
+
+    def test_id_leak_injection(self, state_dir):
+        self._set_id_leak_count(1)
+
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "<system-reminder>" in ctx
+        assert "internal IDs" in ctx
+        assert "natural language" in ctx
+
+    def test_id_leak_count_reset_after_injection(self, state_dir):
+        self._set_id_leak_count(3)
+
+        _run_hook({"session_id": _SESSION_ID}, state_dir)
+
+        # count リセット
+        assert HookState(_SESSION_ID).get_id_leak_count() == 0
+
+        # 2 回目は空JSON
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert json.loads(result.stdout) == {}
+
+    def test_zero_count_no_injection(self, state_dir):
+        # count=0 (state file 不在) なら空JSON
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        assert json.loads(result.stdout) == {}
+
+    def test_existing_nudge_takes_priority(self, state_dir):
+        """既存 nudge (record/follow_up) があれば優先、id_leak は次ターンに繰り越す"""
+        _write_events(
+            [{"e": "nudge", "type": "record", "turn": 2}],
+            state_dir,
+        )
+        self._set_id_leak_count(1)
+
+        # 1 回目: record nudge 注入、id_leak count はリセットされない
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "直近の応答で記録ツール" in ctx
+        assert HookState(_SESSION_ID).get_id_leak_count() == 1
+
+        # 2 回目: id_leak 注入 + count リセット
+        result2 = _run_hook({"session_id": _SESSION_ID}, state_dir)
+        ctx2 = json.loads(result2.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "internal IDs" in ctx2
+        assert HookState(_SESSION_ID).get_id_leak_count() == 0
+
+
 class TestFailOpen:
     """例外→空JSON（フェイルオープン）"""
 

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -36,6 +36,34 @@ class TestBlockCount:
         assert hook_state.get_block_count() == 0
 
 
+class TestIdLeakCount:
+    def test_get_returns_zero_when_no_file(self, hook_state):
+        assert hook_state.get_id_leak_count() == 0
+
+    def test_increment_default_by_one(self, hook_state):
+        assert hook_state.increment_id_leak_count() == 1
+        assert hook_state.increment_id_leak_count() == 2
+
+    def test_increment_with_by(self, hook_state):
+        assert hook_state.increment_id_leak_count(3) == 3
+        assert hook_state.increment_id_leak_count(2) == 5
+
+    def test_reset_then_get(self, hook_state):
+        hook_state.increment_id_leak_count(4)
+        hook_state.reset_id_leak_count()
+        assert hook_state.get_id_leak_count() == 0
+
+    def test_corrupted_file_returns_zero(self, hook_state):
+        path = hook_state._path("id_leak_count")
+        path.write_text("abc")
+        assert hook_state.get_id_leak_count() == 0
+
+    def test_cleared_by_clear_session(self, hook_state):
+        hook_state.increment_id_leak_count(2)
+        HookState.clear_session("test-session-123")
+        assert hook_state.get_id_leak_count() == 0
+
+
 class TestTranscriptOffset:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_transcript_offset() == 0

--- a/tests/unit/test_message_display_id_titles.py
+++ b/tests/unit/test_message_display_id_titles.py
@@ -274,3 +274,116 @@ class TestMain:
         except SystemExit:
             pass
         assert out.getvalue() == ""
+
+
+class TestIdLeakObservation:
+    """MessageDisplay hook が内部 ID リテラル件数を id_leak_count に蓄積する副作用検証。"""
+
+    def _run(self, monkeypatch, payload):
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+        out = io.StringIO()
+        monkeypatch.setattr("sys.stdout", out)
+        try:
+            mdid.main()
+        except SystemExit:
+            pass
+        return out.getvalue()
+
+    @pytest.fixture
+    def state_dir(self, tmp_path, monkeypatch):
+        from hooks.hook_state import HookState
+        monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
+        monkeypatch.setenv("HOOK_STATE_DIR", str(tmp_path))
+        return tmp_path
+
+    def test_increment_called_when_match_found(
+        self, monkeypatch, fake_db, state_dir
+    ):
+        from hooks.hook_state import HookState
+
+        self._run(
+            monkeypatch,
+            {
+                "hook_event_name": "MessageDisplay",
+                "session_id": "obs-test-001",
+                "delta": f"see {_MN('M', 1)} and {_MN('D', 10)}",
+            },
+        )
+        assert HookState("obs-test-001").get_id_leak_count() == 2
+
+    def test_no_increment_when_no_match(self, monkeypatch, fake_db, state_dir):
+        from hooks.hook_state import HookState
+
+        self._run(
+            monkeypatch,
+            {
+                "hook_event_name": "MessageDisplay",
+                "session_id": "obs-test-002",
+                "delta": "plain text no ids",
+            },
+        )
+        assert HookState("obs-test-002").get_id_leak_count() == 0
+
+    def test_no_increment_when_session_id_empty(
+        self, monkeypatch, fake_db, state_dir
+    ):
+        from hooks.hook_state import HookState
+
+        # session_id 空でも display 動作は走るが state file は作られない
+        self._run(
+            monkeypatch,
+            {
+                "hook_event_name": "MessageDisplay",
+                "session_id": "",
+                "delta": f"see {_MN('M', 1)}",
+            },
+        )
+        # state_dir 下にどの session 名でも count は 0
+        assert HookState("any-session-name").get_id_leak_count() == 0
+
+    def test_fullword_form_also_counted(self, monkeypatch, fake_db, state_dir):
+        from hooks.hook_state import HookState
+
+        self._run(
+            monkeypatch,
+            {
+                "hook_event_name": "MessageDisplay",
+                "session_id": "obs-test-003",
+                "delta": f"see {_FW('material', 1)} and {_MN('D', 10)}",
+            },
+        )
+        assert HookState("obs-test-003").get_id_leak_count() == 2
+
+    def test_increment_accumulates_across_chunks(
+        self, monkeypatch, fake_db, state_dir
+    ):
+        from hooks.hook_state import HookState
+
+        session = "obs-test-004"
+        for _ in range(3):
+            self._run(
+                monkeypatch,
+                {
+                    "hook_event_name": "MessageDisplay",
+                    "session_id": session,
+                    "delta": f"ref {_MN('M', 1)}",
+                },
+            )
+        # 3 chunks × 1 match = 3
+        assert HookState(session).get_id_leak_count() == 3
+
+    def test_observation_runs_even_without_db(self, monkeypatch, tmp_path, state_dir):
+        from hooks.hook_state import HookState
+
+        # DB を存在しないパスに向けて display 動作を skip させても、
+        # 観測副作用は走ること (観測は DB アクセス前)
+        monkeypatch.setenv("CC_MEMORY_DB_PATH", str(tmp_path / "nonexistent.db"))
+        self._run(
+            monkeypatch,
+            {
+                "hook_event_name": "MessageDisplay",
+                "session_id": "obs-test-005",
+                "delta": f"ref {_MN('M', 1)}",
+            },
+        )
+        assert HookState("obs-test-005").get_id_leak_count() == 1


### PR DESCRIPTION
## Summary

- MessageDisplay hook が assistant 発話中に観測した内部識別子リテラルの件数を `id_leak_count` state file に蓄積する副作用を追加（補完表示動作は不変）
- UserPromptSubmit hook が次ターンに count を参照し、>0 で英語の system-reminder を additionalContext として注入、注入後に count を reset
- 既存 nudge (record / follow_up / logs_sparse) があれば優先消費し、id_leak は次ターン繰り越す（1 turn 1 reminder ポリシー）

## なぜ要るのか

MessageDisplay hook の `displayContent` は表示のみ書き換える仕様で、transcript と Claude context には元のテキストが残る。そのため補完表示だけでは AI 側の出力規律にフィードバックがかからない。本変更で「観測 → カウント蓄積 → 次ターン system-reminder 注入 → count reset」の漸進的なフィードバック経路を追加する。

## 設計の要点

- **state 管理**: `HookState` クラスに `id_leak_count` ヘルパー (get / increment / reset) を追加。既存 `block_count` のパターンを踏襲、session 単位の独立 state file
- **観測位置**: MessageDisplay hook の main 内、DB アクセス前。`_COMBINED_PATTERN.findall` で件数を取得して increment。観測失敗で補完表示動作を止めない (try/except でフェイルオープン)
- **注入順序**: UserPromptSubmit hook で既存 nudge を消費せず loop 抜けた場合のみ id_leak count を確認。同 turn に 2 リマインダーを同時注入しない方針
- **events.jsonl とは並走**: 既存 nudge framework の events.jsonl は「reversed で最初の未消費 1 件のみ consume」仕様で、streaming delta で複数件 append される性質上「ゼロ戻し」を満たすには既存フローに専用分岐が必要になる。独立 state にすることで既存フローの清潔さを保つ
- **`hooks/hooks.json` は変更なし**: MessageDisplay / UserPromptSubmit hook は既に登録済み

## Test plan

- [x] `tests/unit/test_hook_state.py`: id_leak_count の get / increment(by) / reset / clear_session 連動 / 不正値 fallback
- [x] `tests/unit/test_message_display_id_titles.py`:
  - マッチ存在で increment が呼ばれる
  - マッチなしで increment 呼ばれない
  - session_id 空で state file 作られない
  - 英単語フルワード形式（material/decision/log/activity/topic に番号が続く形）もカウント対象
  - 複数 chunk 跨ぎで累積
  - DB 不在でも観測副作用は走る
- [x] `tests/e2e/test_user_prompt_submit_hook.py`:
  - count >0 で英語 reminder 注入
  - 注入後に count reset、2 回目は空 JSON
  - count=0 で空 JSON
  - 既存 record nudge があれば優先消費、id_leak は次ターン繰り越し
- [x] 既存 80 件のテスト ( `test_hook_state.py` / `test_message_display_id_titles.py` / `test_user_prompt_submit_hook.py` ) は全 pass を維持

実行結果: 89 passed in 1.13s

## マージ後の反映手順

`CLAUDE.md` / `CLAUDE.local.md` 記載の手順を実行する必要あり (plugin cache 削除 → MCP サーバー再起動 → セッション再起動)。