### PR TITLE
検索実装衛生: タグindex追加 + vec_index孤児行掃除のmigration

### DIFF
--- a/docs/spec/db-schema.md
+++ b/docs/spec/db-schema.md
@@ -279,9 +279,9 @@ namespace + name による分類タグ。
 
 インデックス:
 - `idx_material_tags_tag` ON `material_tags(tag_id)`（0023）
-- 他の junction には逆引きインデックスが張られていない（未確認: 0009 以降でも追加なし）
+- `idx_topic_tags_tag` / `idx_activity_tags_tag` / `idx_decision_tags_tag` / `idx_log_tags_tag` ON 各 `<junction>(tag_id)`（0049）
 
-関連 migration: 0009 / 0011 / 0023
+関連 migration: 0009 / 0011 / 0023 / 0049
 
 ### 3.9 relations
 
@@ -391,8 +391,9 @@ decision 間の有向 `supersedes` 関係（新→旧）。
 
 インデックス:
 - `idx_search_index_source` ON `search_index(source_type, source_id)`
+- `idx_search_index_created_at` ON `search_index(created_at)`（0049）
 
-関連 migration: 0002 / 0003 / 0008 / 0010 / 0018 / 0030 / 0037
+関連 migration: 0002 / 0003 / 0008 / 0010 / 0018 / 0030 / 0037 / 0049
 
 ### 3.14 search_index_fts
 

--- a/migrations/0049_add_tag_junction_indexes.sql
+++ b/migrations/0049_add_tag_junction_indexes.sql
@@ -1,0 +1,22 @@
+-- Migration 049: タグjunctionテーブルへのtag_id逆引きindex + search_index.created_atのindex
+--
+-- depends: 0048_session_identity
+--
+-- 背景:
+--   topic_tags / activity_tags / decision_tags / log_tags はPK(entity_id, tag_id)
+--   のみでtag_id側の逆引きindexが無く、タグでの絞り込みクエリが実質フルスキャンに
+--   なっている（material_tagsのみ0023でidx_material_tags_tagを持つ）。
+--   search_index.created_atも0030でカラム追加のみでindex未整備であり、日付フィルタ
+--   クエリの補助が無い。
+--
+-- 変更内容:
+--   - idx_topic_tags_tag / idx_activity_tags_tag / idx_decision_tags_tag /
+--     idx_log_tags_tag を追加
+--   - idx_search_index_created_at を追加
+
+CREATE INDEX idx_topic_tags_tag    ON topic_tags(tag_id);
+CREATE INDEX idx_activity_tags_tag ON activity_tags(tag_id);
+CREATE INDEX idx_decision_tags_tag ON decision_tags(tag_id);
+CREATE INDEX idx_log_tags_tag      ON log_tags(tag_id);
+
+CREATE INDEX idx_search_index_created_at ON search_index(created_at);

--- a/migrations/0050_cleanup_vec_orphans.sql
+++ b/migrations/0050_cleanup_vec_orphans.sql
@@ -1,0 +1,15 @@
+-- Migration 050: vec_index孤児行の掃除
+--
+-- depends: 0049_add_tag_junction_indexes
+--
+-- 背景:
+--   vec_indexはsearch_indexのidと同値のrowidで運用される仮想テーブルだが、
+--   retract経路以外のエンティティ削除（ON DELETE CASCADE等）ではvec_index側の
+--   対応行が掃除されない。対応するsearch_index行を持たない孤児行はベクトル検索の
+--   グローバルKNN候補スロットを浪費し、search_indexとのJOIN段で黙って消える。
+--
+-- 変更内容:
+--   - search_indexに対応行を持たないvec_index行を削除する
+
+DELETE FROM vec_index
+WHERE rowid NOT IN (SELECT id FROM search_index);

--- a/migrations/0050_cleanup_vec_orphans.sql
+++ b/migrations/0050_cleanup_vec_orphans.sql
@@ -10,6 +10,14 @@
 --
 -- 変更内容:
 --   - search_indexに対応行を持たないvec_index行を削除する
