### PR TITLE
feat: topic専用ベクトル索引 topic_vec と precedent_telemetry テーブルを追加

### DIFF
--- a/migrations/0049_add_topic_vec.sql
+++ b/migrations/0049_add_topic_vec.sql
@@ -1,0 +1,26 @@
+-- Migration 0049: topic_vec 仮想テーブル追加（topic 専用ベクトル索引）
+--
+-- depends: 0048_session_identity
+--
+-- 背景:
+--   topic の近傍検索は既存の全 entity 共用 vec_index を使うと、グローバル KNN で
+--   k 件取得してから source_type='topic' で絞り込む post-filter 方式になる。
+--   corpus が増えると topic が top-k から脱落し、絞り込み後に空集合になりうる
+--   構造的弱点を持つ。tag_vec（migration 0009）と同じ「型専用の vec0 テーブル」
+--   方式を topic にも適用し、KNN の母集団を最初から topic のみに限定する。
+--
+--   distance_metric=cosine を明示するのは、vec0 の既定が L2 であり、
+--   埋め込みベクトルが非正規化（ノルムが一定でない）のため L2 だとノルムが
+--   距離に混入してしまうため。cosine はノルムに依存せず、add_topic が
+--   既に生成しているベクトルをそのまま使い回せる。
+--
+-- スキーマ:
+--   rowid = discussion_topics.id（vec_index が search_index.id を rowid にするのと異なり、
+--   topic_vec は topic 専用のため topic_id を直接 rowid にする）。
+--
+-- 注意: 仮想テーブルのため外部キー制約が使えない。topic を削除する経路を
+--   将来追加する場合は、同じトランザクション内で topic_vec の対応行も
+--   削除すること（0005 の vec_index と同じ規約）。
+CREATE VIRTUAL TABLE IF NOT EXISTS topic_vec USING vec0(
+  embedding float[384] distance_metric=cosine
+);

--- a/migrations/0050_add_precedent_telemetry.sql
+++ b/migrations/0050_add_precedent_telemetry.sql
@@ -1,0 +1,35 @@
+-- Migration 0050: precedent_telemetry テーブル追加
+--
+-- depends: 0049_add_topic_vec
+--
+-- 背景:
+--   判例（decision）を topic 単位で網羅列挙して提示する機能のための計測テーブル。
+--   呼び出しごとに「何を問い、どの topic が routing で選ばれ、判例が何件
+--   提示されたか」を記録し、routing の当たり外れやカバレッジを事後分析できる
+--   ようにする。書込元のサービスは別 PR で実装する。
+--
+-- スキーマ:
+--   id               : 主キー
+--   context          : routing クエリ全文
+--   parameters       : topic_ids / k / budget 等の呼び出しパラメータ（JSON）
+--   guarantee        : routing・列挙が保証成立したかを表す状態文字列
+--   routing_json     : routing 候補 + 採用 topic + 距離（JSON）
+--   decisions_total  : 列挙対象になった判例の総数
+--   full_count       : 本文まで展開された判例の件数
+--   timestamp        : 書込時刻
+--
+--   search_telemetry（migration 0041）と同型。書込は別スレッドで非同期に行い、
+--   失敗しても呼び出し元の処理には影響させない方針を踏襲する（実装側の責務）。
+
+CREATE TABLE precedent_telemetry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    context TEXT NOT NULL,
+    parameters TEXT NOT NULL,
+    guarantee TEXT NOT NULL,
+    routing_json TEXT NOT NULL,
+    decisions_total INTEGER NOT NULL,
+    full_count INTEGER NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_precedent_telemetry_timestamp ON precedent_telemetry(timestamp);

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -166,6 +166,7 @@ def _ensure_initialized() -> bool:
         _server_initialized = True
         if not _backfill_done:
             backfill_embeddings()
+            backfill_topic_embeddings()
             _backfill_done = True
     return running
 
@@ -531,6 +532,89 @@ def backfill_tag_embeddings() -> int:
 
     except Exception as e:
         logger.warning(f"Tag embedding backfill failed: {e}")
