### PR TITLE
feat: 境界ゲート検出器を追加

### DIFF
--- a/docs/spec/go-gate.md
+++ b/docs/spec/go-gate.md
@@ -81,7 +81,7 @@ PR のワークツリーには変更済みの検出器が含まれ得るため�
 | 検出器 | 対象 |
 |---|---|
 | `migration_touch` | `migrations/` 配下への接触(追加・変更・削除・rename すべて) |
-| `ddl_in_code` | コード内の DDL(`CREATE`/`ALTER`/`DROP` + `TABLE`/`INDEX`/`TRIGGER`/`VIEW`/`VIRTUAL TABLE`、書き込み `PRAGMA`)。追加行・削除行の両方を走査する |
+| `ddl_in_code` | コード内の DDL(`CREATE`/`ALTER`/`DROP` + `TABLE`/`INDEX`/`TRIGGER`/`VIEW`。動詞と対象の間に `UNIQUE`/`TEMP`/`TEMPORARY`/`VIRTUAL` 等の修飾語を挟む形も拾う。書き込み `PRAGMA`)。追加行・削除行の両方を走査する |
 | `public_if` | 公開IF(`src/main.py`、`src/remote.py`、`src/http_config.py`、`src/services/visibility_middleware.py`、`docs/spec/openapi.yaml`、`hooks/hooks.json`、`marketplace.json`)への接触 |
 | `data_destructive` | 追加行の破壊的SQL(`DELETE FROM`/`UPDATE ... SET`/`TRUNCATE`)・破壊的ファイル操作(`shutil.rmtree`/`os.remove`等) |
 | `binary_change` | numstat が `-`(バイナリ)を返す変更 |

--- a/docs/spec/go-gate.md
+++ b/docs/spec/go-gate.md
@@ -1,0 +1,231 @@
+# 境界ゲート判定(go-gate)運用マニュアル
+
+対象: `scripts/gate_check.py` / `scripts/gate_check.sh`。
+
+設計案の変更が「事前にコードを読んで確認すべき類」か「事後に拒否権を行使できれば足りる類」かを、
+`git diff` から機械的に判定するための検出器の仕様と運用手順をまとめる。
+
+確定した事実は断定形(〜である)、推測・仮説は「〜と考えられる」「〜が望ましい」で書き分ける。
+
+## 現状の実装範囲
+
+現時点でリポジトリに存在するのは検出器本体(`scripts/gate_check.py`、`scripts/gate_check.sh`)と
+このドキュメントのみである。以下は未実装である:
+
+- GO判定パッケージのテンプレート・雛形生成・lint ツール(`scripts/go_package.py`)
+- CI ワークフロー(`.github/workflows/gate.yml`)による PR ごとの自動判定
+- shadow 集計ツール(`go_package.py shadow-report`)
+- plan.md / task-plan・task-execute skill への組み込み(分類予測欄、パッケージ生成手順)
+
+検出器は現状、手元で `uv run python3 scripts/gate_check.py --base <ref> --head <ref>` として
+単体で呼び出せる状態にあるのみで、shadow 校正期の運用(下記)はこれらの後続コンポーネントが
+揃ってから開始する。
+
+## 3値分類
+
+| 分類 | 意味 |
+|---|---|
+| `pre_go` | 事前にコードを読んで確認すべき変更。締め領域(ブラスト半径が大きい・revertが困難)に触れている、または判定不能 |
+| `gray` | 機械的にどちらとも判定し切れない変更。人間の追加判断(グレー解決)が必要 |
+| `post_veto_candidate` | 事後の拒否権行使で足りる変更候補。ブラスト半径が小さく revert が容易 |
+
+`post_veto_candidate` は「デフォルトで進めてよい」ことを機械的に**保証する**分類ではなく、
+事後拒否権運用の**候補**であることに注意する。実際にデフォルト進行の対象にするかどうかは
+ダイヤル運用(体制側の裁定)に従う。shadow 校正期間中は `post_veto_candidate` であっても
+運用上の判断には一切使わない(後述)。
+
+各分類には理由コード(`reason`)が付与される。
+
+| reason | 分類 | 意味 |
+|---|---|---|
+| `detector_error` | pre_go | git コマンド失敗・diffパース例外・非UTF-8デコード失敗など、判定不能 |
+| `self_protection` | pre_go | 検出器自身のパス(下記)への接触 |
+| `axis_a_hit` | pre_go | ブラスト半径検出器(migration接触・DDL・公開IF・破壊系・バイナリ)がヒット |
+| `policy_pending` | gray | 依存ライブラリ変更(`pyproject.toml` / `uv.lock`)への接触。裁定待ちにつき強制グレー |
+| `axis_b_unmet` | gray | ブラスト半径はクリアだが revert 容易性の条件(サイズ・テスト・機械rollback)を満たさない |
+| `axis_b_met` | post_veto_candidate | ブラスト半径・revert容易性の両方をクリア |
+
+## 判定規則とフェイルセーフ
+
+評価順序は次の通りで、上から短絡する(`classify()` の実装がそのまま規則である)。
+
+1. **判定不能は事前go**(`detector_error`): git 呼び出し失敗・diffパース例外・非UTF-8デコード
+   失敗は握り潰さず `errors` に積み、`pre_go` を返す。検出器はどの経路でも必ず verdict を返し、
+   内部バグによる例外だけが非0終了になる
+2. **検出器自己保護**(`self_protection`): 以下のパスへの接触は他の結果によらず `pre_go` 固定にする
+
+   ```
+   scripts/gate_check.py
+   scripts/gate_check.sh
+   scripts/go_package.py
+   .github/workflows/gate.yml
+   tests/unit/test_gate_check.py
+   tests/unit/test_go_package.py
+   ```
+
+   判定器を触る変更が判定そのものを迂回できないための invariant である
+3. **軸Aヒットは事前go**(`axis_a_hit`): migration接触・DDL・公開IF変更・破壊系操作・バイナリ変更の
+   いずれかが `counted` ステータスで検出された場合
+4. **依存変更は強制グレー**(`policy_pending`): `pyproject.toml` / `uv.lock` への接触は軸Bの結果に
+   かかわらず `gray` にする
+5. **軸B充足で事後拒否権候補**(`axis_b_met`)、**未充足でグレー**(`axis_b_unmet`)
+
+### 改竄耐性
+
+PR のワークツリーには変更済みの検出器が含まれ得るため、正規の判定は常に **origin/main 版の
+検出器**で行う。ローカルは `scripts/gate_check.sh`(origin/main から取り出して実行する)を使う。
+`scripts/gate_check.py` を直接叩いた結果は、ブランチ側の改変を反映した参考値でしかない。
+
+## 軸A: ブラスト半径検出器
+
+| 検出器 | 対象 |
+|---|---|
+| `migration_touch` | `migrations/` 配下への接触(追加・変更・削除・rename すべて) |
+| `ddl_in_code` | コード内の DDL(`CREATE`/`ALTER`/`DROP` + `TABLE`/`INDEX`/`TRIGGER`/`VIEW`/`VIRTUAL TABLE`、書き込み `PRAGMA`)。追加行・削除行の両方を走査する |
+| `public_if` | 公開IF(`src/main.py`、`src/remote.py`、`src/http_config.py`、`src/services/visibility_middleware.py`、`docs/spec/openapi.yaml`、`hooks/hooks.json`、`marketplace.json`)への接触 |
+| `data_destructive` | 追加行の破壊的SQL(`DELETE FROM`/`UPDATE ... SET`/`TRUNCATE`)・破壊的ファイル操作(`shutil.rmtree`/`os.remove`等) |
+| `binary_change` | numstat が `-`(バイナリ)を返す変更 |
+| `dependency_change` | `pyproject.toml` / `uv.lock` への接触。軸Aヒットではなく強制グレー(`policy_pending`) |
+
+除外規則:
+
+- `tests/` 配下の DDL・破壊的操作は `downgraded_tests` として記録するが、分類のゲーティングには
+  数えない(テストは ephemeral DB に対して走り、本番DBへの到達経路が無いため)
+- `*.md` と `docs/` 配下はコンテンツ走査の対象外(SQL実行面を持たないため)。ただし
+  `docs/spec/openapi.yaml` は `public_if` のパス一致対象であり、これとは独立している
+- コメント内の DDL・破壊系キーワード(例: `# ALTER TABLE ...` というコメント追加)は誤検出を
+  許容する。誤検出は安全側(pre_go)に倒れるため、正規表現でコメント判定を積むより単純さを
+  優先している
+
+`src/main.py` が diff に含まれる場合のみ、公開IFの差分を AST 解析で抽出する(`public_if_delta`)。
+これは判定材料の**充実**(人間が読む「何が変わったか」の要約)にのみ使い、分類そのものには
+影響しない。parse に失敗した場合は `errors` に積むが、`public_if` のパス一致による `pre_go` 判定
+自体はそれとは独立に成立する。
+
+## 軸B: revert容易性
+
+軸Aが全クリア(counted findingsが無い)の場合のみ評価する。3条件のANDで `met` を決める。
+
+- **サイズ**: 本体コード行(`tests/`・`docs/`・`*.md`・`uv.lock` を除外した追加+削除行数)が
+  `MAX_LINES`(既定400)以下、かつファイル数(`uv.lock` のみ除外)が `MAX_FILES`(既定15)以下
+- **テスト差分**: 変更ファイルに `tests/` 配下が1つ以上含まれる。全変更ファイルが `.md` または
+  `docs/` 配下のときは `waived_docs_only` として充足扱いにする
+- **機械rollback**: migration非接触・DDL非検出・破壊系非検出・バイナリ変更なしのとき成立する
+
+閾値(`MAX_LINES` / `MAX_FILES`)は初期提案値であり、shadow 期の実測データで校正する前提を置く。
+
+## verdict JSON
+
+`scripts/gate_check.py --base <ref> --head <ref> --format json` の出力例:
+
+```json
+{
+  "schema_version": 1,
+  "detector_sha256": "...",
+  "detector_source": "main",
+  "repo": "cc-memory",
+  "base_ref": "origin/main",
+  "merge_base": "<sha>",
+  "head": "<sha>",
+  "classification": "pre_go",
+  "reason": "axis_a_hit",
+  "axis_a": { "hit": true, "findings": [ { "detector": "migration_touch", "path": "migrations/0049_x.sql", "lineno": null, "evidence": "status=A", "status": "counted" } ] },
+  "axis_b": { "lines_changed": 214, "files_changed": 6, "size_ok": true, "has_tests": true, "mechanical_rollback": true, "met": true },
+  "public_if_delta": { "tools_added": [], "tools_removed": [], "params_changed": [], "docstring_changed": [] },
+  "ignored_paths": ["uv.lock"],
+  "errors": []
+}
+```
+
+同一 diff 入力に対して出力はバイト同一になる(findings は `(detector, path, lineno)` でソート、
+JSON は `sort_keys=True` で出力する)。`--render <verdict.json>` で `axis_a`/`axis_b` を人間可読な
+markdown に変換できる。
+
+## CLI
+
+```
+uv run python3 scripts/gate_check.py --base origin/main --head HEAD \
+    [--repo <path>] [--format json|markdown|both] [--out <path>] \
+    [--detector-source main|worktree]
+
+uv run python3 scripts/gate_check.py --render <verdict.json> [--out <path>]
+
+scripts/gate_check.sh --base origin/main --head HEAD   # 正規経路。origin/main 版検出器を使う
+```
+
+exit code は verdict を返せた場合は常に0。内部例外(検出器自身のバグ)のみ非0になる。
+
+## shadow 校正期の運用(パッケージツール・CI導入後に開始)
+
+以下は設計時点の運用方針であり、`go_package.py` と `.github/workflows/gate.yml` が揃うまでは
+実施できない。揃った時点でこの節を実運用の起点とする。
+
+### 何を影判定するか
+
+- 対象は cc-memory リポジトリの main 向け全 PR(例外なし)
+- shadow 期間中、検出器の分類は**運用に一切使わない**。全案件を従来通り人間判断で進める。
+  検出器は記録だけを積む
+
+### 何と突き合わせるか
+
+- ground truth はユーザー自身が下す分類判断(「コード読みが必要な類か / パッケージだけで
+  判断できる類か」を1問だけ聞く)
+- 突き合わせ(`divergence`)は下表から機械的に導出する。手で分類しない
+
+| machine | human | divergence | 意味 |
+|---|---|---|---|
+| post_veto_candidate | post_veto_candidate | none | 一致 |
+| pre_go | pre_go | none | 一致 |
+| post_veto_candidate | pre_go | false_negative | 締め領域の見逃し。最優先で検出器改修 |
+| pre_go | post_veto_candidate | false_positive | 過剰保守。安全側。頻度のみ監視 |
+| gray | いずれか | gray_case | 検出器の失敗ではない。グレー解決手続きの校正データ |
+
+### 乖離への対処優先順位
+
+1. `false_negative`: 締め領域の見逃し。検出器の改修対象として最優先。該当ケースを再現する
+   回帰テストを必ず伴う
+2. `gray_case`: 検出器の欠陥ではないが、`axis_b_unmet` の内訳(サイズ超過かテスト欠如か)を
+   集計し閾値の校正データにする
+3. `false_positive`: 安全側。頻度が高い検出器は精緻化候補として記録するに留め、shadow期間中の
+   緩和は原則行わない(緩和は false_negative リスクとの交換になるため)
+
+### 昇格条件(件数基準)
+
+以下の AND を満たしたときのみ、ユーザーの明示判断として本番化する(自動昇格はしない)。
+
+1. 直近 N 件の連続案件で `false_negative` がゼロ(N は shadow開始時にユーザーが決める)
+2. 連続無事故のカウントは `detector_sha256` が変わるたびにリセットする
+3. shadow期に発生した全乖離に `divergence_reason` が記入済みで、`false_negative` は全件が
+   検出器改修+回帰テスト追加済み
+4. 連続無事故ウィンドウ内の全 merge済みPRにパッケージが存在する(欠落ゼロ)
+
+### 降格条件
+
+昇格後、merge済み `post_veto_candidate` 案件について `false_negative` が1件でも事後判明したら
+(抜き取り監査での発覚を含む)、即座に shadow へ戻す。降格・原因分析・検出器改修・再昇格の
+記録を残す。
+
+## 既知の検出ギャップ・過剰検出
+
+shadow 期の観察対象として記録しておく。`false_negative` として実測されたら検出器を拡張し、
+実測されなければ現状の単純さを維持する。過剰検出(`false_positive`)の緩和は昇格前の校正課題
+として扱う。
+
+- サービス層の返り値 dict の形状変更(レスポンス形状の変更だが `PUBLIC_IF_PATHS` 外で起きうる)
+- skill markdown 内の破壊的指示文(markdown除外規則の盲点。LLMへの指示文として
+  「DELETE FROM を実行せよ」と書ける)
+- 実行時に組み立てられる動的SQL(文字列連結でDDL/破壊文が完成するケース)
+- サービス層CRUD由来の `data_destructive` 過剰ヒット: `UPDATE ... SET` / `DELETE FROM` は
+  通常のCRUD実装として多数存在するため、永続化を触る通常の機能追加PRが高確率で `pre_go`
+  固定になる構造的 false positive がある。shadow期に CRUD由来ヒット率を計測し、パラメタライズド
+  WHERE付きUPDATE/DELETEの扱い(降格または文脈限定)を昇格前の校正課題とする
+- `public_if` の広すぎるヒット: `src/main.py` はツール定義とヘルパーが同居しており、任意行の
+  接触で hit する。ツール表面 vs ヘルパーのみ、の内訳を AST差分で分類集計し、同じく昇格前の
+  校正課題とする
+
+## 他コンポーネントとの共有物
+
+- パターン定数(`DDL_PATTERNS` / `DESTRUCTIVE_SQL_PATTERNS` / `DESTRUCTIVE_FS_PATTERNS`)と
+  サイズ計数関数(`count_diff_size()`)・閾値定数(`MAX_LINES` / `MAX_FILES`)は
+  `scripts/gate_check.py` を単一ソースとする。他コンポーネント(PRサイズlint、migration安全
+  装置)はこれを import して使い、二重定義しない

