### PR TITLE
feat: export_material tool 新設（資材を md ファイルに出力）

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -862,6 +862,46 @@ def get_material(
 
 
 @mcp.tool()
+def export_material(
+    material_id: int,
+    dest_path: Optional[str] = None,
+) -> dict:
+    """
+    Choose: 資材の全文を cc-memory 外で参照したい（obsidian vault に置く / docs リポに commit する / third-party レビュー用に配布する）とき。cc-memory 内で読むだけなら get_material、複数種別を横断で全文取得したいなら get_by_ids。
+
+    資材を YAML frontmatter + h1 + content 形式の md ファイルとして出力する。
+
+    出力ファイル構造:
+        ---
+        <YAML frontmatter>
+        ---
+
+        # <title>
+
+        <content>
+
+    frontmatter には資材のメタ情報（識別子・title・tags・source・関連エンティティ・
+    created_at・updated_at）を含む。往復同期の鍵として資材IDを frontmatter に保持する。
+
+    dest_path の 3 パターン振り分け:
+    - 省略時: ~/cc-memory-export/M-{id}-{title-slug}.md に出力
+    - 既存ディレクトリを指定: そのディレクトリ配下に M-{id}-{title-slug}.md として出力
+    - ファイルパスを指定: そのパスをそのまま使用（親ディレクトリは自動作成）
+
+    上書き確認はしない。既存ファイルは無警告で上書きされる（戻り値の overwritten で通知）。
+
+    Args:
+        material_id: 資材のID
+        dest_path: 出力先パス（optional）。省略/ディレクトリ/ファイルパスで振り分ける
+
+    Returns:
+        成功時: {"path": 絶対パス, "overwritten": 既存ファイルを上書きしたか, "material_id": ID, "title": タイトル}
+        失敗時: {"error": {"code": "NOT_FOUND" | "IO_ERROR" | "DATABASE_ERROR", "message": str}}
+    """
+    return material_service.export_material_to_file(material_id, dest_path=dest_path)
+
+
+@mcp.tool()
 def check_in(
     activity_id: int,
     flavor: _FlavorArg = "internal",

--- a/src/main.py
+++ b/src/main.py
@@ -888,15 +888,21 @@ def export_material(
     - 既存ディレクトリを指定: そのディレクトリ配下に M-{id}-{title-slug}.md として出力
     - ファイルパスを指定: そのパスをそのまま使用（親ディレクトリは自動作成）
 
+    書き込み先は ~/cc-memory-export 配下に限定される。配下外を指す dest_path
+    （シンボリックリンク経由の脱出を含む）は VALIDATION_ERROR で拒否され、
+    ファイルもディレクトリも作成されない。cc-memory 管理外の場所（obsidian vault や
+    docs リポ等）へ置きたい場合は、この配下に出力してから移動する。
+
     上書き確認はしない。既存ファイルは無警告で上書きされる（戻り値の overwritten で通知）。
 
     Args:
         material_id: 資材のID
-        dest_path: 出力先パス（optional）。省略/ディレクトリ/ファイルパスで振り分ける
+        dest_path: 出力先パス（optional）。省略/ディレクトリ/ファイルパスで振り分ける。
+            指定する場合は ~/cc-memory-export 配下でなければならない
 
     Returns:
         成功時: {"path": 絶対パス, "overwritten": 既存ファイルを上書きしたか, "material_id": ID, "title": タイトル}
-        失敗時: {"error": {"code": "NOT_FOUND" | "IO_ERROR" | "DATABASE_ERROR", "message": str}}
+        失敗時: {"error": {"code": "NOT_FOUND" | "VALIDATION_ERROR" | "IO_ERROR" | "DATABASE_ERROR", "message": str}}
     """
     return material_service.export_material_to_file(material_id, dest_path=dest_path)
 

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -57,6 +57,7 @@ CAPABILITY_MATRIX: CapabilityMatrix = {
     "get_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
     "get_topics":        {"orch": True,  "dispatcher": True,  "worker": True},
     "get_material":      {"orch": True,  "dispatcher": True,  "worker": True},
+    "export_material":   {"orch": True,  "dispatcher": True,  "worker": True},
     "get_habits":        {"orch": True,  "dispatcher": True,  "worker": True},
     "get_map":           {"orch": True,  "dispatcher": True,  "worker": True},
     "get_timeline":      {"orch": True,  "dispatcher": True,  "worker": True},

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -1,7 +1,11 @@
 """資材管理サービス"""
 import logging
+import os
+import re
 import sqlite3
 from typing import Literal, Optional
+
+import yaml
 
 from src.db import get_connection, row_to_dict
 from src.services.readable_id import apply_readable_id_inplace
@@ -418,3 +422,148 @@ def get_material(material_id: int, include_retracted: bool = False) -> dict:
         }
     finally:
         conn.close()
+
+
+DEFAULT_EXPORT_DIR = "~/cc-memory-export"
+SLUG_MAX_LEN = 50
+
+
+def _slugify_title(title: str) -> str:
+    """ファイル名に安全な slug を返す。
+
+    ASCII 英数字とハイフン以外を "-" に置換し、連続 "-" を圧縮、
+    先頭末尾 "-" を除去、SLUG_MAX_LEN で切り詰め、空文字なら "untitled"。
+    日本語 title は事実上全てハイフン化されるため、"untitled" にフォールバックする。
+    """
+    slug = re.sub(r"[^A-Za-z0-9-]+", "-", title or "")
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    if len(slug) > SLUG_MAX_LEN:
+        slug = slug[:SLUG_MAX_LEN].rstrip("-")
+    return slug or "untitled"
+
+
+def _resolve_dest_path(entity_id: int, title: str, dest_path: Optional[str]) -> str:
+    """dest_path を 3 パターンで振り分けて絶対パスを返す。
+
+    - None: DEFAULT_EXPORT_DIR/M-{id}-{slug}.md
+    - 既存ディレクトリ: そこに M-{id}-{slug}.md
+    - それ以外: ユーザー指定パスをそのまま使用（親ディレクトリの自動作成対象）
+    """
+    slug = _slugify_title(title)
+    filename = f"M-{entity_id}-{slug}.md"
+    if dest_path is None:
+        return os.path.join(os.path.expanduser(DEFAULT_EXPORT_DIR), filename)
+    expanded = os.path.expanduser(dest_path)
+    if os.path.isdir(expanded):
+        return os.path.join(expanded, filename)
+    return expanded
+
+
+def _get_material_relations_with_conn(conn, entity_id: int) -> list[dict]:
+    """material が source または target として参加している relations を related 配列にする。"""
+    rows = conn.execute(
+        """
+        SELECT target_type AS type, target_id AS eid FROM relations
+          WHERE source_type = 'material' AND source_id = ?
+        UNION
+        SELECT source_type AS type, source_id AS eid FROM relations
+          WHERE target_type = 'material' AND target_id = ?
+        ORDER BY type, eid
+        """,
+        (entity_id, entity_id),
+    ).fetchall()
+    return [{"type": r["type"], "id": r["eid"]} for r in rows]
+
+
+def _build_frontmatter(
+    entity_id: int,
+    title: str,
+    tags: list[str],
+    source: str,
+    related: list[dict],
+    created_at: str,
+    updated_at: str,
+) -> str:
+    """YAML frontmatter 文字列（`---\\n...\\n---\\n`）を返す。"""
+    data = {
+        "material_id": entity_id,
+        "title": title,
+        "tags": list(tags),
+        "source": source,
+        "related": related,
+        "created_at": created_at,
+        "updated_at": updated_at,
+    }
+    body = yaml.safe_dump(
+        data,
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    return f"---\n{body}---\n"
+
+
+def export_material_to_file(material_id: int, dest_path: Optional[str] = None) -> dict:
+    """資材を md ファイルとして出力する。
+
+    Returns:
+        成功時: {"path": str, "overwritten": bool, "material_id": int, "title": str}
+        失敗時: {"error": {"code": str, "message": str}}
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM materials WHERE id = ?", (material_id,)
+        ).fetchone()
+        if not row or row["retracted_at"] is not None:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"Material with id {material_id} not found",
+                }
+            }
+
+        material = row_to_dict(row)
+        tags = get_entity_tags(conn, "material_tags", "material_id", material_id)
+        related = _get_material_relations_with_conn(conn, material_id)
+    except Exception as e:
+        return {"error": {"code": "DATABASE_ERROR", "message": str(e)}}
+    finally:
+        conn.close()
+
+    title = material["title"]
+    content = material["content"] or ""
+    frontmatter = _build_frontmatter(
+        entity_id=material_id,
+        title=title,
+        tags=tags,
+        source=material["source"],
+        related=related,
+        created_at=material["created_at"],
+        updated_at=material.get("updated_at") or material["created_at"],
+    )
+    body = f"{frontmatter}\n# {title}\n\n{content}"
+    if not body.endswith("\n"):
+        body += "\n"
+
+    path = _resolve_dest_path(material_id, title, dest_path)
+    parent = os.path.dirname(path)
+    if parent:
+        try:
+            os.makedirs(parent, exist_ok=True)
+        except OSError as e:
+            return {"error": {"code": "IO_ERROR", "message": str(e)}}
+
+    overwritten = os.path.exists(path)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body)
+    except OSError as e:
+        return {"error": {"code": "IO_ERROR", "message": str(e)}}
+
+    return {
+        "path": path,
+        "overwritten": overwritten,
+        "material_id": material_id,
+        "title": title,
+    }

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -447,7 +447,7 @@ def _resolve_dest_path(entity_id: int, title: str, dest_path: Optional[str]) -> 
 
     - None: DEFAULT_EXPORT_DIR/M-{id}-{slug}.md
     - 既存ディレクトリ: そこに M-{id}-{slug}.md
