### PR TITLE
search_telemetryにresults/diagnostics列を追加しfetch_telemetryを新設

### DIFF
--- a/migrations/0049_extend_search_telemetry.sql
+++ b/migrations/0049_extend_search_telemetry.sql
@@ -12,24 +12,33 @@
 --   スキーマと書込先のみを用意する。
 --
 -- スキーマ:
---   search_telemetry.results_json     : 返却ページの [{"type":..,"id":..,"final_score":..}, ...]
---   search_telemetry.diagnostics_json : retriever 内訳（fts_hits/vec_hits/tag_hits/
+--   search_telemetry.results_json      : 返却ページの [{"type":..,"id":..,"final_score":..}, ...]
+--   search_telemetry.diagnostics_json  : retriever 内訳（fts_hits/vec_hits/tag_hits/
 --                                        methods_used/candidate_set_size/qe_expansions/
 --                                        adaptive_weights 等）
---   fetch_telemetry.tool        : 計装元ツール名（例: 'get_by_ids'）
---   fetch_telemetry.items_json  : [{"type": "decision", "id": 3195}, ...]
---   fetch_telemetry.timestamp   : 書込時刻 (UTC)
+--   search_telemetry.caller_session_id : 検索を呼んだセッション（0048 と同じ相関キー）
+--   fetch_telemetry.tool              : 計装元ツール名（例: 'get_by_ids'）
+--   fetch_telemetry.items_json        : [{"type": "decision", "id": 3195}, ...]
+--   fetch_telemetry.caller_session_id : 取得を呼んだセッション（0048 と同じ相関キー）
+--   fetch_telemetry.timestamp         : 書込時刻 (UTC)
+--
+--   caller_session_id は search / fetch を同一セッションにスコープして突合するための
+--   相関キー。同一 (type, id) が別々の検索呼出で返るため、(type, id) 単独では
+--   「どの検索が実際に取得されたか」を区別できない。0048 の caller_session_id 規約と
+--   揃え、FK は張らず NULL 許容の TEXT で保持する（MCP context 外の呼出は NULL）。
 --
 --   search_telemetry と同じく、書込は daemon thread の非同期・失敗握りつぶし規約に
---   載せる。既存行の results_json / diagnostics_json は NULL のまま残る（後方互換）。
+--   載せる。既存行の results_json / diagnostics_json / caller_session_id は NULL のまま残る（後方互換）。
 
 ALTER TABLE search_telemetry ADD COLUMN results_json TEXT;
 ALTER TABLE search_telemetry ADD COLUMN diagnostics_json TEXT;