--- a/scripts/gate_check.py
+++ b/scripts/gate_check.py
@@ -1,0 +1,879 @@
+#!/usr/bin/env python3
+"""境界ゲート検出器: git diff からブラスト半径(軸A)とrevert容易性(軸B)を機械判定する。
+
+標準ライブラリのみで動く単一ファイル。外部依存なしで `python3 scripts/gate_check.py`
+として直接実行できる(uv sync 不要)。
+
+判定不能なときは常に安全側(pre_go)へフォールバックする。検出器自身が例外で
+落ちることは無く、どの経路でも verdict を返す(内部バグによる例外のみ非0終了)。
+
+出力は decision(pre_go/gray/post_veto_candidate)と reason コードを持つ JSON
+(verdict)。`--render` で verdict JSON を人間可読な markdown に変換できる。
+
+正規の呼び出し経路は `scripts/gate_check.sh`(origin/main 版検出器を取り出して
+実行する)であり、このファイル単体を worktree 上で直接叩いた判定は改竄され得る
+参考値として扱うこと。
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import dataclasses
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional, Union
+
+# ---------------------------------------------------------------------------
+# 定数: 検出パターン・パスリスト・閾値
+#
+# migration 安全装置(破壊的変更 lint)・PR サイズ lint はこのモジュールの
+# パターン定数・閾値定数・count_diff_size() を単一ソースとして import する。
+# ---------------------------------------------------------------------------
+
+DDL_PATTERNS: tuple[str, ...] = (
+    r"(?i)\b(CREATE|ALTER|DROP)\s+(TABLE|INDEX|TRIGGER|VIEW|VIRTUAL\s+TABLE)\b",
+    r"(?i)\bPRAGMA\s+\w+\s*=",  # PRAGMA の「書き込み」のみ。読み取りは対象外
+)
+
+DESTRUCTIVE_SQL_PATTERNS: tuple[str, ...] = (
+    r"(?i)\bDELETE\s+FROM\b",
+    r"(?i)\bUPDATE\s+\w+\s+SET\b",  # update_material( 等の関数名にはマッチしない
+    r"(?i)\bTRUNCATE\b",
+)
+
+DESTRUCTIVE_FS_PATTERNS: tuple[str, ...] = (
+    r"\bshutil\.rmtree\b",
+    r"\bos\.(remove|unlink|rmdir)\b",
+    r"\.unlink\(",
+)
+
+PUBLIC_IF_PATHS: tuple[str, ...] = (
+    "src/main.py",
+    "src/remote.py",
+    "src/http_config.py",
+    "src/services/visibility_middleware.py",
+    "docs/spec/openapi.yaml",
+    "hooks/hooks.json",
+    "marketplace.json",
+)
+
+DEPENDENCY_PATHS: tuple[str, ...] = (
+    "pyproject.toml",
+    "uv.lock",
+)
+
+# 判定器を触る変更が判定を迂回できないための自己保護パス。
+# ここに列挙されたパスへの接触は他の検出結果によらず pre_go に固定する。
+DETECTOR_SELF_PATHS: tuple[str, ...] = (
+    "scripts/gate_check.py",
+    "scripts/gate_check.sh",
+    "scripts/go_package.py",
+    ".github/workflows/gate.yml",
+    "tests/unit/test_gate_check.py",
+    "tests/unit/test_go_package.py",
+)
+
+DEPENDENCY_LOCK_FILE = "uv.lock"
+
+MAX_LINES = 400
+MAX_FILES = 15
+
+EVIDENCE_MAX_LEN = 200
+
+Classification = Literal["pre_go", "gray", "post_veto_candidate"]
+
+
+# ---------------------------------------------------------------------------
+# 中間表現
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileChange:
+    """git diff --name-status 1件分の正規化表現。"""
+
+    path: str  # rename は新パス
+    old_path: Optional[str]
+    status: str  # "A" | "M" | "D" | "R" | "C" | "T"
+    additions: int  # numstat 由来。バイナリは -1、未解決は 0
+    deletions: int
+    is_binary: bool
+
+
+@dataclass(frozen=True)
+class NumstatRow:
+    """git diff --numstat 1行分の正規化表現。"""
+
+    path: str
+    old_path: Optional[str]
+    additions: int  # バイナリは -1
+    deletions: int
+    is_binary: bool
+
+
+@dataclass(frozen=True)
+class DiffLine:
+    """git diff --unified=0 の追加/削除行1件。"""
+
+    path: str
+    sign: str  # "+" | "-"
+    new_lineno: Optional[int]  # 追加行のみ
+    old_lineno: Optional[int]  # 削除行のみ
+    text: str  # +/- 記号を除いた本文
+
+
+@dataclass(frozen=True)
+class Finding:
+    detector: str
+    path: str
+    lineno: Optional[int]
+    evidence: str
+    status: str  # "counted" | "downgraded_tests" | "policy_pending"
+
+
+@dataclass(frozen=True)
+class AxisB:
+    lines_changed: int
+    files_changed: int
+    size_ok: bool
+    has_tests: Union[bool, str]  # True / False / "waived_docs_only"
+    mechanical_rollback: bool
+    met: bool
+
+
+_EMPTY_PUBLIC_IF_DELTA = {
+    "tools_added": [],
+    "tools_removed": [],
+    "params_changed": [],
+    "docstring_changed": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# git 呼び出し
+# ---------------------------------------------------------------------------
+
+
+def _run_git_bytes(repo: Path, args: list[str]) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return result.stdout
+
+
+def _run_git_text(repo: Path, args: list[str]) -> str:
+    return _run_git_bytes(repo, args).decode("utf-8")
+
+
+def get_merge_base(repo: Path, base_ref: str, head_ref: str) -> str:
+    return _run_git_text(repo, ["merge-base", base_ref, head_ref]).strip()
+
+
+def get_head_sha(repo: Path, head_ref: str) -> str:
+    return _run_git_text(repo, ["rev-parse", head_ref]).strip()
+
+
+def _git_show_file(repo: Path, rev: str, path: str) -> Optional[str]:
+    """rev 時点の path の内容を返す。存在しない(新規追加/既に削除)なら None。"""
+    try:
+        raw = _run_git_bytes(repo, ["show", f"{rev}:{path}"])
+    except subprocess.CalledProcessError:
+        return None
+    return raw.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# パース
+# ---------------------------------------------------------------------------
+
+
+def parse_name_status(raw: bytes) -> list[FileChange]:
+    """`git diff --name-status -M -z` の出力をパースする。"""
+    text = raw.decode("utf-8")
+    tokens = text.split("\0")
+    if tokens and tokens[-1] == "":
+        tokens.pop()
+    changes: list[FileChange] = []
+    i = 0
+    while i < len(tokens):
+        status_field = tokens[i]
+        if not status_field:
+            raise ValueError("empty status field in name-status output")
+        status = status_field[0]
+        i += 1
+        if status in ("R", "C"):
+            if i + 1 >= len(tokens):
+                raise ValueError(f"truncated rename/copy record: {status_field!r}")
+            old_path = tokens[i]
+            i += 1
+            new_path = tokens[i]
+            i += 1
+            changes.append(
+                FileChange(path=new_path, old_path=old_path, status=status, additions=0, deletions=0, is_binary=False)
+            )
+        else:
+            if i >= len(tokens):
+                raise ValueError(f"truncated record: {status_field!r}")
+            path = tokens[i]
+            i += 1
+            changes.append(
+                FileChange(path=path, old_path=None, status=status, additions=0, deletions=0, is_binary=False)
+            )
+    return changes
+
+
+_RENAME_BRACE_RE = re.compile(r"\{([^{}]*) => ([^{}]*)\}")
+
+
+def _resolve_numstat_path(pathspec: str) -> tuple[str, Optional[str]]:
+    """numstat のパス欄(rename時は `{old => new}` または `old => new` 形式)を解決する。"""
+    if "{" in pathspec and " => " in pathspec:
+        new_path = _RENAME_BRACE_RE.sub(lambda m: m.group(2), pathspec)
+        old_path = _RENAME_BRACE_RE.sub(lambda m: m.group(1), pathspec)
+        return new_path, old_path
+    if " => " in pathspec:
+        old_path, new_path = pathspec.split(" => ", 1)
+        return new_path, old_path
+    return pathspec, None
+
+
+def parse_numstat(raw: str) -> list[NumstatRow]:
+    """`git diff --numstat -M` の出力をパースする。"""
+    rows: list[NumstatRow] = []
+    for line in raw.split("\n"):
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) != 3:
+            raise ValueError(f"unparseable numstat line: {line!r}")
+        added_s, deleted_s, pathspec = parts
+        is_binary = added_s == "-" or deleted_s == "-"
+        additions = -1 if is_binary else int(added_s)
+        deletions = -1 if is_binary else int(deleted_s)
+        new_path, old_path = _resolve_numstat_path(pathspec)
+        rows.append(NumstatRow(path=new_path, old_path=old_path, additions=additions, deletions=deletions, is_binary=is_binary))
+    return rows
+
+
+def merge_numstat_into_changes(changes: list[FileChange], numstat_rows: list[NumstatRow]) -> list[FileChange]:
+    """numstat の additions/deletions/is_binary を name-status 由来の FileChange に反映する。"""
+    by_path = {row.path: row for row in numstat_rows}
+    merged: list[FileChange] = []
+    for c in changes:
+        row = by_path.get(c.path)
+        if row is not None:
+            merged.append(dataclasses.replace(c, additions=row.additions, deletions=row.deletions, is_binary=row.is_binary))
+        else:
+            merged.append(c)
+    return merged
+
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _strip_diff_prefix(path: str) -> Optional[str]:
+    if path == "/dev/null":
+        return None
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def parse_diff_lines(diff_text: str) -> list[DiffLine]:
+    """`git diff --unified=0 --no-color` の出力から追加/削除行を抽出する。
+
+    文脈行が無い(unified=0)ため、パーサは +/- 行だけを追えばよい。
+    """
+    lines = diff_text.split("\n")
+    result: list[DiffLine] = []
+    old_path: Optional[str] = None
+    new_path: Optional[str] = None
+    current_path: Optional[str] = None
+    old_lineno: Optional[int] = None
+    new_lineno: Optional[int] = None
+    in_hunk = False
+
+    for line in lines:
+        if line.startswith("diff --git "):
+            old_path = None
+            new_path = None
+            current_path = None
+            in_hunk = False
+            continue
+        if line.startswith("--- "):
+            old_path = _strip_diff_prefix(line[4:])
+            continue
+        if line.startswith("+++ "):
+            new_path = _strip_diff_prefix(line[4:])
+            current_path = new_path if new_path is not None else old_path
+            in_hunk = False
+            continue
+        if line.startswith("@@"):
+            m = _HUNK_RE.match(line)
+            if not m:
+                raise ValueError(f"unparseable hunk header: {line!r}")
+            old_lineno = int(m.group(1))
+            new_lineno = int(m.group(3))
+            in_hunk = True
+            continue
+        if not in_hunk or current_path is None:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            result.append(DiffLine(path=current_path, sign="+", new_lineno=new_lineno, old_lineno=None, text=line[1:]))
+            new_lineno = (new_lineno or 0) + 1
+        elif line.startswith("-"):
+            result.append(DiffLine(path=current_path, sign="-", new_lineno=None, old_lineno=old_lineno, text=line[1:]))
+            old_lineno = (old_lineno or 0) + 1
+        elif line.startswith("\\"):
+            continue  # "\ No newline at end of file"
+        else:
+            continue
+    return result
+
+
+def _evidence(sign: str, text: str, max_len: int = EVIDENCE_MAX_LEN) -> str:
+    joined = f"{sign}{text}"
+    return joined[:max_len]
+
+
+# ---------------------------------------------------------------------------
+# 軸A検出器
+# ---------------------------------------------------------------------------
+
+
+def _is_docs_excluded(path: str) -> bool:
+    return path.endswith(".md") or path.startswith("docs/")
+
+
+def _is_tests_path(path: str) -> bool:
+    return path.startswith("tests/")
+
+
+def detect_migration_touch(changes: list[FileChange]) -> list[Finding]:
+    findings = []
+    for c in changes:
+        touched_paths = [c.path] + ([c.old_path] if c.old_path else [])
+        if any(p.startswith("migrations/") for p in touched_paths):
+            findings.append(Finding(detector="migration_touch", path=c.path, lineno=None, evidence=f"status={c.status}", status="counted"))
+    return findings
+
+
+def detect_ddl_in_code(diff_lines: list[DiffLine]) -> list[Finding]:
+    findings = []
+    for dl in diff_lines:
+        if _is_docs_excluded(dl.path):
+            continue
+        for pattern in DDL_PATTERNS:
+            if re.search(pattern, dl.text):
+                status = "downgraded_tests" if _is_tests_path(dl.path) else "counted"
+                lineno = dl.new_lineno if dl.sign == "+" else dl.old_lineno
+                findings.append(Finding(detector="ddl_in_code", path=dl.path, lineno=lineno, evidence=_evidence(dl.sign, dl.text), status=status))
+                break
+    return findings
+
+
+def detect_public_if(changes: list[FileChange]) -> list[Finding]:
+    findings = []
+    public_if_set = set(PUBLIC_IF_PATHS)
+    for c in changes:
+        touched_paths = {c.path}
+        if c.old_path:
+            touched_paths.add(c.old_path)
+        if touched_paths & public_if_set:
+            findings.append(Finding(detector="public_if", path=c.path, lineno=None, evidence=f"status={c.status}", status="counted"))
+    return findings
+
+
+def detect_data_destructive(diff_lines: list[DiffLine]) -> list[Finding]:
+    findings = []
+    patterns = DESTRUCTIVE_SQL_PATTERNS + DESTRUCTIVE_FS_PATTERNS
+    for dl in diff_lines:
+        if dl.sign != "+":
+            continue
+        if _is_docs_excluded(dl.path):
+            continue
+        for pattern in patterns:
+            if re.search(pattern, dl.text):
+                status = "downgraded_tests" if _is_tests_path(dl.path) else "counted"
+                findings.append(Finding(detector="data_destructive", path=dl.path, lineno=dl.new_lineno, evidence=_evidence(dl.sign, dl.text), status=status))
+                break
+    return findings
+
+
+def detect_binary_change(changes: list[FileChange]) -> list[Finding]:
+    return [
+        Finding(detector="binary_change", path=c.path, lineno=None, evidence=f"status={c.status}", status="counted")
+        for c in changes
+        if c.is_binary
+    ]
+
+
+def detect_dependency_change(changes: list[FileChange]) -> list[Finding]:
+    findings = []
+    dep_set = set(DEPENDENCY_PATHS)
+    for c in changes:
+        touched_paths = {c.path}
+        if c.old_path:
+            touched_paths.add(c.old_path)
+        if touched_paths & dep_set:
+            findings.append(Finding(detector="dependency_change", path=c.path, lineno=None, evidence=f"status={c.status}", status="policy_pending"))
+    return findings
+
+
+def counted(findings: list[Finding]) -> bool:
+    return any(f.status == "counted" for f in findings)
+
+
+def pending(findings: list[Finding]) -> bool:
+    return any(f.status == "policy_pending" for f in findings)
+
+
+def is_self_touched(changes: list[FileChange]) -> bool:
+    self_paths = set(DETECTOR_SELF_PATHS)
+    for c in changes:
+        if c.path in self_paths:
+            return True
+        if c.old_path and c.old_path in self_paths:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 公開IF差分の AST 抽出(判定材料の充実。判定そのものには使わない)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolSig:
+    name: str
+    params: tuple[str, ...]
+    docstring_sha256: str
+
+
+def _is_mcp_tool_decorator(dec: ast.expr) -> bool:
+    node: ast.expr = dec.func if isinstance(dec, ast.Call) else dec
+    return isinstance(node, ast.Attribute) and node.attr == "tool" and isinstance(node.value, ast.Name) and node.value.id == "mcp"
+
+
+def _unparse_safe(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return "<?>"
+
+
+def _format_tool_params(node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> tuple[str, ...]:
+    args = node.args
+    params: list[str] = []
+    positional = list(getattr(args, "posonlyargs", [])) + list(args.args)
+    defaults = list(args.defaults)
+    num_no_default = len(positional) - len(defaults)
+    for idx, a in enumerate(positional):
+        seg = a.arg
+        if a.annotation is not None:
+            seg += f": {_unparse_safe(a.annotation)}"
+        if idx >= num_no_default:
+            seg += f" = {_unparse_safe(defaults[idx - num_no_default])}"
+        params.append(seg)
+    if args.vararg:
+        seg = f"*{args.vararg.arg}"
+        if args.vararg.annotation is not None:
+            seg += f": {_unparse_safe(args.vararg.annotation)}"
+        params.append(seg)
+    for kwa, d in zip(args.kwonlyargs, args.kw_defaults):
+        seg = kwa.arg
+        if kwa.annotation is not None:
+            seg += f": {_unparse_safe(kwa.annotation)}"
+        if d is not None:
+            seg += f" = {_unparse_safe(d)}"
+        params.append(seg)
+    if args.kwarg:
+        seg = f"**{args.kwarg.arg}"
+        if args.kwarg.annotation is not None:
+            seg += f": {_unparse_safe(args.kwarg.annotation)}"
+        params.append(seg)
+    return tuple(params)
+
+
+def extract_tool_surface(source: Optional[str], errors: list[str], label: str) -> dict[str, ToolSig]:
+    """`@mcp.tool()` 付き関数の表面を抽出する。
+
+    parse 失敗は例外を投げず errors に積んで空辞書を返す(呼び出し側の
+    public_if パス hit が既に判定へ影響しているため、ここでの失敗は
+    判定材料の欠落としてのみ扱う)。
+    """
+    if source is None:
+        return {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        errors.append(f"ast_parse_failed:{label}: {exc}")
+        return {}
+    tools: dict[str, ToolSig] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if any(_is_mcp_tool_decorator(dec) for dec in node.decorator_list):
+                docstring = ast.get_docstring(node) or ""
+                tools[node.name] = ToolSig(
+                    name=node.name,
+                    params=_format_tool_params(node),
+                    docstring_sha256=hashlib.sha256(docstring.encode("utf-8")).hexdigest(),
+                )
+    return tools
+
+
+def _param_name(param: str) -> str:
+    return param.lstrip("*").split(":")[0].split("=")[0].strip()
+
+
+def _describe_params_change(name: str, before: tuple[str, ...], after: tuple[str, ...]) -> str:
+    before_names = {_param_name(p) for p in before}
+    after_names = {_param_name(p) for p in after}
+    added = sorted(after_names - before_names)
+    removed = sorted(before_names - after_names)
+    before_by_name = {_param_name(p): p for p in before}
+    after_by_name = {_param_name(p): p for p in after}
+    changed = sorted(n for n in (before_names & after_names) if before_by_name[n] != after_by_name[n])
+    parts = []
+    if added:
+        parts.append(f"{','.join(added)} 引数追加")
+    if removed:
+        parts.append(f"{','.join(removed)} 引数削除")
+    if changed:
+        parts.append(f"{','.join(changed)} 型/デフォルト変更")
+    if not parts:
+        parts.append("引数変更")
+    return f"{name}: {'; '.join(parts)}"
+
+
+def compute_public_if_delta(base_source: Optional[str], head_source: Optional[str], errors: list[str]) -> dict:
+    base_tools = extract_tool_surface(base_source, errors, "base")
+    head_tools = extract_tool_surface(head_source, errors, "head")
+    added = sorted(set(head_tools) - set(base_tools))
+    removed = sorted(set(base_tools) - set(head_tools))
+    common = set(base_tools) & set(head_tools)
+    params_changed = sorted(
+        _describe_params_change(name, base_tools[name].params, head_tools[name].params)
+        for name in common
+        if base_tools[name].params != head_tools[name].params
+    )
+    docstring_changed = sorted(name for name in common if base_tools[name].docstring_sha256 != head_tools[name].docstring_sha256)
+    return {
+        "tools_added": added,
+        "tools_removed": removed,
+        "params_changed": params_changed,
+        "docstring_changed": docstring_changed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 軸B検出器
+# ---------------------------------------------------------------------------
+
+
+def _is_core_code_path(path: str) -> bool:
+    if path.startswith("tests/") or path.startswith("docs/"):
+        return False
+    if path.endswith(".md"):
+        return False
+    return True
+
+
+def count_diff_size(numstat_rows: list[NumstatRow]) -> tuple[int, int]:
+    """(lines_changed, files_changed) を返す。
+
+    lines_changed の母集団は tests/・docs/・*.md・uv.lock を除外した本体コード行。
+    files_changed は uv.lock のみ除外する。
+    """
+    lines = 0
+    files = 0
+    for row in numstat_rows:
+        if row.path == DEPENDENCY_LOCK_FILE:
+            continue
+        files += 1
+        if row.is_binary:
+            continue
+        if _is_core_code_path(row.path):
+            lines += row.additions + row.deletions
+    return lines, files
+
+
+def compute_has_tests(numstat_rows: list[NumstatRow]) -> Union[bool, str]:
+    paths = [row.path for row in numstat_rows if row.path != DEPENDENCY_LOCK_FILE]
+    if not paths:
+        return True
+    if all(p.endswith(".md") or p.startswith("docs/") for p in paths):
+        return "waived_docs_only"
+    return any(p.startswith("tests/") for p in paths)
+
+
+_MECHANICAL_ROLLBACK_DETECTORS = frozenset({"migration_touch", "ddl_in_code", "data_destructive", "binary_change"})
+
+
+def compute_mechanical_rollback(findings: list[Finding]) -> bool:
+    return not any(f.detector in _MECHANICAL_ROLLBACK_DETECTORS and f.status == "counted" for f in findings)
+
+
+def compute_axis_b(numstat_rows: list[NumstatRow], findings: list[Finding]) -> AxisB:
+    lines, files = count_diff_size(numstat_rows)
+    size_ok = lines <= MAX_LINES and files <= MAX_FILES
+    has_tests = compute_has_tests(numstat_rows)
+    mechanical_rollback = compute_mechanical_rollback(findings)
+    met = bool(size_ok and has_tests and mechanical_rollback)
+    return AxisB(lines_changed=lines, files_changed=files, size_ok=size_ok, has_tests=has_tests, mechanical_rollback=mechanical_rollback, met=met)
+
+
+# ---------------------------------------------------------------------------
+# 判定規則
+# ---------------------------------------------------------------------------
+
+
+def classify(findings: list[Finding], axis_b: AxisB, errors: list[str], self_touched: bool) -> tuple[Classification, str]:
+    """評価順序がフェイルセーフの実体。上から順に短絡する。"""
+    if errors:
+        return "pre_go", "detector_error"
+    if self_touched:
+        return "pre_go", "self_protection"
+    if counted(findings):
+        return "pre_go", "axis_a_hit"
+    if pending(findings):
+        return "gray", "policy_pending"
+    if axis_b.met:
+        return "post_veto_candidate", "axis_b_met"
+    return "gray", "axis_b_unmet"
+
+
+# ---------------------------------------------------------------------------
+# verdict の組み立て
+# ---------------------------------------------------------------------------
+
+
+def _detector_sha256() -> str:
+    try:
+        data = Path(__file__).resolve().read_bytes()
+    except OSError:
+        return ""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _finding_to_dict(f: Finding) -> dict:
+    return {"detector": f.detector, "path": f.path, "lineno": f.lineno, "evidence": f.evidence, "status": f.status}
+
+
+def _finding_sort_key(f: Finding) -> tuple[str, str, int]:
+    return (f.detector, f.path, -1 if f.lineno is None else f.lineno)
+
+
+def run_detector(repo: Path, base_ref: str, head_ref: str, detector_source: str = "main") -> dict:
+    """diff を取得・解析し、verdict(dict)を返す。
+
+    どの経路でも例外を投げない(内部の全ステップを try/except で囲み、
+    失敗は errors に積んで pre_go/detector_error にフォールバックする)。
+    """
+    errors: list[str] = []
+    changes: list[FileChange] = []
+    diff_lines: list[DiffLine] = []
+    numstat_rows: list[NumstatRow] = []
+    merge_base: Optional[str] = None
+    head_sha: Optional[str] = None
+
+    try:
+        merge_base = get_merge_base(repo, base_ref, head_ref)
+        head_sha = get_head_sha(repo, head_ref)
+        name_status_raw = _run_git_bytes(repo, ["diff", "--name-status", "-M", "-z", merge_base, head_ref])
+        changes = parse_name_status(name_status_raw)
+        numstat_raw = _run_git_text(repo, ["diff", "--numstat", "-M", merge_base, head_ref])
+        numstat_rows = parse_numstat(numstat_raw)
+        changes = merge_numstat_into_changes(changes, numstat_rows)
+        diff_text = _run_git_text(repo, ["diff", "--unified=0", "--no-color", merge_base, head_ref])
+        diff_lines = parse_diff_lines(diff_text)
+    except Exception as exc:  # noqa: BLE001 — F1: 判定不能は握り潰さず errors へ積む
+        errors.append(f"{type(exc).__name__}: {exc}")
+
+    findings: list[Finding] = []
+    if not errors:
+        try:
+            findings = [
+                *detect_migration_touch(changes),
+                *detect_ddl_in_code(diff_lines),
+                *detect_public_if(changes),
+                *detect_data_destructive(diff_lines),
+                *detect_binary_change(changes),
+                *detect_dependency_change(changes),
+            ]
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    axis_b = AxisB(lines_changed=0, files_changed=0, size_ok=True, has_tests=True, mechanical_rollback=True, met=True)
+    if not errors:
+        try:
+            axis_b = compute_axis_b(numstat_rows, findings)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    public_if_delta = dict(_EMPTY_PUBLIC_IF_DELTA)
+    if not errors:
+        try:
+            touches_main = any(p in ("src/main.py",) for c in changes for p in (c.path, c.old_path) if p)
+            if touches_main:
+                base_source = _git_show_file(repo, merge_base, "src/main.py")
+                head_source = _git_show_file(repo, head_ref, "src/main.py")
+                public_if_delta = compute_public_if_delta(base_source, head_source, errors)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    self_touched = is_self_touched(changes)
+    classification, reason = classify(findings, axis_b, errors, self_touched)
+
+    sorted_findings = sorted(findings, key=_finding_sort_key)
+
+    return {
+        "schema_version": 1,
+        "detector_sha256": _detector_sha256(),
+        "detector_source": detector_source,
+        "repo": repo.name,
+        "base_ref": base_ref,
+        "merge_base": merge_base or "",
+        "head": head_sha or head_ref or "",
+        "classification": classification,
+        "reason": reason,
+        "axis_a": {
+            "hit": counted(findings) or pending(findings),
+            "findings": [_finding_to_dict(f) for f in sorted_findings],
+        },
+        "axis_b": {
+            "lines_changed": axis_b.lines_changed,
+            "files_changed": axis_b.files_changed,
+            "size_ok": axis_b.size_ok,
+            "has_tests": axis_b.has_tests,
+            "mechanical_rollback": axis_b.mechanical_rollback,
+            "met": axis_b.met,
+        },
+        "public_if_delta": public_if_delta,
+        "ignored_paths": [DEPENDENCY_LOCK_FILE],
+        "errors": errors,
+    }
+
+
+def verdict_to_json(verdict: dict) -> str:
+    """決定性のあるJSON文字列化(キー順固定)。"""
+    return json.dumps(verdict, sort_keys=True, ensure_ascii=False, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# markdown レンダリング(1-a 用)
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(verdict: dict) -> str:
+    axis_a = verdict.get("axis_a") or {}
+    axis_b = verdict.get("axis_b") or {}
+    delta = verdict.get("public_if_delta") or {}
+    findings = axis_a.get("findings") or []
+
+    lines: list[str] = []
+    lines.append("### ブラスト半径(機械判定)")
+    lines.append(f"- 判定: {verdict.get('classification')}({verdict.get('reason')})")
+    if findings:
+        lines.append("- 検出:")
+        for f in findings:
+            loc = f"{f['path']}:{f['lineno']}" if f.get("lineno") is not None else f["path"]
+            lines.append(f"  - `{f['detector']}` {loc} ({f['status']}): {f['evidence']}")
+    else:
+        lines.append("- 検出: 検出なし")
+
+    delta_labels = (("tools_added", "追加"), ("tools_removed", "削除"), ("params_changed", "引数変更"), ("docstring_changed", "docstring変更"))
+    delta_lines = [f"  - {label}: {', '.join(values)}" for key, label in delta_labels if (values := delta.get(key))]
+    if delta_lines:
+        lines.append("- 公開IF差分:")
+        lines.extend(delta_lines)
+    else:
+        lines.append("- 公開IF差分: なし")
+
+    lines.append("")
+    lines.append("### revert容易性(機械判定)")
+    lines.append(f"- 変更規模: {axis_b.get('lines_changed')}行 / {axis_b.get('files_changed')}ファイル(閾値 {MAX_LINES}/{MAX_FILES})")
+    has_tests = axis_b.get("has_tests")
+    if has_tests == "waived_docs_only":
+        tests_desc = "docs-only免除"
+    elif has_tests:
+        tests_desc = "あり"
+    else:
+        tests_desc = "なし"
+    lines.append(f"- テスト差分: {tests_desc}")
+    rollback_desc = "成立" if axis_b.get("mechanical_rollback") else "不成立"
+    lines.append(f"- 機械rollback: {rollback_desc}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="境界ゲート検出器: diff からブラスト半径とrevert容易性を機械判定する")
+    parser.add_argument("--base", help="比較元 ref(例: origin/main)")
+    parser.add_argument("--head", help="比較先 ref(例: HEAD)")
+    parser.add_argument("--repo", default=".", help="git リポジトリのパス(既定: カレントディレクトリ)")
+    parser.add_argument("--format", choices=["json", "markdown", "both"], default="json")
+    parser.add_argument("--out", help="出力先パス(省略時は stdout)")
+    parser.add_argument("--detector-source", choices=["main", "worktree"], default="main", help="verdict に記録するメタ情報")
+    parser.add_argument("--render", metavar="VERDICT_JSON", help="verdict JSON ファイルを markdown に変換して出力する")
+    return parser
+
+
+def _write_output(text: str, out_path: Optional[str]) -> None:
+    if out_path:
+        Path(out_path).write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text if text.endswith("\n") else text + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.render:
+        verdict = json.loads(Path(args.render).read_text(encoding="utf-8"))
+        _write_output(render_markdown(verdict), args.out)
+        return 0
+
+    if not args.base or not args.head:
+        parser.error("--base と --head は --render 未指定時に必須です")
+
+    repo = Path(args.repo).resolve()
+    verdict = run_detector(repo, args.base, args.head, args.detector_source)
+
+    if args.format == "json":
+        output = verdict_to_json(verdict)
+    elif args.format == "markdown":
+        output = render_markdown(verdict)
+    else:
+        output = verdict_to_json(verdict) + "\n\n" + render_markdown(verdict)
+
+    _write_output(output, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception:  # noqa: BLE001 — 内部例外のみ非0終了(仕様通り)
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)

--- a/scripts/gate_check.py
+++ b/scripts/gate_check.py
@@ -38,7 +38,9 @@ from typing import Literal, Optional, Union
 # ---------------------------------------------------------------------------
 
 DDL_PATTERNS: tuple[str, ...] = (
-    r"(?i)\b(CREATE|ALTER|DROP)\s+(TABLE|INDEX|TRIGGER|VIEW|VIRTUAL\s+TABLE)\b",
+    # 動詞と対象キーワードの間に UNIQUE / TEMP / TEMPORARY / VIRTUAL などの修飾語を
+    # 挟む形(CREATE UNIQUE INDEX / CREATE TEMP TABLE / CREATE VIRTUAL TABLE 等)も拾う。
+    r"(?i)\b(CREATE|ALTER|DROP)\s+(?:(?:UNIQUE|TEMP|TEMPORARY|VIRTUAL)\s+)*(TABLE|INDEX|TRIGGER|VIEW)\b",
     r"(?i)\bPRAGMA\s+\w+\s*=",  # PRAGMA の「書き込み」のみ。読み取りは対象外
 )
 
@@ -232,35 +234,42 @@ def parse_name_status(raw: bytes) -> list[FileChange]:
     return changes
 
 
-_RENAME_BRACE_RE = re.compile(r"\{([^{}]*) => ([^{}]*)\}")
+def parse_numstat(raw: bytes) -> list[NumstatRow]:
+    """`git diff --numstat -M -z` の出力をパースする。
 