-    - それ以外: ユーザー指定パスをそのまま使用（親ディレクトリの自動作成対象）
+    - それ以外: ユーザー指定パスを絶対パス化して使用（親ディレクトリの自動作成対象）
     """
     slug = _slugify_title(title)
     filename = f"M-{entity_id}-{slug}.md"
@@ -455,24 +455,35 @@ def _resolve_dest_path(entity_id: int, title: str, dest_path: Optional[str]) -> 
         return os.path.join(os.path.expanduser(DEFAULT_EXPORT_DIR), filename)
     expanded = os.path.expanduser(dest_path)
     if os.path.isdir(expanded):
-        return os.path.join(expanded, filename)
-    return expanded
+        return os.path.abspath(os.path.join(expanded, filename))
+    return os.path.abspath(expanded)
+
+
+def _is_within_export_dir(path: str) -> bool:
+    """path が DEFAULT_EXPORT_DIR のサブツリー内かを realpath 基準で判定する。
+
+    許可ルート・対象パス双方を realpath で正規化してから比較するため、
+    シンボリックリンク経由で許可ルート外へ抜けるパスも配下外と判定される。
+    """
+    export_root = os.path.realpath(os.path.expanduser(DEFAULT_EXPORT_DIR))
+    resolved = os.path.realpath(path)
+    return resolved == export_root or resolved.startswith(export_root + os.sep)
 
 
 def _get_material_relations_with_conn(conn, entity_id: int) -> list[dict]:
-    """material が source または target として参加している relations を related 配列にする。"""
+    """material に直接紐づく関連エンティティを related 配列にする。
+
+    relations_view は related の正方向・逆方向を UNION ALL 済みのため、material を
+    source とする1クエリで双方向の直接関連が揃う。depends_on / supersedes は
+    activity / decision 専用で material には該当しない。
+    """
     rows = conn.execute(
-        """
-        SELECT target_type AS type, target_id AS eid FROM relations
-          WHERE source_type = 'material' AND source_id = ?
-        UNION
-        SELECT source_type AS type, source_id AS eid FROM relations
-          WHERE target_type = 'material' AND target_id = ?
-        ORDER BY type, eid
-        """,
-        (entity_id, entity_id),
+        "SELECT target_type, target_id FROM relations_view "
+        "WHERE source_type = ? AND source_id = ? "
+        "ORDER BY target_type, target_id",
+        ("material", entity_id),
     ).fetchall()
-    return [{"type": r["type"], "id": r["eid"]} for r in rows]
+    return [{"type": r["target_type"], "id": r["target_id"]} for r in rows]
 
 
 def _build_frontmatter(
@@ -505,6 +516,10 @@ def _build_frontmatter(
 
 def export_material_to_file(material_id: int, dest_path: Optional[str] = None) -> dict:
     """資材を md ファイルとして出力する。