+        return 0
+    finally:
+        conn.close()
+
+
+# ========================================
+# Topic embedding ヘルパー
+# ========================================
+
+
+def _insert_topic_embedding_row(conn, topic_id: int, embedding: list[float]) -> None:
+    """topic_vecに1行UPSERT（DELETE+INSERT）する（コミットは呼び出し側の責任）。"""
+    blob = serialize_float32(embedding)
+    conn.execute("DELETE FROM topic_vec WHERE rowid = ?", (topic_id,))
+    conn.execute(
+        "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
+        (topic_id, blob),
+    )
+
+
+def insert_topic_embedding(topic_id: int, embedding: list[float]) -> None:
+    """topic_vecにembeddingをINSERTする。
+
+    add_topicが既に生成したembeddingをそのまま渡す想定であり、
+    ここでは再エンコードしない。
+    """
+    conn = get_connection()
+    try:
+        _insert_topic_embedding_row(conn, topic_id, embedding)
+        conn.commit()
+    except Exception as e:
+        logger.warning(f"Failed to insert topic embedding for topic_id={topic_id}: {e}")
+    finally:
+        conn.close()
+
+
+def delete_topic_embedding_with_conn(conn, topic_id: int) -> None:
+    """topic_vecから1行削除する（コミットは呼び出し側の責任）。
+
+    vec0仮想テーブルは外部キー制約を持てないため、topic削除処理を実装する際は
+    同じトランザクション内でこの関数を呼び、孤児レコードを残さないようにする。
+    """
+    conn.execute("DELETE FROM topic_vec WHERE rowid = ?", (topic_id,))
+
+
+def backfill_topic_embeddings() -> int:
+    """topic_vecにembeddingが無いtopicへ、vec_index格納済みのembeddingを複製する。
+
+    add_topic時に生成されvec_indexへ格納済みのembeddingをsearch_index経由で
+    引き当てて複製するだけであり、再エンコードは行わない。vec_indexにも
+    embeddingが無いtopic（embeddingサーバー停止中に作成された等）は対象外となる。
+    その場合はbackfill_embeddings()でvec_indexが埋まった後の呼び出しで拾われる。
+
+    Returns: 複製したembedding数
+    """
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT dt.id AS topic_id, vi.embedding AS embedding
+            FROM discussion_topics dt
+            INNER JOIN search_index si ON si.source_type = 'topic' AND si.source_id = dt.id
+            INNER JOIN vec_index vi ON vi.rowid = si.id
+            LEFT JOIN topic_vec tv ON tv.rowid = dt.id
+            WHERE tv.rowid IS NULL
+            """
+        ).fetchall()
+
+        if not rows:
+            return 0
+
+        total = 0
+        for row in rows:
+            conn.execute(
+                "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
+                (row["topic_id"], row["embedding"]),
+            )
+            total += 1
+        conn.commit()
+        logger.info(f"Backfilled {total} topic embeddings")
+        return total
+    except Exception as e:
+        logger.warning(f"Topic embedding backfill failed: {e}")
         return 0
     finally:
         conn.close()

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -539,33 +539,26 @@ def backfill_tag_embeddings() -> int:
 
 # ========================================
 # Topic embedding ヘルパー
+#
+# topic_vec は distance_metric=cosine で作成される（migration 0049）。同じく非正規化
+# embedding を格納する vec_index（0005）と tag_vec（0009）は vec0 既定の L2 のままで、
+# topic_vec の distance とはスケールが異なり直接比較できない。topic_vec の近傍距離に
+# 閾値を掛ける際は L2 前提の既存しきい値（QE_DISTANCE_THRESHOLD 等）を流用しないこと。
 # ========================================
 
 
-def _insert_topic_embedding_row(conn, topic_id: int, embedding: list[float]) -> None:
-    """topic_vecに1行UPSERT（DELETE+INSERT）する（コミットは呼び出し側の責任）。"""
+def insert_topic_embedding_with_conn(conn, topic_id: int, embedding: list[float]) -> None:
+    """呼び出し側の conn で topic_vec に1行UPSERT（DELETE+INSERT）する（コミットは呼び出し側の責任）。
+
+    add_topic が既に生成した embedding をそのまま渡す想定であり、ここでは再エンコードしない。
+    リクエストパス上で新規コネクションを開かないため、sqlite-vec 拡張の再ロードも発生しない。
+    """
     blob = serialize_float32(embedding)
     conn.execute("DELETE FROM topic_vec WHERE rowid = ?", (topic_id,))
     conn.execute(
         "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
         (topic_id, blob),
     )
-
-
-def insert_topic_embedding(topic_id: int, embedding: list[float]) -> None:
-    """topic_vecにembeddingをINSERTする。
-
-    add_topicが既に生成したembeddingをそのまま渡す想定であり、
-    ここでは再エンコードしない。
-    """
-    conn = get_connection()
-    try:
-        _insert_topic_embedding_row(conn, topic_id, embedding)
-        conn.commit()
-    except Exception as e:
-        logger.warning(f"Failed to insert topic embedding for topic_id={topic_id}: {e}")
-    finally:
-        conn.close()
 
 
 def delete_topic_embedding_with_conn(conn, topic_id: int) -> None:
@@ -585,8 +578,14 @@ def backfill_topic_embeddings() -> int:
     embeddingが無いtopic（embeddingサーバー停止中に作成された等）は対象外となる。
     その場合はbackfill_embeddings()でvec_indexが埋まった後の呼び出しで拾われる。
 
+    embeddingサーバー未起動時は何もせず0を返す（backfill_embeddings /
+    backfill_tag_embeddings と揃えたガード）。
+
     Returns: 複製したembedding数
     """
