### PR TITLE
fix: export_material のパス制限を撤廃しorch専用に変更

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -889,21 +889,19 @@ def export_material(
     - 既存ディレクトリを指定: そのディレクトリ配下に M-{id}-{title-slug}.md として出力
     - ファイルパスを指定: そのパスをそのまま使用（親ディレクトリは自動作成）
 
-    書き込み先は ~/cc-memory-export 配下に限定される。配下外を指す dest_path
-    （シンボリックリンク経由の脱出を含む）は VALIDATION_ERROR で拒否され、
-    ファイルもディレクトリも作成されない。cc-memory 管理外の場所（obsidian vault や
-    docs リポ等）へ置きたい場合は、この配下に出力してから移動する。
+    dest_path は ~/cc-memory-export 配下に限定されない。obsidian vault や docs
+    リポ等、cc-memory 管理外の任意の場所を直接指定できる。
 
     上書き確認はしない。既存ファイルは無警告で上書きされる（戻り値の overwritten で通知）。
 
     Args:
         material_id: 資材のID
         dest_path: 出力先パス（optional）。省略/ディレクトリ/ファイルパスで振り分ける。
-            指定する場合は ~/cc-memory-export 配下でなければならない
+            任意の場所を指定でき、~/cc-memory-export 配下に限定されない
 
     Returns:
         成功時: {"path": 絶対パス, "overwritten": 既存ファイルを上書きしたか, "material_id": ID, "title": タイトル}
-        失敗時: {"error": {"code": "NOT_FOUND" | "VALIDATION_ERROR" | "IO_ERROR" | "DATABASE_ERROR", "message": str}}
+        失敗時: {"error": {"code": "NOT_FOUND" | "IO_ERROR" | "DATABASE_ERROR", "message": str}}
     """
     return material_service.export_material_to_file(material_id, dest_path=dest_path)
 

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -57,7 +57,7 @@ CAPABILITY_MATRIX: CapabilityMatrix = {
     "get_logs":          {"orch": True,  "dispatcher": True,  "worker": True},
     "get_topics":        {"orch": True,  "dispatcher": True,  "worker": True},
     "get_material":      {"orch": True,  "dispatcher": True,  "worker": True},
-    "export_material":   {"orch": True,  "dispatcher": True,  "worker": True},
+    "export_material":   {"orch": True,  "dispatcher": False, "worker": False},
     "get_habits":        {"orch": True,  "dispatcher": True,  "worker": True},
     "get_map":           {"orch": True,  "dispatcher": True,  "worker": True},
     "get_timeline":      {"orch": True,  "dispatcher": True,  "worker": True},

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -459,17 +459,6 @@ def _resolve_dest_path(entity_id: int, title: str, dest_path: Optional[str]) -> 
     return os.path.abspath(expanded)
 
 
-def _is_within_export_dir(path: str) -> bool:
-    """path が DEFAULT_EXPORT_DIR のサブツリー内かを realpath 基準で判定する。
-
-    許可ルート・対象パス双方を realpath で正規化してから比較するため、
-    シンボリックリンク経由で許可ルート外へ抜けるパスも配下外と判定される。
-    """
-    export_root = os.path.realpath(os.path.expanduser(DEFAULT_EXPORT_DIR))
-    resolved = os.path.realpath(path)
-    return resolved == export_root or resolved.startswith(export_root + os.sep)
-
-
 def _get_material_relations_with_conn(conn, entity_id: int) -> list[dict]:
     """material に直接紐づく関連エンティティを related 配列にする。
 
@@ -517,9 +506,10 @@ def _build_frontmatter(
 def export_material_to_file(material_id: int, dest_path: Optional[str] = None) -> dict:
     """資材を md ファイルとして出力する。
 
-    書き込み先は DEFAULT_EXPORT_DIR のサブツリー内に限定する。配下外を指す
-    dest_path（シンボリックリンク経由の脱出を含む）は VALIDATION_ERROR で拒否し、
-    ディレクトリ作成もファイル書き込みも一切行わない。
+    dest_path 省略時は DEFAULT_EXPORT_DIR 配下、既存ディレクトリ指定時はその
+    配下、ファイルパス指定時はそのパスをそのまま使う（DEFAULT_EXPORT_DIR 外も
+    許可）。capability matrix で本 tool は orch 専用に制限されており、
+    worker/dispatcher からは呼び出せない。
 
     Returns:
         成功時: {"path": str, "overwritten": bool, "material_id": int, "title": str}
@@ -562,17 +552,6 @@ def export_material_to_file(material_id: int, dest_path: Optional[str] = None) -
         body += "\n"
 
     path = _resolve_dest_path(material_id, title, dest_path)
-    if not _is_within_export_dir(path):
-        allowed = os.path.expanduser(DEFAULT_EXPORT_DIR)
-        return {
-            "error": {
-                "code": "VALIDATION_ERROR",
-                "message": (
-                    f"dest_path must resolve to a location within {allowed}. "
-                    f"resolved path: {path}"
-                ),
-            }
-        }
     parent = os.path.dirname(path)
     if parent:
         try:

--- a/tests/integration/test_export_material_tool.py
+++ b/tests/integration/test_export_material_tool.py
@@ -62,11 +62,10 @@ def material_with_related(temp_db):
 
 @pytest.fixture(autouse=True)
 def _export_dir_under_tmp(monkeypatch, tmp_path):
-    """書き込みガードの許可ルートを各テストの tmp_path に向ける。
+    """dest_path 省略時のデフォルト書き込み先を各テストの tmp_path に向ける。
 
-    export_material_to_file は DEFAULT_EXPORT_DIR 配下のみ書き込みを許可する。
-    テストの dest_path はすべて tmp_path 配下を指すため、許可ルートを tmp_path に
-    合わせることで通常ケースを許可し、配下外テストは tmp_path 外を指して検証する。
+    実際の ~/cc-memory-export への書き込みを避けるため、テスト中は
+    DEFAULT_EXPORT_DIR を tmp_path に差し替える。
     """
     monkeypatch.setattr("src.services.material_service.DEFAULT_EXPORT_DIR", str(tmp_path))
 
@@ -185,37 +184,32 @@ class TestErrors:
         assert result["error"]["code"] == "NOT_FOUND"
 
 
-class TestPathGuard:
-    def test_path_outside_export_dir_is_rejected(self, material_id, tmp_path):
-        with tempfile.TemporaryDirectory() as outside:
-            target = os.path.join(outside, "escape.md")
-            result = export_material_to_file(material_id, dest_path=target)
-            assert "error" in result
-            assert result["error"]["code"] == "VALIDATION_ERROR"
-            assert not os.path.exists(target)
+class TestDestPathOutsideDefaultDir:
+    """DEFAULT_EXPORT_DIR 外への書き出しは拒否されず、そのまま成功する。"""
 
-    def test_rejection_does_not_create_parent_dir(self, material_id, tmp_path):
+    def test_path_outside_default_dir_succeeds(self, material_id, tmp_path):
         with tempfile.TemporaryDirectory() as outside:
-            target = os.path.join(outside, "new-sub", "escape.md")
+            target = os.path.join(outside, "vault-note.md")
             result = export_material_to_file(material_id, dest_path=target)
-            assert result["error"]["code"] == "VALIDATION_ERROR"
-            assert not os.path.exists(os.path.join(outside, "new-sub"))
+            assert "error" not in result
+            assert result["path"] == target
+            assert os.path.isfile(target)
 
-    def test_symlink_escape_is_rejected(self, material_id, tmp_path):
+    def test_path_outside_default_dir_creates_parent_dir(self, material_id, tmp_path):
+        with tempfile.TemporaryDirectory() as outside:
+            target = os.path.join(outside, "new-sub", "vault-note.md")
+            result = export_material_to_file(material_id, dest_path=target)
+            assert "error" not in result
+            assert os.path.isfile(target)
+
+    def test_symlink_target_succeeds(self, material_id, tmp_path):
         with tempfile.TemporaryDirectory() as outside:
             link = tmp_path / "vault-link"
             os.symlink(outside, str(link))
-            target = link / "escape.md"
+            target = link / "vault-note.md"
             result = export_material_to_file(material_id, dest_path=str(target))
-            assert "error" in result
-            assert result["error"]["code"] == "VALIDATION_ERROR"
-            assert not os.path.exists(os.path.join(outside, "escape.md"))
-
-    def test_error_message_names_allowed_dir(self, material_id, tmp_path):
-        with tempfile.TemporaryDirectory() as outside:
-            target = os.path.join(outside, "escape.md")
-            result = export_material_to_file(material_id, dest_path=target)
-            assert str(tmp_path) in result["error"]["message"]
+            assert "error" not in result
+            assert os.path.isfile(os.path.join(outside, "vault-note.md"))
 
 
 class TestMcpTool:


### PR DESCRIPTION
## Summary
- `export_material` の書き込み先を `~/cc-memory-export/` 配下に強制するガードを撤廃し、`dest_path` にファイルパスを指定した場合はそのまま使う元仕様に戻す
- 上記に伴い、worker/dispatcher が任意の場所へ書き込めてしまうリスクを避けるため、capability matrix で `export_material` を orch 専用に制限する

## Motivation
`export_material` は obsidian vault や別リポジトリなど cc-memory 外への書き出しを主目的とするツールだが、直前の PR (#469) のレビュー対応で追加されたパスガードにより `~/cc-memory-export/` 外への書き出しが一律 `VALIDATION_ERROR` になっていた。マージ後にこの制約が主目的を満たせていないことが判明したため修正する。

## Test plan
- [x] `dest_path` に `DEFAULT_EXPORT_DIR` 外の絶対パスを指定して正常に書き出せること
- [x] 存在しない親ディレクトリを含む `dest_path` でも自動作成されて書き出せること
- [x] symlink 経由の `dest_path` でも実体側に正常に書き出せること（旧テストは拒否検証、今回は成功検証に置き換え）
- [x] capability matrix / role gating の既存テスト群が新しい role 設定 (`orch` のみ許可) でも通過すること
- 影響範囲テスト (test_export_material_tool.py / test_material_service.py / capability matrix 関連4ファイル) 208件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)