+
+    書き込み先は DEFAULT_EXPORT_DIR のサブツリー内に限定する。配下外を指す
+    dest_path（シンボリックリンク経由の脱出を含む）は VALIDATION_ERROR で拒否し、
+    ディレクトリ作成もファイル書き込みも一切行わない。
 
     Returns:
         成功時: {"path": str, "overwritten": bool, "material_id": int, "title": str}
@@ -547,6 +562,17 @@ def export_material_to_file(material_id: int, dest_path: Optional[str] = None) -
         body += "\n"
 
     path = _resolve_dest_path(material_id, title, dest_path)
+    if not _is_within_export_dir(path):
+        allowed = os.path.expanduser(DEFAULT_EXPORT_DIR)
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": (
+                    f"dest_path must resolve to a location within {allowed}. "
+                    f"resolved path: {path}"
+                ),
+            }
+        }
     parent = os.path.dirname(path)
     if parent:
         try:

--- a/tests/integration/test_export_material_tool.py
+++ b/tests/integration/test_export_material_tool.py
@@ -60,6 +60,17 @@ def material_with_related(temp_db):
     return result["material_id"], activity_id
 
 
+@pytest.fixture(autouse=True)
+def _export_dir_under_tmp(monkeypatch, tmp_path):
+    """書き込みガードの許可ルートを各テストの tmp_path に向ける。
+
+    export_material_to_file は DEFAULT_EXPORT_DIR 配下のみ書き込みを許可する。
+    テストの dest_path はすべて tmp_path 配下を指すため、許可ルートを tmp_path に
+    合わせることで通常ケースを許可し、配下外テストは tmp_path 外を指して検証する。
+    """
+    monkeypatch.setattr("src.services.material_service.DEFAULT_EXPORT_DIR", str(tmp_path))
+
+
 def _read(path: str) -> str:
     with open(path, "r", encoding="utf-8") as f:
         return f.read()