+ALTER TABLE search_telemetry ADD COLUMN caller_session_id TEXT;
 
 CREATE TABLE fetch_telemetry (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     tool TEXT NOT NULL,
     items_json TEXT NOT NULL,
+    caller_session_id TEXT,
     timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/migrations/0049_extend_search_telemetry.sql
+++ b/migrations/0049_extend_search_telemetry.sql
@@ -1,0 +1,36 @@
+-- Migration 0049: search_telemetry に results_json / diagnostics_json を追加 + fetch_telemetry 新設
+--
+-- depends: 0048_session_identity
+--
+-- 背景:
+--   search_telemetry (0041) は query / parameters / result_count のみを記録し、
+--   「どの id を何位で返したか」「retriever 別のヒット内訳」を保持していないため、
+--   検索結果が実際に後続で使われたか（pull hit 率等）を突合できない。
+--   本 migration はその生データ供給のため、search_telemetry に返却ページと
+--   retriever 内訳の JSON カラムを追加し、取得側の追跡テーブル fetch_telemetry を
+--   新設する。集計・可視化は別コンポーネントの管轄であり、ここでは生データの
+--   スキーマと書込先のみを用意する。
+--
+-- スキーマ:
+--   search_telemetry.results_json     : 返却ページの [{"type":..,"id":..,"final_score":..}, ...]
+--   search_telemetry.diagnostics_json : retriever 内訳（fts_hits/vec_hits/tag_hits/
+--                                        methods_used/candidate_set_size/qe_expansions/
+--                                        adaptive_weights 等）
+--   fetch_telemetry.tool        : 計装元ツール名（例: 'get_by_ids'）
+--   fetch_telemetry.items_json  : [{"type": "decision", "id": 3195}, ...]
+--   fetch_telemetry.timestamp   : 書込時刻 (UTC)
+--
+--   search_telemetry と同じく、書込は daemon thread の非同期・失敗握りつぶし規約に
+--   載せる。既存行の results_json / diagnostics_json は NULL のまま残る（後方互換）。
+
+ALTER TABLE search_telemetry ADD COLUMN results_json TEXT;
+ALTER TABLE search_telemetry ADD COLUMN diagnostics_json TEXT;
+
+CREATE TABLE fetch_telemetry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool TEXT NOT NULL,
+    items_json TEXT NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_fetch_telemetry_timestamp ON fetch_telemetry(timestamp);

--- a/src/main.py
+++ b/src/main.py
@@ -487,7 +487,8 @@ def search(
         include_retracted=Trueを指定する。
     """
     flavor = _normalize_flavor(flavor)
-    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before)
+    caller_session_id = get_caller_session_id()
+    result = search_service.search(keyword, tags, entity_type, limit, offset, keyword_mode, include_details, domain, date_after, date_before, caller_session_id=caller_session_id)
     if "error" not in result:
         _apply_flavor_to_snippets(result.get("results", []), flavor)
     if "error" not in result and tags:
@@ -517,7 +518,8 @@ def get_by_ids(
         取得結果（各アイテムの詳細情報）
     """
     flavor = _normalize_flavor(flavor)
-    result = search_service.get_by_ids(items)
+    caller_session_id = get_caller_session_id()
+    result = search_service.get_by_ids(items, caller_session_id=caller_session_id)
     if "error" not in result:
         conn = get_connection()
         try:

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1872,7 +1872,8 @@ def search(
 def _telemetry_get_connection() -> sqlite3.Connection:
     """telemetry 書込専用の軽量コネクション。
 
-    `search_telemetry` への INSERT は sqlite-vec 拡張を必要としないため、
+    telemetry テーブル（`search_telemetry` / `fetch_telemetry`）への INSERT は
+    sqlite-vec 拡張を必要としないため、
     `db.get_connection()` の `enable_load_extension(True)` → 拡張ロード →
     `enable_load_extension(False)` のオーバーヘッドや拡張ロード失敗時の
     warning ログを避ける目的で、最小構成（WAL + busy_timeout）のみ設定する。

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1283,6 +1283,7 @@ def _rrf_merge(
     vec_results: list[dict],
     limit: int,
     tag_results: Optional[list[dict]] = None,
+    adaptive_weights: Optional[tuple[float, float]] = None,
 ) -> list[dict]:
     """RRF（Reciprocal Rank Fusion）でFTS5・ベクトル・タグLIKE結果を統合する。
 
@@ -1302,11 +1303,18 @@ def _rrf_merge(
     ことを呼出元が保証する。重複があると `+=` により寄与が二重に加算され rrf_normalized が
     1.0 を超える可能性がある。現状の `_fts_search` / `_vector_search` / `_tag_like_search` は
     重複を返さない実装になっている。
+
+    ``adaptive_weights`` が渡された場合はそれを (w_fts, w_vec) として使い、内部の
+    `_compute_adaptive_weights` 再計算を省く。同一 search 呼出内で diagnostics 側と
+    重みを共有し二重計算を避けるための入口。None のときは従来通り自前で算出する。
     """
     scores: dict[tuple, dict] = {}  # key: (type, id)
 
     # Adaptive RRF: ヒット数比率に応じてFTS/ベクトルの重みを動的調整
-    w_fts, w_vec = _compute_adaptive_weights(len(fts_results), len(vec_results))
+    if adaptive_weights is None:
+        w_fts, w_vec = _compute_adaptive_weights(len(fts_results), len(vec_results))
+    else:
+        w_fts, w_vec = adaptive_weights
 
     def _ensure_entry(item: dict) -> dict:
         key = (item["type"], item["id"])
@@ -1612,10 +1620,15 @@ def _retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> dict:
     }
 
 
-def _build_diagnostics(ctx: SearchContext, retrieval: dict) -> dict:
+def _build_diagnostics(
+    ctx: SearchContext, retrieval: dict, adaptive_weights: tuple[float, float],
+) -> dict:
     """telemetry 用の retriever 内訳を組み立てる。
 
     ``_retrieve`` の戻り値と ``ctx``（QE 拡張後）だけから計算できる範囲に留める。
+    ``adaptive_weights`` は呼出元 (``search``) が 1 回だけ算出した (w_fts, w_vec) を
+    そのまま受け取る。RRF 統合 (`_rrf_merge`) と同じ重みを共有し、同一 search 呼出内で
+    `_compute_adaptive_weights` が二重に走るのを避ける。
 
     Returns:
         {"fts_hits": int, "vec_hits": int | None, "tag_hits": int,
@@ -1631,9 +1644,7 @@ def _build_diagnostics(ctx: SearchContext, retrieval: dict) -> dict:
     qe_expansions: list[str] = []
     if ctx.original_keyword_count is not None:
         qe_expansions = list(ctx.fts_keywords[ctx.original_keyword_count:])
-    w_fts, w_vec = _compute_adaptive_weights(
-        len(retrieval["fts"]), len(vec_results) if vec_results is not None else 0,
-    )
+    w_fts, w_vec = adaptive_weights
     return {
         "fts_hits": len(retrieval["fts"]),
         "vec_hits": len(vec_results) if vec_results is not None else None,
@@ -1645,14 +1656,21 @@ def _build_diagnostics(ctx: SearchContext, retrieval: dict) -> dict:
     }
 
 
-def _merge(ctx: SearchContext, retrieval: dict) -> list[dict]:
-    """RRF 統合ステージ。各 result に score_breakdown.{fts,vec,tag,rrf_normalized} を付与する。"""
+def _merge(
+    ctx: SearchContext, retrieval: dict, adaptive_weights: tuple[float, float],
+) -> list[dict]:
+    """RRF 統合ステージ。各 result に score_breakdown.{fts,vec,tag,rrf_normalized} を付与する。
+
+    ``adaptive_weights`` は呼出元 (``search``) が 1 回だけ算出した (w_fts, w_vec)。
+    diagnostics 側と同じ重みを共有し `_compute_adaptive_weights` の二重計算を避ける。
+    """
     effective_vec = retrieval["vec"] if retrieval["vec"] is not None else []
     return _rrf_merge(
         retrieval["fts"],
         effective_vec,
         ctx.fetch_limit,
         tag_results=retrieval["tag"],
+        adaptive_weights=adaptive_weights,
     )
 
 
@@ -1750,6 +1768,7 @@ def search(
     domain: Optional[str] = None,
     date_after: Optional[str] = None,
     date_before: Optional[str] = None,
+    caller_session_id: Optional[str] = None,
 ) -> dict:
     """
     キーワードで横断検索する。
@@ -1774,6 +1793,8 @@ def search(
         domain: ドメインフィルタ。内部でtags=["domain:{domain}"]にマージされる
         date_after: 日付フィルタ（以降）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
         date_before: 日付フィルタ（以前）。YYYY-MM-DD or YYYY-MM-DD HH:MM:SS形式
+        caller_session_id: 呼出セッションの相関キー。telemetry に記録し fetch_telemetry と
+            突合するために使う。MCP context 外の直接呼出では None（記録は NULL）。
 
     Returns:
         検索結果一覧（type, id, title, score, final_score, score_breakdown, snippet, tags）。
@@ -1800,8 +1821,10 @@ def search(
             )
             ctx = _expand(ctx)
             retrieval = _retrieve(ctx, conn)
-            diagnostics = _build_diagnostics(ctx, retrieval)
-            merged = _merge(ctx, retrieval)
+            vec_hits = len(retrieval["vec"]) if retrieval["vec"] is not None else 0
+            adaptive_weights = _compute_adaptive_weights(len(retrieval["fts"]), vec_hits)
+            diagnostics = _build_diagnostics(ctx, retrieval, adaptive_weights)
+            merged = _merge(ctx, retrieval, adaptive_weights)
             merged = _rerank(ctx, merged)
             sliced, total_count = _slice(ctx, merged)
             results_snapshot = _build_results_snapshot(sliced)
@@ -1825,6 +1848,7 @@ def search(
             result_count=total_count,
             results=results_snapshot,
             diagnostics=diagnostics,
+            caller_session_id=caller_session_id,
         )
 
         return {
@@ -1875,6 +1899,18 @@ class _JsonCol:
         self.value = value
 
 
+# telemetry テーブルごとに書込を許す列の allowlist。
+# `_record_telemetry_async` は table / column 名を検証なしで SQL に埋め込むため、
+# ここに載っていない table / column の書込は組立前に弾く（f-string 埋込前の安全弁）。
+_TELEMETRY_WRITABLE_COLUMNS: dict[str, frozenset[str]] = {
+    "search_telemetry": frozenset(
+        {"query", "parameters", "result_count", "results_json",
+         "diagnostics_json", "caller_session_id"}
+    ),
+    "fetch_telemetry": frozenset({"tool", "items_json", "caller_session_id"}),
+}
+
+
 def _record_telemetry_async(table: str, payload: dict) -> threading.Thread | None:
     """telemetry テーブルへの 1 行 INSERT を daemon thread で非同期に行う共通ヘルパ。
 
@@ -1885,14 +1921,25 @@ def _record_telemetry_async(table: str, payload: dict) -> threading.Thread | Non
     含む）は全て `_write` 内、すなわち daemon thread 側で行う。呼出元スレッドで例外が
     発生する余地を残さないため。
 
+    table / column 名は SQL に f-string で埋め込まれる。呼出元がハードコードした定数を
+    渡す前提だが、`_TELEMETRY_WRITABLE_COLUMNS` の allowlist に対して同期部分で assert し、
+    想定外の table / column が混入した場合は SQL 組立前に開発時点で気付けるようにする。
+
     Args:
-        table: 書込先テーブル名。呼出元がハードコードした定数文字列を渡す前提で
-            それ自体はエスケープ・検証しない（ユーザー入力を渡さないこと）。
+        table: 書込先テーブル名。allowlist に載っている定数文字列のみ許す
+            （ユーザー入力を渡さないこと）。
         payload: カラム名 → 値 の dict。JSON エンコードが必要な値は `_JsonCol` で包む。
 
     Returns:
         起動した daemon Thread。起動に失敗した場合は None。
     """
+    allowed = _TELEMETRY_WRITABLE_COLUMNS.get(table)
+    assert allowed is not None, f"unknown telemetry table: {table!r}"
+    unknown_columns = set(payload) - allowed
+    assert not unknown_columns, (
+        f"unknown telemetry columns for {table!r}: {sorted(unknown_columns)}"
+    )
+
     def _write() -> None:
         columns = list(payload.keys())
         try:
@@ -1934,6 +1981,7 @@ def _record_search_telemetry_async(
     result_count: int,
     results: Optional[list[dict]] = None,
     diagnostics: Optional[dict] = None,
+    caller_session_id: Optional[str] = None,
 ) -> threading.Thread | None:
     """search 呼出の telemetry を別スレッドで非同期書込する。
 
@@ -1952,6 +2000,8 @@ def _record_search_telemetry_async(
         result_count: 返却件数（total_count）。
         results: 返却ページの [{"type", "id", "final_score"}, ...]。省略時は空リストとして記録する。
         diagnostics: retriever 内訳（`_build_diagnostics` の戻り値）。省略時は空 dict として記録する。
+        caller_session_id: 呼出セッションの相関キー。fetch_telemetry と突合するために記録する。
+            None のとき NULL で記録する（MCP context 外の呼出）。
 
     Returns:
         起動した daemon Thread。起動に失敗した場合は None。
@@ -1964,6 +2014,7 @@ def _record_search_telemetry_async(
             "result_count": result_count,
             "results_json": _JsonCol(results if results is not None else []),
             "diagnostics_json": _JsonCol(diagnostics if diagnostics is not None else {}),
+            "caller_session_id": caller_session_id,
         },
     )
 
@@ -1971,16 +2022,19 @@ def _record_search_telemetry_async(
 def _record_fetch_telemetry_async(
     tool: str,
     items: list[dict],
+    caller_session_id: Optional[str] = None,
 ) -> threading.Thread | None:
     """取得系ツール呼出（get_by_ids 等）を fetch_telemetry へ非同期書込する。
 
     search_telemetry の results_json と突合することで、検索結果が実際に後続取得
     されたか（pull hit 率のプロキシ）を後から算出できるようにするための生データ記録。
+    caller_session_id を両テーブルに持たせ、同一セッションにスコープして突合する。
     書込方針は `_record_search_telemetry_async` と同じ（非同期・失敗握りつぶし）。
 
     Args:
         tool: 計装元ツール名（例: 'get_by_ids'）。
         items: 取得対象の [{"type": str, "id": int}, ...]。
+        caller_session_id: 呼出セッションの相関キー。None のとき NULL で記録する。
 
     Returns:
         起動した daemon Thread。起動に失敗した場合は None。
@@ -1990,6 +2044,7 @@ def _record_fetch_telemetry_async(
         {
             "tool": tool,
             "items_json": _JsonCol(items),
+            "caller_session_id": caller_session_id,
         },
     )
 
@@ -2144,7 +2199,7 @@ def get_by_id(type: str, id: int, conn=None) -> dict:
             conn.close()
 
 
-def get_by_ids(items: list[dict]) -> dict:
+def get_by_ids(items: list[dict], caller_session_id: Optional[str] = None) -> dict:
     """
     複数のtype+idペアをバッチ取得する。
 
@@ -2153,6 +2208,8 @@ def get_by_ids(items: list[dict]) -> dict:
 
     Args:
         items: [{type: str, id: int}, ...] のリスト（最大20件）
+        caller_session_id: 呼出セッションの相関キー。telemetry に記録し search_telemetry と
+            突合するために使う。MCP context 外の直接呼出では None（記録は NULL）。
 
     Returns:
         {"results": [get_by_idの結果, ...]}
@@ -2171,6 +2228,7 @@ def get_by_ids(items: list[dict]) -> dict:
     _record_fetch_telemetry_async(
         "get_by_ids",
         [{"type": item.get("type"), "id": item.get("id")} for item in items],
+        caller_session_id=caller_session_id,
     )
 
     conn = get_connection()

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1612,6 +1612,39 @@ def _retrieve(ctx: SearchContext, conn: sqlite3.Connection) -> dict:
     }
 
 
+def _build_diagnostics(ctx: SearchContext, retrieval: dict) -> dict:
+    """telemetry 用の retriever 内訳を組み立てる。
+
+    ``_retrieve`` の戻り値と ``ctx``（QE 拡張後）だけから計算できる範囲に留める。
+
+    Returns:
+        {"fts_hits": int, "vec_hits": int | None, "tag_hits": int,
+         "methods_used": list[str], "candidate_set_size": None,
+         "qe_expansions": list[str], "adaptive_weights": {"w_fts": float, "w_vec": float}}
+
+        vec_hits はベクトル検索自体が無効（embedding サーバー未起動等）のとき None、
+        有効だがヒット 0 件のとき 0 になる（`retrieval["vec"] is None` で区別する）。
+        candidate_set_size は post-filter 方式の vector_retrieve では算出できないため
+        常に None。qe_expansions は Query Expansion で追加されたキーワードのみ（元キーワードは含まない）。
+    """
+    vec_results = retrieval["vec"]
+    qe_expansions: list[str] = []
+    if ctx.original_keyword_count is not None:
+        qe_expansions = list(ctx.fts_keywords[ctx.original_keyword_count:])
+    w_fts, w_vec = _compute_adaptive_weights(
+        len(retrieval["fts"]), len(vec_results) if vec_results is not None else 0,
+    )
+    return {
+        "fts_hits": len(retrieval["fts"]),
+        "vec_hits": len(vec_results) if vec_results is not None else None,
+        "tag_hits": len(retrieval["tag"]),
+        "methods_used": retrieval["methods_used"],
+        "candidate_set_size": None,
+        "qe_expansions": qe_expansions,
+        "adaptive_weights": {"w_fts": w_fts, "w_vec": w_vec},
+    }
+
+
 def _merge(ctx: SearchContext, retrieval: dict) -> list[dict]:
     """RRF 統合ステージ。各 result に score_breakdown.{fts,vec,tag,rrf_normalized} を付与する。"""
     effective_vec = retrieval["vec"] if retrieval["vec"] is not None else []
@@ -1640,6 +1673,18 @@ def _slice(ctx: SearchContext, results: list[dict]) -> tuple[list[dict], int]:
     total_count = len(results)
     sliced = results[ctx.offset:ctx.offset + ctx.limit]
     return sliced, total_count
+
+
+def _build_results_snapshot(sliced: list[dict]) -> list[dict]:
+    """telemetry 用に返却ページから (type, id, final_score) だけを抜き出す。
+
+    `_decorate` が in-place で `id` を `id_raw` に退避する前（`_slice` 直後）の
+    `sliced` を受け取る想定。
+    """
+    return [
+        {"type": item["type"], "id": item["id"], "final_score": item.get("final_score")}
+        for item in sliced
+    ]
 
 
 def _attach_superseded_by(results: list[dict]) -> None:
@@ -1755,9 +1800,11 @@ def search(
             )
             ctx = _expand(ctx)
             retrieval = _retrieve(ctx, conn)
+            diagnostics = _build_diagnostics(ctx, retrieval)
             merged = _merge(ctx, retrieval)
             merged = _rerank(ctx, merged)
             sliced, total_count = _slice(ctx, merged)
+            results_snapshot = _build_results_snapshot(sliced)
             sliced, nearby_tags = _decorate(ctx, sliced, query_tag_ids)
         finally:
             conn.close()
@@ -1776,6 +1823,8 @@ def search(
                 "date_before": date_before,
             },
             result_count=total_count,
+            results=results_snapshot,
+            diagnostics=diagnostics,
         )
 
         return {
@@ -1812,10 +1861,79 @@ def _telemetry_get_connection() -> sqlite3.Connection:
     return conn
 
 
+class _JsonCol:
+    """`_record_telemetry_async` の payload 内で「json.dumps してから bind する」列を示すマーカー。
+
+    通常の str/int 値は素通しで bind される一方、このクラスで包んだ値は書込 thread の
+    中で `json.dumps` される。素の str/list を型で判別すると「search_telemetry.query
+    は str が来ても常に JSON エンコードする（配列と同じ形にして呼出側の parse を統一する）」
+    という既存仕様を表現できないため、型ではなく明示マーカーで判別する。
+    """
+    __slots__ = ("value",)
+
+    def __init__(self, value) -> None:
+        self.value = value
+
+
+def _record_telemetry_async(table: str, payload: dict) -> threading.Thread | None:
+    """telemetry テーブルへの 1 行 INSERT を daemon thread で非同期に行う共通ヘルパ。
+
+    `search_telemetry` / `fetch_telemetry` 共通の書込方針（呼出元のレスポンスタイムに
+    影響しない・書込失敗は logger.warning に出して握りつぶし呼出元を絶対に壊さない）を
+    一本化したもの。`payload` の組立（dict の構築）自体は呼出元の同期コードで行われるが、
+    値が実際に SQL にバインドされる形へ変換される処理（`_JsonCol` の json.dumps 展開を
+    含む）は全て `_write` 内、すなわち daemon thread 側で行う。呼出元スレッドで例外が
+    発生する余地を残さないため。
+
+    Args:
+        table: 書込先テーブル名。呼出元がハードコードした定数文字列を渡す前提で
+            それ自体はエスケープ・検証しない（ユーザー入力を渡さないこと）。
+        payload: カラム名 → 値 の dict。JSON エンコードが必要な値は `_JsonCol` で包む。
+
+    Returns:
+        起動した daemon Thread。起動に失敗した場合は None。
+    """
+    def _write() -> None:
+        columns = list(payload.keys())
+        try:
+            values = [
+                json.dumps(v.value, ensure_ascii=False) if isinstance(v, _JsonCol) else v
+                for v in payload.values()
+            ]
+        except (TypeError, ValueError) as e:
+            logger.warning("%s serialize failed: %s", table, e)
+            return
+
+        column_sql = ", ".join(columns)
+        placeholder_sql = ", ".join("?" * len(columns))
+        try:
+            conn = _telemetry_get_connection()
+            try:
+                conn.execute(
+                    f"INSERT INTO {table} ({column_sql}) VALUES ({placeholder_sql})",
+                    values,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.warning("%s write failed: %s", table, e)
+
+    try:
+        thread = threading.Thread(target=_write, daemon=True)
+        thread.start()
+    except Exception as e:
+        logger.warning("%s thread start failed: %s", table, e)
+        return None
+    return thread
+
+
 def _record_search_telemetry_async(
     query: str | list[str],
     parameters: dict,
     result_count: int,
+    results: Optional[list[dict]] = None,
+    diagnostics: Optional[dict] = None,
 ) -> threading.Thread | None:
     """search 呼出の telemetry を別スレッドで非同期書込する。
 
@@ -1828,38 +1946,52 @@ def _record_search_telemetry_async(
     書込は `_telemetry_get_connection()` 経由で sqlite-vec 拡張を
     ロードしない軽量コネクションを使う。
 
+    Args:
+        query: 検索キーワード（str または list[str]）。JSON エンコードして保存する。
+        parameters: telemetry 用パラメータ snapshot。
+        result_count: 返却件数（total_count）。
+        results: 返却ページの [{"type", "id", "final_score"}, ...]。省略時は空リストとして記録する。
+        diagnostics: retriever 内訳（`_build_diagnostics` の戻り値）。省略時は空 dict として記録する。
+
     Returns:
         起動した daemon Thread。起動に失敗した場合は None。
     """
-    def _write() -> None:
-        try:
-            query_json = json.dumps(query, ensure_ascii=False)
-            parameters_json = json.dumps(parameters, ensure_ascii=False)
-        except (TypeError, ValueError) as e:
-            logger.warning("search_telemetry serialize failed: %s", e)
-            return
+    return _record_telemetry_async(
+        "search_telemetry",
+        {
+            "query": _JsonCol(query),
+            "parameters": _JsonCol(parameters),
+            "result_count": result_count,
+            "results_json": _JsonCol(results if results is not None else []),
+            "diagnostics_json": _JsonCol(diagnostics if diagnostics is not None else {}),
+        },
+    )
 
-        try:
-            conn = _telemetry_get_connection()
-            try:
-                conn.execute(
-                    "INSERT INTO search_telemetry (query, parameters, result_count) "
-                    "VALUES (?, ?, ?)",
-                    (query_json, parameters_json, int(result_count)),
-                )
-                conn.commit()
-            finally:
-                conn.close()
-        except Exception as e:
-            logger.warning("search_telemetry write failed: %s", e)
 
-    try:
-        thread = threading.Thread(target=_write, daemon=True)
-        thread.start()
-    except Exception as e:
-        logger.warning("search_telemetry thread start failed: %s", e)
-        return None
-    return thread
+def _record_fetch_telemetry_async(
+    tool: str,
+    items: list[dict],
+) -> threading.Thread | None:
+    """取得系ツール呼出（get_by_ids 等）を fetch_telemetry へ非同期書込する。
+
+    search_telemetry の results_json と突合することで、検索結果が実際に後続取得
+    されたか（pull hit 率のプロキシ）を後から算出できるようにするための生データ記録。
+    書込方針は `_record_search_telemetry_async` と同じ（非同期・失敗握りつぶし）。
+
+    Args:
+        tool: 計装元ツール名（例: 'get_by_ids'）。
+        items: 取得対象の [{"type": str, "id": int}, ...]。
+
+    Returns:
+        起動した daemon Thread。起動に失敗した場合は None。
+    """
+    return _record_telemetry_async(
+        "fetch_telemetry",
+        {
+            "tool": tool,
+            "items_json": _JsonCol(items),
+        },
+    )
 
 
 def _format_row(type_name: str, data: dict, tags: list[str]) -> dict:
@@ -2016,6 +2148,9 @@ def get_by_ids(items: list[dict]) -> dict:
     """
     複数のtype+idペアをバッチ取得する。
 
+    呼出内容は fetch_telemetry に非同期で記録される（search_telemetry の
+    results_json と突合し、検索結果が実際に取得されたかを後から算出するための生データ）。
+
     Args:
         items: [{type: str, id: int}, ...] のリスト（最大20件）
 
@@ -2032,6 +2167,11 @@ def get_by_ids(items: list[dict]) -> dict:
                 "message": f"Maximum {GET_BY_IDS_MAX} items allowed, got {len(items)}"
             }
         }
+
+    _record_fetch_telemetry_async(
+        "get_by_ids",
+        [{"type": item.get("type"), "id": item.get("id")} for item in items],
+    )
 
     conn = get_connection()
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,26 @@ def _synchronous_telemetry(monkeypatch):
     monkeypatch.setattr(search_service, "_record_search_telemetry_async", synchronous_wrapper)
 
 
+@pytest.fixture(autouse=True)
+def _synchronous_fetch_telemetry(monkeypatch):
+    """fetch_telemetry (get_by_ids 計装) 書込を同期実行に切り替える。
+
+    `_synchronous_telemetry` と同じ理由（daemon thread と TemporaryDirectory cleanup
+    のレース回避）で、get_by_ids を呼ぶ既存テスト全般に波及するため autouse にする。
+    """
+    from src.services import search_service
+
+    original = search_service._record_fetch_telemetry_async
+
+    def synchronous_wrapper(*args, **kwargs):
+        thread = original(*args, **kwargs)
+        if thread is not None:
+            thread.join(timeout=5.0)
+        return thread
+
+    monkeypatch.setattr(search_service, "_record_fetch_telemetry_async", synchronous_wrapper)
+
+
 @pytest.fixture
 def disable_embedding(monkeypatch):
     """embeddingサービスを無効化する共通フィクスチャ。

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -1,4 +1,4 @@
-"""search_telemetry テーブル書込のテスト
+"""search_telemetry / fetch_telemetry テーブル書込のテスト
 
 検証項目:
 1. migration 0041 後に search_telemetry テーブルが存在する (id / query / parameters /
@@ -7,6 +7,10 @@
    が期待する JSON / 整数で記録される
 3. 書込は別スレッドで行われる (`_record_search_telemetry_async` が Thread を返す)
 4. 書込中に例外が発生しても search() の戻り値は通常通りで、本体を壊さない
+5. search_telemetry に results_json / diagnostics_json 列が追加され、search() 呼出ごとに
+   返却ページと retriever 内訳が記録される
+6. fetch_telemetry テーブルが新設され、get_by_ids 呼出が非同期で記録される
+7. fetch_telemetry の書込失敗は get_by_ids の戻り値に波及しない
 """
 import json
 import os
@@ -17,6 +21,7 @@ import pytest
 from src.db import get_connection, init_database
 from src.services import search_service
 from src.services.topic_service import add_topic
+from src.services.decision_service import add_decisions
 import src.services.embedding_service as emb
 
 
@@ -57,6 +62,21 @@ def capture_telemetry_threads(monkeypatch):
     return threads
 
 
+@pytest.fixture
+def capture_fetch_telemetry_threads(monkeypatch):
+    """get_by_ids が起動する fetch_telemetry 書込 thread を捕捉して join() できるようにする"""
+    threads = []
+    original = search_service._record_fetch_telemetry_async
+
+    def wrapped(*args, **kwargs):
+        thread = original(*args, **kwargs)
+        threads.append(thread)
+        return thread
+
+    monkeypatch.setattr(search_service, "_record_fetch_telemetry_async", wrapped)
+    return threads
+
+
 def _wait_for_telemetry(threads, timeout=5.0):
     for t in threads:
         if t is not None:
@@ -67,7 +87,7 @@ def _fetch_all_telemetry():
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT id, query, parameters, result_count, timestamp "
+            "SELECT id, query, parameters, result_count, results_json, diagnostics_json, timestamp "
             "FROM search_telemetry ORDER BY id"
         ).fetchall()
         return [dict(r) for r in rows]
@@ -75,19 +95,36 @@ def _fetch_all_telemetry():
         conn.close()
 
 
+def _fetch_all_fetch_telemetry():
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT id, tool, items_json, timestamp FROM fetch_telemetry ORDER BY id"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
 def test_search_telemetry_table_schema(temp_db):
-    """migration 0041 で search_telemetry テーブルと必要なカラムが作られる"""
+    """migration 0041 + 0049 で search_telemetry テーブルと必要なカラムが作られる"""
     conn = get_connection()
     try:
         rows = conn.execute("PRAGMA table_info(search_telemetry)").fetchall()
     finally:
         conn.close()
     columns = {r["name"]: r for r in rows}
-    assert {"id", "query", "parameters", "result_count", "timestamp"}.issubset(columns)
+    assert {
+        "id", "query", "parameters", "result_count",
+        "results_json", "diagnostics_json", "timestamp",
+    }.issubset(columns)
     assert columns["query"]["notnull"] == 1
     assert columns["parameters"]["notnull"] == 1
     assert columns["result_count"]["notnull"] == 1
     assert columns["timestamp"]["notnull"] == 1
+    # results_json / diagnostics_json は既存行 (NULL) との後方互換のため NULL 許容
+    assert columns["results_json"]["notnull"] == 0
+    assert columns["diagnostics_json"]["notnull"] == 0
 
 
 def test_search_telemetry_index_on_timestamp(temp_db):
@@ -102,6 +139,34 @@ def test_search_telemetry_index_on_timestamp(temp_db):
         conn.close()
     index_names = {r["name"] for r in rows}
     assert "idx_search_telemetry_timestamp" in index_names
+
+
+def test_fetch_telemetry_table_schema(temp_db):
+    """migration 0049 で fetch_telemetry テーブルと必要なカラムが作られる"""
+    conn = get_connection()
+    try:
+        rows = conn.execute("PRAGMA table_info(fetch_telemetry)").fetchall()
+    finally:
+        conn.close()
+    columns = {r["name"]: r for r in rows}
+    assert {"id", "tool", "items_json", "timestamp"}.issubset(columns)
+    assert columns["tool"]["notnull"] == 1
+    assert columns["items_json"]["notnull"] == 1
+    assert columns["timestamp"]["notnull"] == 1
+
+
+def test_fetch_telemetry_index_on_timestamp(temp_db):
+    """fetch_telemetry.timestamp に index が張られている"""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='fetch_telemetry'"
+        ).fetchall()
+    finally:
+        conn.close()
+    index_names = {r["name"] for r in rows}
+    assert "idx_fetch_telemetry_timestamp" in index_names
 
 
 def test_search_records_telemetry_row(temp_db, capture_telemetry_threads):
@@ -133,6 +198,24 @@ def test_search_records_telemetry_row(temp_db, capture_telemetry_threads):
     assert "include_details" in params
     assert "tags" in params
     assert row["timestamp"] is not None
+
+    # results_json: 返却ページの (type, id, final_score)
+    results = json.loads(row["results_json"])
+    assert len(results) == result["total_count"]
+    returned_ids = {(r["type"], r["id"]) for r in results}
+    assert ("topic", result["results"][0]["id_raw"]) in returned_ids
+    for r in results:
+        assert set(r.keys()) == {"type", "id", "final_score"}
+
+    # diagnostics_json: retriever 内訳
+    diagnostics = json.loads(row["diagnostics_json"])
+    assert diagnostics["fts_hits"] >= 1
+    assert diagnostics["vec_hits"] is None  # disable_embedding によりベクトル検索無効
+    assert diagnostics["tag_hits"] == 0
+    assert diagnostics["methods_used"] == result["search_methods_used"]
+    assert diagnostics["candidate_set_size"] is None
+    assert diagnostics["qe_expansions"] == []
+    assert set(diagnostics["adaptive_weights"].keys()) == {"w_fts", "w_vec"}
 
 
 def test_search_records_list_keyword_and_parameters(temp_db, capture_telemetry_threads):
@@ -264,4 +347,81 @@ def test_search_unaffected_when_telemetry_write_fails(
     assert call_counter["writer"] >= 1
     assert any(
         "search_telemetry write failed" in record.message for record in caplog.records
+    ), f"warning log が出ていない: {[r.message for r in caplog.records]}"
+
+
+def test_get_by_ids_records_fetch_telemetry(temp_db, capture_fetch_telemetry_threads):
+    """get_by_ids 呼出ごとに fetch_telemetry に 1 行追加される"""
+    topic = add_topic(
+        title="fetch telemetry 記録テスト",
+        description="get_by_ids 呼出で fetch_telemetry が書かれることを検証する",
+        tags=DEFAULT_TAGS,
+    )
+    decision = add_decisions([{
+        "topic_id": topic["topic_id"],
+        "decision": "fetch telemetry 検証用の決定内容",
+        "reason": "fetch telemetry 検証用の理由",
+    }])["created"][0]
+
+    result = search_service.get_by_ids([
+        {"type": "topic", "id": topic["topic_id"]},
+        {"type": "decision", "id": decision["decision_id"]},
+    ])
+    assert "error" not in result
+
+    _wait_for_telemetry(capture_fetch_telemetry_threads)
+
+    rows = _fetch_all_fetch_telemetry()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tool"] == "get_by_ids"
+    items = json.loads(row["items_json"])
+    assert items == [
+        {"type": "topic", "id": topic["topic_id"]},
+        {"type": "decision", "id": decision["decision_id"]},
+    ]
+    assert row["timestamp"] is not None
+
+
+def test_get_by_ids_empty_items_records_nothing(temp_db):
+    """items=[] の no-op 呼出は fetch_telemetry に記録されない"""
+    result = search_service.get_by_ids([])
+    assert result == {"results": []}
+    assert _fetch_all_fetch_telemetry() == []
+
+
+def test_get_by_ids_too_many_items_records_nothing(temp_db):
+    """TOO_MANY_ITEMS エラーになる呼出は fetch_telemetry に記録されない"""
+    items = [{"type": "topic", "id": i} for i in range(search_service.GET_BY_IDS_MAX + 1)]
+
+    result = search_service.get_by_ids(items)
+
+    assert result["error"]["code"] == "TOO_MANY_ITEMS"
+    assert _fetch_all_fetch_telemetry() == []
+
+
+def test_get_by_ids_unaffected_when_fetch_telemetry_write_fails(
+    temp_db, capture_fetch_telemetry_threads, monkeypatch, caplog
+):
+    """fetch_telemetry 書込に失敗しても get_by_ids の戻り値は壊れず、警告ログが出る"""
+    topic = add_topic(
+        title="fetch telemetry 書込失敗フォールバック検証",
+        description="例外発生時に get_by_ids 本体が影響を受けないことを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    def flaky_get_connection():
+        raise RuntimeError("simulated fetch_telemetry write failure")
+
+    monkeypatch.setattr(search_service, "_telemetry_get_connection", flaky_get_connection)
+
+    with caplog.at_level("WARNING"):
+        result = search_service.get_by_ids([{"type": "topic", "id": topic["topic_id"]}])
+
+    _wait_for_telemetry(capture_fetch_telemetry_threads)
+
+    assert "error" not in result
+    assert result["results"][0]["type"] == "topic"
+    assert any(
+        "fetch_telemetry write failed" in record.message for record in caplog.records
     ), f"warning log が出ていない: {[r.message for r in caplog.records]}"

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -11,6 +11,10 @@
    返却ページと retriever 内訳が記録される
 6. fetch_telemetry テーブルが新設され、get_by_ids 呼出が非同期で記録される
 7. fetch_telemetry の書込失敗は get_by_ids の戻り値に波及しない
+8. search_telemetry / fetch_telemetry に caller_session_id 列が追加され、search() /
+   get_by_ids() に渡した相関キーが記録される（未指定時は NULL）
+9. _build_diagnostics の分岐（vec_hits の整数/None/0、tag_hits>0、qe_expansions 非空、
+   methods_used への vector / tag_like 混入）が期待通り diagnostics に反映される
 """
 import json
 import os
@@ -87,7 +91,8 @@ def _fetch_all_telemetry():
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT id, query, parameters, result_count, results_json, diagnostics_json, timestamp "
+            "SELECT id, query, parameters, result_count, results_json, diagnostics_json, "
+            "caller_session_id, timestamp "
             "FROM search_telemetry ORDER BY id"
         ).fetchall()
         return [dict(r) for r in rows]
@@ -99,7 +104,8 @@ def _fetch_all_fetch_telemetry():
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT id, tool, items_json, timestamp FROM fetch_telemetry ORDER BY id"
+            "SELECT id, tool, items_json, caller_session_id, timestamp "
+            "FROM fetch_telemetry ORDER BY id"
         ).fetchall()
         return [dict(r) for r in rows]
     finally:
@@ -116,15 +122,16 @@ def test_search_telemetry_table_schema(temp_db):
     columns = {r["name"]: r for r in rows}
     assert {
         "id", "query", "parameters", "result_count",
-        "results_json", "diagnostics_json", "timestamp",
+        "results_json", "diagnostics_json", "caller_session_id", "timestamp",
     }.issubset(columns)
     assert columns["query"]["notnull"] == 1
     assert columns["parameters"]["notnull"] == 1
     assert columns["result_count"]["notnull"] == 1
     assert columns["timestamp"]["notnull"] == 1
-    # results_json / diagnostics_json は既存行 (NULL) との後方互換のため NULL 許容
+    # results_json / diagnostics_json / caller_session_id は既存行 (NULL) との後方互換のため NULL 許容
     assert columns["results_json"]["notnull"] == 0
     assert columns["diagnostics_json"]["notnull"] == 0
+    assert columns["caller_session_id"]["notnull"] == 0
 
 
 def test_search_telemetry_index_on_timestamp(temp_db):
@@ -149,10 +156,12 @@ def test_fetch_telemetry_table_schema(temp_db):
     finally:
         conn.close()
     columns = {r["name"]: r for r in rows}
-    assert {"id", "tool", "items_json", "timestamp"}.issubset(columns)
+    assert {"id", "tool", "items_json", "caller_session_id", "timestamp"}.issubset(columns)
     assert columns["tool"]["notnull"] == 1
     assert columns["items_json"]["notnull"] == 1
     assert columns["timestamp"]["notnull"] == 1
+    # caller_session_id は MCP context 外の呼出で NULL になるため NULL 許容
+    assert columns["caller_session_id"]["notnull"] == 0
 
 
 def test_fetch_telemetry_index_on_timestamp(temp_db):
@@ -198,6 +207,8 @@ def test_search_records_telemetry_row(temp_db, capture_telemetry_threads):
     assert "include_details" in params
     assert "tags" in params
     assert row["timestamp"] is not None
+    # caller_session_id 未指定の直接呼出は NULL で記録される
+    assert row["caller_session_id"] is None
 
     # results_json: 返却ページの (type, id, final_score)
     results = json.loads(row["results_json"])
@@ -381,6 +392,8 @@ def test_get_by_ids_records_fetch_telemetry(temp_db, capture_fetch_telemetry_thr
         {"type": "decision", "id": decision["decision_id"]},
     ]
     assert row["timestamp"] is not None
+    # caller_session_id 未指定の直接呼出は NULL で記録される
+    assert row["caller_session_id"] is None
 
 
 def test_get_by_ids_empty_items_records_nothing(temp_db):
@@ -425,3 +438,121 @@ def test_get_by_ids_unaffected_when_fetch_telemetry_write_fails(
     assert any(
         "fetch_telemetry write failed" in record.message for record in caplog.records
     ), f"warning log が出ていない: {[r.message for r in caplog.records]}"
+
+
+def test_search_records_caller_session_id(temp_db, capture_telemetry_threads):
+    """search() に渡した caller_session_id が search_telemetry に記録される"""
+    add_topic(
+        title="相関キー記録テスト用トピック",
+        description="caller_session_id が telemetry に載ることを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    search_service.search(keyword="相関キー記録テスト", caller_session_id="sess-search-1")
+
+    _wait_for_telemetry(capture_telemetry_threads)
+
+    rows = _fetch_all_telemetry()
+    assert len(rows) == 1
+    assert rows[0]["caller_session_id"] == "sess-search-1"
+
+
+def test_get_by_ids_records_caller_session_id(temp_db, capture_fetch_telemetry_threads):
+    """get_by_ids() に渡した caller_session_id が fetch_telemetry に記録される"""
+    topic = add_topic(
+        title="fetch 相関キー記録テスト",
+        description="caller_session_id が fetch_telemetry に載ることを検証する",
+        tags=DEFAULT_TAGS,
+    )
+
+    result = search_service.get_by_ids(
+        [{"type": "topic", "id": topic["topic_id"]}],
+        caller_session_id="sess-fetch-1",
+    )
+    assert "error" not in result
+
+    _wait_for_telemetry(capture_fetch_telemetry_threads)
+
+    rows = _fetch_all_fetch_telemetry()
+    assert len(rows) == 1
+    assert rows[0]["caller_session_id"] == "sess-fetch-1"
+
+
+def _make_search_context(**overrides):
+    """`_build_diagnostics` 単体テスト用の最小 SearchContext を組み立てる。"""
+    defaults = dict(
+        keywords=("foo",),
+        fts_keywords=("foo",),
+        original_keyword_count=None,
+        tag_ids=None,
+        entity_type=None,
+        limit=10,
+        offset=0,
+        fetch_limit=30,
+        keyword_mode="and",
+        include_details=False,
+        date_after=None,
+        date_before=None,
+        domain=None,
+    )
+    defaults.update(overrides)
+    return search_service.SearchContext(**defaults)
+
+
+def test_build_diagnostics_vector_and_tag_hits():
+    """ベクトル検索有効時 vec_hits は実際の整数、tag ヒット時 tag_hits>0、
+    methods_used に vector / tag_like が含まれる"""
+    ctx = _make_search_context()
+    retrieval = {
+        "fts": [{"type": "topic", "id": 1}],
+        "vec": [{"type": "topic", "id": 1}, {"type": "decision", "id": 2}],
+        "tag": [{"type": "log", "id": 3}],
+        "methods_used": ["fts5", "vector", "tag_like"],
+    }
+    weights = search_service._compute_adaptive_weights(1, 2)
+    diag = search_service._build_diagnostics(ctx, retrieval, weights)
+
+    assert diag["fts_hits"] == 1
+    assert diag["vec_hits"] == 2  # 有効時はヒット数の整数（None ではない）
+    assert diag["tag_hits"] == 1  # tag ヒットあり
+    assert "vector" in diag["methods_used"]
+    assert "tag_like" in diag["methods_used"]
+    assert diag["qe_expansions"] == []
+    assert diag["adaptive_weights"] == {"w_fts": weights[0], "w_vec": weights[1]}
+
+
+def test_build_diagnostics_vec_hits_zero_when_enabled_but_no_hits():
+    """ベクトル検索有効かつヒット 0 件のとき vec_hits は 0（None と区別される）"""
+    ctx = _make_search_context()
+    retrieval = {
+        "fts": [{"type": "topic", "id": 1}],
+        "vec": [],  # 有効だがヒットなし
+        "tag": [],
+        "methods_used": ["fts5", "vector"],
+    }
+    weights = search_service._compute_adaptive_weights(1, 0)
+    diag = search_service._build_diagnostics(ctx, retrieval, weights)
+
+    assert diag["vec_hits"] == 0
+    assert diag["tag_hits"] == 0
+    assert "vector" in diag["methods_used"]
+
+
+def test_build_diagnostics_qe_expansions_populated():
+    """Query Expansion 発火時 qe_expansions が拡張分キーワードだけを持つ"""
+    ctx = _make_search_context(
+        keywords=("foo",),
+        fts_keywords=("foo", "bar", "baz"),
+        original_keyword_count=1,  # 元 1 件 + 拡張 2 件
+    )
+    retrieval = {
+        "fts": [],
+        "vec": None,  # ベクトル検索無効
+        "tag": [],
+        "methods_used": ["fts5"],
+    }
+    weights = search_service._compute_adaptive_weights(0, 0)
+    diag = search_service._build_diagnostics(ctx, retrieval, weights)
+
+    assert diag["qe_expansions"] == ["bar", "baz"]  # 元キーワードは含まない
+    assert diag["vec_hits"] is None  # 無効時は None


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

検索の telemetry を拡張し、「どの結果を何位で返したか」「retriever ごとの内訳」「返した結果が実際に取得されたか」を後から突合できるようにする。

これまで `search_telemetry` はクエリ文字列とパラメータ、返却件数のみを記録しており、返した結果が実際に役に立ったかを検証する手段がなかった。今回、返却ページ（type / id / final_score のリスト）と retriever 内訳（FTS / ベクトル / タグ LIKE 各ヒット数、実際に使われた検索手法、Query Expansion で追加されたキーワード、Adaptive RRF の重み）を `search_telemetry` に追加で記録するようにした。あわせて `get_by_ids`（検索結果の本文取得エンドポイント）の呼出内容を記録する `fetch_telemetry` テーブルを新設した。両テーブルの (type, id) を突き合わせれば、「検索で返した結果のうちどれだけが実際に取得されたか」を後から計算できる。

書込はどちらも非同期・失敗握りつぶしで、`search()` / `get_by_ids()` のレスポンスタイムや戻り値には一切影響しない。テレメトリの書込処理自体は共通化し、新しいテーブルを追加する際に非同期書込・エラーハンドリングを毎回書き直さずに済むようにした。

filter-first KNN 化や authority boost などの後続改善はこの PR のスコープ外で、今回追加する `diagnostics_json` のうち `candidate_set_size`（絞り込み後の候補集合サイズ）はそれらが実装されるまで常に `null` になる。

## 補足

このリポジトリの migration 運用ドキュメントには、migration を含む PR は特定の 5 本のみに限定するという記載があるが、それとは別の一覧表では本 PR (results/diagnostics 列追加) にも migration が伴う旨が明記されており、両者は矛盾している。今回参照した詳細設計書（このコンポーネントの一次ドキュメント）では本 PR が migration を伴う前提で スキーマ・実装・テスト観点まで具体的に書かれていたため、そちらを優先し migration を追加する形で実装した。他 PR で同種の変更を convention-only（migration なし）で済ませている例もあるが、そちらは既存カラムがアプリ層バリデーションのみで拡張可能な場合の話であり、本 PR は既存テーブルに存在しない列・テーブルを追加する必要があるため同じ手法は使えない。詳しくは実装判断のメモを参照。

## テスト計画

新規・更新したテストで以下を検証した:

- `search_telemetry` に `results_json` / `diagnostics_json` 列が追加され、NULL 許容（既存行との後方互換）であること
- `fetch_telemetry` テーブルが必要なカラム（`tool` / `items_json` NOT NULL 等）と `timestamp` の index を持って作られること
- `search()` を呼ぶと `results_json` に返却ページの (type, id, final_score) が、`diagnostics_json` に retriever 内訳（ヒット数・使用手法・QE 拡張語・adaptive weights・`candidate_set_size=null`）が記録されること
- ベクトル検索無効時に `vec_hits` が `null`（0 件ヒットと区別）になること
- `get_by_ids` を呼ぶと `fetch_telemetry` に `tool="get_by_ids"` と要求された (type, id) の一覧が記録されること
- `get_by_ids` の空リスト呼出・`TOO_MANY_ITEMS` エラー時は `fetch_telemetry` に何も書かれないこと
- `fetch_telemetry` への書込が失敗しても `get_by_ids` の戻り値・ログにエラーが波及しないこと（`search_telemetry` 既存の同種フォールバックテストと同じ形で追加）

既存のユニット・統合・E2E テスト（2018 + 507 件、他 1 件は元々 skip）が全件 pass することを確認済み。get_by_ids を呼ぶ既存テストが本 PR の非同期書込と競合しないよう、`tests/conftest.py` に既存の search telemetry 用と対になる同期化フィクスチャを追加した。
