### PR TITLE
docs: ow cache docstringの真実源記述を現行合意に修正

### DIFF
--- a/src/services/ow/__init__.py
+++ b/src/services/ow/__init__.py
@@ -1,8 +1,9 @@
 """ow runtime state cache layer.
 
-真実源は relay events。本パッケージが管理する JSON ファイルキャッシュは
-relay から再生成可能な派生データに過ぎず、破損・schema mismatch時には
-削除して呼び出し側に full pull を促す。
+本パッケージが管理する JSON ファイルキャッシュは relay events から再生成可能な
+派生データに過ぎず、真実源ではない (耐久的事実の真実源は cc-memory、relay は
+bounded transport buffer で liveness の直近窓のみを担う)。破損・schema mismatch
+時には削除して呼び出し側に full pull を促す。
 """
 
 from src.services.ow.cache import (

--- a/src/services/ow/cache.py
+++ b/src/services/ow/cache.py
@@ -1,9 +1,10 @@
 """ow runtime state ファイルキャッシュ。
 
-真実源は relay events (`ow_history`)。本モジュールが書き出す JSON ファイルは
-relay から再生成可能な派生キャッシュであり、破損・schema mismatch・channel
-mismatch を検出した場合は即削除して None を返す (cache は再生成可能なので
-backup は取らない)。
+本モジュールが書き出す JSON ファイルは relay events (`ow_history`) から再生成
+可能な派生キャッシュであり、真実源ではない (耐久的事実の真実源は cc-memory、
+relay は bounded transport buffer で liveness の直近窓のみを担う)。破損・
+schema mismatch・channel mismatch を検出した場合は即削除して None を返す
+(cache は再生成可能なので backup は取らない)。
 
 配置:
     $OW_STATE_DIR (未設定時は ~/.cc-memory/ow/cache/)

--- a/src/services/ow_service.py
+++ b/src/services/ow_service.py
@@ -1507,7 +1507,9 @@ def _parse_frontmatter(content: str) -> tuple[dict, str]:
 def ow_status(channel: str, topic_id: str | None = None) -> dict:
     """cache (派生1) + presence の統合ビュー (D#2751、SKILL.md §状態取得経路)。
 
-    cache は relay events を真実源として projector が再構築する派生キャッシュ。
+    cache は relay events (`ow_history`) から projector が再構築する派生キャッシュ
+    であり、真実源ではない (耐久的事実の真実源は cc-memory、relay は bounded
+    transport buffer で liveness の直近窓のみを担う)。
     本関数は load_state → cache miss なら projector で再構築する fallback 経路で
     取得し、cache.workers 各 handle のサマリを ``tasks`` リストに整形する。
 


### PR DESCRIPTION
## 変更内容

ow runtime state キャッシュモジュールの docstring が「真実源は relay events」と説明していたのを、現行の合意（耐久的事実の真実源は cc-memory、relay は bounded transport buffer で liveness の直近窓のみを担う）に合わせて修正する。「relay events から再生成可能な派生キャッシュ」という機構の説明は現実装のままなので維持している。挙動変更はない。

## なぜ要るのか

このモジュールの docstring は、ow まわりのコード調査で最初に読まれる場所であり、すでに改訂済みの旧公理を根拠として設計判断してしまう汚染源になっていた（第三者監査で検出）。同趣旨の記述は tag note 側も修正済みで、本 PR はコード側の残りを揃えるもの。

## テスト計画

docstring のみの変更で実行時挙動への影響はない。既存テストへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)