+    if not _is_server_running():
+        return 0
+
     conn = get_connection()
     try:
         rows = conn.execute(

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -5,7 +5,11 @@ from typing import Optional
 from src.db import get_connection, row_to_dict
 from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
-from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
+from src.services.embedding_service import (
+    build_embedding_text,
+    generate_and_store_embedding,
+    insert_topic_embedding,
+)
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.search_service import find_similar_topics
 from src.services.title_validation import validate_title
@@ -198,6 +202,9 @@ def add_topic(
         tag_text = " ".join(tag_strings) if tag_strings else ""
         embedding_text = build_embedding_text(title, description, tag_text)
         embedding_vec = generate_and_store_embedding("topic", topic_id, embedding_text)
+        # topic routing 専用索引にも同じベクトルを書き込む（再エンコードしない）
+        if embedding_vec is not None:
+            insert_topic_embedding(topic_id, embedding_vec)
 
         # 類似トピックをサジェスト（生成済みembeddingを再利用しHTTPリクエストを削減）
         similar = find_similar_topics(embedding_text, exclude_id=topic_id, embedding=embedding_vec)

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -8,7 +8,7 @@ from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import (
     build_embedding_text,
     generate_and_store_embedding,
-    insert_topic_embedding,
+    insert_topic_embedding_with_conn,
 )
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.search_service import find_similar_topics
@@ -202,9 +202,11 @@ def add_topic(
         tag_text = " ".join(tag_strings) if tag_strings else ""
         embedding_text = build_embedding_text(title, description, tag_text)
         embedding_vec = generate_and_store_embedding("topic", topic_id, embedding_text)
-        # topic routing 専用索引にも同じベクトルを書き込む（再エンコードしない）
+        # topic routing 専用索引にも同じベクトルを書き込む（再エンコードしない）。
+        # 既に開いている conn を再利用し、新規コネクション+拡張再ロードを避ける。
         if embedding_vec is not None:
-            insert_topic_embedding(topic_id, embedding_vec)
+            insert_topic_embedding_with_conn(conn, topic_id, embedding_vec)
+            conn.commit()
 
         # 類似トピックをサジェスト（生成済みembeddingを再利用しHTTPリクエストを削減）
         similar = find_similar_topics(embedding_text, exclude_id=topic_id, embedding=embedding_vec)

--- a/tests/test_migrations/test_0049_add_topic_vec.py
+++ b/tests/test_migrations/test_0049_add_topic_vec.py
@@ -1,0 +1,197 @@
+"""migration 0049_add_topic_vec のテスト
+
+0049 適用後に topic_vec 仮想テーブルが作成され、rowid をキーにした
+ベクトルの INSERT / KNN 検索ができることを確認する。
+"""
+import os
+import tempfile
+
+import pytest
+from sqlite_vec import serialize_float32
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+from test_migrations.conftest import table_exists
+
+EMBEDDING_DIM = 384
+
+
+@pytest.fixture
+def migrated_db():
+    """全 migration（0049 含む）を適用済みのテスト用 DB を提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0049():
+    """0048 までの migration を適用した DB を提供する。0049 の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0049 = MigrationList([m for m in all_migs if m.id < "0049"])
+        with backend.lock():
+            backend.apply_migrations(pre_0049)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0049(db_path: str) -> None:
+    """db_path に対して migration 0049 のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0049 = MigrationList([m for m in all_migs if m.id.startswith("0049")])
+    with backend.lock():
+        backend.apply_migrations(only_0049)
+
+
+class TestTopicVecTableCreated:
+    def test_topic_vec_table_exists_after_0049(self, migrated_db):
+        """migration 0049 適用後、topic_vec テーブルが存在する"""
+        conn = get_connection()
+        try:
+            assert table_exists(conn, "topic_vec"), (
+                "topic_vec テーブルが 0049 適用後に存在しない"
+            )
+        finally:
+            conn.close()
+
+    def test_topic_vec_table_not_exists_before_0049(self, db_before_0049):
+        """0049 適用前は topic_vec テーブルが存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            assert not table_exists(conn, "topic_vec"), (
+                "0049 適用前に topic_vec テーブルが既に存在している"
+            )
+        finally:
+            conn.close()
+
+
+class TestTopicVecCRUD:
+    def test_insert_and_knn_search(self, migrated_db):
+        """topic_vec に rowid = topic_id でINSERTし、KNN検索で引ける"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("KNNテストトピック", "テスト"),
+            )
+            topic_id = cur.lastrowid
+            conn.commit()
+
+            embedding = [0.1] * EMBEDDING_DIM
+            blob = serialize_float32(embedding)
+            conn.execute(
+                "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
+                (topic_id, blob),
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT rowid, distance FROM topic_vec WHERE embedding MATCH ? AND k = ?",
+                (blob, 1),
+            ).fetchone()
+            assert row is not None
+            assert row["rowid"] == topic_id
+            assert row["distance"] == pytest.approx(0.0, abs=1e-6)
+        finally:
+            conn.close()
+
+    def test_only_topic_entities_in_knn_population(self, migrated_db):
+        """topic_vec の母集団が topic のみである（他 entity を大量投入しても脱落しない）
+
+        vec_index（全 entity 共用）はグローバル KNN 後に post-filter するため
+        corpus 増大で topic が候補から脱落しうる。topic_vec は型専用テーブルの
+        ため、他エンティティが何件あっても topic の KNN 結果には混入しない
+        （母集団自体が topic だけであることを確認する）。
+        """
+        conn = get_connection()
+        try:
+            topic_ids = []
+            for i in range(3):
+                cur = conn.execute(
+                    "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                    (f"母集団テストトピック{i}", "テスト"),
+                )
+                topic_id = cur.lastrowid
+                topic_ids.append(topic_id)
+                embedding = [float(i)] * EMBEDDING_DIM
+                conn.execute(
+                    "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
+                    (topic_id, serialize_float32(embedding)),
+                )
+
+            # 大量の decision embedding を vec_index 側にのみ投入する
+            # （topic_vec には影響しないはず）
+            for i in range(20):
+                cur = conn.execute(
+                    "INSERT INTO decisions (decision, reason) VALUES (?, ?)",
+                    (f"母集団攪乱decision{i}", "テスト"),
+                )
+                dec_id = cur.lastrowid
+                si = conn.execute(
+                    "SELECT id FROM search_index WHERE source_type = 'decision' AND source_id = ?",
+                    (dec_id,),
+                ).fetchone()
+                assert si is not None
+                conn.execute(
+                    "INSERT INTO vec_index(rowid, embedding) VALUES (?, ?)",
+                    (si["id"], serialize_float32([1.0] * EMBEDDING_DIM)),
+                )
+            conn.commit()
+
+            rows = conn.execute(
+                "SELECT rowid FROM topic_vec WHERE embedding MATCH ? AND k = ?",
+                (serialize_float32([0.0] * EMBEDDING_DIM), 10),
+            ).fetchall()
+            result_ids = {r["rowid"] for r in rows}
+            assert result_ids.issubset(set(topic_ids)), (
+                "topic_vec の KNN 結果に topic 以外の rowid が混入している"
+            )
+            # 投入した 3 topic 全てが候補に含まれる（脱落していない）
+            assert result_ids == set(topic_ids)
+        finally:
+            conn.close()
+
+    def test_delete_removes_row(self, migrated_db):
+        """topic_vec から DELETE すると行が消える（孤児防止の delete 経路確認）"""
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO discussion_topics (title, description) VALUES (?, ?)",
+                ("削除テストトピック", "テスト"),
+            )
+            topic_id = cur.lastrowid
+            conn.execute(
+                "INSERT INTO topic_vec(rowid, embedding) VALUES (?, ?)",
+                (topic_id, serialize_float32([0.2] * EMBEDDING_DIM)),
+            )
+            conn.commit()
+
+            conn.execute("DELETE FROM topic_vec WHERE rowid = ?", (topic_id,))
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT rowid FROM topic_vec WHERE rowid = ?", (topic_id,)
+            ).fetchone()
+            assert row is None
+        finally:
+            conn.close()

--- a/tests/test_migrations/test_0050_add_precedent_telemetry.py
+++ b/tests/test_migrations/test_0050_add_precedent_telemetry.py
@@ -1,0 +1,158 @@
+"""migration 0050_add_precedent_telemetry のテスト
+
+0050 適用後に precedent_telemetry テーブルとタイムスタンプ index が作成され、
+NOT NULL 制約とデフォルト timestamp が機能することを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+from test_migrations.conftest import get_column_names, index_names, table_exists
+
+
+@pytest.fixture
+def migrated_db():
+    """全 migration（0050 含む）を適用済みのテスト用 DB を提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0050():
+    """0049 までの migration を適用した DB を提供する。0050 の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0050 = MigrationList([m for m in all_migs if m.id < "0050"])
+        with backend.lock():
+            backend.apply_migrations(pre_0050)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+class TestPrecedentTelemetryTableCreated:
+    def test_table_exists_after_0050(self, migrated_db):
+        """migration 0050 適用後、precedent_telemetry テーブルが存在する"""
+        conn = get_connection()
+        try:
+            assert table_exists(conn, "precedent_telemetry"), (
+                "precedent_telemetry テーブルが 0050 適用後に存在しない"
+            )
+        finally:
+            conn.close()
+
+    def test_table_not_exists_before_0050(self, db_before_0050):
+        """0050 適用前は precedent_telemetry テーブルが存在しない（前提確認）"""
+        conn = get_connection()
+        try:
+            assert not table_exists(conn, "precedent_telemetry"), (
+                "0050 適用前に precedent_telemetry テーブルが既に存在している"
+            )
+        finally:
+            conn.close()
+
+    def test_required_columns_exist(self, migrated_db):
+        """0050 適用後、precedent_telemetry テーブルに必須カラムが全部存在する"""
+        conn = get_connection()
+        try:
+            column_names = get_column_names(conn, "precedent_telemetry")
+            required = {
+                "id",
+                "context",
+                "parameters",
+                "guarantee",
+                "routing_json",
+                "decisions_total",
+                "full_count",
+                "timestamp",
+            }
+            for col in required:
+                assert col in column_names, (
+                    f"precedent_telemetry.{col} が 0050 適用後に存在しない"
+                )
+        finally:
+            conn.close()
+
+    def test_timestamp_index_created(self, migrated_db):
+        """0050 適用後、timestamp に index が作成されている"""
+        conn = get_connection()
+        try:
+            idx_names = index_names(conn, "idx_precedent_telemetry_%")
+            assert "idx_precedent_telemetry_timestamp" in idx_names
+        finally:
+            conn.close()
+
+
+class TestPrecedentTelemetryCRUD:
+    def test_insert_and_select(self, migrated_db):
+        """precedent_telemetry に INSERT して SELECT で読み取れる。timestamp が自動設定される"""
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO precedent_telemetry "
+                "(context, parameters, guarantee, routing_json, decisions_total, full_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("設計文脈のテスト", '{"k": 3}', "enumerated", '{"candidates": []}', 5, 5),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT context, parameters, guarantee, routing_json, decisions_total, "
+                "full_count, timestamp FROM precedent_telemetry WHERE context = ?",
+                ("設計文脈のテスト",),
+            ).fetchone()
+            assert row is not None
+            assert row["guarantee"] == "enumerated"
+            assert row["decisions_total"] == 5
+            assert row["full_count"] == 5
+            assert row["timestamp"] is not None
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize(
+        "missing_col",
+        ["context", "parameters", "guarantee", "routing_json", "decisions_total", "full_count"],
+    )
+    def test_not_null_columns_enforced(self, migrated_db, missing_col):
+        """NOT NULL カラムを欠いた INSERT は IntegrityError になる"""
+        conn = get_connection()
+        try:
+            values = {
+                "context": "文脈",
+                "parameters": "{}",
+                "guarantee": "enumerated",
+                "routing_json": "{}",
+                "decisions_total": 0,
+                "full_count": 0,
+            }
+            values[missing_col] = None
+            cols = ", ".join(values.keys())
+            placeholders = ", ".join("?" for _ in values)
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    f"INSERT INTO precedent_telemetry ({cols}) VALUES ({placeholders})",
+                    tuple(values.values()),
+                )
+                conn.commit()
+        finally:
+            conn.close()

--- a/tests/unit/test_topic_vec.py
+++ b/tests/unit/test_topic_vec.py
@@ -1,0 +1,329 @@
+"""topic_vec 索引の書込・バックフィル・削除整合のテスト。
+
+topic routing 専用のベクトル索引 topic_vec に対する add_topic 経由の書込、
+バックフィル（vec_index からの再利用・二重エンコード無し）、削除経路を検証する。
+"""
+import os
+import tempfile
+
+import numpy as np
+import pytest
+from sqlite_vec import serialize_float32
+
+from src.db import get_connection, init_database
+from src.services.topic_service import add_topic
+import src.services.embedding_service as emb
+
+EMBEDDING_DIM = 384
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def mock_embedding_server(monkeypatch):
+    """embedding_serverへのHTTPリクエストをモック化。呼び出し回数も記録する。"""
+    call_count = {"n": 0}
+
+    def mock_encode_batch(texts, prefix):
+        call_count["n"] += 1
+        embeddings = []
+        for text in texts:
+            prefix_str = "検索文書: " if prefix == "document" else "検索クエリ: "
+            np.random.seed(hash(prefix_str + text) % (2**32))
+            embeddings.append(np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist())
+        return embeddings
+
+    monkeypatch.setattr(emb, '_encode_batch', mock_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    yield call_count
+
+
+def _topic_vec_row(conn, topic_id):
+    return conn.execute(
+        "SELECT rowid, embedding FROM topic_vec WHERE rowid = ?", (topic_id,)
+    ).fetchone()
+
+
+# ========================================
+# add_topic 経由の書込
+# ========================================
+
+
+def test_add_topic_writes_topic_vec_with_rowid_eq_topic_id(temp_db, mock_embedding_server):
+    """add_topic後、topic_vecにrowid=topic_idでレコードが1件だけ存在する"""
+    topic = add_topic(
+        title="topic_vec書込テスト",
+        description="rowid対応を検証する",
+        tags=DEFAULT_TAGS,
+    )
+    assert "error" not in topic
+    topic_id = topic["topic_id"]
+
+    conn = get_connection()
+    try:
+        row = _topic_vec_row(conn, topic_id)
+        assert row is not None
+        assert row["rowid"] == topic_id
+    finally:
+        conn.close()
+
+
+def test_add_topic_does_not_double_encode(temp_db, mock_embedding_server):
+    """add_topicはvec_index用に生成したembeddingをtopic_vecでも再利用し、
+    topic_vec用に追加でencode_batchを呼ばない（二重エンコード無し）"""
+    call_count = mock_embedding_server
+    add_topic(
+        title="二重エンコード検証トピック",
+        description="topic_vec書込のためにencode_batchが増えないことを確認する",
+        tags=DEFAULT_TAGS,
+    )
+    # add_topic 1回あたりのencode_batch呼び出しはtopic本文分の1回のみ
+    # （類似トピック検索は生成済みembeddingを再利用するため追加呼び出しは発生しない）
+    assert call_count["n"] == 1
+
+
+def test_add_topic_vec_embedding_matches_vec_index(temp_db, mock_embedding_server):
+    """topic_vecに書かれたembeddingはvec_indexに書かれたものと同一（bit-identical）"""
+    topic = add_topic(
+        title="embedding一致テストトピック",
+        description="topic_vecとvec_indexが同じベクトルを持つことを確認する",
+        tags=DEFAULT_TAGS,
+    )
+    topic_id = topic["topic_id"]
+
+    conn = get_connection()
+    try:
+        search_index_id = conn.execute(
+            "SELECT id FROM search_index WHERE source_type = 'topic' AND source_id = ?",
+            (topic_id,),
+        ).fetchone()["id"]
+        vec_index_row = conn.execute(
+            "SELECT embedding FROM vec_index WHERE rowid = ?", (search_index_id,)
+        ).fetchone()
+        topic_vec_row = _topic_vec_row(conn, topic_id)
+        assert vec_index_row is not None
+        assert topic_vec_row is not None
+        assert vec_index_row["embedding"] == topic_vec_row["embedding"]
+    finally:
+        conn.close()
+
+
+def test_add_topic_succeeds_when_embedding_fails(temp_db, monkeypatch):
+    """embedding生成失敗時もadd_topic自体は成功し、topic_vecにも何も書かれない"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+    topic = add_topic(
+        title="Embedding失敗テスト",
+        description="サーバー接続失敗時もtopic作成は成功する",
+        tags=DEFAULT_TAGS,
+    )
+    assert "error" not in topic
+    topic_id = topic["topic_id"]
+
+    conn = get_connection()
+    try:
+        assert _topic_vec_row(conn, topic_id) is None
+    finally:
+        conn.close()
+
+
+# ========================================
+# KNN の母集団が topic のみであること
+# ========================================
+
+
+def test_knn_population_is_topic_only(temp_db, mock_embedding_server):
+    """topic_vecのKNN母集団はtopicのみで、decision等の他entityが混入しない"""
+    topic_ids = []
+    for i in range(3):
+        topic = add_topic(
+            title=f"KNN母集団テスト{i}",
+            description="topicのみが母集団であることを確認する",
+            tags=DEFAULT_TAGS,
+        )
+        topic_ids.append(topic["topic_id"])
+
+    from tests.helpers import add_decision
+
+    for i in range(5):
+        dec = add_decision(
+            topic_id=topic_ids[0],
+            decision=f"母集団攪乱decision{i}",
+            reason="topic_vecに混入しないことを確認する",
+        )
+        assert "error" not in dec
+
+    conn = get_connection()
+    try:
+        query_blob = serialize_float32([0.0] * EMBEDDING_DIM)
+        rows = conn.execute(
+            "SELECT rowid FROM topic_vec WHERE embedding MATCH ? AND k = ?",
+            (query_blob, 50),
+        ).fetchall()
+        result_ids = {r["rowid"] for r in rows}
+        # 母集団に decision の rowid（search_index.id 由来）が混入していない
+        assert result_ids.issubset(set(topic_ids))
+    finally:
+        conn.close()
+
+
+# ========================================
+# insert / delete ヘルパー関数単体
+# ========================================
+
+
+def test_insert_topic_embedding(temp_db):
+    """insert_topic_embedding: topic_vecに1行追加される"""
+    topic = add_topic(title="insert単体テスト", description="テスト", tags=DEFAULT_TAGS)
+    topic_id = topic["topic_id"]
+
+    embedding = [0.5] * EMBEDDING_DIM
+    emb.insert_topic_embedding(topic_id, embedding)
+
+    conn = get_connection()
+    try:
+        row = _topic_vec_row(conn, topic_id)
+        assert row is not None
+    finally:
+        conn.close()
+
+
+def test_insert_topic_embedding_upserts(temp_db):
+    """insert_topic_embedding: 既存rowidへの再INSERTはUPSERT（DELETE+INSERT）される"""
+    topic = add_topic(title="upsertテスト", description="テスト", tags=DEFAULT_TAGS)
+    topic_id = topic["topic_id"]
+
+    emb.insert_topic_embedding(topic_id, [0.1] * EMBEDDING_DIM)
+    emb.insert_topic_embedding(topic_id, [0.9] * EMBEDDING_DIM)
+
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT rowid FROM topic_vec WHERE rowid = ?", (topic_id,)
+        ).fetchall()
+        assert len(rows) == 1, "同一rowidへの再INSERTで行が重複してはならない"
+    finally:
+        conn.close()
+
+
+def test_delete_topic_embedding_with_conn(temp_db, mock_embedding_server):
+    """delete_topic_embedding_with_conn: topic_vecから対象行のみ削除される"""
+    topic = add_topic(title="削除テスト", description="テスト", tags=DEFAULT_TAGS)
+    topic_id = topic["topic_id"]
+
+    conn = get_connection()
+    try:
+        assert _topic_vec_row(conn, topic_id) is not None
+        emb.delete_topic_embedding_with_conn(conn, topic_id)
+        conn.commit()
+        assert _topic_vec_row(conn, topic_id) is None
+    finally:
+        conn.close()
+
+
+# ========================================
+# backfill_topic_embeddings: vec_index からの再利用（二重エンコード無し）
+# ========================================
+
+
+def test_backfill_reuses_vec_index_embedding_without_reencoding(temp_db, monkeypatch):
+    """backfill_topic_embeddings: vec_indexに既存embeddingがあるtopicは
+    encode_batchを呼ばずにtopic_vecへ複製される"""
+    call_count = {"n": 0}
+
+    def counting_encode_batch(texts, prefix):
+        call_count["n"] += 1
+        return [np.random.rand(EMBEDDING_DIM).astype(np.float32).tolist() for _ in texts]
+
+    monkeypatch.setattr(emb, '_encode_batch', counting_encode_batch)
+    monkeypatch.setattr(emb, '_server_initialized', True)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+
+    topic = add_topic(title="バックフィル再利用テスト", description="テスト", tags=DEFAULT_TAGS)
+    topic_id = topic["topic_id"]
+    assert call_count["n"] == 1  # add_topic時の1回のみ
+
+    # topic_vecから一旦消し、backfillで復元させる
+    conn = get_connection()
+    try:
+        conn.execute("DELETE FROM topic_vec WHERE rowid = ?", (topic_id,))
+        conn.commit()
+        assert _topic_vec_row(conn, topic_id) is None
+    finally:
+        conn.close()
+
+    filled = emb.backfill_topic_embeddings()
+    assert filled >= 1
+    # backfillはvec_indexの既存embeddingを複製するだけで、追加のencode_batch呼び出しは発生しない
+    assert call_count["n"] == 1
+
+    conn = get_connection()
+    try:
+        assert _topic_vec_row(conn, topic_id) is not None
+    finally:
+        conn.close()
+
+
+def test_backfill_skips_topic_without_vec_index_embedding(temp_db, monkeypatch):
+    """backfill_topic_embeddings: vec_indexにもembeddingが無いtopicは対象外のまま"""
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: False)
+
+    topic = add_topic(
+        title="vec_indexも無いtopic", description="サーバー未起動で作成", tags=DEFAULT_TAGS
+    )
+    topic_id = topic["topic_id"]
+
+    filled = emb.backfill_topic_embeddings()
+
+    conn = get_connection()
+    try:
+        assert _topic_vec_row(conn, topic_id) is None
+    finally:
+        conn.close()
+    # このtopic分は複製されないが、他のtopic（init_database由来のfirst_topic等）が
+    # 既にvec_indexを持っていれば0件とは限らないため filled の値自体は断定しない
+
+
+def test_backfill_noop_when_all_filled(temp_db, mock_embedding_server):
+    """backfill_topic_embeddings: 全topicが既にtopic_vecを持つ場合は0を返す"""
+    add_topic(title="全件充足テスト", description="テスト", tags=DEFAULT_TAGS)
+    # 既存の未充足分（init_database由来等）を先に埋めておく
+    emb.backfill_topic_embeddings()
+
+    filled = emb.backfill_topic_embeddings()
+    assert filled == 0
+
+
+def test_ensure_initialized_runs_topic_backfill(temp_db, monkeypatch):
+    """_ensure_initialized: backfill_embeddings と同じ経路でbackfill_topic_embeddingsも呼ばれる"""
+    calls = []
+
+    monkeypatch.setattr(emb, '_server_initialized', False)
+    monkeypatch.setattr(emb, '_backfill_done', False)
+    monkeypatch.setattr(emb, '_ensure_server_running', lambda: True)
+    monkeypatch.setattr(emb, 'backfill_embeddings', lambda: calls.append('embeddings') or 0)
+    monkeypatch.setattr(emb, 'backfill_topic_embeddings', lambda: calls.append('topic_embeddings') or 0)
+
+    emb._ensure_initialized()
+
+    assert calls == ['embeddings', 'topic_embeddings']
+
+    # 2回目は _backfill_done により再実行されない
+    emb._ensure_initialized()
+    assert calls == ['embeddings', 'topic_embeddings']

--- a/tests/unit/test_topic_vec.py
+++ b/tests/unit/test_topic_vec.py
@@ -186,32 +186,32 @@ def test_knn_population_is_topic_only(temp_db, mock_embedding_server):
 # ========================================
 
 
-def test_insert_topic_embedding(temp_db):
-    """insert_topic_embedding: topic_vecに1行追加される"""
+def test_insert_topic_embedding_with_conn(temp_db):
+    """insert_topic_embedding_with_conn: 渡したconnでtopic_vecに1行追加される"""
     topic = add_topic(title="insert単体テスト", description="テスト", tags=DEFAULT_TAGS)
     topic_id = topic["topic_id"]
 
     embedding = [0.5] * EMBEDDING_DIM
-    emb.insert_topic_embedding(topic_id, embedding)
-
     conn = get_connection()
     try:
+        emb.insert_topic_embedding_with_conn(conn, topic_id, embedding)
+        conn.commit()
         row = _topic_vec_row(conn, topic_id)
         assert row is not None
     finally:
         conn.close()
 
 
-def test_insert_topic_embedding_upserts(temp_db):
-    """insert_topic_embedding: 既存rowidへの再INSERTはUPSERT（DELETE+INSERT）される"""
+def test_insert_topic_embedding_with_conn_upserts(temp_db):
+    """insert_topic_embedding_with_conn: 既存rowidへの再INSERTはUPSERT（DELETE+INSERT）される"""
     topic = add_topic(title="upsertテスト", description="テスト", tags=DEFAULT_TAGS)
     topic_id = topic["topic_id"]
 
-    emb.insert_topic_embedding(topic_id, [0.1] * EMBEDDING_DIM)
-    emb.insert_topic_embedding(topic_id, [0.9] * EMBEDDING_DIM)
-
     conn = get_connection()
     try:
+        emb.insert_topic_embedding_with_conn(conn, topic_id, [0.1] * EMBEDDING_DIM)
+        emb.insert_topic_embedding_with_conn(conn, topic_id, [0.9] * EMBEDDING_DIM)
+        conn.commit()
         rows = conn.execute(
             "SELECT rowid FROM topic_vec WHERE rowid = ?", (topic_id,)
         ).fetchall()
@@ -252,6 +252,7 @@ def test_backfill_reuses_vec_index_embedding_without_reencoding(temp_db, monkeyp
     monkeypatch.setattr(emb, '_encode_batch', counting_encode_batch)
     monkeypatch.setattr(emb, '_server_initialized', True)
     monkeypatch.setattr(emb, '_backfill_done', True)
+    monkeypatch.setattr(emb, '_is_server_running', lambda: True)
 
     topic = add_topic(title="バックフィル再利用テスト", description="テスト", tags=DEFAULT_TAGS)
     topic_id = topic["topic_id"]
@@ -289,6 +290,9 @@ def test_backfill_skips_topic_without_vec_index_embedding(temp_db, monkeypatch):
     )
     topic_id = topic["topic_id"]
 
+    # backfill 自体はサーバー復帰後に走る想定。vec_index が無いこのtopicが
+    # 複製対象外であることを検証するため、backfillガードは通過させる。
+    monkeypatch.setattr(emb, '_is_server_running', lambda: True)
     filled = emb.backfill_topic_embeddings()
 
     conn = get_connection()
@@ -300,8 +304,9 @@ def test_backfill_skips_topic_without_vec_index_embedding(temp_db, monkeypatch):
     # 既にvec_indexを持っていれば0件とは限らないため filled の値自体は断定しない
 
 
-def test_backfill_noop_when_all_filled(temp_db, mock_embedding_server):
+def test_backfill_noop_when_all_filled(temp_db, mock_embedding_server, monkeypatch):
     """backfill_topic_embeddings: 全topicが既にtopic_vecを持つ場合は0を返す"""
+    monkeypatch.setattr(emb, '_is_server_running', lambda: True)
     add_topic(title="全件充足テスト", description="テスト", tags=DEFAULT_TAGS)
     # 既存の未充足分（init_database由来等）を先に埋めておく
     emb.backfill_topic_embeddings()


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

topic の近傍検索専用のベクトル索引 `topic_vec` を新設した。現状の topic 類似検索は全 entity 共用の `vec_index` をグローバル KNN してから `source_type='topic'` で絞り込む方式で、corpus が増えると topic が上位候補から脱落し、絞り込み後に空集合になりうる構造的な弱点を持つ。`topic_vec` は KNN の母集団を最初から topic のみに限定することでこれを避ける。distance metric は最初から cosine で作成する（埋め込みベクトルが非正規化のため、既定の L2 だとノルムが距離に混入してしまう）。

`add_topic` は topic 作成時に生成するベクトルを `topic_vec` にもそのまま書き込む。新たにエンコードし直すことはしない。サーバー起動時のバックフィルも既存の `vec_index` バックフィル経路に統合し、`vec_index` に格納済みのベクトルを複製するだけで新規エンコードは発生させない（`vec_index` にも無い topic は対象外とし、次回呼び出しで拾われる）。

あわせて、判例（decision）を topic 単位で網羅提示する後続機能向けの計測テーブル `precedent_telemetry` を追加した。書込を行うサービス自体は別 PR で実装する（本 PR はテーブル定義のみ）。

## 補足

- 本 PR は判例提示機能の基盤（topic routing 用の索引とスキーマ）のみを対象とし、`pull_precedents` ツール本体・routing ロジック・`precedent_telemetry` への書込は含まない（後続 PR の対象）。
- `topic_vec` の孤児レコード防止用に `delete_topic_embedding_with_conn` を用意したが、現状 topic を削除する MCP ツールが存在しないため未使用。将来 topic 削除機能を追加する際に、同一トランザクション内で呼ぶ想定。
- migration 番号（0049/0050）は着手時点の最新（0048）から採番した。並行して別 PR が同じ番号を採番する可能性があるが、実際のマージ順で確定する運用のため対応不要。

## テスト計画

- migration テスト: `topic_vec` / `precedent_telemetry` それぞれについて、適用前後でのテーブル存在・カラム構成・index の有無、NOT NULL 制約、`topic_vec` への INSERT + KNN 検索、DELETE による孤児防止経路を検証
- `topic_vec` 書込・バックフィルの単体テスト:
  - `add_topic` 後に `topic_vec` へ `rowid = topic_id` で 1 件だけ書き込まれること
  - `add_topic` が `topic_vec` 用に追加の embedding サーバー呼び出しを発生させないこと（呼び出し回数を計測して確認）
  - `topic_vec` に書き込まれたベクトルが `vec_index` のものと bit-identical であること
  - embedding サーバー停止時は `topic_vec` にも何も書き込まれず、`add_topic` 自体は成功すること
  - `topic_vec` の KNN 母集団に decision 等の他 entity が混入しないこと（大量の decision embedding を投入した状態で確認）
  - `backfill_topic_embeddings` が `vec_index` の既存ベクトルを再エンコードなしで複製すること、`vec_index` にも無い topic は対象外のままであること、全件充足時は 0 件を返すこと
  - `_ensure_initialized` の一度きりのバックフィル経路に `backfill_topic_embeddings` が組み込まれていること
- 既存テスト（`tests/unit`, `tests/integration`, `tests/e2e`, `tests/test_migrations`）が全て無破壊で通ることを確認
