### PR TITLE
feat: get_decisions と search に supersede chain 情報を追加

### DIFF
--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -15,6 +15,7 @@ from src.services.tag_service import (
 )
 from src.services.habit_service import _add_habit_with_conn
 from src.services.relation_service import _add_relation_with_conn
+from src.services.supersede_service import compute_supersede_info_batch
 from src.services.title_validation import validate_title
 
 PROPAGATE_TYPES = {"habit", "tag_note"}
@@ -224,6 +225,39 @@ def add_decisions(items: list[dict], caller_session_id: Optional[str] = None) ->
         conn.close()
 
 
+def _build_decision_item(
+    dec: dict,
+    tags_map: dict[int, list[str]],
+    supersede_map: dict[int, dict],
+) -> dict:
+    """SELECT * FROM decisions の 1 行から返却用の decision item を組み立てる。
+
+    is_superseded / is_retracted / supersede_chain をここで付与する。詳細:
+    - is_retracted は decisions.retracted_at の NOT NULL 判定
+    - is_superseded / supersede_chain は supersede_service.compute_supersede_info_batch の結果
+    - retracted_at 生値は従来通り retracted 済みのときのみ含める (retract 時刻が呼出側で必要)
+    """
+    display_title = dec.get("title") or (dec["decision"] or "")[:50]
+    supersede_info = supersede_map.get(
+        dec["id"], {"is_superseded": False, "supersede_chain": [dec["id"]]}
+    )
+    item = {
+        "id": dec["id"],
+        "title": display_title,
+        "decision": dec["decision"],
+        "reason": dec["reason"],
+        "tags": tags_map.get(dec["id"], []),
+        "created_at": dec["created_at"],
+        "is_superseded": supersede_info["is_superseded"],
+        "is_retracted": bool(dec.get("retracted_at")),
+        "supersede_chain": supersede_info["supersede_chain"],
+    }
+    if dec.get("retracted_at"):
+        item["retracted_at"] = dec["retracted_at"]
+    apply_readable_id_inplace(item, "decision")
+    return item
+
+
 def get_decisions(
     entity_type: str,
     entity_id: int,
@@ -300,23 +334,13 @@ def get_decisions(
 
             # バッチでタグ取得
             tags_map = get_effective_tags_batch(conn, "decision", topic_id)
+            decision_ids = [row_to_dict(row)["id"] for row in rows]
+            supersede_map = compute_supersede_info_batch(conn, decision_ids)
 
             decisions = []
             for row in rows:
                 dec = row_to_dict(row)
-                # α化用 title: 明示 title 優先、無ければ decision 本文先頭をフォールバック
-                display_title = dec.get("title") or (dec["decision"] or "")[:50]
-                item = {
-                    "id": dec["id"],
-                    "title": display_title,
-                    "decision": dec["decision"],
-                    "reason": dec["reason"],
-                    "tags": tags_map.get(dec["id"], []),
-                    "created_at": dec["created_at"],
-                }
-                if dec.get("retracted_at"):
-                    item["retracted_at"] = dec["retracted_at"]
-                apply_readable_id_inplace(item, "decision")
+                item = _build_decision_item(dec, tags_map, supersede_map)
                 decisions.append(item)
 
             return {
@@ -370,23 +394,12 @@ def get_decisions(
             # 全topic_idを横断してバッチでタグ取得
             decision_ids = [row_to_dict(row)["id"] for row in rows]
             tags_map = get_effective_tags_batch_by_ids(conn, "decision", decision_ids) if decision_ids else {}
+            supersede_map = compute_supersede_info_batch(conn, decision_ids)
 
             decisions = []
             for row in rows:
                 dec = row_to_dict(row)
-                # α化用 title: 明示 title 優先、無ければ decision 本文先頭をフォールバック
-                display_title = dec.get("title") or (dec["decision"] or "")[:50]
-                item = {
-                    "id": dec["id"],
-                    "title": display_title,
-                    "decision": dec["decision"],
-                    "reason": dec["reason"],
-                    "tags": tags_map.get(dec["id"], []),
-                    "created_at": dec["created_at"],
-                }
-                if dec.get("retracted_at"):
-                    item["retracted_at"] = dec["retracted_at"]
-                apply_readable_id_inplace(item, "decision")
+                item = _build_decision_item(dec, tags_map, supersede_map)
                 decisions.append(item)
 
             return {"decisions": decisions}

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -4,6 +4,7 @@ import sqlite3
 from typing import Optional, Union
 
 from src.db import get_connection
+from src.services.supersede_service import get_superseded_by_batch
 from src.services.tag_service import parse_tag, resolve_tag_ids
 
 logger = logging.getLogger(__name__)
@@ -21,15 +22,11 @@ ENTITY_TABLE_MAP = {
 def _is_decision_superseded(conn: sqlite3.Connection, decision_id: int) -> Optional[int]:
     """decisionがsupersedeされていれば、supersederのdecision_id（1件）を返す。
 
-    複数のsupersederがある場合は最新の created_at の1件を返す。
+    複数のsupersederがある場合は最新の1件を返す（最新判定の tie-break は
+    get_superseded_by_batch に委譲して全経路で一致させる）。
     superseded されていなければ None。
     """
-    row = conn.execute(
-        "SELECT source_id FROM decision_supersedes WHERE target_id = ? "
-        "ORDER BY created_at DESC LIMIT 1",
-        (decision_id,),
-    ).fetchone()
-    return row["source_id"] if row else None
+    return get_superseded_by_batch(conn, [decision_id])[decision_id]
 
 
 def _transfer_pins_with_conn(

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -16,6 +16,7 @@ from sqlite_vec import serialize_float32
 from src.db import execute_query, get_connection, get_db_path, row_to_dict
 from src.services import embedding_service
 from src.services.readable_id import apply_readable_id_inplace
+from src.services.supersede_service import get_superseded_by_batch
 from src.services.tag_service import (
     get_entity_tags,
     get_entity_tags_batch,
@@ -1641,12 +1642,32 @@ def _slice(ctx: SearchContext, results: list[dict]) -> tuple[list[dict], int]:
     return sliced, total_count
 
 
+def _attach_superseded_by(results: list[dict]) -> None:
+    """decision タイプの結果に superseded_by を付与する (in-place)。
+
+    supersede されている decision の最新 superseder id を「早期警告」として乗せる軽量
+    マーカー。詳細な chain は get_decisions 側で取り直す前提のため、supersede されて
+    いなければ None、複数 superseder があれば最新1件のみ返す。
+    """
+    decision_ids = [item["id"] for item in results if item["type"] == "decision"]
+    if not decision_ids:
+        return
+    conn = get_connection()
+    try:
+        superseded_by_map = get_superseded_by_batch(conn, decision_ids)
+    finally:
+        conn.close()
+    for item in results:
+        if item["type"] == "decision":
+            item["superseded_by"] = superseded_by_map.get(item["id"])
+
+
 def _decorate(
     ctx: SearchContext,
     sliced: list[dict],
     query_tag_ids: Optional[list[int]],
 ) -> tuple[list[dict], list[dict]]:
-    """検索結果に snippet / tags / details / readable_id を付与し、nearby_tags を計算する。
+    """検索結果に snippet / tags / details / superseded_by / readable_id を付与し、nearby_tags を計算する。
 
     ``sliced`` は in-place で書き換わるが、データフローを明示するため戻り値にも含める。
     呼出元 (orchestrator) は ``decorated, nearby_tags = _decorate(...)`` のパターンで
@@ -1659,6 +1680,7 @@ def _decorate(
     """
     _attach_snippets(sliced)
     _attach_tags(sliced)
+    _attach_superseded_by(sliced)
     if ctx.include_details:
         _attach_details(sliced[:DETAILS_MAX_RESULTS])
 

--- a/src/services/supersede_service.py
+++ b/src/services/supersede_service.py
@@ -1,0 +1,125 @@
+"""decision_supersedes を辿って chain / superseded_by を算出するヘルパー。
+
+decision_supersedes(source_id, target_id): source が target を supersede する。
+source が新しい / target が古い。多対多。
+"""
+import sqlite3
+from typing import Optional
+
+
+def _bfs_related(
+    conn: sqlite3.Connection,
+    start_id: int,
+    direction: str,
+) -> set[int]:
+    """direction 方向に BFS で decision_supersedes を辿り、到達可能な decision_id を返す。
+
+    Args:
+        direction: "older" なら source_id=x → target_id を辿る (古い方向)、
+                   "newer" なら target_id=x → source_id を辿る (新しい方向)。
+
+    Returns:
+        start_id を含まない、到達可能な decision_id の集合。
+    """
+    if direction == "older":
+        query = "SELECT target_id AS next_id FROM decision_supersedes WHERE source_id = ?"
+    elif direction == "newer":
+        query = "SELECT source_id AS next_id FROM decision_supersedes WHERE target_id = ?"
+    else:
+        raise ValueError(f"invalid direction: {direction}")
+
+    reached: set[int] = set()
+    visited: set[int] = {start_id}
+    queue: list[int] = [start_id]
+    while queue:
+        current = queue.pop(0)
+        rows = conn.execute(query, (current,)).fetchall()
+        for r in rows:
+            nid = r["next_id"]
+            if nid not in visited:
+                visited.add(nid)
+                reached.add(nid)
+                queue.append(nid)
+    return reached
+
+
+def compute_supersede_info(
+    conn: sqlite3.Connection,
+    decision_id: int,
+) -> dict:
+    """単一 decision の supersede chain / is_superseded を算出する。
+
+    supersede_chain は decision_id 自身 + 古い方向で到達できる decision + 新しい方向で
+    到達できる decision の全体を、created_at 昇順 (同時刻は id 昇順) で並べた id 配列。
+    未 supersede でかつ何も supersede していない場合は [decision_id] のみを返す。
+
+    is_superseded は「新しい方向」に少なくとも1件到達可能かで判定する。retract の
+    有無は分岐しない (retract 済み decision も chain には含める)。
+    """
+    older = _bfs_related(conn, decision_id, direction="older")
+    newer = _bfs_related(conn, decision_id, direction="newer")
+
+    is_superseded = bool(newer)
+
+    all_ids = older | newer | {decision_id}
+    if len(all_ids) == 1:
+        return {
+            "is_superseded": is_superseded,
+            "supersede_chain": [decision_id],
+        }
+
+    placeholders = ",".join("?" * len(all_ids))
+    rows = conn.execute(
+        f"SELECT id FROM decisions WHERE id IN ({placeholders}) "
+        f"ORDER BY created_at ASC, id ASC",
+        tuple(all_ids),
+    ).fetchall()
+    chain = [r["id"] for r in rows]
+    return {
+        "is_superseded": is_superseded,
+        "supersede_chain": chain,
+    }
+
+
+def compute_supersede_info_batch(
+    conn: sqlite3.Connection,
+    decision_ids: list[int],
+) -> dict[int, dict]:
+    """複数 decision に対して supersede chain / is_superseded を一括算出する。
+
+    Returns:
+        {decision_id: {"is_superseded": bool, "supersede_chain": [ids...]}}
+    """
+    if not decision_ids:
+        return {}
+    return {did: compute_supersede_info(conn, did) for did in decision_ids}
+
+
+def get_superseded_by_batch(
+    conn: sqlite3.Connection,
+    decision_ids: list[int],
+) -> dict[int, Optional[int]]:
+    """各 decision_id について、それを supersede している最新の source_id を返す。
+
+    複数 superseder が存在する場合は decision_supersedes.created_at が最新の1件を採用する
+    (pin_service._is_decision_superseded と同じ規則)。superseder が無ければ None。
+
+    Returns:
+        {decision_id: latest_superseder_id or None}
+    """
+    result: dict[int, Optional[int]] = {did: None for did in decision_ids}
+    if not decision_ids:
+        return result
+
+    placeholders = ",".join("?" * len(decision_ids))
+    rows = conn.execute(
+        f"SELECT target_id, source_id FROM decision_supersedes "
+        f"WHERE target_id IN ({placeholders}) "
+        f"ORDER BY target_id, created_at DESC, source_id DESC",
+        tuple(decision_ids),
+    ).fetchall()
+    for r in rows:
+        tid = r["target_id"]
+        if result[tid] is None:
+            result[tid] = r["source_id"]
+    return result

--- a/src/services/supersede_service.py
+++ b/src/services/supersede_service.py
@@ -81,18 +81,77 @@ def compute_supersede_info(
     }
 
 
+def _reach_in_memory(start_id: int, adjacency: dict[int, list[int]]) -> set[int]:
+    """メモリ上の隣接リストを BFS で辿り、start_id から到達可能な id を返す (start 自身は含まない)。"""
+    reached: set[int] = set()
+    visited: set[int] = {start_id}
+    queue: list[int] = [start_id]
+    while queue:
+        current = queue.pop(0)
+        for nid in adjacency.get(current, ()):
+            if nid not in visited:
+                visited.add(nid)
+                reached.add(nid)
+                queue.append(nid)
+    return reached
+
+
 def compute_supersede_info_batch(
     conn: sqlite3.Connection,
     decision_ids: list[int],
 ) -> dict[int, dict]:
     """複数 decision に対して supersede chain / is_superseded を一括算出する。
 
+    decision_supersedes を全件1クエリで読み、方向別の隣接リストをメモリ上に構築してから
+    各 decision の到達可能集合を辿る。supersede 関係は疎なため全件読みでも軽量で、decision
+    数に比例した追加クエリ (N+1) を避けられる。chain 内 id の created_at も1クエリで一括取得
+    してソートに使う。
+
     Returns:
         {decision_id: {"is_superseded": bool, "supersede_chain": [ids...]}}
     """
     if not decision_ids:
         return {}
-    return {did: compute_supersede_info(conn, did) for did in decision_ids}
+
+    # source が target を supersede する。older 方向は source→target、newer 方向は target→source。
+    older_adj: dict[int, list[int]] = {}
+    newer_adj: dict[int, list[int]] = {}
+    for r in conn.execute("SELECT source_id, target_id FROM decision_supersedes").fetchall():
+        s, t = r["source_id"], r["target_id"]
+        older_adj.setdefault(s, []).append(t)
+        newer_adj.setdefault(t, []).append(s)
+
+    chain_ids_by_decision: dict[int, set[int]] = {}
+    is_superseded_by_decision: dict[int, bool] = {}
+    all_chain_ids: set[int] = set()
+    for did in decision_ids:
+        older = _reach_in_memory(did, older_adj)
+        newer = _reach_in_memory(did, newer_adj)
+        chain_ids = older | newer | {did}
+        chain_ids_by_decision[did] = chain_ids
+        is_superseded_by_decision[did] = bool(newer)
+        all_chain_ids |= chain_ids
+
+    # chain を created_at 昇順 (同時刻は id 昇順) に並べるためのソートキーを一括取得する
+    order_key: dict[int, tuple] = {}
+    placeholders = ",".join("?" * len(all_chain_ids))
+    for r in conn.execute(
+        f"SELECT id, created_at FROM decisions WHERE id IN ({placeholders})",
+        tuple(all_chain_ids),
+    ).fetchall():
+        order_key[r["id"]] = (r["created_at"], r["id"])
+
+    result: dict[int, dict] = {}
+    for did in decision_ids:
+        chain = sorted(
+            (i for i in chain_ids_by_decision[did] if i in order_key),
+            key=lambda i: order_key[i],
+        )
+        result[did] = {
+            "is_superseded": is_superseded_by_decision[did],
+            "supersede_chain": chain,
+        }
+    return result
 
 
 def get_superseded_by_batch(

--- a/src/services/timeline_service.py
+++ b/src/services/timeline_service.py
@@ -156,10 +156,12 @@ def get_timeline(
             # supersedes関係はスカラー（1:1前提）で返す。
             # decision_supersedesは多対多のスキーマだが、APIレスポンスのreplaces/replaced_byは
             # {type, id}のスカラーと定義されているため、最新の1件のみ返す。
+            # created_atが同一秒で並んだ場合は選択列のid降順で決定的に1件へ絞る
+            # （最新superseder判定を supersede_service 側と一致させる）。
             union_parts.append(
                 f"SELECT DISTINCT d.id, 'decision' AS type, COALESCE(d.title, d.decision) AS title, d.created_at,"
-                f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaces_id,"
-                f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id ORDER BY created_at DESC LIMIT 1) AS replaced_by_id"
+                f" (SELECT target_id FROM decision_supersedes WHERE source_id = d.id ORDER BY created_at DESC, target_id DESC LIMIT 1) AS replaces_id,"
+                f" (SELECT source_id FROM decision_supersedes WHERE target_id = d.id ORDER BY created_at DESC, source_id DESC LIMIT 1) AS replaced_by_id"
                 f" FROM decisions d"
                 f" JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id"
                 f"                 AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'"

--- a/tests/unit/test_entity_type_get_logs_decisions.py
+++ b/tests/unit/test_entity_type_get_logs_decisions.py
@@ -9,6 +9,7 @@ from src.services.topic_service import add_topic
 from src.services.relation_service import add_relation
 from src.services.discussion_log_service import get_logs
 from src.services.decision_service import get_decisions
+from src.services.retract_service import retract
 from tests.helpers import add_log, add_decision
 from src.services.tag_service import _injected_tags
 
@@ -384,3 +385,54 @@ class TestGetDecisionsInvalidType:
 
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestGetDecisionsSupersedeMetadata:
+    """get_decisions が is_superseded / is_retracted / supersede_chain を返す"""
+
+    def test_solo_decision_marks_chain_as_self_only(self, topic):
+        """supersede 関係が無い decision は chain=[self]、is_superseded=False、is_retracted=False"""
+        tid = topic["topic_id"]
+        d = add_decision(decision="独立", reason="理由", topic_id=tid)
+
+        result = get_decisions("topic", tid)
+
+        assert "error" not in result
+        assert len(result["decisions"]) == 1
+        item = result["decisions"][0]
+        assert item["is_superseded"] is False
+        assert item["is_retracted"] is False
+        assert item["supersede_chain"] == [d["decision_id"]]
+
+    def test_linear_chain_returns_full_history_ordered(self, topic):
+        """d_old→d_new の chain で両方の supersede_chain が [old, new] を返す"""
+        tid = topic["topic_id"]
+        d_old = add_decision(decision="古", reason="理由", topic_id=tid)
+        d_new = add_decision(decision="新", reason="理由", topic_id=tid)
+        add_relation(
+            "decision", d_new["decision_id"],
+            [{"type": "decision", "ids": [d_old["decision_id"]]}],
+            relation_type="supersedes",
+        )
+
+        result = get_decisions("topic", tid)
+        by_id = {item["id_raw"]: item for item in result["decisions"]}
+
+        chain = [d_old["decision_id"], d_new["decision_id"]]
+        assert by_id[d_old["decision_id"]]["supersede_chain"] == chain
+        assert by_id[d_old["decision_id"]]["is_superseded"] is True
+        assert by_id[d_new["decision_id"]]["supersede_chain"] == chain
+        assert by_id[d_new["decision_id"]]["is_superseded"] is False
+
+    def test_retracted_decision_flag_true(self, topic):
+        """retract 済み decision は is_retracted=True (include_retracted 経由で確認)"""
+        tid = topic["topic_id"]
+        d = add_decision(decision="retracted", reason="r", topic_id=tid)
+        retract("decision", [d["decision_id"]])
+
+        result = get_decisions("topic", tid, include_retracted=True)
+
+        assert "error" not in result
+        assert len(result["decisions"]) == 1
+        item = result["decisions"][0]
+        assert item["is_retracted"] is True

--- a/tests/unit/test_entity_type_get_logs_decisions.py
+++ b/tests/unit/test_entity_type_get_logs_decisions.py
@@ -436,3 +436,63 @@ class TestGetDecisionsSupersedeMetadata:
         assert len(result["decisions"]) == 1
         item = result["decisions"][0]
         assert item["is_retracted"] is True
+
+
+class TestGetDecisionsActivitySupersedeMetadata:
+    """get_decisions(entity_type="activity") も is_superseded / is_retracted / supersede_chain を返す"""
+
+    def _activity_for_topic(self, topic_id: int) -> int:
+        """topic に belongs_to で紐づく activity を作って activity_id を返す。"""
+        act = add_activity(title="[作業] タスク", description="Desc", tags=DEFAULT_TAGS, check_in=False)
+        add_relation("activity", act["activity_id"], [{"type": "topic", "ids": [topic_id]}])
+        return act["activity_id"]
+
+    def test_solo_decision_marks_chain_as_self_only(self, topic):
+        """supersede 関係が無い decision は chain=[self]、is_superseded=False、is_retracted=False"""
+        tid = topic["topic_id"]
+        d = add_decision(decision="独立", reason="理由", topic_id=tid)
+        activity_id = self._activity_for_topic(tid)
+
+        result = get_decisions("activity", activity_id)
+
+        assert "error" not in result
+        assert len(result["decisions"]) == 1
+        item = result["decisions"][0]
+        assert item["is_superseded"] is False
+        assert item["is_retracted"] is False
+        assert item["supersede_chain"] == [d["decision_id"]]
+
+    def test_linear_chain_returns_full_history_ordered(self, topic):
+        """d_old→d_new の chain で両方の supersede_chain が [old, new]、is_superseded が向き別に返る"""
+        tid = topic["topic_id"]
+        d_old = add_decision(decision="古", reason="理由", topic_id=tid)
+        d_new = add_decision(decision="新", reason="理由", topic_id=tid)
+        add_relation(
+            "decision", d_new["decision_id"],
+            [{"type": "decision", "ids": [d_old["decision_id"]]}],
+            relation_type="supersedes",
+        )
+        activity_id = self._activity_for_topic(tid)
+
+        result = get_decisions("activity", activity_id)
+        by_id = {item["id_raw"]: item for item in result["decisions"]}
+
+        chain = [d_old["decision_id"], d_new["decision_id"]]
+        assert by_id[d_old["decision_id"]]["supersede_chain"] == chain
+        assert by_id[d_old["decision_id"]]["is_superseded"] is True
+        assert by_id[d_new["decision_id"]]["supersede_chain"] == chain
+        assert by_id[d_new["decision_id"]]["is_superseded"] is False
+
+    def test_retracted_decision_flag_true(self, topic):
+        """retract 済み decision は is_retracted=True (include_retracted 経由で確認)"""
+        tid = topic["topic_id"]
+        d = add_decision(decision="retracted", reason="r", topic_id=tid)
+        retract("decision", [d["decision_id"]])
+        activity_id = self._activity_for_topic(tid)
+
+        result = get_decisions("activity", activity_id, include_retracted=True)
+
+        assert "error" not in result
+        assert len(result["decisions"]) == 1
+        item = result["decisions"][0]
+        assert item["is_retracted"] is True

--- a/tests/unit/test_search_superseded_by.py
+++ b/tests/unit/test_search_superseded_by.py
@@ -1,0 +1,108 @@
+"""search 結果の decision に superseded_by が付与されることを検証する"""
+import hashlib
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database
+from src.services import search_service
+from src.services.relation_service import add_relation
+from src.services.tag_service import _injected_tags
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+
+EMBEDDING_DIM = 384
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def mock_embedding_model(monkeypatch):
+    def mock_encode_batch(texts, prefix):
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            seed = int(hashlib.sha256((prefix_str + text).encode()).hexdigest(), 16) % (2**32)
+            np.random.seed(seed)
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, "_encode_batch", mock_encode_batch)
+    monkeypatch.setattr(emb, "_server_initialized", True)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    yield
+
+
+def _find_decision(results: list[dict], id_raw: int) -> dict:
+    for item in results:
+        if item["type"] == "decision" and item.get("id_raw") == id_raw:
+            return item
+    raise AssertionError(f"decision id_raw={id_raw} not found in results")
+
+
+def test_search_decision_superseded_by_is_none_when_not_superseded(temp_db, mock_embedding_model):
+    """未 supersede の decision は superseded_by=None"""
+    topic = add_topic(title="スーパーシード検索用トピック", description="Desc", tags=DEFAULT_TAGS)
+    d = add_decision(decision="スーパーシード検索対象決定", reason="理由", topic_id=topic["topic_id"])
+
+    result = search_service.search(keyword="スーパーシード検索対象決定", entity_type="decision")
+
+    assert "error" not in result
+    item = _find_decision(result["results"], d["decision_id"])
+    assert "superseded_by" in item
+    assert item["superseded_by"] is None
+
+
+def test_search_decision_superseded_by_returns_source_id(temp_db, mock_embedding_model):
+    """supersede されている decision は最新 superseder id を返す"""
+    topic = add_topic(title="スーパーシード検索用トピック", description="Desc", tags=DEFAULT_TAGS)
+    d_old = add_decision(
+        decision="スーパーシード検索対象古い決定",
+        reason="古い理由",
+        topic_id=topic["topic_id"],
+    )
+    d_new = add_decision(decision="新しい決定", reason="新しい理由", topic_id=topic["topic_id"])
+    add_relation(
+        "decision", d_new["decision_id"],
+        [{"type": "decision", "ids": [d_old["decision_id"]]}],
+        relation_type="supersedes",
+    )
+
+    result = search_service.search(
+        keyword="スーパーシード検索対象古い決定", entity_type="decision"
+    )
+
+    assert "error" not in result
+    item = _find_decision(result["results"], d_old["decision_id"])
+    assert item["superseded_by"] == d_new["decision_id"]
+
+
+def test_search_non_decision_results_have_no_superseded_by_field(temp_db, mock_embedding_model):
+    """topic など decision 以外の結果には superseded_by は付かない"""
+    add_topic(
+        title="トピック側のみのスーパーシードテスト用",
+        description="Desc",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.search(keyword="トピック側のみのスーパーシードテスト用")
+
+    assert "error" not in result
+    for item in result["results"]:
+        if item["type"] != "decision":
+            assert "superseded_by" not in item

--- a/tests/unit/test_supersede_service.py
+++ b/tests/unit/test_supersede_service.py
@@ -1,0 +1,290 @@
+"""supersede_service (chain 計算 + superseded_by マップ) の単体テスト"""
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.relation_service import add_relation
+from src.services.retract_service import retract
+from src.services.supersede_service import (
+    _bfs_related,
+    compute_supersede_info,
+    compute_supersede_info_batch,
+    get_superseded_by_batch,
+)
+from src.services.tag_service import _injected_tags
+from src.services.topic_service import add_topic
+from tests.helpers import add_decision
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic_id(temp_db):
+    t = add_topic(title="テスト", description="Desc", tags=DEFAULT_TAGS)
+    return t["topic_id"]
+
+
+def _link_supersede(newer_id: int, older_id: int) -> None:
+    """newer が older を supersede するリレーションを張る。"""
+    result = add_relation(
+        "decision",
+        newer_id,
+        [{"type": "decision", "ids": [older_id]}],
+        relation_type="supersedes",
+    )
+    assert "error" not in result, result
+
+
+class TestBfsRelated:
+    """_bfs_related の方向別テスト"""
+
+    def test_no_edges_returns_empty(self, topic_id):
+        """supersede 関係が無い decision は BFS 結果が空"""
+        d = add_decision(decision="d1", reason="r", topic_id=topic_id)
+        conn = get_connection()
+        try:
+            assert _bfs_related(conn, d["decision_id"], direction="older") == set()
+            assert _bfs_related(conn, d["decision_id"], direction="newer") == set()
+        finally:
+            conn.close()
+
+    def test_older_direction_follows_target(self, topic_id):
+        """direction=older は source_id=x → target_id を辿る"""
+        d_old = add_decision(decision="old", reason="r", topic_id=topic_id)
+        d_mid = add_decision(decision="mid", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="new", reason="r", topic_id=topic_id)
+        _link_supersede(d_mid["decision_id"], d_old["decision_id"])
+        _link_supersede(d_new["decision_id"], d_mid["decision_id"])
+
+        conn = get_connection()
+        try:
+            older = _bfs_related(conn, d_new["decision_id"], direction="older")
+        finally:
+            conn.close()
+        assert older == {d_mid["decision_id"], d_old["decision_id"]}
+
+    def test_newer_direction_follows_source(self, topic_id):
+        """direction=newer は target_id=x → source_id を辿る"""
+        d_old = add_decision(decision="old", reason="r", topic_id=topic_id)
+        d_mid = add_decision(decision="mid", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="new", reason="r", topic_id=topic_id)
+        _link_supersede(d_mid["decision_id"], d_old["decision_id"])
+        _link_supersede(d_new["decision_id"], d_mid["decision_id"])
+
+        conn = get_connection()
+        try:
+            newer = _bfs_related(conn, d_old["decision_id"], direction="newer")
+        finally:
+            conn.close()
+        assert newer == {d_mid["decision_id"], d_new["decision_id"]}
+
+    def test_invalid_direction_raises(self, topic_id):
+        """不正な direction は ValueError"""
+        d = add_decision(decision="d1", reason="r", topic_id=topic_id)
+        conn = get_connection()
+        try:
+            with pytest.raises(ValueError):
+                _bfs_related(conn, d["decision_id"], direction="sideways")
+        finally:
+            conn.close()
+
+
+class TestComputeSupersedeInfo:
+    """compute_supersede_info の単一 decision 挙動"""
+
+    def test_solo_decision_returns_self_only(self, topic_id):
+        """supersede 関係が無い decision は chain が自身1件、is_superseded=False"""
+        d = add_decision(decision="独立", reason="r", topic_id=topic_id)
+        conn = get_connection()
+        try:
+            info = compute_supersede_info(conn, d["decision_id"])
+        finally:
+            conn.close()
+        assert info == {
+            "is_superseded": False,
+            "supersede_chain": [d["decision_id"]],
+        }
+
+    def test_linear_chain_ordered_old_to_new(self, topic_id):
+        """直線 chain (d_old → d_mid → d_new) は中央から見て古い→新しい順"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_mid = add_decision(decision="中", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="新", reason="r", topic_id=topic_id)
+        _link_supersede(d_mid["decision_id"], d_old["decision_id"])
+        _link_supersede(d_new["decision_id"], d_mid["decision_id"])
+
+        conn = get_connection()
+        try:
+            info = compute_supersede_info(conn, d_mid["decision_id"])
+        finally:
+            conn.close()
+
+        assert info["is_superseded"] is True
+        assert info["supersede_chain"] == [
+            d_old["decision_id"],
+            d_mid["decision_id"],
+            d_new["decision_id"],
+        ]
+
+    def test_head_of_chain_not_superseded(self, topic_id):
+        """chain の先頭 (最新 decision) は is_superseded=False で chain 全件返す"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="新", reason="r", topic_id=topic_id)
+        _link_supersede(d_new["decision_id"], d_old["decision_id"])
+
+        conn = get_connection()
+        try:
+            info = compute_supersede_info(conn, d_new["decision_id"])
+        finally:
+            conn.close()
+
+        assert info["is_superseded"] is False
+        assert info["supersede_chain"] == [
+            d_old["decision_id"],
+            d_new["decision_id"],
+        ]
+
+    def test_branching_chain_dedupes_ids(self, topic_id):
+        """d_old が d_a と d_b の両方に supersede される分岐 chain は重複なく chain 化される"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_a = add_decision(decision="A", reason="r", topic_id=topic_id)
+        d_b = add_decision(decision="B", reason="r", topic_id=topic_id)
+        _link_supersede(d_a["decision_id"], d_old["decision_id"])
+        _link_supersede(d_b["decision_id"], d_old["decision_id"])
+
+        conn = get_connection()
+        try:
+            info = compute_supersede_info(conn, d_old["decision_id"])
+        finally:
+            conn.close()
+
+        assert info["is_superseded"] is True
+        chain = info["supersede_chain"]
+        assert set(chain) == {
+            d_old["decision_id"],
+            d_a["decision_id"],
+            d_b["decision_id"],
+        }
+        # 重複なし
+        assert len(chain) == len(set(chain))
+        # created_at 昇順で d_old が先頭
+        assert chain[0] == d_old["decision_id"]
+
+    def test_retracted_decision_still_in_chain(self, topic_id):
+        """retract 済み decision も supersede chain に残す"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="新", reason="r", topic_id=topic_id)
+        _link_supersede(d_new["decision_id"], d_old["decision_id"])
+        retract("decision", [d_old["decision_id"]])
+
+        conn = get_connection()
+        try:
+            info = compute_supersede_info(conn, d_new["decision_id"])
+        finally:
+            conn.close()
+
+        assert d_old["decision_id"] in info["supersede_chain"]
+
+
+class TestComputeSupersedeInfoBatch:
+    """compute_supersede_info_batch のバッチ挙動"""
+
+    def test_empty_input_returns_empty_map(self, temp_db):
+        conn = get_connection()
+        try:
+            assert compute_supersede_info_batch(conn, []) == {}
+        finally:
+            conn.close()
+
+    def test_batch_returns_per_decision_info(self, topic_id):
+        """複数 decision に対して個別の chain 情報を返す"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="新", reason="r", topic_id=topic_id)
+        d_solo = add_decision(decision="独立", reason="r", topic_id=topic_id)
+        _link_supersede(d_new["decision_id"], d_old["decision_id"])
+
+        conn = get_connection()
+        try:
+            result = compute_supersede_info_batch(
+                conn,
+                [d_old["decision_id"], d_new["decision_id"], d_solo["decision_id"]],
+            )
+        finally:
+            conn.close()
+
+        assert result[d_old["decision_id"]]["is_superseded"] is True
+        assert result[d_new["decision_id"]]["is_superseded"] is False
+        assert result[d_solo["decision_id"]] == {
+            "is_superseded": False,
+            "supersede_chain": [d_solo["decision_id"]],
+        }
+
+
+class TestGetSupersededByBatch:
+    """get_superseded_by_batch: 最新 superseder id を返す"""
+
+    def test_empty_input_returns_empty_map(self, temp_db):
+        conn = get_connection()
+        try:
+            assert get_superseded_by_batch(conn, []) == {}
+        finally:
+            conn.close()
+
+    def test_not_superseded_returns_none(self, topic_id):
+        """supersede されていない decision は None"""
+        d = add_decision(decision="d1", reason="r", topic_id=topic_id)
+        conn = get_connection()
+        try:
+            result = get_superseded_by_batch(conn, [d["decision_id"]])
+        finally:
+            conn.close()
+        assert result == {d["decision_id"]: None}
+
+    def test_superseded_returns_source_id(self, topic_id):
+        """supersede されている decision は source_id (最新 superseder) を返す"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_new = add_decision(decision="新", reason="r", topic_id=topic_id)
+        _link_supersede(d_new["decision_id"], d_old["decision_id"])
+
+        conn = get_connection()
+        try:
+            result = get_superseded_by_batch(
+                conn, [d_old["decision_id"], d_new["decision_id"]]
+            )
+        finally:
+            conn.close()
+
+        assert result[d_old["decision_id"]] == d_new["decision_id"]
+        assert result[d_new["decision_id"]] is None
+
+    def test_multiple_supersedes_returns_latest(self, topic_id):
+        """複数 superseder があれば最新の 1 件 (created_at DESC の先頭) を返す"""
+        d_old = add_decision(decision="古", reason="r", topic_id=topic_id)
+        d_a = add_decision(decision="A", reason="r", topic_id=topic_id)
+        d_b = add_decision(decision="B", reason="r", topic_id=topic_id)
+        _link_supersede(d_a["decision_id"], d_old["decision_id"])
+        _link_supersede(d_b["decision_id"], d_old["decision_id"])
+
+        conn = get_connection()
+        try:
+            result = get_superseded_by_batch(conn, [d_old["decision_id"]])
+        finally:
+            conn.close()
+
+        # d_b の supersede リレーションが後から張られたので、created_at DESC で d_b が最新
+        assert result[d_old["decision_id"]] == d_b["decision_id"]


### PR DESCRIPTION
## Summary

- `get_decisions` の各 decision に `is_superseded` / `is_retracted` / `supersede_chain` を追加。`supersede_chain` はその decision を中心に古い→新しい順に並ぶ id 配列で、双方向 BFS で `decision_supersedes` を辿って算出する。分岐 chain も一つの id 配列にまとめる。
- `search` の decision 結果に `superseded_by` (最新 superseder の id、無ければ null) を追加。詳細な chain は get_decisions 側で取り直す前提の軽量マーカーとして、古い decision にヒットしたときの早期警告になる。
- 実装は `src/services/supersede_service.py` に helper を集約し、`decision_service` (get_decisions) と `search_service` (\_decorate) から呼ぶ。

## Test plan

新規テスト:
- `tests/unit/test_supersede_service.py` (15件): BFS の方向別到達、chain の順序、分岐時の重複排除、retract 済み decision の chain 残置、複数 superseder 時の「最新1件」採用ルール。
- `tests/unit/test_entity_type_get_logs_decisions.py` の追記 (3件): solo decision で chain=[self]、直線 chain で両端が同じ id 配列を共有、retract 済み decision が `is_retracted=True` になる。
- `tests/unit/test_search_superseded_by.py` (3件): 未 supersede は `superseded_by=None`、supersede されていれば superseder id、非 decision 結果に `superseded_by` を付けない。

周辺テスト (271件、hybrid_search / search_orchestrator / search_pipeline / batch_logs_decisions / tag_notes / timeline_service / pin_service) が既存挙動を保っていること確認済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)