+--
+-- 適用範囲（既知の制約）:
+--   これは適用時点で存在する孤児行を整合する一回限りの掃除であり、発生源には手を入れない。
+--   トピック削除等でdecisions/discussion_logsがCASCADE削除されるとtrg_search_*_deleteが
+--   発火するが、これらはsearch_index/search_index_ftsのみ削除しvec_indexには触れないため、
+--   同経路を通れば孤児行は再び蓄積し得る。vec_indexはvec0仮想テーブルでFK制約を持てず、
+--   トリガーからのvec_index削除は全接続でsqlite-vec拡張のロードを必須化する（現状は拡張が
+--   ロードできない環境でも削除系操作を許容する設計）ため、この掃除には含めていない。
 
 DELETE FROM vec_index
 WHERE rowid NOT IN (SELECT id FROM search_index);

--- a/tests/test_migrations/test_0049_add_tag_junction_indexes.py
+++ b/tests/test_migrations/test_0049_add_tag_junction_indexes.py
@@ -1,0 +1,229 @@
+"""migration 0049_add_tag_junction_indexes のテスト
+
+0049 適用後に topic_tags / activity_tags / decision_tags / log_tags への
+tag_id 逆引き index と search_index(created_at) の index が作成され、
+既存データ・タグフィルタ結果が変わらないことを確認する。
+"""
+import os
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags, ensure_tag_ids, link_tags
+from test_migrations.conftest import index_names
+
+
+@pytest.fixture
+def migrated_db():
+    """全 migration（0049 含む）を適用済みのテスト用 DB を提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0049():
+    """0048 までの migration を適用した DB を提供する。0049 の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0049 = MigrationList([m for m in all_migs if m.id < "0049"])
+        with backend.lock():
+            backend.apply_migrations(pre_0049)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0049(db_path: str) -> None:
+    """db_path に対して migration 0049 のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0049 = MigrationList([m for m in all_migs if m.id.startswith("0049")])
+    with backend.lock():
+        backend.apply_migrations(only_0049)
+
+
+class TestIndexesCreated:
+    """0049 適用後に 5 本の index が作成されることの確認"""
+
+    EXPECTED_INDEXES = {
+        "idx_topic_tags_tag",
+        "idx_activity_tags_tag",
+        "idx_decision_tags_tag",
+        "idx_log_tags_tag",
+        "idx_search_index_created_at",
+    }
+
+    def test_indexes_exist_after_0049(self, migrated_db):
+        """0049 適用後、5 本の index すべてが sqlite_master に存在する"""
+        conn = get_connection()
+        try:
+            existing = set()
+            for pattern in ["idx_topic_tags_tag", "idx_activity_tags_tag",
+                             "idx_decision_tags_tag", "idx_log_tags_tag",
+                             "idx_search_index_created_at"]:
+                existing |= index_names(conn, pattern)
+            for idx in self.EXPECTED_INDEXES:
+                assert idx in existing, f"インデックス {idx} が 0049 適用後に存在しない"
+        finally:
+            conn.close()
+
+    def test_indexes_not_exist_before_0049(self, db_before_0049):
+        """0049 適用前は 5 本の index がいずれも存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            existing = set()
+            for pattern in ["idx_topic_tags_tag", "idx_activity_tags_tag",
+                             "idx_decision_tags_tag", "idx_log_tags_tag",
+                             "idx_search_index_created_at"]:
+                existing |= index_names(conn, pattern)
+            assert existing.isdisjoint(self.EXPECTED_INDEXES), (
+                "0049 適用前に対象インデックスが既に存在している"
+            )
+        finally:
+            conn.close()
+
+    def test_indexes_target_tag_id_column(self, migrated_db):
+        """junction 4 本の index が tag_id カラムを対象にしている"""
+        conn = get_connection()
+        try:
+            for table, idx in [
+                ("topic_tags", "idx_topic_tags_tag"),
+                ("activity_tags", "idx_activity_tags_tag"),
+                ("decision_tags", "idx_decision_tags_tag"),
+                ("log_tags", "idx_log_tags_tag"),
+            ]:
+                rows = conn.execute(f"PRAGMA index_info({idx})").fetchall()
+                assert len(rows) == 1, f"{idx} は単一カラムindexであるべき"
+                assert rows[0]["name"] == "tag_id", (
+                    f"{idx} は tag_id を対象にすべき（table={table}）"
+                )
+        finally:
+            conn.close()
+
+    def test_search_index_created_at_index_targets_created_at(self, migrated_db):
+        """idx_search_index_created_at が created_at カラムを対象にしている"""
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "PRAGMA index_info(idx_search_index_created_at)"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0]["name"] == "created_at"
+        finally:
+            conn.close()
+
+
+class TestExistingDataPreserved:
+    """0049 適用前に投入したタグ紐付けデータが、適用後も破壊されないことの確認"""
+
+    def test_existing_tag_links_preserved(self, db_before_0049):
+        """0049 適用前の topic_tags / activity_tags / decision_tags / log_tags 行は
+        適用後も残る"""
+        conn = get_connection()
+        try:
+            topic_cur = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("既存トピック", "説明"),
+            )
+            topic_id = topic_cur.lastrowid
+            activity_cur = conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                ("既存activity", "説明", "in_progress"),
+            )
+            activity_id = activity_cur.lastrowid
+            decision_cur = conn.execute(
+                "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                ("既存決定", "既存理由"),
+            )
+            decision_id = decision_cur.lastrowid
+            log_cur = conn.execute(
+                "INSERT INTO discussion_logs (title, content) VALUES (?, ?)",
+                ("既存ログ", "内容"),
+            )
+            log_id = log_cur.lastrowid
+            conn.commit()
+
+            tag_ids = ensure_tag_ids(conn, [("domain", "hygiene-test")])
+            link_tags(conn, "topic_tags", "topic_id", topic_id, tag_ids)
+            link_tags(conn, "activity_tags", "activity_id", activity_id, tag_ids)
+            link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
+            link_tags(conn, "log_tags", "log_id", log_id, tag_ids)
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0049(db_before_0049)
+
+        conn = get_connection()
+        try:
+            tag_id = tag_ids[0]
+            assert conn.execute(
+                "SELECT 1 FROM topic_tags WHERE topic_id = ? AND tag_id = ?",
+                (topic_id, tag_id),
+            ).fetchone() is not None
+            assert conn.execute(
+                "SELECT 1 FROM activity_tags WHERE activity_id = ? AND tag_id = ?",
+                (activity_id, tag_id),
+            ).fetchone() is not None
+            assert conn.execute(
+                "SELECT 1 FROM decision_tags WHERE decision_id = ? AND tag_id = ?",
+                (decision_id, tag_id),
+            ).fetchone() is not None
+            assert conn.execute(
+                "SELECT 1 FROM log_tags WHERE log_id = ? AND tag_id = ?",
+                (log_id, tag_id),
+            ).fetchone() is not None
+        finally:
+            conn.close()
+
+
+class TestTagFilterResultsUnchanged:
+    """index 追加が検索結果の集合に影響しないことの確認（性能のみの変更である裏取り）"""
+
+    def test_tag_filter_query_result_unchanged_by_index(self, migrated_db):
+        """tag_id で絞る典型クエリが、期待通りの行集合を返す
+        （index はクエリプランを変えるだけで結果集合は変わらない）"""
+        conn = get_connection()
+        try:
+            d1 = conn.execute(
+                "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                ("対象決定", "理由1"),
+            ).lastrowid
+            d2 = conn.execute(
+                "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                ("対象外決定", "理由2"),
+            ).lastrowid
+            conn.commit()
+
+            tag_ids = ensure_tag_ids(conn, [("domain", "filter-target")])
+            link_tags(conn, "decision_tags", "decision_id", d1, tag_ids)
+            conn.commit()
+
+            rows = conn.execute(
+                "SELECT decision_id FROM decision_tags WHERE tag_id = ?",
+                (tag_ids[0],),
+            ).fetchall()
+            matched_ids = {row["decision_id"] for row in rows}
+            assert matched_ids == {d1}
+            assert d2 not in matched_ids
+        finally:
+            conn.close()