@@ -172,6 +183,39 @@ class TestErrors:
         )
         assert "error" in result
         assert result["error"]["code"] == "NOT_FOUND"
+
+
+class TestPathGuard:
+    def test_path_outside_export_dir_is_rejected(self, material_id, tmp_path):
+        with tempfile.TemporaryDirectory() as outside:
+            target = os.path.join(outside, "escape.md")
+            result = export_material_to_file(material_id, dest_path=target)
+            assert "error" in result
+            assert result["error"]["code"] == "VALIDATION_ERROR"
+            assert not os.path.exists(target)
+
+    def test_rejection_does_not_create_parent_dir(self, material_id, tmp_path):
+        with tempfile.TemporaryDirectory() as outside:
+            target = os.path.join(outside, "new-sub", "escape.md")
+            result = export_material_to_file(material_id, dest_path=target)
+            assert result["error"]["code"] == "VALIDATION_ERROR"
+            assert not os.path.exists(os.path.join(outside, "new-sub"))
+
+    def test_symlink_escape_is_rejected(self, material_id, tmp_path):
+        with tempfile.TemporaryDirectory() as outside:
+            link = tmp_path / "vault-link"
+            os.symlink(outside, str(link))
+            target = link / "escape.md"
+            result = export_material_to_file(material_id, dest_path=str(target))
+            assert "error" in result
+            assert result["error"]["code"] == "VALIDATION_ERROR"
+            assert not os.path.exists(os.path.join(outside, "escape.md"))
+
+    def test_error_message_names_allowed_dir(self, material_id, tmp_path):
+        with tempfile.TemporaryDirectory() as outside:
+            target = os.path.join(outside, "escape.md")
+            result = export_material_to_file(material_id, dest_path=target)
+            assert str(tmp_path) in result["error"]["message"]
 
 
 class TestMcpTool:

--- a/tests/integration/test_export_material_tool.py
+++ b/tests/integration/test_export_material_tool.py
@@ -1,0 +1,189 @@
+"""export_material MCP tool の統合テスト"""
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from src.db import init_database
+from src.services.activity_service import add_activity
+from src.services.material_service import add_material, export_material_to_file
+from src.services.retract_service import retract
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時DB。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def material_id(temp_db):
+    """基本的な資材を1件作成して material_id を返す。"""
+    result = add_material(
+        title="Export Sample",
+        content="# 見出し\n\nこれは export 用のサンプル本文です。\n",
+        tags=["domain:test", "export-test"],
+        source="unit test",
+    )
+    assert "error" not in result
+    return result["material_id"]
+
+
+@pytest.fixture
+def material_with_related(temp_db):
+    """関連付きの資材を作成し material_id を返す。"""
+    activity = add_activity(
+        title="Related Activity",
+        description="for export test",
+        tags=DEFAULT_TAGS,
+        check_in=False,
+    )
+    activity_id = activity["activity_id"]
+    result = add_material(
+        title="Related Material",
+        content="content body",
+        tags=["domain:test"],
+        source="unit test",
+        related=[{"type": "activity", "ids": [activity_id]}],
+    )
+    assert "error" not in result
+    return result["material_id"], activity_id
+
+
+def _read(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    """`---\\n...\\n---\\n\\n# ...` を frontmatter dict と body に分解する。"""
+    assert text.startswith("---\n"), text[:20]
+    end = text.index("\n---\n", 4)
+    fm_body = text[4:end]
+    remainder = text[end + len("\n---\n") :]
+    return yaml.safe_load(fm_body), remainder
+
+
+class TestExportDestPathVariants:
+    def test_dest_path_omitted_uses_default_dir(self, material_id, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "src.services.material_service.DEFAULT_EXPORT_DIR", str(tmp_path)
+        )
+        result = export_material_to_file(material_id)
+        assert "error" not in result
+        assert result["material_id"] == material_id
+        assert result["path"] == os.path.join(
+            str(tmp_path), f"M-{material_id}-Export-Sample.md"
+        )
+        assert result["overwritten"] is False
+        assert os.path.isfile(result["path"])
+
+    def test_dest_path_directory_places_default_filename(self, material_id, tmp_path):
+        result = export_material_to_file(material_id, dest_path=str(tmp_path))
+        assert "error" not in result
+        assert result["path"] == os.path.join(
+            str(tmp_path), f"M-{material_id}-Export-Sample.md"
+        )
+        assert os.path.isfile(result["path"])
+
+    def test_dest_path_file_uses_it_as_is(self, material_id, tmp_path):
+        target = tmp_path / "sub" / "custom-name.md"
+        result = export_material_to_file(material_id, dest_path=str(target))
+        assert "error" not in result
+        assert result["path"] == str(target)
+        assert os.path.isfile(result["path"])
+
+
+class TestOverwriteFlag:
+    def test_first_write_overwritten_false(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        result = export_material_to_file(material_id, dest_path=str(target))
+        assert result["overwritten"] is False
+
+    def test_second_write_overwritten_true(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        export_material_to_file(material_id, dest_path=str(target))
+        result = export_material_to_file(material_id, dest_path=str(target))
+        assert result["overwritten"] is True
+
+
+class TestOutputStructure:
+    def test_body_starts_with_frontmatter_fence(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        export_material_to_file(material_id, dest_path=str(target))
+        text = _read(str(target))
+        assert text.startswith("---\n")
+
+    def test_h1_uses_title(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        export_material_to_file(material_id, dest_path=str(target))
+        text = _read(str(target))
+        _, body = _split_frontmatter(text)
+        assert body.startswith("\n# Export Sample\n\n")
+
+    def test_frontmatter_contains_required_fields(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        export_material_to_file(material_id, dest_path=str(target))
+        fm, _ = _split_frontmatter(_read(str(target)))
+        assert fm["material_id"] == material_id
+        assert fm["title"] == "Export Sample"
+        assert set(fm["tags"]) == {"domain:test", "export-test"}
+        assert fm["source"] == "unit test"
+        assert "created_at" in fm
+        assert "updated_at" in fm
+        assert fm["related"] == []
+
+    def test_related_reflects_relations(self, material_with_related, tmp_path):
+        mid, aid = material_with_related
+        target = tmp_path / "out.md"
+        export_material_to_file(mid, dest_path=str(target))
+        fm, _ = _split_frontmatter(_read(str(target)))
+        assert {"type": "activity", "id": aid} in fm["related"]
+
+    def test_content_is_preserved(self, material_id, tmp_path):
+        target = tmp_path / "out.md"
+        export_material_to_file(material_id, dest_path=str(target))
+        text = _read(str(target))
+        assert "これは export 用のサンプル本文です。" in text
+
+
+class TestErrors:
+    def test_missing_material_returns_not_found(self, temp_db, tmp_path):
+        result = export_material_to_file(999999, dest_path=str(tmp_path / "x.md"))
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_retracted_material_returns_not_found(self, material_id, tmp_path):
+        r = retract("material", [material_id])
+        assert "error" not in r, r
+        assert material_id in r.get("success", [])
+        result = export_material_to_file(
+            material_id, dest_path=str(tmp_path / "x.md")
+        )
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+
+class TestMcpTool:
+    def test_mcp_tool_end_to_end(self, material_id, tmp_path):
+        """main.py 経由の MCP tool から呼んでも同じ挙動になる。"""
+        from src import main as main_mod
+
+        target = tmp_path / "mcp-out.md"
+        # FastMCP 3.x で @mcp.tool() は元関数を返すのでそのまま呼べる
+        result = main_mod.export_material(material_id, dest_path=str(target))
+        assert "error" not in result
+        assert result["path"] == str(target)
+        assert os.path.isfile(result["path"])
+        fm, _ = _split_frontmatter(_read(str(target)))
+        assert fm["material_id"] == material_id

--- a/tests/unit/test_material_service.py
+++ b/tests/unit/test_material_service.py
@@ -1,0 +1,107 @@
+"""material_service の純粋関数（DB非依存）ユニットテスト"""
+import os
+
+from src.services.material_service import (
+    DEFAULT_EXPORT_DIR,
+    SLUG_MAX_LEN,
+    _build_frontmatter,
+    _resolve_dest_path,
+    _slugify_title,
+)
+
+
+class TestSlugifyTitle:
+    def test_ascii_alnum_and_hyphen_are_preserved(self):
+        assert _slugify_title("hello-world-42") == "hello-world-42"
+
+    def test_spaces_and_symbols_are_replaced_with_hyphen(self):
+        assert _slugify_title("hello world! foo/bar") == "hello-world-foo-bar"
+
+    def test_consecutive_replacement_is_compressed(self):
+        assert _slugify_title("a   b___c") == "a-b-c"
+
+    def test_leading_and_trailing_hyphens_are_stripped(self):
+        assert _slugify_title("---foo---") == "foo"
+
+    def test_japanese_only_title_becomes_untitled(self):
+        assert _slugify_title("設計メモ") == "untitled"
+
+    def test_empty_string_becomes_untitled(self):
+        assert _slugify_title("") == "untitled"
+
+    def test_only_symbols_becomes_untitled(self):
+        assert _slugify_title("***///") == "untitled"
+
+    def test_truncated_to_max_length_without_trailing_hyphen(self):
+        title = "a" * (SLUG_MAX_LEN + 20)
+        slug = _slugify_title(title)
+        assert len(slug) == SLUG_MAX_LEN
+        assert not slug.endswith("-")
+
+    def test_truncation_strips_trailing_hyphen(self):
+        title = "a" * SLUG_MAX_LEN + " " + "b" * 10
+        slug = _slugify_title(title)
+        assert len(slug) <= SLUG_MAX_LEN
+        assert not slug.endswith("-")
+
+
+class TestResolveDestPath:
+    def test_none_uses_default_export_dir(self):
+        path = _resolve_dest_path(123, "hello", None)
+        expected_prefix = os.path.expanduser(DEFAULT_EXPORT_DIR)
+        assert path.startswith(expected_prefix + os.sep)
+        assert path.endswith("M-123-hello.md")
+
+    def test_existing_dir_places_default_filename_under_it(self, tmp_path):
+        path = _resolve_dest_path(7, "foo bar", str(tmp_path))
+        assert path == os.path.join(str(tmp_path), "M-7-foo-bar.md")
+
+    def test_non_existing_path_is_used_as_file_path(self, tmp_path):
+        target = tmp_path / "sub" / "custom.md"
+        path = _resolve_dest_path(9, "irrelevant", str(target))
+        assert path == str(target)
+
+    def test_japanese_title_falls_back_to_untitled_in_default_filename(self, tmp_path):
+        path = _resolve_dest_path(5, "設計メモ", str(tmp_path))
+        assert path == os.path.join(str(tmp_path), "M-5-untitled.md")
+
+    def test_expanduser_on_dest_path(self):
+        path = _resolve_dest_path(1, "t", "~/nonexistent-cc-memory-test-file.md")
+        assert not path.startswith("~")
+
+
+class TestBuildFrontmatter:
+    def test_wraps_body_with_hyphen_fences(self):
+        fm = _build_frontmatter(
+            entity_id=1,
+            title="t",
+            tags=["a"],
+            source="s",
+            related=[],
+            created_at="2026-01-01 00:00:00",
+            updated_at="2026-01-01 00:00:00",
+        )
+        assert fm.startswith("---\n")
+        assert fm.endswith("---\n")
+
+    def test_yaml_content_contains_all_required_keys(self):
+        import yaml
+
+        fm = _build_frontmatter(
+            entity_id=42,
+            title="サンプル",
+            tags=["domain:test", "feature"],
+            source="unit-test",
+            related=[{"type": "activity", "id": 100}],
+            created_at="2026-06-01 12:00:00",
+            updated_at="2026-06-02 12:00:00",
+        )
+        body = fm.strip().strip("-").strip()
+        parsed = yaml.safe_load(body)
+        assert parsed["material_id"] == 42
+        assert parsed["title"] == "サンプル"
+        assert parsed["tags"] == ["domain:test", "feature"]
+        assert parsed["source"] == "unit-test"
+        assert parsed["related"] == [{"type": "activity", "id": 100}]
+        assert parsed["created_at"] == "2026-06-01 12:00:00"
+        assert parsed["updated_at"] == "2026-06-02 12:00:00"

--- a/tests/unit/test_material_service.py
+++ b/tests/unit/test_material_service.py
@@ -69,6 +69,16 @@ class TestResolveDestPath:
         path = _resolve_dest_path(1, "t", "~/nonexistent-cc-memory-test-file.md")
         assert not path.startswith("~")
 
+    def test_relative_file_path_is_made_absolute(self):
+        path = _resolve_dest_path(3, "t", "out.md")
+        assert os.path.isabs(path)
+        assert path == os.path.abspath("out.md")
+
+    def test_relative_subdir_file_path_is_made_absolute(self):
+        path = _resolve_dest_path(4, "t", os.path.join("sub", "out.md"))
+        assert os.path.isabs(path)
+        assert path == os.path.abspath(os.path.join("sub", "out.md"))
+
 
 class TestBuildFrontmatter:
     def test_wraps_body_with_hyphen_fences(self):


### PR DESCRIPTION
## Summary

- 資材を YAML frontmatter + h1 + content 形式の md ファイルに書き出す `export_material` MCP tool を新設
- `dest_path` を省略 / 既存ディレクトリ / ファイルパスの 3 パターンで振り分け、`~/cc-memory-export/` を既定出力先とする
- frontmatter に識別子・title・tags・source・関連エンティティ・created_at・updated_at を保持し、往復同期の鍵を残す

## Behavior

- 上書きは無確認。既存ファイル有無は戻り値の `overwritten` で通知する
- 対象資材が存在しない・retract 済みの場合は `NOT_FOUND` を返す
- 出力先の親ディレクトリは自動作成
- content は加工せずそのまま貼り付ける

## Test plan

- 新規 unit test で保証している振る舞い
  - `_slugify_title`: ASCII 英数字とハイフンのみ保持 / 記号は `-` に置換 / 連続 `-` の圧縮 / 先頭末尾 `-` の除去 / 日本語のみ・空文字・記号のみは `untitled` にフォールバック / SLUG_MAX_LEN で切り詰め時も末尾 `-` を残さない
  - `_resolve_dest_path`: 省略時は既定ディレクトリ配下 / 既存ディレクトリはその下に既定ファイル名 / 存在しないパスはそのまま採用 / `~` は expand
  - `_build_frontmatter`: `---` フェンスで包み、YAML パースで material_id / title / tags / source / related / created_at / updated_at の全キーを保持する
- 新規 integration test で保証している振る舞い
  - dest_path の 3 パターン（省略 / ディレクトリ / ファイルパス）で正しい出力先を選ぶ
  - 新規書き込みは `overwritten=false`、同パスへの再書き込みは `overwritten=true`
  - 出力ファイルは `---\n` で始まり、frontmatter 直後に `# {title}` が来る
  - frontmatter に必須キーが揃い、related は relations テーブルの内容を反映する
  - content は加工なしで書き出される
  - 存在しない ID・retract 済み資材は `NOT_FOUND`
  - MCP tool 経由 (`main.export_material`) でも同じ結果になる
- 既存の material 系テスト（16 unit + 47 integration）は破壊なし、合計 76 件 pass 維持