### PR TITLE
feat: alias validation を緩和し命名規約を docstring に集約

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1293,7 +1293,12 @@ def ow_spawn_worker(
     worker paneを垂直分割）。未指定時は従来の `ow-workers` 別sessionに新windowで起動する。
 
     Args:
-        alias: workerのhandle（例: "w-a"）
+        alias: worker の handle。命名規約の正本はここに置く。
+            推奨形式: w-<purpose>-<activity_id> （例: w-design-1064）
+            必須制約: 最小 4 文字、kebab-case（小文字英数字とハイフン、
+                先頭は英字、末尾は英数字、連続ハイフン禁止）
+            prefix `w-` は推奨だが必須ではない（role 識別のため追従推奨）
+            purpose は task の簡潔記述（例: design / impl / fixup / migrate）
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル。claude-opus-4-7 のみ許可。sonnet/haiku/opus-4-8 はバリデーションで拒否

--- a/src/main.py
+++ b/src/main.py
@@ -1296,7 +1296,7 @@ def ow_spawn_worker(
         alias: worker の handle。命名規約の正本はここに置く。
             推奨形式: w-<purpose>-<activity_id> （例: w-design-1064）
             必須制約: 最小 4 文字、kebab-case（小文字英数字とハイフン、
-                先頭は英字、末尾は英数字、連続ハイフン禁止）
+                先頭は小文字英字、末尾は英数字、連続ハイフン禁止）
             prefix `w-` は推奨だが必須ではない（role 識別のため追従推奨）
             purpose は task の簡潔記述（例: design / impl / fixup / migrate）
         channel: channelコード

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -123,34 +123,42 @@ THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathin
 _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
 
 # worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字、
-# 連続ハイフン禁止）かつ最小長 8 文字以上。短すぎる alias は名前衝突や視認性低下を招き、
-# queue/relay 識別子として再利用しづらいため一律で拒否する。
+# 連続ハイフン禁止）かつ最小長 4 文字以上。命名規約 (推奨 prefix `w-` / purpose / activity_id)
+# は強制せず、ow_spawn_worker の docstring を正本としてソフトに伝える。
 # alias の上限長は意図的に設けない（relay messages の handle / spawn-bundle envelope の
-# `to` フィールドに埋め込まれるが、物理上限は relay 側に委ねる。orch 運用上は
-# kebab-case の自然な命名で十分短く収まる）。
-_ALIAS_MIN_LENGTH: int = 8
+# `to` フィールドに埋め込まれるが、物理上限は relay 側に委ねる）。
+_ALIAS_MIN_LENGTH: int = 4
 _ALIAS_PATTERN: re.Pattern[str] = re.compile(r"^[a-z]([a-z0-9]|-(?!-))*[a-z0-9]$")
+_ALIAS_RECOMMENDED_HINT: str = (
+    "Recommended: w-<purpose>-<activity_id> (e.g. w-design-1064)."
+)
 
 
 def _validate_alias_format(alias: str) -> str | None:
     """alias の書式検証。OK なら None、NG ならユーザー向けエラーメッセージ文字列を返す。
 
     検証項目:
-        - 最小長: 8 文字以上
+        - 最小長: 4 文字以上
         - kebab-case: 小文字英数字とハイフンのみ。先頭は英字、末尾は英数字、連続ハイフン禁止
+
+    命名規約 (prefix `w-` / purpose / activity_id の組合せ) は強制せず、エラー文言に
+    推奨形式ヒントを添えて呼び出し側に方向を伝える（ソフト誘導）。正本は
+    ``ow_spawn_worker`` の docstring。
     """
     if not isinstance(alias, str) or not alias:
         return "alias must be a non-empty string"
     if len(alias) < _ALIAS_MIN_LENGTH:
         return (
             f"alias '{alias}' is too short "
-            f"(length={len(alias)}, min={_ALIAS_MIN_LENGTH})"
+            f"(length={len(alias)}, min={_ALIAS_MIN_LENGTH}). "
+            f"{_ALIAS_RECOMMENDED_HINT}"
         )
     if not _ALIAS_PATTERN.match(alias):
         return (
             f"alias '{alias}' does not match required kebab-case pattern "
             "(lowercase letters/digits/hyphen, start with letter, "
-            "end with letter or digit, no consecutive hyphens)"
+            "end with letter or digit, no consecutive hyphens). "
+            f"{_ALIAS_RECOMMENDED_HINT}"
         )
     return None
 
@@ -1109,7 +1117,9 @@ def ow_spawn_worker(
     permission_modeは常にautoに固定される。
 
     Args:
-        alias: workerのhandle（例: "w-a"）
+        alias: worker の handle。命名規約の正本は MCP tool ラッパー側 docstring
+            (src/main.py の ``ow_spawn_worker``) に置く。書式制約は
+            ``_validate_alias_format`` を参照（最小 4 文字、kebab-case）。
         channel: channelコード
         cwd: workerの作業ディレクトリ
         model: 使用モデル（claude-opus-4-7 のみ許可。"opus", "opus-4-7" 等の

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -122,7 +122,7 @@ THINKING_EFFORTS: frozenset[str] = frozenset({"high", "xhigh", "max", "ultrathin
 # orch は sentinel `ultratink` を使い、ow_service 側で正規綴りに畳む。
 _EFFORT_ALIASES: dict[str, str] = {"ultratink": "ultrathink"}
 
-# worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は英字、末尾は英数字、
+# worker alias の書式制約。kebab-case（小文字英数字+ハイフン、先頭は小文字英字、末尾は英数字、
 # 連続ハイフン禁止）かつ最小長 4 文字以上。命名規約 (推奨 prefix `w-` / purpose / activity_id)
 # は強制せず、ow_spawn_worker の docstring を正本としてソフトに伝える。
 # alias の上限長は意図的に設けない（relay messages の handle / spawn-bundle envelope の
@@ -139,7 +139,7 @@ def _validate_alias_format(alias: str) -> str | None:
 
     検証項目:
         - 最小長: 4 文字以上
-        - kebab-case: 小文字英数字とハイフンのみ。先頭は英字、末尾は英数字、連続ハイフン禁止
+        - kebab-case: 小文字英数字とハイフンのみ。先頭は小文字英字、末尾は英数字、連続ハイフン禁止
 
     命名規約 (prefix `w-` / purpose / activity_id の組合せ) は強制せず、エラー文言に
     推奨形式ヒントを添えて呼び出し側に方向を伝える（ソフト誘導）。正本は

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -156,7 +156,7 @@ def _validate_alias_format(alias: str) -> str | None:
     if not _ALIAS_PATTERN.match(alias):
         return (
             f"alias '{alias}' does not match required kebab-case pattern "
-            "(lowercase letters/digits/hyphen, start with letter, "
+            "(lowercase letters/digits/hyphen, start with lowercase letter, "
             "end with letter or digit, no consecutive hyphens). "
             f"{_ALIAS_RECOMMENDED_HINT}"
         )
@@ -192,7 +192,7 @@ def _validate_dispatcher_handle(handle: str) -> str | None:
         return (
             f"dispatcher handle '{handle}' has invalid characters after "
             f"'{_DISPATCHER_HANDLE_PREFIX}' "
-            "(lowercase letters/digits/hyphen, start with letter, "
+            "(lowercase letters/digits/hyphen, start with lowercase letter, "
             "end with letter or digit, no consecutive hyphens)"
         )
     return None

--- a/tests/unit/test_ow_spawn_alias_and_settings.py
+++ b/tests/unit/test_ow_spawn_alias_and_settings.py
@@ -36,6 +36,9 @@ class TestValidateAliasFormat:
             "w-alpha01",       # 9 chars, digit suffix OK
             "w-pp",            # 4 chars 境界, prefix あり
             "impl",            # 4 chars 境界, prefix なし → prefix 強制しないので OK
+            "w-tiny",          # 6 chars, 旧 8 文字制約では reject、緩和後 valid
+            "w-abcde",         # 7 chars, 同上
+            "abcdefg",         # 7 chars, prefix なし、同上
             "worker01",        # 8 chars, prefix なし OK
             "abcdefgh",        # 8 chars, ハイフンなし OK
             "w-a-b-c-d",       # 9 chars, 連続ハイフンを含まない多ハイフン OK

--- a/tests/unit/test_ow_spawn_alias_and_settings.py
+++ b/tests/unit/test_ow_spawn_alias_and_settings.py
@@ -1,6 +1,8 @@
 """ow_service: alias 書式バリデーションと worker workspace 用 settings.local.json 生成のテスト。
 
-- `_validate_alias_format`: 単独でのOK/NG分類（最小長 + kebab-case regex）
+- `_validate_alias_format`: 単独での OK/NG 分類。最小長は 4 文字、kebab-case 制約のみ。
+  prefix `w-` は推奨だが必須ではない。長さ・kebab-case 違反のエラー文言に推奨形式ヒント
+  (`Recommended:`) が含まれる
 - `_validate_spawn_preconditions` 経由での alias 書式違反 → ok=False
 - `ow_spawn_worker` 経由での書式違反 → SPAWN_PRECONDITION_FAILED
 - `_ensure_worker_askuser_deny`: 新規作成 / 既存 merge / dedup / 壊れた JSON 上書き
@@ -21,17 +23,22 @@ from src.services import ow_service
 
 
 class TestValidateAliasFormat:
-    """alias の書式（min-length 8 + kebab-case）のユニットテスト"""
+    """alias の書式 (最小長 4 + kebab-case) のユニットテスト。
+
+    prefix `w-` は強制しない（推奨にとどめる）。長さ違反・kebab-case 違反のエラー文言には
+    推奨形式ヒント (`Recommended:`) が必ず含まれる。
+    """
 
     @pytest.mark.parametrize(
         "alias",
         [
-            "w-playbook",      # 10 chars
+            "w-playbook",      # 10 chars, 推奨形式
             "w-alpha01",       # 9 chars, digit suffix OK
-            "w-tinyworker",    # 12 chars
-            "worker01",        # 8 chars exact
-            "abcdefgh",        # 8 chars, no hyphen
-            "w-a-b-c-d",       # 9 chars, multi-hyphen OK (末尾は英字)
+            "w-pp",            # 4 chars 境界, prefix あり
+            "impl",            # 4 chars 境界, prefix なし → prefix 強制しないので OK
+            "worker01",        # 8 chars, prefix なし OK
+            "abcdefgh",        # 8 chars, ハイフンなし OK
+            "w-a-b-c-d",       # 9 chars, 連続ハイフンを含まない多ハイフン OK
         ],
     )
     def test_valid_aliases_return_none(self, alias: str):
@@ -39,20 +46,26 @@ class TestValidateAliasFormat:
 
     @pytest.mark.parametrize(
         "alias",
-        ["", "w", "w-a", "w-tiny", "w-abcde", "abcdefg"],  # all < 8 chars
+        ["w", "w-a", "xx"],  # 3 文字以下は長さ違反
     )
-    def test_too_short_aliases_rejected(self, alias: str):
+    def test_too_short_aliases_rejected_with_recommended_hint(self, alias: str):
         err = ow_service._validate_alias_format(alias)
         assert err is not None
-        # 空文字は別メッセージ
-        if alias:
-            assert "too short" in err
+        assert "too short" in err
+        assert "Recommended:" in err
+
+    def test_empty_string_rejected_without_recommended_hint(self):
+        """空文字は型ガード相当の別系統エラー。推奨ヒントは付かない。"""
+        err = ow_service._validate_alias_format("")
+        assert err is not None
+        assert "non-empty" in err
 
     @pytest.mark.parametrize(
         "alias",
         [
             "W-playbook",      # 大文字始まり
             "w-Playbook",      # 大文字混入
+            "w-Abc",           # 大文字混入 (4 文字以上、長さは満たす)
             "w_playbook",      # アンダースコア禁止
             "-playbook",       # 先頭ハイフン
             "playbook-",       # 末尾ハイフン
@@ -60,13 +73,16 @@ class TestValidateAliasFormat:
             "w-play book",     # スペース
             "w-play.book",     # ドット
             "w-プレイブック",   # 非ASCII
+            "w--p",            # 連続ハイフン (4 文字、長さは満たす)
             "w--playbook",     # 連続ハイフン
             "abc---def",       # 3連続ハイフン
         ],
     )
-    def test_invalid_kebab_case_rejected(self, alias: str):
+    def test_invalid_kebab_case_rejected_with_recommended_hint(self, alias: str):
         err = ow_service._validate_alias_format(alias)
         assert err is not None
+        assert "kebab-case" in err
+        assert "Recommended:" in err
 
     def test_non_string_rejected(self):
         # 型ガードも兼ねる

--- a/tests/unit/test_ow_spawn_dispatcher.py
+++ b/tests/unit/test_ow_spawn_dispatcher.py
@@ -75,6 +75,8 @@ class TestValidateDispatcherHandle:
     def test_invalid_chars_after_prefix_rejected(self, handle: str):
         err = ow_service._validate_dispatcher_handle(handle)
         assert err is not None
+        assert "invalid characters" in err
+        assert "lowercase letter" in err
 
 
 # ----------------------------


### PR DESCRIPTION
## Summary

- worker alias の最小長を 8 → 4 に緩和し、ユーザー・AI が短い handle を取りやすくする
- prefix `w-` は推奨にとどめ強制しない（kebab-case 制約だけ維持）
- 命名規約の正本を `ow_spawn_worker` の tool docstring に集約し、推奨形式 `w-<purpose>-<activity_id>` を示す
- 書式エラー文言に `Recommended:` ヒントを添えて、引っかかった呼び出し側が自力で直せるようソフトに誘導

## Behavior change

Before:
- `w-pp` (4 文字) や `impl` (4 文字、prefix なし) はバリデーションで弾かれて spawn 不能
- エラー文言は「短すぎる」「kebab-case 違反」とだけ伝え、何が良い形か示さない

After:
- 4 文字以上で kebab-case を満たせば通る。prefix `w-` を付けるかは呼び出し側の判断（推奨）
- 長さ違反・kebab-case 違反のエラー末尾に `Recommended: w-<purpose>-<activity_id> (e.g. w-design-1064).` が付き、推奨形式に倒すヒントになる
- 3 文字以下 (`w-a` 等) や大文字混入・連続ハイフンは引き続き拒否

## Out of scope

別ターンで対応する範囲:

- glossary:ow material の命名規約セクション更新（docstring を正本とした参照差し替え）
- orch / dispatcher / worker SKILL.md の sweep（命名規約の重複記述を docstring ポインタに統一）
- 2 層 ID 体系（物理 ID + 論理名）の本質再設計
- dispatcher handle (`d-` prefix) 側の validator 緩和
- alias を自動生成する `_suggest_alias` ヘルパーの追加（ソフト誘導路線では warning メッセージのみで十分と判断）

## Test plan

`tests/unit/test_ow_spawn_alias_and_settings.py` の `TestValidateAliasFormat` を新仕様に合わせて再構成し、以下を保証:

- 4 文字境界 (`w-pp` / `impl`) が valid 扱いになる
- prefix なし 4 文字 (`impl`) も valid（prefix `w-` を強制しないことの保証）
- 3 文字以下 (`w`, `w-a`, `xx`) は長さ違反、エラー文言に `Recommended:` が含まれる
- 大文字混入・連続ハイフン (`w-Abc`, `w--p` 等) は kebab-case 違反、エラー文言に `Recommended:` が含まれる
- 空文字は型ガード相当の別系統エラーで推奨ヒントは付かない（混乱を避けるため）

`_validate_spawn_preconditions` / `ow_spawn_worker` 経由のテストは既存ケース (`w-a` / `W-Playbook` / `w_playbook` / `w-playbook`) のまま新仕様でも期待挙動が変わらないため、変更なしで pass する。

ow 関連の全ユニットテスト (516 件) を回して回帰なしを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)