--- a/tests/test_migrations/test_0050_cleanup_vec_orphans.py
+++ b/tests/test_migrations/test_0050_cleanup_vec_orphans.py
@@ -12,23 +12,10 @@ from yoyo import default_migration_table, read_migrations
 from yoyo.connections import parse_uri
 from yoyo.migrations import MigrationList
 
-from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection
 from src.services.tag_service import _injected_tags
 
 EMBEDDING_DIM = 384
-
-
-@pytest.fixture
-def migrated_db():
-    """全 migration（0050 含む）を適用済みのテスト用 DB を提供する。"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        os.environ["DISCUSSION_DB_PATH"] = db_path
-        init_database()
-        _injected_tags.clear()
-        yield db_path
-        if "DISCUSSION_DB_PATH" in os.environ:
-            del os.environ["DISCUSSION_DB_PATH"]
 
 
 @pytest.fixture
@@ -203,11 +190,57 @@ class TestNonOrphanRowsPreserved:
         finally:
             conn.close()
 
-    def test_no_orphans_no_op(self, migrated_db):
-        """孤児が無い状態でも 0050 適用済みDBの初期化は正常に完走する（no-op確認）"""
+    def test_no_orphans_no_op(self, db_before_0050):
+        """孤児が 1 行も無い状態（vec_index の全行が search_index の行に対応）で
+        0050 を適用しても、vec_index の行は 1 行も削除されないことを確認する。
+
+        search_index には行があるが vec_index には対応行が無いエントリを混在させ、
+        それらが誤って削除の巻き添えにならないことも合わせて確認する。
+        """
         conn = get_connection()
         try:
-            count = conn.execute("SELECT COUNT(*) AS c FROM vec_index").fetchone()["c"]
-            assert count == 0
+            # search_index に登録される複数エンティティを作成
+            search_ids = []
+            for i in range(4):
+                cur = conn.execute(
+                    "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                    (f"決定{i}", f"理由{i}"),
+                )
+                conn.commit()
+                sid = conn.execute(
+                    "SELECT id FROM search_index WHERE source_type='decision' AND source_id=?",
+                    (cur.lastrowid,),
+                ).fetchone()["id"]
+                search_ids.append(sid)
+
+            # 前半のみ vec_index に登録する（後半は search_index 行だけ存在し vec 行なし）。
+            # vec_index の全行が search_index の行に対応する = 孤児ゼロの状態。
+            vec_rowids = search_ids[:2]
+            for i, sid in enumerate(vec_rowids):
+                conn.execute(
+                    "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                    (sid, _make_embedding(0.05 * (i + 1))),
+                )
+            conn.commit()
+
+            before = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            assert before == set(vec_rowids)
+        finally:
+            conn.close()
+
+        _apply_migration_0050(db_before_0050)
+
+        conn = get_connection()
+        try:
+            after = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            assert after == before, (
+                "孤児が 1 行も無い状態で 0050 が vec_index の行を削除してしまった"
+            )
         finally:
             conn.close()

--- a/tests/test_migrations/test_0050_cleanup_vec_orphans.py
+++ b/tests/test_migrations/test_0050_cleanup_vec_orphans.py
@@ -1,0 +1,213 @@
+"""migration 0050_cleanup_vec_orphans のテスト
+
+0050 適用後に、対応する search_index 行を持たない vec_index の孤児行が削除され、
+対応行を持つ vec_index 行は 1 行も消えないことを確認する。
+"""
+import os
+import tempfile
+
+import pytest
+from sqlite_vec import serialize_float32
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+
+EMBEDDING_DIM = 384
+
+
+@pytest.fixture
+def migrated_db():
+    """全 migration（0050 含む）を適用済みのテスト用 DB を提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0050():
+    """0049 までの migration を適用した DB を提供する。0050 の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0050 = MigrationList([m for m in all_migs if m.id < "0050"])
+        with backend.lock():
+            backend.apply_migrations(pre_0050)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0050(db_path: str) -> None:
+    """db_path に対して migration 0050 のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0050 = MigrationList([m for m in all_migs if m.id.startswith("0050")])
+    with backend.lock():
+        backend.apply_migrations(only_0050)
+
+
+def _make_embedding(seed: float) -> bytes:
+    return serialize_float32([seed] * EMBEDDING_DIM)
+
+
+class TestOrphanRowsRemoved:
+    """search_index に対応行の無い vec_index 行が 0050 適用で削除されることの確認"""
+
+    def test_orphan_vec_rows_deleted_after_0050(self, db_before_0050):
+        """search_index に無い rowid を持つ vec_index 行は 0050 適用後に消える"""
+        conn = get_connection()
+        try:
+            # 実エンティティ（search_indexに行がある）
+            real_cur = conn.execute(
+                "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                ("実在決定", "理由"),
+            )
+            conn.commit()
+            real_search_id = conn.execute(
+                "SELECT id FROM search_index WHERE source_type='decision' AND source_id=?",
+                (real_cur.lastrowid,),
+            ).fetchone()["id"]
+
+            conn.execute(
+                "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                (real_search_id, _make_embedding(0.1)),
+            )
+            # 孤児: search_indexに対応行が無いrowid
+            orphan_rowid = real_search_id + 10000
+            conn.execute(
+                "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                (orphan_rowid, _make_embedding(0.2)),
+            )
+            conn.commit()
+
+            # 前提確認: 適用前は両方存在する
+            rowids_before = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            assert real_search_id in rowids_before
+            assert orphan_rowid in rowids_before
+        finally:
+            conn.close()
+
+        _apply_migration_0050(db_before_0050)
+
+        conn = get_connection()
+        try:
+            rowids_after = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            assert orphan_rowid not in rowids_after, (
+                "search_index に対応行の無い孤児 vec_index 行が 0050 適用後も残っている"
+            )
+            assert real_search_id in rowids_after, (
+                "search_index に対応行のある vec_index 行が誤って削除された"
+            )
+        finally:
+            conn.close()
+
+    def test_multiple_orphans_all_removed(self, db_before_0050):
+        """複数の孤児行がすべて削除される"""
+        conn = get_connection()
+        try:
+            orphan_rowids = [900001, 900002, 900003]
+            for i, rowid in enumerate(orphan_rowids):
+                conn.execute(
+                    "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                    (rowid, _make_embedding(0.1 * (i + 1))),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0050(db_before_0050)
+
+        conn = get_connection()
+        try:
+            remaining = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            for rowid in orphan_rowids:
+                assert rowid not in remaining
+        finally:
+            conn.close()
+
+
+class TestNonOrphanRowsPreserved:
+    """search_index に対応行を持つ vec_index 行が 1 行も消えないことの確認"""
+
+    def test_all_valid_vec_rows_survive_migration(self, db_before_0050):
+        """search_index の全行に対応する vec_index 行を作った状態で 0050 を適用しても、
+        1 行も消えない"""
+        conn = get_connection()
+        try:
+            search_ids = []
+            for i in range(5):
+                cur = conn.execute(
+                    "INSERT INTO discussion_logs (title, content) VALUES (?, ?)",
+                    (f"ログ{i}", f"内容{i}"),
+                )
+                conn.commit()
+                sid = conn.execute(
+                    "SELECT id FROM search_index WHERE source_type='log' AND source_id=?",
+                    (cur.lastrowid,),
+                ).fetchone()["id"]
+                search_ids.append(sid)
+
+            for i, sid in enumerate(search_ids):
+                conn.execute(
+                    "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                    (sid, _make_embedding(0.01 * (i + 1))),
+                )
+            conn.commit()
+
+            before_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM vec_index"
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+
+        _apply_migration_0050(db_before_0050)
+
+        conn = get_connection()
+        try:
+            after_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM vec_index"
+            ).fetchone()["c"]
+            assert after_count == before_count, (
+                "search_index に対応行を持つ vec_index 行が 0050 適用で減ってしまった"
+            )
+            remaining = {
+                row["rowid"]
+                for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
+            }
+            assert remaining == set(search_ids)
+        finally:
+            conn.close()
+
+    def test_no_orphans_no_op(self, migrated_db):
+        """孤児が無い状態でも 0050 適用済みDBの初期化は正常に完走する（no-op確認）"""
+        conn = get_connection()
+        try:
+            count = conn.execute("SELECT COUNT(*) AS c FROM vec_index").fetchone()["c"]
+            assert count == 0
+        finally:
+            conn.close()


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