-
-def _resolve_numstat_path(pathspec: str) -> tuple[str, Optional[str]]:
-    """numstat のパス欄(rename時は `{old => new}` または `old => new` 形式)を解決する。"""
-    if "{" in pathspec and " => " in pathspec:
-        new_path = _RENAME_BRACE_RE.sub(lambda m: m.group(2), pathspec)
-        old_path = _RENAME_BRACE_RE.sub(lambda m: m.group(1), pathspec)
-        return new_path, old_path
-    if " => " in pathspec:
-        old_path, new_path = pathspec.split(" => ", 1)
-        return new_path, old_path
-    return pathspec, None
-
-
-def parse_numstat(raw: str) -> list[NumstatRow]:
-    """`git diff --numstat -M` の出力をパースする。"""
+    -z のため各レコードは NUL 区切り。通常の変更は `add<TAB>del<TAB>path` が
+    1 要素で来るが、rename/copy は `add<TAB>del<TAB>`(path 欄が空)の後に
+    old-path・new-path が別々の NUL 要素として続く。-z を付けることで
+    name-status 側と同様に生パスを受け取れ、非ASCII・空白入りパスの
+    quotepath エスケープ差異を避けられる。
+    """
+    text = raw.decode("utf-8")
+    tokens = text.split("\0")
+    if tokens and tokens[-1] == "":
+        tokens.pop()
     rows: list[NumstatRow] = []
-    for line in raw.split("\n"):
-        if not line:
-            continue
-        parts = line.split("\t")
+    i = 0
+    while i < len(tokens):
+        head = tokens[i]
+        i += 1
+        parts = head.split("\t")
         if len(parts) != 3:
-            raise ValueError(f"unparseable numstat line: {line!r}")
+            raise ValueError(f"unparseable numstat record: {head!r}")
         added_s, deleted_s, pathspec = parts
         is_binary = added_s == "-" or deleted_s == "-"
         additions = -1 if is_binary else int(added_s)
         deletions = -1 if is_binary else int(deleted_s)
-        new_path, old_path = _resolve_numstat_path(pathspec)
+        if pathspec == "":
+            # rename/copy: old-path・new-path が後続の NUL 要素として続く
+            if i + 1 >= len(tokens):
+                raise ValueError(f"truncated numstat rename record: {head!r}")
+            old_path: Optional[str] = tokens[i]
+            i += 1
+            new_path = tokens[i]
+            i += 1
+        else:
+            old_path = None
+            new_path = pathspec
         rows.append(NumstatRow(path=new_path, old_path=old_path, additions=additions, deletions=deletions, is_binary=is_binary))
     return rows
 
@@ -694,10 +703,10 @@ def run_detector(repo: Path, base_ref: str, head_ref: str, detector_source: str 
         head_sha = get_head_sha(repo, head_ref)
         name_status_raw = _run_git_bytes(repo, ["diff", "--name-status", "-M", "-z", merge_base, head_ref])
         changes = parse_name_status(name_status_raw)
-        numstat_raw = _run_git_text(repo, ["diff", "--numstat", "-M", merge_base, head_ref])
+        numstat_raw = _run_git_bytes(repo, ["diff", "--numstat", "-M", "-z", merge_base, head_ref])
         numstat_rows = parse_numstat(numstat_raw)
         changes = merge_numstat_into_changes(changes, numstat_rows)
-        diff_text = _run_git_text(repo, ["diff", "--unified=0", "--no-color", merge_base, head_ref])
+        diff_text = _run_git_text(repo, ["diff", "--unified=0", "--no-color", "-M", merge_base, head_ref])
         diff_lines = parse_diff_lines(diff_text)
     except Exception as exc:  # noqa: BLE001 — F1: 判定不能は握り潰さず errors へ積む
         errors.append(f"{type(exc).__name__}: {exc}")

--- a/scripts/gate_check.sh
+++ b/scripts/gate_check.sh
@@ -8,7 +8,10 @@ set -eu
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-git fetch -q origin main
+# fetch 失敗(ネットワーク不通・origin 未設定など)でスクリプトごと落とさない。
+# set -e 配下でも下の分岐へ必ず進み、ローカルに既存の origin/main があればそれで、
+# 無ければ worktree 版へフォールバックして必ず verdict を返す。
+git fetch -q origin main 2>/dev/null || true
 
 if git show origin/main:scripts/gate_check.py > "$tmp/gate_check.py" 2>/dev/null; then
   exec python3 "$tmp/gate_check.py" "$@"

--- a/scripts/gate_check.sh
+++ b/scripts/gate_check.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# 正規のローカル呼び出し経路: origin/main 版の検出器を取り出して実行する。
+#
+# PR branch 上の gate_check.py はブランチ側で改変され得るため、判定は常に
+# origin/main 版で行う。これにより検出器自身への変更が判定を迂回できない。
+set -eu
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git fetch -q origin main
+
+if git show origin/main:scripts/gate_check.py > "$tmp/gate_check.py" 2>/dev/null; then
+  exec python3 "$tmp/gate_check.py" "$@"
+else
+  # 検出器がまだ main に未マージの導入初期のみ: worktree 版で代用し、
+  # その旨を verdict に残す(detector_source=worktree)。
+  script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+  exec python3 "$script_dir/gate_check.py" --detector-source worktree "$@"
+fi

--- a/tests/unit/test_gate_check.py
+++ b/tests/unit/test_gate_check.py
@@ -124,6 +124,10 @@ def test_migration_touch_no_hit_for_non_migration_path():
         "conn.execute('ALTER TABLE foo DROP COLUMN bar')",
         "conn.execute('DROP INDEX idx_foo')",
         "conn.execute('CREATE VIRTUAL TABLE foo USING fts5(x)')",
+        "conn.execute('CREATE UNIQUE INDEX idx_x ON foo(x)')",
+        "conn.execute('CREATE TEMP TABLE foo (id INTEGER)')",
+        "conn.execute('CREATE TEMPORARY TABLE foo (id INTEGER)')",
+        "conn.execute('CREATE TEMP VIEW v AS SELECT 1')",
         "conn.execute('PRAGMA foreign_keys = ON')",
     ],
 )
@@ -406,17 +410,36 @@ def test_parse_name_status_handles_add_modify_delete_rename():
 
 
 def test_parse_numstat_binary_row():
-    rows = parse_numstat("-\t-\tassets/logo.png\n")
+    rows = parse_numstat(b"-\t-\tassets/logo.png\0")
     assert len(rows) == 1
     assert rows[0].is_binary is True
     assert rows[0].additions == -1
     assert rows[0].deletions == -1
 
 
-def test_parse_numstat_rename_with_common_prefix():
-    rows = parse_numstat("1\t0\tscripts/{snapshot.py => snapshot_renamed.py}\n")
+def test_parse_numstat_rename_uses_separate_z_tokens():
+    # -z では rename は `add<TAB>del<TAB>`(path欄空) + old-path + new-path の3要素
+    rows = parse_numstat(b"1\t0\t\0scripts/snapshot.py\0scripts/snapshot_renamed.py\0")
     assert rows[0].path == "scripts/snapshot_renamed.py"
     assert rows[0].old_path == "scripts/snapshot.py"
+    assert rows[0].additions == 1
+    assert rows[0].deletions == 0
+
+
+def test_parse_numstat_preserves_non_ascii_path_verbatim():
+    # -z は quotepath エスケープをせず生パスをそのまま返す
+    rows = parse_numstat("1\t0\tsrc/なまえ.py\0".encode("utf-8"))
+    assert rows[0].path == "src/なまえ.py"
+    assert rows[0].old_path is None
+
+
+def test_parse_numstat_handles_add_and_rename_together():
+    raw = "1\t0\ta b.txt\0".encode("utf-8") + b"0\t0\t\0old.py\0new.py\0"
+    rows = parse_numstat(raw)
+    by_path = {r.path: r for r in rows}
+    assert by_path["a b.txt"].old_path is None
+    assert by_path["a b.txt"].additions == 1
+    assert by_path["new.py"].old_path == "old.py"
 
 
 def test_parse_diff_lines_tracks_added_and_removed_line_numbers():
@@ -600,6 +623,28 @@ def test_run_detector_findings_are_sorted_by_detector_then_path(git_repo: Path):
     assert detectors == sorted(detectors)
 
 
+def test_run_detector_handles_quoted_non_ascii_paths(git_repo: Path):
+    """非ASCIIパス(非-z numstat では quotepath でエスケープされ name-status と
+    食い違う)でも numstat と name-status が突合し、binary 検出とサイズ計数が
+    崩れないことを保証する。core.quotepath=true を明示して回帰を意味あるものにする。"""
+    subprocess.run(["git", "-C", str(git_repo), "config", "core.quotepath", "true"], check=True)
+    (git_repo / "src").mkdir()
+    (git_repo / "src" / "foo.py").write_text("x = 1\n")
+    base_sha = _commit_all(git_repo, "base")
+    # 非ASCII名の本体コード: 追加行がサイズ計数される
+    (git_repo / "src" / "名前.py").write_text("a = 1\nb = 2\nc = 3\n")
+    # 非ASCII名のバイナリ: binary_change 検出対象
+    (git_repo / "画像.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x01\x02")
+    head_sha = _commit_all(git_repo, "add non-ascii files")
+
+    verdict = run_detector(git_repo, base_sha, head_sha)
+    binary_paths = [f["path"] for f in verdict["axis_a"]["findings"] if f["detector"] == "binary_change"]
+    assert binary_paths == ["画像.png"]
+    assert verdict["axis_b"]["lines_changed"] == 3
+    assert verdict["classification"] == "pre_go"
+    assert verdict["reason"] == "axis_a_hit"
+
+
 def test_render_markdown_produces_expected_sections():
     verdict = {
         "classification": "pre_go",
@@ -629,3 +674,28 @@ def test_run_detector_end_to_end_smoke_matches_classify(git_repo: Path):
     assert verdict["reason"] == "axis_b_met"
     # JSON化してもクラッシュしない
     json.loads(verdict_to_json(verdict))
+
+
+def test_gate_check_sh_falls_back_to_worktree_when_fetch_fails(tmp_path: Path):
+    """gate_check.sh は origin 未設定などで git fetch が失敗しても非0終了せず、
+    worktree 版検出器へフォールバックして verdict を返す(フェイルセーフ)。"""
+    gate_sh = _PROJECT_ROOT / "scripts" / "gate_check.sh"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "foo.py").write_text("x = 1\n")
+    base_sha = _commit_all(repo, "base")
+    (repo / "src" / "foo.py").write_text("x = 2\n")
+    head_sha = _commit_all(repo, "change")
+    # origin remote 未設定のため `git fetch origin main` は失敗する
+
+    result = subprocess.run(
+        ["sh", str(gate_sh), "--repo", str(repo), "--base", base_sha, "--head", head_sha, "--format", "json"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    verdict = json.loads(result.stdout)
+    assert verdict["detector_source"] == "worktree"

--- a/tests/unit/test_gate_check.py
+++ b/tests/unit/test_gate_check.py
@@ -1,0 +1,631 @@
+"""scripts/gate_check.py の検出器ロジックを検証するunit test。
+
+大半は git を介さない純粋関数レベルのテスト(FileChange/DiffLine/NumstatRow を
+直接組み立てて検出器に渡す)。git の実挙動に依存する項目(自己保護パスの実ファイル
+接触、判定不能フォールバック、決定性、公開IFがdiffに無いときAST未実行)のみ、
+一時git リポジトリを使った統合テストとして書く。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.gate_check import (  # noqa: E402
+    DETECTOR_SELF_PATHS,
+    MAX_FILES,
+    MAX_LINES,
+    PUBLIC_IF_PATHS,
+    AxisB,
+    DiffLine,
+    FileChange,
+    Finding,
+    NumstatRow,
+    classify,
+    compute_axis_b,
+    compute_has_tests,
+    compute_mechanical_rollback,
+    compute_public_if_delta,
+    count_diff_size,
+    detect_binary_change,
+    detect_data_destructive,
+    detect_ddl_in_code,
+    detect_dependency_change,
+    detect_migration_touch,
+    detect_public_if,
+    extract_tool_surface,
+    is_self_touched,
+    parse_diff_lines,
+    parse_name_status,
+    parse_numstat,
+    render_markdown,
+    run_detector,
+    verdict_to_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _fc(path: str, status: str, old_path: str | None = None, is_binary: bool = False) -> FileChange:
+    return FileChange(path=path, old_path=old_path, status=status, additions=0, deletions=0, is_binary=is_binary)
+
+
+def _dl(path: str, sign: str, text: str, lineno: int = 1) -> DiffLine:
+    if sign == "+":
+        return DiffLine(path=path, sign="+", new_lineno=lineno, old_lineno=None, text=text)
+    return DiffLine(path=path, sign="-", new_lineno=None, old_lineno=lineno, text=text)
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "commit.gpgsign", "false"], check=True)
+
+
+def _commit_all(path: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", message], check=True)
+    out = subprocess.run(["git", "-C", str(path), "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# migration_touch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["A", "M", "D"])
+def test_migration_touch_hits_for_add_modify_delete(status):
+    changes = [_fc("migrations/0049_x.sql", status)]
+    findings = detect_migration_touch(changes)
+    assert len(findings) == 1
+    assert findings[0].status == "counted"
+    assert findings[0].detector == "migration_touch"
+
+
+def test_migration_touch_hits_on_rename_into_migrations():
+    changes = [_fc("migrations/0050_y.sql", "R", old_path="scripts/not_migration.sql")]
+    findings = detect_migration_touch(changes)
+    assert len(findings) == 1
+
+
+def test_migration_touch_hits_on_rename_out_of_migrations():
+    changes = [_fc("scripts/not_migration.sql", "R", old_path="migrations/0049_x.sql")]
+    findings = detect_migration_touch(changes)
+    assert len(findings) == 1
+
+
+def test_migration_touch_no_hit_for_non_migration_path():
+    changes = [_fc("src/services/foo.py", "M")]
+    assert detect_migration_touch(changes) == []
+
+
+# ---------------------------------------------------------------------------
+# ddl_in_code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "conn.execute('CREATE TABLE foo (id INTEGER)')",
+        "conn.execute('ALTER TABLE foo DROP COLUMN bar')",
+        "conn.execute('DROP INDEX idx_foo')",
+        "conn.execute('CREATE VIRTUAL TABLE foo USING fts5(x)')",
+        "conn.execute('PRAGMA foreign_keys = ON')",
+    ],
+)
+def test_ddl_in_code_hits_added_line(text):
+    findings = detect_ddl_in_code([_dl("src/services/foo.py", "+", text)])
+    assert len(findings) == 1
+    assert findings[0].status == "counted"
+
+
+def test_ddl_in_code_hits_removed_line():
+    findings = detect_ddl_in_code([_dl("src/services/foo.py", "-", "conn.execute('CREATE TABLE foo (id INTEGER)')")])
+    assert len(findings) == 1
+    assert findings[0].lineno == 1
+
+
+def test_ddl_in_code_pragma_read_does_not_hit():
+    findings = detect_ddl_in_code([_dl("src/services/foo.py", "+", "conn.execute('PRAGMA table_info(foo)')")])
+    assert findings == []
+
+
+def test_ddl_in_code_tests_dir_is_downgraded():
+    findings = detect_ddl_in_code([_dl("tests/unit/test_foo.py", "+", "conn.execute('CREATE TABLE foo (id INTEGER)')")])
+    assert len(findings) == 1
+    assert findings[0].status == "downgraded_tests"
+    # downgraded findings はゲーティングに数えない
+    assert not any(f.status == "counted" for f in findings)
+
+
+@pytest.mark.parametrize("path", ["docs/spec/db-schema.md", "README.md"])
+def test_ddl_in_code_docs_and_md_are_excluded_entirely(path):
+    findings = detect_ddl_in_code([_dl(path, "+", "CREATE TABLE foo (id INTEGER)")])
+    assert findings == []
+
+
+def test_ddl_in_code_comment_false_positive_is_locked_in():
+    """コメント内のDDL語は誤検出を許容する(安全側に倒れるため仕様として固定)。"""
+    findings = detect_ddl_in_code([_dl("src/services/foo.py", "+", "# ALTER TABLE のメモ")])
+    assert len(findings) == 1
+    assert findings[0].status == "counted"
+
+
+# ---------------------------------------------------------------------------
+# data_destructive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "conn.execute('DELETE FROM foo WHERE id = ?')",
+        "conn.execute('UPDATE foo SET bar = ?')",
+        "shutil.rmtree(path)",
+        "os.remove(path)",
+    ],
+)
+def test_data_destructive_hits_added_line(text):
+    findings = detect_data_destructive([_dl("src/services/foo.py", "+", text)])
+    assert len(findings) == 1
+    assert findings[0].status == "counted"
+
+
+def test_data_destructive_does_not_hit_function_name_update_material():
+    findings = detect_data_destructive([_dl("src/main.py", "+", "update_material(title, content)")])
+    assert findings == []
+
+
+def test_data_destructive_ignores_removed_lines():
+    findings = detect_data_destructive([_dl("src/services/foo.py", "-", "conn.execute('DELETE FROM foo')")])
+    assert findings == []
+
+
+def test_data_destructive_tests_dir_is_downgraded():
+    findings = detect_data_destructive([_dl("tests/unit/test_foo.py", "+", "conn.execute('DELETE FROM foo')")])
+    assert len(findings) == 1
+    assert findings[0].status == "downgraded_tests"
+
+
+# ---------------------------------------------------------------------------
+# public_if
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", PUBLIC_IF_PATHS)
+def test_public_if_hits_for_every_listed_path(path):
+    findings = detect_public_if([_fc(path, "M")])
+    assert len(findings) == 1
+    assert findings[0].detector == "public_if"
+
+
+def test_public_if_no_hit_for_unrelated_src_path():
+    findings = detect_public_if([_fc("src/services/foo.py", "M")])
+    assert findings == []
+
+
+def test_public_if_hits_regardless_of_which_lines_changed():
+    # public_if はパス一致のみで判定する。diff_lines の中身は問わない。
+    findings = detect_public_if([_fc("src/main.py", "M")])
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# binary_change / dependency_change
+# ---------------------------------------------------------------------------
+
+
+def test_binary_change_hits_for_binary_file():
+    changes = [_fc("assets/logo.png", "A", is_binary=True), _fc("src/foo.py", "M", is_binary=False)]
+    findings = detect_binary_change(changes)
+    assert len(findings) == 1
+    assert findings[0].path == "assets/logo.png"
+    assert findings[0].status == "counted"
+
+
+def test_dependency_change_marks_policy_pending():
+    findings = detect_dependency_change([_fc("pyproject.toml", "M")])
+    assert len(findings) == 1
+    assert findings[0].status == "policy_pending"
+
+
+def test_dependency_change_hits_uv_lock_too():
+    findings = detect_dependency_change([_fc("uv.lock", "M")])
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# self_touched
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", DETECTOR_SELF_PATHS)
+def test_is_self_touched_true_for_each_self_path(path):
+    assert is_self_touched([_fc(path, "M")]) is True
+
+
+def test_is_self_touched_false_when_untouched():
+    assert is_self_touched([_fc("src/services/foo.py", "M")]) is False
+
+
+# ---------------------------------------------------------------------------
+# classify (短絡順序)
+# ---------------------------------------------------------------------------
+
+
+_MET_AXIS_B = AxisB(lines_changed=1, files_changed=1, size_ok=True, has_tests=True, mechanical_rollback=True, met=True)
+_UNMET_AXIS_B = AxisB(lines_changed=9999, files_changed=99, size_ok=False, has_tests=True, mechanical_rollback=True, met=False)
+
+
+def test_classify_errors_wins_over_everything():
+    counted_finding = Finding(detector="migration_touch", path="migrations/x.sql", lineno=None, evidence="", status="counted")
+    classification, reason = classify([counted_finding], _MET_AXIS_B, errors=["boom"], self_touched=True)
+    assert classification == "pre_go"
+    assert reason == "detector_error"
+
+
+def test_classify_self_touched_without_errors():
+    classification, reason = classify([], _MET_AXIS_B, errors=[], self_touched=True)
+    assert (classification, reason) == ("pre_go", "self_protection")
+
+
+def test_classify_axis_a_hit():
+    counted_finding = Finding(detector="migration_touch", path="migrations/x.sql", lineno=None, evidence="", status="counted")
+    classification, reason = classify([counted_finding], _MET_AXIS_B, errors=[], self_touched=False)
+    assert (classification, reason) == ("pre_go", "axis_a_hit")
+
+
+def test_classify_policy_pending():
+    pending_finding = Finding(detector="dependency_change", path="pyproject.toml", lineno=None, evidence="", status="policy_pending")
+    classification, reason = classify([pending_finding], _MET_AXIS_B, errors=[], self_touched=False)
+    assert (classification, reason) == ("gray", "policy_pending")
+    # 軸B充足でも policy_pending が優先され post_veto_candidate にはならない
+
+
+def test_classify_axis_b_met():
+    classification, reason = classify([], _MET_AXIS_B, errors=[], self_touched=False)
+    assert (classification, reason) == ("post_veto_candidate", "axis_b_met")
+
+
+def test_classify_axis_b_unmet():
+    classification, reason = classify([], _UNMET_AXIS_B, errors=[], self_touched=False)
+    assert (classification, reason) == ("gray", "axis_b_unmet")
+
+
+# ---------------------------------------------------------------------------
+# axis B
+# ---------------------------------------------------------------------------
+
+
+def test_count_diff_size_excludes_uv_lock_from_both_lines_and_files():
+    rows = [
+        NumstatRow(path="uv.lock", old_path=None, additions=3000, deletions=3000, is_binary=False),
+        NumstatRow(path="src/foo.py", old_path=None, additions=10, deletions=5, is_binary=False),
+    ]
+    lines, files = count_diff_size(rows)
+    assert lines == 15
+    assert files == 1
+
+
+def test_count_diff_size_excludes_tests_docs_md_from_lines_but_counts_files():
+    rows = [
+        NumstatRow(path="tests/unit/test_foo.py", old_path=None, additions=100, deletions=0, is_binary=False),
+        NumstatRow(path="docs/spec/foo.md", old_path=None, additions=50, deletions=0, is_binary=False),
+        NumstatRow(path="README.md", old_path=None, additions=20, deletions=0, is_binary=False),
+        NumstatRow(path="src/foo.py", old_path=None, additions=10, deletions=5, is_binary=False),
+    ]
+    lines, files = count_diff_size(rows)
+    assert lines == 15  # src/foo.py のみ
+    assert files == 4
+
+
+def test_compute_has_tests_true_when_tests_present():
+    rows = [NumstatRow(path="tests/unit/test_foo.py", old_path=None, additions=1, deletions=0, is_binary=False)]
+    assert compute_has_tests(rows) is True
+
+
+def test_compute_has_tests_false_when_no_tests_and_not_docs_only():
+    rows = [NumstatRow(path="src/foo.py", old_path=None, additions=1, deletions=0, is_binary=False)]
+    assert compute_has_tests(rows) is False
+
+
+def test_compute_has_tests_waived_when_all_docs_only():
+    rows = [
+        NumstatRow(path="docs/spec/foo.md", old_path=None, additions=1, deletions=0, is_binary=False),
+        NumstatRow(path="README.md", old_path=None, additions=1, deletions=0, is_binary=False),
+    ]
+    assert compute_has_tests(rows) == "waived_docs_only"
+
+
+def test_compute_mechanical_rollback_false_on_migration_touch():
+    findings = [Finding(detector="migration_touch", path="migrations/x.sql", lineno=None, evidence="", status="counted")]
+    assert compute_mechanical_rollback(findings) is False
+
+
+def test_compute_mechanical_rollback_true_when_only_downgraded_findings():
+    findings = [Finding(detector="ddl_in_code", path="tests/unit/test_foo.py", lineno=1, evidence="", status="downgraded_tests")]
+    assert compute_mechanical_rollback(findings) is True
+
+
+def test_compute_mechanical_rollback_true_when_only_public_if_hit():
+    findings = [Finding(detector="public_if", path="src/main.py", lineno=None, evidence="", status="counted")]
+    assert compute_mechanical_rollback(findings) is True
+
+
+def test_compute_axis_b_size_exceeded_is_unmet():
+    rows = [NumstatRow(path="src/foo.py", old_path=None, additions=MAX_LINES + 1, deletions=0, is_binary=False),
+            NumstatRow(path="tests/unit/test_foo.py", old_path=None, additions=1, deletions=0, is_binary=False)]
+    axis_b = compute_axis_b(rows, [])
+    assert axis_b.size_ok is False
+    assert axis_b.met is False
+
+
+def test_compute_axis_b_missing_tests_is_unmet():
+    rows = [NumstatRow(path="src/foo.py", old_path=None, additions=10, deletions=0, is_binary=False)]
+    axis_b = compute_axis_b(rows, [])
+    assert axis_b.has_tests is False
+    assert axis_b.met is False
+
+
+def test_compute_axis_b_too_many_files_is_unmet():
+    rows = [NumstatRow(path=f"src/foo_{i}.py", old_path=None, additions=1, deletions=0, is_binary=False) for i in range(MAX_FILES + 1)]
+    rows.append(NumstatRow(path="tests/unit/test_foo.py", old_path=None, additions=1, deletions=0, is_binary=False))
+    axis_b = compute_axis_b(rows, [])
+    assert axis_b.size_ok is False
+    assert axis_b.met is False
+
+
+# ---------------------------------------------------------------------------
+# parse_name_status / parse_numstat / parse_diff_lines(git出力形式の直接パース)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_name_status_handles_add_modify_delete_rename():
+    raw = b"A\0new_file.py\0M\0src/foo.py\0D\0old_file.py\0R100\0scripts/old.py\0scripts/new.py\0"
+    changes = parse_name_status(raw)
+    by_path = {c.path: c for c in changes}
+    assert by_path["new_file.py"].status == "A"
+    assert by_path["src/foo.py"].status == "M"
+    assert by_path["old_file.py"].status == "D"
+    assert by_path["scripts/new.py"].status == "R"
+    assert by_path["scripts/new.py"].old_path == "scripts/old.py"
+
+
+def test_parse_numstat_binary_row():
+    rows = parse_numstat("-\t-\tassets/logo.png\n")
+    assert len(rows) == 1
+    assert rows[0].is_binary is True
+    assert rows[0].additions == -1
+    assert rows[0].deletions == -1
+
+
+def test_parse_numstat_rename_with_common_prefix():
+    rows = parse_numstat("1\t0\tscripts/{snapshot.py => snapshot_renamed.py}\n")
+    assert rows[0].path == "scripts/snapshot_renamed.py"
+    assert rows[0].old_path == "scripts/snapshot.py"
+
+
+def test_parse_diff_lines_tracks_added_and_removed_line_numbers():
+    diff_text = (
+        "diff --git a/src/foo.py b/src/foo.py\n"
+        "index 111..222 100644\n"
+        "--- a/src/foo.py\n"
+        "+++ b/src/foo.py\n"
+        "@@ -10,2 +10,2 @@\n"
+        "-old line one\n"
+        "-old line two\n"
+        "+new line one\n"
+        "+new line two\n"
+    )
+    lines = parse_diff_lines(diff_text)
+    added = [dl for dl in lines if dl.sign == "+"]
+    removed = [dl for dl in lines if dl.sign == "-"]
+    assert [dl.new_lineno for dl in added] == [10, 11]
+    assert [dl.old_lineno for dl in removed] == [10, 11]
+    assert added[0].text == "new line one"
+
+
+# ---------------------------------------------------------------------------
+# AST 抽出(public_if_delta)
+# ---------------------------------------------------------------------------
+
+
+_BASE_SRC_TWO_TOOLS = '''
+@mcp.tool()
+def add_topic(title: str) -> dict:
+    """add topic"""
+    return {}
+
+@mcp.tool()
+def remove_topic(id: int) -> dict:
+    """remove topic"""
+    return {}
+'''
+
+
+def test_extract_tool_surface_only_picks_mcp_tool_decorated_functions():
+    errors: list[str] = []
+    tools = extract_tool_surface(_BASE_SRC_TWO_TOOLS, errors, "test")
+    assert set(tools) == {"add_topic", "remove_topic"}
+    assert errors == []
+
+
+def test_public_if_delta_detects_tool_added():
+    base = "@mcp.tool()\ndef remove_topic(id: int) -> dict:\n    \"\"\"remove\"\"\"\n    return {}\n"
+    head = _BASE_SRC_TWO_TOOLS
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert delta["tools_added"] == ["add_topic"]
+    assert delta["tools_removed"] == []
+
+
+def test_public_if_delta_detects_tool_removed():
+    base = _BASE_SRC_TWO_TOOLS
+    head = "@mcp.tool()\ndef remove_topic(id: int) -> dict:\n    \"\"\"remove\"\"\"\n    return {}\n"
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert delta["tools_removed"] == ["add_topic"]
+    assert delta["tools_added"] == []
+
+
+def test_public_if_delta_detects_param_added():
+    base = "@mcp.tool()\ndef add_topic(title: str) -> dict:\n    \"\"\"doc\"\"\"\n    return {}\n"
+    head = "@mcp.tool()\ndef add_topic(title: str, tags: list[str] = None) -> dict:\n    \"\"\"doc\"\"\"\n    return {}\n"
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert len(delta["params_changed"]) == 1
+    assert delta["params_changed"][0].startswith("add_topic:")
+    assert delta["docstring_changed"] == []
+
+
+def test_public_if_delta_detects_default_value_changed():
+    base = "@mcp.tool()\ndef foo(x: int = 1) -> dict:\n    \"\"\"doc\"\"\"\n    return {}\n"
+    head = "@mcp.tool()\ndef foo(x: int = 2) -> dict:\n    \"\"\"doc\"\"\"\n    return {}\n"
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert len(delta["params_changed"]) == 1
+
+
+def test_public_if_delta_detects_docstring_changed():
+    base = "@mcp.tool()\ndef foo(x: int) -> dict:\n    \"\"\"old doc\"\"\"\n    return {}\n"
+    head = "@mcp.tool()\ndef foo(x: int) -> dict:\n    \"\"\"new doc\"\"\"\n    return {}\n"
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert delta["docstring_changed"] == ["foo"]
+    assert delta["params_changed"] == []
+
+
+def test_public_if_delta_records_parse_failure_without_raising():
+    base = _BASE_SRC_TWO_TOOLS
+    head = "def broken(:\n    this is not python\n"
+    errors: list[str] = []
+    delta = compute_public_if_delta(base, head, errors)
+    assert delta["tools_removed"] == ["add_topic", "remove_topic"]  # head 側は parse失敗で空扱い
+    assert any("ast_parse_failed:head" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# 統合テスト(実 git リポジトリを使う)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    return repo
+
+
+def test_run_detector_returns_pre_go_detector_error_when_git_fails(tmp_path: Path):
+    missing_repo = tmp_path / "does-not-exist"
+    verdict = run_detector(missing_repo, "main", "HEAD")
+    assert verdict["classification"] == "pre_go"
+    assert verdict["reason"] == "detector_error"
+    assert verdict["errors"]
+
+
+def test_run_detector_self_protection_via_real_file_touch(git_repo: Path):
+    (git_repo / "scripts").mkdir()
+    (git_repo / "scripts" / "gate_check.py").write_text("# placeholder\n")
+    base_sha = _commit_all(git_repo, "base")
+    (git_repo / "scripts" / "gate_check.py").write_text("# placeholder changed\n")
+    head_sha = _commit_all(git_repo, "touch detector")
+
+    verdict = run_detector(git_repo, base_sha, head_sha)
+    assert verdict["classification"] == "pre_go"
+    assert verdict["reason"] == "self_protection"
+
+
+def test_run_detector_ast_not_run_when_main_py_untouched(git_repo: Path):
+    (git_repo / "src").mkdir()
+    (git_repo / "src" / "foo.py").write_text("x = 1\n")
+    base_sha = _commit_all(git_repo, "base")
+    (git_repo / "src" / "foo.py").write_text("x = 2\n")
+    head_sha = _commit_all(git_repo, "change foo")
+
+    verdict = run_detector(git_repo, base_sha, head_sha)
+    assert verdict["public_if_delta"] == {
+        "tools_added": [],
+        "tools_removed": [],
+        "params_changed": [],
+        "docstring_changed": [],
+    }
+    assert not any("ast_parse_failed" in e for e in verdict["errors"])
+
+
+def test_run_detector_is_deterministic_across_runs(git_repo: Path):
+    (git_repo / "migrations").mkdir()
+    (git_repo / "migrations" / "0001_init.sql").write_text("CREATE TABLE foo (id INTEGER);\n")
+    (git_repo / "src").mkdir()
+    (git_repo / "src").joinpath("main.py").write_text("@mcp.tool()\ndef foo():\n    pass\n")
+    base_sha = _commit_all(git_repo, "base")
+    (git_repo / "migrations" / "0002_next.sql").write_text("ALTER TABLE foo ADD COLUMN bar TEXT;\n")
+    head_sha = _commit_all(git_repo, "add migration")
+
+    v1 = run_detector(git_repo, base_sha, head_sha)
+    v2 = run_detector(git_repo, base_sha, head_sha)
+    assert verdict_to_json(v1) == verdict_to_json(v2)
+    assert v1["classification"] == "pre_go"
+    assert v1["reason"] == "axis_a_hit"
+
+
+def test_run_detector_findings_are_sorted_by_detector_then_path(git_repo: Path):
+    (git_repo / "migrations").mkdir()
+    (git_repo / "migrations" / "0001_init.sql").write_text("CREATE TABLE foo (id INTEGER);\n")
+    (git_repo / "src").mkdir()
+    (git_repo / "src" / "main.py").write_text("x = 1\n")
+    base_sha = _commit_all(git_repo, "base")
+    (git_repo / "migrations" / "0002_a.sql").write_text("CREATE TABLE bar (id INTEGER);\n")
+    (git_repo / "src" / "main.py").write_text("x = 2\n")
+    head_sha = _commit_all(git_repo, "touch multiple detectors")
+
+    verdict = run_detector(git_repo, base_sha, head_sha)
+    findings = verdict["axis_a"]["findings"]
+    detectors = [f["detector"] for f in findings]
+    assert detectors == sorted(detectors)
+
+
+def test_render_markdown_produces_expected_sections():
+    verdict = {
+        "classification": "pre_go",
+        "reason": "axis_a_hit",
+        "axis_a": {"findings": [{"detector": "migration_touch", "path": "migrations/x.sql", "lineno": None, "evidence": "status=A", "status": "counted"}]},
+        "axis_b": {"lines_changed": 10, "files_changed": 2, "has_tests": True, "mechanical_rollback": True},
+        "public_if_delta": {"tools_added": [], "tools_removed": [], "params_changed": [], "docstring_changed": []},
+    }
+    md = render_markdown(verdict)
+    assert "ブラスト半径" in md
+    assert "revert容易性" in md
+    assert "migration_touch" in md
+
+
+def test_run_detector_end_to_end_smoke_matches_classify(git_repo: Path):
+    (git_repo / "src").mkdir()
+    (git_repo / "src" / "foo.py").write_text("x = 1\n")
+    (git_repo / "tests").mkdir()
+    (git_repo / "tests" / "test_foo.py").write_text("def test_x(): assert True\n")
+    base_sha = _commit_all(git_repo, "base")
+    (git_repo / "src" / "foo.py").write_text("x = 2\n")
+    (git_repo / "tests" / "test_foo.py").write_text("def test_x(): assert True\n# updated\n")
+    head_sha = _commit_all(git_repo, "small clean change with tests")
+
+    verdict = run_detector(git_repo, base_sha, head_sha)
+    assert verdict["classification"] == "post_veto_candidate"
+    assert verdict["reason"] == "axis_b_met"
+    # JSON化してもクラッシュしない
+    json.loads(verdict_to_json(verdict))


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

PRの変更を「事前にコードを読んで確認すべきか」「事後の拒否権行使で足りるか」に機械的に振り分けるための検出器 `scripts/gate_check.py` を追加する。`git diff` を読み、以下の2軸で判定する。

- **ブラスト半径**: migration ファイルへの接触、コード内のスキーマDDL(CREATE/ALTER/DROP等)、公開IF(MCPツール定義・HTTP面・機械可読仕様等)の変更、破壊的なSQL/ファイル操作、バイナリ変更、依存ライブラリ変更を検出する
- **revert容易性**: 変更行数・ファイル数が閾値内か、テスト差分があるか、1コミットのrevertで完全に戻せるか

この2軸から `pre_go`(事前確認が要る) / `gray`(機械では決めきれない) / `post_veto_candidate`(事後拒否権で足りる候補)の3値に分類する。判定不能な入力(git呼び出し失敗・diffパース失敗など)や検出器自身への変更は、常に安全側の `pre_go` にフォールバックする。

ローカルの正規呼び出し経路として `scripts/gate_check.sh` を追加した。PRブランチのワークツリーには変更済みの検出器が含まれ得るため、この wrapper は常に `origin/main` 版の検出器を取り出して実行する。ブランチ側で検出器のロジック自体を書き換えても、判定はbase側のコードで行われるため迂回できない。

検出パターン(DDL/破壊操作の正規表現・公開IFのパス一覧)とサイズ計数関数・閾値は本検出器を単一ソースとし、将来追加されるPRサイズlintやmigration安全装置がこれをimportして使う想定である。

DBスキーマ変更・既存ランタイム(`src/services/`, `src/main.py`)への変更は無い。標準ライブラリのみで動作し、`uv sync` を必要としない。

## 補足

このPRは検出器コア(スクリプト本体・呼び出しラッパ・テスト・運用ドキュメント初版)のみを対象とする。以下は本PRのスコープ外で、別PRで扱う想定:

- CIワークフローへの組み込み(`.github/workflows/gate.yml` によるPRごとの自動判定)
- GO判定パッケージのテンプレート・雛形生成・lintツール
- shadow集計ツール、task-plan/task-execute skillへの組み込み

`docs/spec/go-gate.md` には上記未実装分も含めた運用マニュアル(3値分類の定義、shadow校正期の運用手順、昇格/降格条件、既知の検出ギャップ)を書いているが、現時点で実際に動くのは検出器本体のみである旨を文書冒頭に明記した。

設計文書に明記の無かった実装判断:

- `git diff --numstat` にも `--name-status` と同じく `-M`(rename検出)を明示的に付けた。設計文書のコマンド例には `-M` が無いが、rename検出の挙動はローカルgitの `diff.renames` 設定に依存し得るため、環境非依存の決定的な出力を保証するために明示指定した
- 公開IF差分(`params_changed`)の記述粒度は「引数追加/削除/型変更」を検出して人間可読な短文にする実装とした(設計文書のJSON例は結果の一例のみを示しており、生成ロジックまでは規定していない)

## テスト計画

`tests/unit/test_gate_check.py` に78件のテストを追加した。既存テスト(2090件)への影響は無い。

検証項目:

- 軸A各検出器(migration接触・DDL・公開IF・破壊的SQL/ファイル操作・バイナリ変更・依存変更)が、追加/変更/削除/renameそれぞれで正しく発火し、対象外(`tests/`配下は降格、`*.md`/`docs/`配下は非走査)が期待通り扱われること
- コメント内DDL誤検出(`# ALTER TABLE ...`)や`update_material(`のような関数名の非誤検出など、既知の仕様上の挙動が固定されていること
- 公開IFのAST差分抽出(ツール追加/削除/引数変更/デフォルト値変更/docstring変更)が正しいリストに分類されること。AST parse失敗時もクラッシュせずerrorsに記録され、パス一致による`pre_go`判定自体は独立に成立すること
- 判定規則の短絡順序(判定不能 > 自己保護 > 軸Aヒット > 依存変更グレー > 軸B充足/未充足)が、複合条件下でも仕様通りの優先順位で評価されること
- revert容易性(軸B)の計数が `uv.lock` を除外すること、`tests/`/`docs/`/`*.md` を行数集計から除外しつつファイル数には含めること、全変更がdocsのみのとき免除扱いになること
- 検出器自身のパス(`scripts/gate_check.py`等6ファイル)への接触が、他が全クリーンでも強制的に`pre_go`になること
- git呼び出し自体が失敗する入力(存在しないリポジトリパス)でも例外で落ちずに`pre_go`のverdictを返すこと
- 同一diff入力に対してverdict JSONがバイト同一になること(findings順序・JSONキー順の決定性)

`scripts/gate_check.sh` は実リポジトリ上で手動実行し、origin/mainに検出器が未マージの状態でworktree版へフォールバックする挙動(`detector_source: worktree`)を確認した。