タグでの絞り込みクエリがindex欠如で実質フルスキャンになっていた問題と、ベクトル検索のグローバルKNN候補スロットを孤児行が浪費していた問題を、2本のmigrationで解消する。

- `topic_tags` / `activity_tags` / `decision_tags` / `log_tags` はいずれも複合主キー (entity_id, tag_id) のみを持ち、tag_id側からの逆引きindexが無かった（`material_tags`のみ既に持っていた）。タグでの絞り込み・タグ削除影響調査などのクエリはこの4テーブルで実質フルスキャンになる。逆引きindexを追加する。
- `search_index.created_at` にも日付フィルタクエリの補助としてindexを追加する。
- `vec_index`（ベクトル検索用の仮想テーブル）は、対応する `search_index` 行を持たない孤児行を実測で31.5%抱えていた。原因は、retract経路以外のエンティティ削除（CASCADE等）が `vec_index` 側を掃除しない構造にある。孤児行はグローバルKNNの候補スロットを消費し、`search_index` とのJOIN段で黙って消えるため、名目の取得件数が実質目減りする。対応する `search_index` 行を持たない `vec_index` 行を削除する。

いずれもデータの意味・既存クエリの結果集合は変えない（indexはクエリプランのみに影響し、孤児行削除は「元々使えていなかった行」の除去）。挙動不変・性能/容量のみの変更。

## 補足

設計文書上、方向性層（タグのnamespace実装）が `idx_decision_tags_tag` を含むこのindex群に依存する形で計画されている。本PRはその依存の解消を含む。

なお、依存関係にある `feature/search-hygiene-migration` ブランチは他PRと migration 番号が衝突する可能性がある（並行して他のPRも同じ番号帯を採番することがあるため）。実際のマージ順で若い番号を持つ側が確定する運用と認識している。

## テスト計画

新規テスト（`tests/test_migrations/test_0049_add_tag_junction_indexes.py`）:
- 5本のindex（junction 4本 + search_index.created_at）が migration 適用後に存在し、適用前には存在しないこと
- 各indexが対象とするカラム（tag_id / created_at）が正しいこと
- migration適用前に投入したタグ紐付けデータが適用後も保持されること
- タグでの絞り込みクエリの結果集合がindex追加前後で変わらないこと

新規テスト（`tests/test_migrations/test_0050_cleanup_vec_orphans.py`）:
- `search_index` に対応行の無い `vec_index` 孤児行が単数・複数いずれのケースでも削除されること
- `search_index` に対応行を持つ `vec_index` 行は1行も削除されないこと（行数・rowid集合の完全一致で確認）
- 孤児が無い状態でもmigrationがno-opとして正常完走すること

既存テスト群への影響: unit 2012件 + skip 1件、test_migrations/integration/e2e 643件、いずれも既存分の破壊なし。