### PR TITLE
DBスナップショットをkind別管理+防護つきrestoreに拡張

### DIFF
--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -27,7 +27,7 @@ from src.services.readable_id import format_readable_id
 from src.services.habit_service import get_active_habit_contents_with_conn
 from src.services.tag_service import get_entity_tags_batch
 from src.services.topic_service import get_activity_topics_batch
-from scripts.snapshot import health_check, should_take_snapshot, take_snapshot
+from src.services.backup_service import health_check, should_take_snapshot, take_snapshot
 from hooks.hook_transcript import _is_worker_session
 
 # description先頭の切り出し文字数

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1,13 +1,10 @@
-"""DB自動スナップショット: 取得・ヘルスチェック・ローテーション・復元
+"""DBスナップショットCLIエントリポイント
 
-SessionStart hookから呼び出される。独立モジュールとして動作し、
-db_pathベースでスナップショットの管理を行う。
+実装本体は src/services/backup_service.py に移設した。
+本モジュールは `uv run python scripts/snapshot.py <command>` 経由の起動と、
+既存コードとの後方互換のためのre-exportのみを持つ。
 """
-import json
-import sqlite3
 import sys
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 
 # プロジェクトルートをパスに追加（src.config等の参照用）
@@ -15,230 +12,26 @@ _project_root = Path(__file__).resolve().parents[1]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-HEALTH_CHECK_TABLES = [
-    "discussion_topics",
-    "decisions",
-    "discussion_logs",
-    "activities",
-    "materials",
-]
-
-SNAPSHOT_PREFIX = "discussion_"
-SNAPSHOT_DB_SUFFIX = ".db"
-SNAPSHOT_JSON_SUFFIX = ".json"
-
-
-@dataclass
-class HealthCheckResult:
-    """ヘルスチェック結果"""
-    is_healthy: bool = True
-    warnings: list[str] = field(default_factory=list)
-    current_counts: dict[str, int] = field(default_factory=dict)
-    previous_counts: dict[str, int] = field(default_factory=dict)
-
-
-def _get_snapshot_dir(db_path: str) -> Path:
-    """スナップショット保存ディレクトリを返す（DBと同階層の snapshots/）"""
-    return Path(db_path).parent / "snapshots"
-
-
-def get_row_counts(db_path: str) -> dict[str, int]:
-    """各テーブルのCOUNTを取得する"""
-    conn = sqlite3.connect(db_path)
-    try:
-        counts = {}
-        for table in HEALTH_CHECK_TABLES:
-            try:
-                cursor = conn.execute(f"SELECT COUNT(*) FROM {table}")  # noqa: S608
-                counts[table] = cursor.fetchone()[0]
-            except sqlite3.OperationalError:
-                # テーブルが存在しない場合はスキップ
-                counts[table] = 0
-        return counts
-    finally:
-        conn.close()
-
-
-def _get_latest_json(snapshot_dir: Path) -> dict | None:
-    """最新のメタデータJSONを読み込む。なければNone。"""
-    if not snapshot_dir.exists():
-        return None
-
-    json_files = sorted(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_JSON_SUFFIX}"), reverse=True)
-    if not json_files:
-        return None
-
-    try:
-        return json.loads(json_files[0].read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-
-
-def health_check(db_path: str, snapshot_dir: Path | None = None, threshold: int | None = None) -> HealthCheckResult:
-    """最新JSONと現在の行数を比較してヘルスチェックを行う。
-
-    threshold件以上の減少があるテーブルを異常と判定する。
-    """
-    from src.config import SNAPSHOT_ANOMALY_THRESHOLD
-
-    if snapshot_dir is None:
-        snapshot_dir = _get_snapshot_dir(db_path)
-    if threshold is None:
-        threshold = SNAPSHOT_ANOMALY_THRESHOLD
-
-    current_counts = get_row_counts(db_path)
-    result = HealthCheckResult(current_counts=current_counts)
-
-    latest_json = _get_latest_json(snapshot_dir)
-    if latest_json is None:
-        # 初回起動（スナップショットなし）: 正常扱い
-        return result
-
-    prev_counts = latest_json.get("row_counts", {})
-    result.previous_counts = prev_counts
-
-    for table in HEALTH_CHECK_TABLES:
-        prev = prev_counts.get(table, 0)
-        current = current_counts.get(table, 0)
-        diff = prev - current
-        if diff >= threshold:
-            result.is_healthy = False
-            result.warnings.append(
-                f"- {table}: {prev} → {current} (-{diff}件)"
-            )
-
-    return result
-
-
-def should_take_snapshot(snapshot_dir: Path | None = None, interval_hours: int | None = None, db_path: str | None = None) -> bool:
-    """最新JSONのcreated_atで間隔チェック。取得すべきならTrue。"""
-    from src.config import SNAPSHOT_INTERVAL_HOURS
-
-    if interval_hours is None:
-        interval_hours = SNAPSHOT_INTERVAL_HOURS
-
-    if snapshot_dir is None:
-        if db_path is None:
-            return True
-        snapshot_dir = _get_snapshot_dir(db_path)
-
-    latest_json = _get_latest_json(snapshot_dir)
-    if latest_json is None:
-        # スナップショットなし: 即取得
-        return True
-
-    created_at_str = latest_json.get("created_at")
-    if not created_at_str:
-        return True
-
-    try:
-        created_at = datetime.fromisoformat(created_at_str)
-        if created_at.tzinfo is None:
-            created_at = created_at.replace(tzinfo=timezone.utc)
-        now = datetime.now(timezone.utc)
-        elapsed_hours = (now - created_at).total_seconds() / 3600
-        return elapsed_hours >= interval_hours
-    except (ValueError, TypeError):
-        return True
-
-
-def take_snapshot(db_path: str, snapshot_dir: Path | None = None, max_snapshots: int | None = None) -> Path:
-    """sqlite3.backup()でスナップショットを取得し、メタデータJSONを保存する。
-
-    ローテーション: max_snapshots超過時に古いペア(.db + .json)を削除する。
-    """
-    from src.config import SNAPSHOT_MAX_COUNT
-
-    if snapshot_dir is None:
-        snapshot_dir = _get_snapshot_dir(db_path)
-    if max_snapshots is None:
-        max_snapshots = SNAPSHOT_MAX_COUNT
-
-    snapshot_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-
-    now = datetime.now(timezone.utc)
-    timestamp = now.strftime("%Y%m%d_%H%M")
-    stem = f"{SNAPSHOT_PREFIX}{timestamp}"
-
-    snapshot_db_path = snapshot_dir / f"{stem}{SNAPSHOT_DB_SUFFIX}"
-    snapshot_json_path = snapshot_dir / f"{stem}{SNAPSHOT_JSON_SUFFIX}"
-
-    # sqlite3.backup()でスナップショット取得
-    source = sqlite3.connect(db_path)
-    try:
-        dest = sqlite3.connect(str(snapshot_db_path))
-        try:
-            source.backup(dest)
-        finally:
-            dest.close()
-    finally:
-        source.close()
-
-    # メタデータJSON保存
-    row_counts = get_row_counts(db_path)
-    metadata = {
-        "created_at": now.isoformat(),
-        "db_size_bytes": snapshot_db_path.stat().st_size,
-        "row_counts": row_counts,
-    }
-    snapshot_json_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
-
-    # ローテーション: 古いスナップショットを削除
-    _rotate_snapshots(snapshot_dir, max_snapshots)
-
-    return snapshot_db_path
-
-
-def _rotate_snapshots(snapshot_dir: Path, max_snapshots: int) -> None:
-    """max_snapshots超過時に古い.db + .jsonペアを削除する。"""
-    db_files = sorted(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}"))
-    while len(db_files) > max_snapshots:
-        oldest_db = db_files.pop(0)
-        oldest_json = oldest_db.with_suffix(SNAPSHOT_JSON_SUFFIX)
-        oldest_db.unlink(missing_ok=True)
-        oldest_json.unlink(missing_ok=True)
-
-
-def restore_snapshot(snapshot_path: str, db_path: str | None = None) -> None:
-    """スナップショットからDBを復元する。
-
-    db_pathが未指定の場合はCCM_DB_PATHまたはデフォルトパスから解決する。
-    """
-    from src.db import get_db_path
-
-    if db_path is None:
-        db_path = get_db_path()
-
-    snapshot_file = Path(snapshot_path)
-    if not snapshot_file.exists():
-        raise FileNotFoundError(f"スナップショットが見つかりません: {snapshot_path}")
-
-    # スナップショットからDBに復元（sqlite3.backup()を使用）
-    source = sqlite3.connect(str(snapshot_file))
-    try:
-        dest = sqlite3.connect(db_path)
-        try:
-            source.backup(dest)
-        finally:
-            dest.close()
-    finally:
-        source.close()
-
-
-def main() -> None:
-    """CLI: restore サブコマンド"""
-    if len(sys.argv) < 3 or sys.argv[1] != "restore":
-        print("Usage: python scripts/snapshot.py restore <snapshot_db_path>", file=sys.stderr)
-        sys.exit(1)
-
-    snapshot_path = sys.argv[2]
-    try:
-        restore_snapshot(snapshot_path)
-        print(f"復元完了: {snapshot_path}")
-    except Exception as e:
-        print(f"復元エラー: {e}", file=sys.stderr)
-        sys.exit(1)
-
+from src.services.backup_service import (  # noqa: F401  (後方互換のためのre-export)
+    HEALTH_CHECK_TABLES,
+    KIND_QUOTAS,
+    SNAPSHOT_DB_SUFFIX,
+    SNAPSHOT_JSON_SUFFIX,
+    SNAPSHOT_PREFIX,
+    HealthCheckResult,
+    RestoreBlockedError,
+    RestoreResult,
+    SnapshotKind,
+    get_row_counts,
+    health_check,
+    list_snapshots,
+    main,
+    restore_snapshot,
+    should_take_snapshot,
+    snapshot_dir_for,
+    take_snapshot,
+    verify_snapshot,
+)
 
 if __name__ == "__main__":
     main()

--- a/src/services/backup_service.py
+++ b/src/services/backup_service.py
@@ -254,26 +254,34 @@ def should_take_snapshot(snapshot_dir: Path | None = None, interval_hours: int |
 
 
 def _unique_snapshot_paths(snapshot_dir: Path) -> tuple[Path, Path]:
-    """衝突しないスナップショットの.db/.jsonパスを発行する。
+    """衝突しないスナップショットの.db/.jsonパスを発行し、.dbを空ファイルとして確保する。
 
-    同一秒内に複数回取得される場合（restore()のprerestore退避が短時間に連続する等）に
-    既存ファイルを上書きしないよう、衝突時は連番を振って別名にする。
+    同一秒内に複数回取得される場合（restore()のprerestore退避が短時間に連続する、
+    複数プロセスがほぼ同時にSessionStart hookを発火する等）に既存ファイルを上書き
+    しないよう、open(path, "x")（O_CREAT | O_EXCL）で.dbをアトミックに排他作成して
+    ファイル名を確定する。.existsチェック→作成の間に別プロセスが割り込むTOCTOUを避ける。
+    確保される.dbは0バイトの空ファイル（＝空DB扱い）で、呼び出し側がbackup()または
+    copy2()で内容を上書きする前提。
     """
+    snapshot_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
     now = datetime.now(timezone.utc)
     timestamp = now.strftime("%Y%m%d_%H%M%S")
     base_stem = f"{SNAPSHOT_PREFIX}{timestamp}"
 
     stem = base_stem
-    db_path = snapshot_dir / f"{stem}{SNAPSHOT_DB_SUFFIX}"
-    json_path = snapshot_dir / f"{stem}{SNAPSHOT_JSON_SUFFIX}"
     suffix = 1
-    while db_path.exists() or json_path.exists():
-        suffix += 1
-        stem = f"{base_stem}_{suffix}"
+    while True:
         db_path = snapshot_dir / f"{stem}{SNAPSHOT_DB_SUFFIX}"
         json_path = snapshot_dir / f"{stem}{SNAPSHOT_JSON_SUFFIX}"
-
-    return db_path, json_path
+        try:
+            with open(db_path, "x"):
+                pass
+        except FileExistsError:
+            suffix += 1
+            stem = f"{base_stem}_{suffix}"
+            continue
+        return db_path, json_path
 
 
 def take_snapshot(
@@ -282,12 +290,15 @@ def take_snapshot(
     max_snapshots: int | None = None,
     kind: SnapshotKind = "periodic",
     extra_metadata: dict | None = None,
+    protect_paths: set[Path] | None = None,
 ) -> Path:
     """sqlite3.backup()でスナップショットを取得し、メタデータJSONを保存する。
 
     取得直後にPRAGMA quick_checkを実行し結果をメタデータに記録する（破損検知）。
     ローテーション: max_snapshots超過時に古いペア(.db + .json)を処理する。
     kind="periodic"の場合のみ、削除の代わりにdaily/への昇格を試みる。
+    protect_paths: ローテーションで削除・昇格させないファイルの集合。復元元スナップショットが
+    自kindのローテーション対象と衝突して消えるのを防ぐ用途で復元経路から渡される。
     """
     if snapshot_dir is None:
         snapshot_dir = snapshot_dir_for(db_path, kind)
@@ -328,30 +339,57 @@ def take_snapshot(
 
     # ローテーション
     if kind == "periodic":
-        _rotate_periodic_with_promotion(db_path, snapshot_dir, max_snapshots)
+        _rotate_periodic_with_promotion(db_path, snapshot_dir, max_snapshots, protect_paths)
     else:
-        _rotate_snapshots(snapshot_dir, max_snapshots)
+        _rotate_snapshots(snapshot_dir, max_snapshots, protect_paths)
 
     return snapshot_db_path
 
 
-def _rotate_snapshots(snapshot_dir: Path, max_snapshots: int) -> None:
-    """max_snapshots超過時に古い.db + .jsonペアを削除する。"""
+def _resolve_protected(protect_paths: set[Path] | None) -> set[Path]:
+    """protect_pathsを解決済み絶対パスの集合に正規化する（比較用）。"""
+    resolved: set[Path] = set()
+    for p in protect_paths or ():
+        try:
+            resolved.add(Path(p).resolve())
+        except OSError:
+            continue
+    return resolved
+
+
+def _rotate_snapshots(
+    snapshot_dir: Path, max_snapshots: int, protect_paths: set[Path] | None = None
+) -> None:
+    """max_snapshots超過時に古い.db + .jsonペアを削除する。
+
+    protect_pathsに含まれるファイルは削除対象から除外する（超過分は次に古い非保護ファイルで
+    賄う）。除外により一時的にmax_snapshotsを超えることは許容する。
+    """
+    protected = _resolve_protected(protect_paths)
     db_files = sorted(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}"))
-    while len(db_files) > max_snapshots:
-        oldest_db = db_files.pop(0)
+    excess = len(db_files) - max_snapshots
+    for oldest_db in db_files:
+        if excess <= 0:
+            break
+        if oldest_db.resolve() in protected:
+            continue
         oldest_json = oldest_db.with_suffix(SNAPSHOT_JSON_SUFFIX)
         oldest_db.unlink(missing_ok=True)
         oldest_json.unlink(missing_ok=True)
+        excess -= 1
 
 
-def _rotate_periodic_with_promotion(db_path: str, periodic_dir: Path, max_snapshots: int) -> None:
+def _rotate_periodic_with_promotion(
+    db_path: str, periodic_dir: Path, max_snapshots: int, protect_paths: set[Path] | None = None
+) -> None:
     """periodicのローテーション。
 
     最古を削除する代わりに、その日付のdaily/スナップショットが未存在なら
     削除せずdaily/へ移動（rename）する。移動先が既にあれば通常通り削除する。
     daily/自体は独立クォータ（KIND_QUOTAS["daily"]）でローテーションする。
+    protect_pathsに含まれるファイルは削除・昇格の対象から除外する。
     """
+    protected = _resolve_protected(protect_paths)
     daily_dir = snapshot_dir_for(db_path, "daily")
     daily_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     daily_dates = {
@@ -359,8 +397,12 @@ def _rotate_periodic_with_promotion(db_path: str, periodic_dir: Path, max_snapsh
     }
 
     db_files = sorted(periodic_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}"))
-    while len(db_files) > max_snapshots:
-        oldest_db = db_files.pop(0)
+    excess = len(db_files) - max_snapshots
+    for oldest_db in db_files:
+        if excess <= 0:
+            break
+        if oldest_db.resolve() in protected:
+            continue
         oldest_json = oldest_db.with_suffix(SNAPSHOT_JSON_SUFFIX)
         date_part = _date_part(oldest_db.name)
 
@@ -372,6 +414,7 @@ def _rotate_periodic_with_promotion(db_path: str, periodic_dir: Path, max_snapsh
             if oldest_json.exists():
                 oldest_json.rename(daily_dir / oldest_json.name)
             daily_dates.add(date_part)
+        excess -= 1
 
     _rotate_snapshots(daily_dir, KIND_QUOTAS["daily"])
 
@@ -588,22 +631,41 @@ def restore_snapshot(
         raise RestoreBlockedError(f"{compat.warning} 承知の上で続行する場合は --yes を指定してください。")
 
     # 4. prerestore退避
+    #    復元元snapshot_fileがprerestore種別かつ最古の場合、退避のローテーションが復元元を
+    #    削除してしまうと、続く手順5が存在しないファイルを空DBとして開き現行DBを無警告で
+    #    消し去る。protect_pathsで復元元をローテーション対象から除外して衝突を防ぐ。
+    protect = {snapshot_file}
     prerestore_path: str | None = None
     prerestore_row_counts: dict[str, int] = {}
     if Path(db_path).exists():
         try:
             prerestore_row_counts = get_row_counts(db_path)
-            prerestore_db = take_snapshot(db_path, kind="prerestore")
+            prerestore_db = take_snapshot(db_path, kind="prerestore", protect_paths=protect)
             prerestore_path = str(prerestore_db)
         except sqlite3.Error:
             # backup APIで読めないほど破損している場合はファイルコピーで退避する
             prerestore_dir = snapshot_dir_for(db_path, "prerestore")
             prerestore_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-            fallback_path, _fallback_json_path = _unique_snapshot_paths(prerestore_dir)
+            fallback_path, fallback_json_path = _unique_snapshot_paths(prerestore_dir)
             shutil.copy2(db_path, fallback_path)
             prerestore_path = str(fallback_path)
             prerestore_row_counts = {}
-            _rotate_snapshots(prerestore_dir, KIND_QUOTAS["prerestore"])
+            # 破損DBの生コピーにもメタデータJSONを添える。JSONが無いとlist_snapshots()の
+            # 列挙対象から漏れ、破損時の「最後の砦」がユーザーから不可視になる。
+            fallback_metadata = {
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "db_size_bytes": fallback_path.stat().st_size,
+                "row_counts": {},
+                "kind": "prerestore",
+                "schema_head": None,
+                "quick_check": _quick_check(fallback_path),
+                "fallback": True,
+                "note": "backup API失敗のため生ファイルコピーで退避（現行DB破損の可能性）",
+            }
+            fallback_json_path.write_text(
+                json.dumps(fallback_metadata, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            _rotate_snapshots(prerestore_dir, KIND_QUOTAS["prerestore"], protect_paths=protect)
 
     # 5. 復元本体
     if file_copy:

--- a/src/services/backup_service.py
+++ b/src/services/backup_service.py
@@ -1,0 +1,753 @@
+"""DBスナップショット: 取得・ヘルスチェック・ローテーション・復元
+
+種別（kind）ごとにディレクトリと保持世代数を分けて管理する。
+periodicはSessionStart hookから呼び出される既存経路との互換のため、
+DBと同階層の snapshots/ 直下に据え置く。他の種別は snapshots/<kind>/ に置く。
+"""
+import argparse
+import json
+import logging
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, get_args
+
+from src.config import SNAPSHOT_MAX_COUNT
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_TABLES = [
+    "discussion_topics",
+    "decisions",
+    "discussion_logs",
+    "activities",
+    "materials",
+]
+
+SNAPSHOT_PREFIX = "discussion_"
+SNAPSHOT_DB_SUFFIX = ".db"
+SNAPSHOT_JSON_SUFFIX = ".json"
+
+SnapshotKind = Literal["periodic", "premigration", "prerestore", "manual", "daily"]
+
+KIND_QUOTAS: dict[str, int] = {
+    "periodic": SNAPSHOT_MAX_COUNT,
+    "premigration": 5,
+    "prerestore": 2,
+    "manual": 3,
+    "daily": 7,
+}
+
+
+@dataclass
+class HealthCheckResult:
+    """ヘルスチェック結果"""
+    is_healthy: bool = True
+    warnings: list[str] = field(default_factory=list)
+    current_counts: dict[str, int] = field(default_factory=dict)
+    previous_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class RestoreResult:
+    """restore_snapshot() の結果"""
+    restored_from: str
+    db_path: str
+    file_copy: bool
+    forced: bool
+    prerestore_path: str | None
+    prerestore_row_counts: dict[str, int] = field(default_factory=dict)
+    restored_row_counts: dict[str, int] = field(default_factory=dict)
+    compatibility_note: str | None = None
+
+
+class RestoreBlockedError(RuntimeError):
+    """安全装置（稼働中チェック・整合性検証・互換性警告）により復元がブロックされたことを示す。"""
+
+
+# =============================================
+# ディレクトリ・メタデータ
+# =============================================
+
+
+def snapshot_dir_for(db_path: str, kind: SnapshotKind = "periodic") -> Path:
+    """kind別のスナップショット保存ディレクトリを返す。
+
+    periodicはDBと同階層のsnapshots/直下（既存互換）、他はそのkind名のサブディレクトリ。
+    """
+    base = Path(db_path).parent / "snapshots"
+    if kind == "periodic":
+        return base
+    return base / kind
+
+
+def get_row_counts(db_path: str) -> dict[str, int]:
+    """各テーブルのCOUNTを取得する"""
+    conn = sqlite3.connect(db_path)
+    try:
+        counts = {}
+        for table in HEALTH_CHECK_TABLES:
+            try:
+                cursor = conn.execute(f"SELECT COUNT(*) FROM {table}")  # noqa: S608
+                counts[table] = cursor.fetchone()[0]
+            except sqlite3.OperationalError:
+                # テーブルが存在しない場合はスキップ
+                counts[table] = 0
+        return counts
+    finally:
+        conn.close()
+
+
+def _get_latest_json(snapshot_dir: Path) -> dict | None:
+    """指定ディレクトリ直下の最新メタデータJSONを読み込む。なければNone。"""
+    if not snapshot_dir.exists():
+        return None
+
+    json_files = sorted(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_JSON_SUFFIX}"), reverse=True)
+    if not json_files:
+        return None
+
+    try:
+        return json.loads(json_files[0].read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _date_part(filename: str) -> str:
+    """スナップショットファイル名から日付部分（YYYYMMDD相当の先頭セグメント）を取り出す。"""
+    stem = filename
+    for suffix in (SNAPSHOT_DB_SUFFIX, SNAPSHOT_JSON_SUFFIX):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    stem = stem[len(SNAPSHOT_PREFIX):]
+    return stem.split("_")[0]
+
+
+def _get_schema_head(db_path: str) -> str | None:
+    """DBの_yoyo_migrationテーブルから最終適用migration_idを取得する。
+
+    yoyoの既定migrationテーブル名（`yoyo.default_migration_table`）は単数形の
+    `_yoyo_migration` であり、`src/db.py` の`_apply_migrations()`もこの名前を使う。
+    テーブルが存在しない（yoyo未適用・破損DB等）場合はNoneを返す。
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            cur = conn.execute(
+                "SELECT migration_id FROM _yoyo_migration ORDER BY applied_at_utc DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+
+def _current_migration_ids() -> list[str]:
+    """現行コードのmigrations/配下のIDを依存関係順（yoyoの解決順）で返す。"""
+    from yoyo import read_migrations
+
+    from src.db import MIGRATIONS_DIR
+
+    migrations = read_migrations(str(MIGRATIONS_DIR))
+    return [m.id for m in migrations]
+
+
+def _quick_check(snapshot_db_path: Path) -> str:
+    """PRAGMA quick_checkを実行し結果文字列を返す。破損検知目的でスナップショット取得直後に呼ぶ。"""
+    try:
+        conn = sqlite3.connect(str(snapshot_db_path))
+        try:
+            row = conn.execute("PRAGMA quick_check").fetchone()
+            result = row[0] if row else "unknown"
+        finally:
+            conn.close()
+        if result != "ok":
+            logger.warning(f"snapshot quick_check failed: {snapshot_db_path} -> {result}")
+        return result
+    except sqlite3.Error as e:
+        logger.warning(f"snapshot quick_check errored: {snapshot_db_path}: {e}")
+        return f"error: {e}"
+
+
+# =============================================
+# ヘルスチェック・間隔判定（既存挙動を維持）
+# =============================================
+
+
+def health_check(db_path: str, snapshot_dir: Path | None = None, threshold: int | None = None) -> HealthCheckResult:
+    """最新JSONと現在の行数を比較してヘルスチェックを行う。
+
+    threshold件以上の減少があるテーブルを異常と判定する。
+    """
+    from src.config import SNAPSHOT_ANOMALY_THRESHOLD
+
+    if snapshot_dir is None:
+        snapshot_dir = snapshot_dir_for(db_path, "periodic")
+    if threshold is None:
+        threshold = SNAPSHOT_ANOMALY_THRESHOLD
+
+    current_counts = get_row_counts(db_path)
+    result = HealthCheckResult(current_counts=current_counts)
+
+    latest_json = _get_latest_json(snapshot_dir)
+    if latest_json is None:
+        # 初回起動（スナップショットなし）: 正常扱い
+        return result
+
+    prev_counts = latest_json.get("row_counts", {})
+    result.previous_counts = prev_counts
+
+    for table in HEALTH_CHECK_TABLES:
+        prev = prev_counts.get(table, 0)
+        current = current_counts.get(table, 0)
+        diff = prev - current
+        if diff >= threshold:
+            result.is_healthy = False
+            result.warnings.append(
+                f"- {table}: {prev} → {current} (-{diff}件)"
+            )
+
+    return result
+
+
+def should_take_snapshot(snapshot_dir: Path | None = None, interval_hours: int | None = None, db_path: str | None = None) -> bool:
+    """最新JSONのcreated_atで間隔チェック。取得すべきならTrue。"""
+    from src.config import SNAPSHOT_INTERVAL_HOURS
+
+    if interval_hours is None:
+        interval_hours = SNAPSHOT_INTERVAL_HOURS
+
+    if snapshot_dir is None:
+        if db_path is None:
+            return True
+        snapshot_dir = snapshot_dir_for(db_path, "periodic")
+
+    latest_json = _get_latest_json(snapshot_dir)
+    if latest_json is None:
+        # スナップショットなし: 即取得
+        return True
+
+    created_at_str = latest_json.get("created_at")
+    if not created_at_str:
+        return True
+
+    try:
+        created_at = datetime.fromisoformat(created_at_str)
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        elapsed_hours = (now - created_at).total_seconds() / 3600
+        return elapsed_hours >= interval_hours
+    except (ValueError, TypeError):
+        return True
+
+
+# =============================================
+# 取得・ローテーション
+# =============================================
+
+
+def _unique_snapshot_paths(snapshot_dir: Path) -> tuple[Path, Path]:
+    """衝突しないスナップショットの.db/.jsonパスを発行する。
+
+    同一秒内に複数回取得される場合（restore()のprerestore退避が短時間に連続する等）に
+    既存ファイルを上書きしないよう、衝突時は連番を振って別名にする。
+    """
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    base_stem = f"{SNAPSHOT_PREFIX}{timestamp}"
+
+    stem = base_stem
+    db_path = snapshot_dir / f"{stem}{SNAPSHOT_DB_SUFFIX}"
+    json_path = snapshot_dir / f"{stem}{SNAPSHOT_JSON_SUFFIX}"
+    suffix = 1
+    while db_path.exists() or json_path.exists():
+        suffix += 1
+        stem = f"{base_stem}_{suffix}"
+        db_path = snapshot_dir / f"{stem}{SNAPSHOT_DB_SUFFIX}"
+        json_path = snapshot_dir / f"{stem}{SNAPSHOT_JSON_SUFFIX}"
+
+    return db_path, json_path
+
+
+def take_snapshot(
+    db_path: str,
+    snapshot_dir: Path | None = None,
+    max_snapshots: int | None = None,
+    kind: SnapshotKind = "periodic",
+    extra_metadata: dict | None = None,
+) -> Path:
+    """sqlite3.backup()でスナップショットを取得し、メタデータJSONを保存する。
+
+    取得直後にPRAGMA quick_checkを実行し結果をメタデータに記録する（破損検知）。
+    ローテーション: max_snapshots超過時に古いペア(.db + .json)を処理する。
+    kind="periodic"の場合のみ、削除の代わりにdaily/への昇格を試みる。
+    """
+    if snapshot_dir is None:
+        snapshot_dir = snapshot_dir_for(db_path, kind)
+    if max_snapshots is None:
+        max_snapshots = KIND_QUOTAS[kind]
+
+    snapshot_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    now = datetime.now(timezone.utc)
+    snapshot_db_path, snapshot_json_path = _unique_snapshot_paths(snapshot_dir)
+
+    # sqlite3.backup()でスナップショット取得
+    source = sqlite3.connect(db_path)
+    try:
+        dest = sqlite3.connect(str(snapshot_db_path))
+        try:
+            source.backup(dest)
+        finally:
+            dest.close()
+    finally:
+        source.close()
+
+    quick_check_result = _quick_check(snapshot_db_path)
+
+    # メタデータJSON保存
+    row_counts = get_row_counts(db_path)
+    metadata = {
+        "created_at": now.isoformat(),
+        "db_size_bytes": snapshot_db_path.stat().st_size,
+        "row_counts": row_counts,
+        "kind": kind,
+        "schema_head": _get_schema_head(db_path),
+        "quick_check": quick_check_result,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    snapshot_json_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # ローテーション
+    if kind == "periodic":
+        _rotate_periodic_with_promotion(db_path, snapshot_dir, max_snapshots)
+    else:
+        _rotate_snapshots(snapshot_dir, max_snapshots)
+
+    return snapshot_db_path
+
+
+def _rotate_snapshots(snapshot_dir: Path, max_snapshots: int) -> None:
+    """max_snapshots超過時に古い.db + .jsonペアを削除する。"""
+    db_files = sorted(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}"))
+    while len(db_files) > max_snapshots:
+        oldest_db = db_files.pop(0)
+        oldest_json = oldest_db.with_suffix(SNAPSHOT_JSON_SUFFIX)
+        oldest_db.unlink(missing_ok=True)
+        oldest_json.unlink(missing_ok=True)
+
+
+def _rotate_periodic_with_promotion(db_path: str, periodic_dir: Path, max_snapshots: int) -> None:
+    """periodicのローテーション。
+
+    最古を削除する代わりに、その日付のdaily/スナップショットが未存在なら
+    削除せずdaily/へ移動（rename）する。移動先が既にあれば通常通り削除する。
+    daily/自体は独立クォータ（KIND_QUOTAS["daily"]）でローテーションする。
+    """
+    daily_dir = snapshot_dir_for(db_path, "daily")
+    daily_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    daily_dates = {
+        _date_part(p.name) for p in daily_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}")
+    }
+
+    db_files = sorted(periodic_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_DB_SUFFIX}"))
+    while len(db_files) > max_snapshots:
+        oldest_db = db_files.pop(0)
+        oldest_json = oldest_db.with_suffix(SNAPSHOT_JSON_SUFFIX)
+        date_part = _date_part(oldest_db.name)
+
+        if date_part in daily_dates:
+            oldest_db.unlink(missing_ok=True)
+            oldest_json.unlink(missing_ok=True)
+        else:
+            oldest_db.rename(daily_dir / oldest_db.name)
+            if oldest_json.exists():
+                oldest_json.rename(daily_dir / oldest_json.name)
+            daily_dates.add(date_part)
+
+    _rotate_snapshots(daily_dir, KIND_QUOTAS["daily"])
+
+
+def list_snapshots(db_path: str) -> list[dict]:
+    """全kind横断のスナップショット一覧をメタデータ込みで返す（created_at降順）。"""
+    results: list[dict] = []
+    for kind in get_args(SnapshotKind):
+        snap_dir = snapshot_dir_for(db_path, kind)
+        if not snap_dir.exists():
+            continue
+        for json_path in sorted(snap_dir.glob(f"{SNAPSHOT_PREFIX}*{SNAPSHOT_JSON_SUFFIX}")):
+            db_file = json_path.with_suffix(SNAPSHOT_DB_SUFFIX)
+            if not db_file.exists():
+                continue
+            try:
+                metadata = json.loads(json_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            entry = {
+                **metadata,
+                "kind": metadata.get("kind", kind),
+                "db_path": str(db_file),
+                "json_path": str(json_path),
+            }
+            results.append(entry)
+
+    results.sort(key=lambda e: e.get("created_at") or "", reverse=True)
+    return results
+
+
+# =============================================
+# 検証
+# =============================================
+
+
+def verify_snapshot(snapshot_path: str) -> dict:
+    """PRAGMA integrity_check + 行数取得でスナップショットの整合性を検証する。
+
+    破損ファイル（途中切断コピー・不正な内容）はok=Falseで返す。
+    """
+    path = Path(snapshot_path)
+    if not path.exists():
+        return {"path": str(path), "ok": False, "error": f"ファイルが見つかりません: {snapshot_path}"}
+
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error as e:
+        return {"path": str(path), "ok": False, "error": str(e)}
+
+    try:
+        try:
+            row = conn.execute("PRAGMA integrity_check").fetchone()
+            integrity = row[0] if row else "unknown"
+        except sqlite3.DatabaseError as e:
+            return {"path": str(path), "ok": False, "error": str(e), "integrity_check": None}
+
+        ok = integrity == "ok"
+        row_counts: dict[str, int] = {}
+        if ok:
+            for table in HEALTH_CHECK_TABLES:
+                try:
+                    cur = conn.execute(f"SELECT COUNT(*) FROM {table}")  # noqa: S608
+                    row_counts[table] = cur.fetchone()[0]
+                except sqlite3.OperationalError:
+                    row_counts[table] = 0
+
+        return {
+            "path": str(path),
+            "ok": ok,
+            "integrity_check": integrity,
+            "row_counts": row_counts,
+            "db_size_bytes": path.stat().st_size,
+        }
+    finally:
+        conn.close()
+
+
+# =============================================
+# 復元
+# =============================================
+
+
+@dataclass
+class _CompatibilityCheck:
+    note: str | None = None       # 情報提供のみ。非ブロッキング
+    warning: str | None = None    # --yes必須のブロッキング警告
+
+
+def _check_schema_compatibility(snapshot_schema_head: str | None) -> _CompatibilityCheck:
+    """スナップショットのschema_headと現行コードのmigrations/を比較する。"""
+    if snapshot_schema_head is None:
+        return _CompatibilityCheck(
+            note="スナップショットにschema_head記録が無く、互換性判定をスキップしました。"
+        )
+
+    try:
+        current_ids = _current_migration_ids()
+    except Exception as e:
+        logger.warning(f"migration一覧の取得に失敗、互換性判定をスキップ: {e}")
+        return _CompatibilityCheck()
+
+    if not current_ids:
+        return _CompatibilityCheck()
+
+    if snapshot_schema_head == current_ids[-1]:
+        return _CompatibilityCheck()
+
+    if snapshot_schema_head in current_ids:
+        return _CompatibilityCheck(
+            note=(
+                f"スナップショットのschema_head（{snapshot_schema_head}）は現行コードより古いです。"
+                "復元後、次回サーバー起動時に差分migrationが自動適用されます。"
+            )
+        )
+
+    return _CompatibilityCheck(
+        warning=(
+            f"スナップショットのschema_head（{snapshot_schema_head}）は現行コードのmigrations/に"
+            "存在しません。コードが巻き戻された可能性があります。"
+        )
+    )
+
+
+def _check_health_endpoint(timeout: float = 2.0) -> bool:
+    """ローカルHTTPサーバーの/healthエンドポイント疎通確認。"""
+    import urllib.error
+    import urllib.request
+
+    from src.http_config import HTTP_HOST, HTTP_PORT
+
+    url = f"http://{HTTP_HOST}:{HTTP_PORT}/health"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def _server_appears_running() -> tuple[bool, str]:
+    """lock file生存 または /healthエンドポイント応答のいずれかでrunningと判定する。"""
+    from src.services.lock_file import is_process_alive
+    from src.services.lock_file import read as read_lock
+
+    reasons = []
+    running = False
+
+    info = read_lock()
+    if info is not None and is_process_alive(info["pid"]):
+        running = True
+        reasons.append(f"lock file: pid={info['pid']} port={info['port']}")
+
+    if _check_health_endpoint():
+        running = True
+        reasons.append("/health エンドポイントが応答")
+
+    return running, "; ".join(reasons)
+
+
+def restore_snapshot(
+    snapshot_path: str,
+    db_path: str | None = None,
+    *,
+    force: bool = False,
+    file_copy: bool = False,
+    yes: bool = False,
+) -> RestoreResult:
+    """スナップショットからDBを復元する。
+
+    db_pathが未指定の場合はCCM_DB_PATHまたはデフォルトパスから解決する。
+
+    防護フロー:
+      1. サーバー稼働チェック（lock file + /health）。稼働中はforce=Trueでのみ続行
+      2. スナップショットの整合性検証（verify_snapshot）。失敗時は常に中断
+      3. schema_head比較による互換性警告。巻き戻し疑いはyes=Trueでのみ続行
+      4. 復元前の現行DBをkind=prerestoreで自動退避（backup API不可なら生ファイルコピー）
+      5. 復元本体（既定はsqlite3.backup()、file_copy=Trueでファイル直接置換 + -wal/-shm削除）
+    """
+    from src.db import get_db_path
+
+    if db_path is None:
+        db_path = get_db_path()
+
+    snapshot_file = Path(snapshot_path)
+    if not snapshot_file.exists():
+        raise FileNotFoundError(f"スナップショットが見つかりません: {snapshot_path}")
+
+    # 1. サーバー稼働チェック
+    running, detail = _server_appears_running()
+    if running and not force:
+        raise RestoreBlockedError(
+            "サーバーが稼働中のため復元を中断しました"
+            f"（{detail}）。"
+            "先にサーバーを停止してください: lsof -ti :52837 | xargs kill "
+            "（停止済みであることを確認の上で続行する場合は --force を指定）"
+        )
+
+    # 2. スナップショット検証
+    verification = verify_snapshot(str(snapshot_file))
+    if not verification.get("ok"):
+        raise RestoreBlockedError(
+            f"スナップショットの整合性検証に失敗しました: {snapshot_path} "
+            f"({verification.get('error') or verification.get('integrity_check')})"
+        )
+
+    # 3. 互換性警告
+    snapshot_json_path = snapshot_file.with_suffix(SNAPSHOT_JSON_SUFFIX)
+    try:
+        snapshot_metadata = json.loads(snapshot_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        snapshot_metadata = {}
+    compat = _check_schema_compatibility(snapshot_metadata.get("schema_head"))
+    if compat.warning and not yes:
+        raise RestoreBlockedError(f"{compat.warning} 承知の上で続行する場合は --yes を指定してください。")
+
+    # 4. prerestore退避
+    prerestore_path: str | None = None
+    prerestore_row_counts: dict[str, int] = {}
+    if Path(db_path).exists():
+        try:
+            prerestore_row_counts = get_row_counts(db_path)
+            prerestore_db = take_snapshot(db_path, kind="prerestore")
+            prerestore_path = str(prerestore_db)
+        except sqlite3.Error:
+            # backup APIで読めないほど破損している場合はファイルコピーで退避する
+            prerestore_dir = snapshot_dir_for(db_path, "prerestore")
+            prerestore_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            fallback_path, _fallback_json_path = _unique_snapshot_paths(prerestore_dir)
+            shutil.copy2(db_path, fallback_path)
+            prerestore_path = str(fallback_path)
+            prerestore_row_counts = {}
+            _rotate_snapshots(prerestore_dir, KIND_QUOTAS["prerestore"])
+
+    # 5. 復元本体
+    if file_copy:
+        shutil.copy2(snapshot_file, db_path)
+        for suffix in ("-wal", "-shm"):
+            Path(f"{db_path}{suffix}").unlink(missing_ok=True)
+    else:
+        source = sqlite3.connect(str(snapshot_file))
+        try:
+            dest = sqlite3.connect(db_path)
+            try:
+                source.backup(dest)
+            finally:
+                dest.close()
+        finally:
+            source.close()
+
+    restored_row_counts = get_row_counts(db_path)
+
+    return RestoreResult(
+        restored_from=str(snapshot_file),
+        db_path=db_path,
+        file_copy=file_copy,
+        forced=force and running,
+        prerestore_path=prerestore_path,
+        prerestore_row_counts=prerestore_row_counts,
+        restored_row_counts=restored_row_counts,
+        compatibility_note=compat.note,
+    )
+
+
+# =============================================
+# CLI
+# =============================================
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    from src.db import get_db_path
+
+    db_path = args.db_path or get_db_path()
+    snapshots = list_snapshots(db_path)
+    if not snapshots:
+        print("スナップショットはありません")
+        return 0
+
+    print(f"{'kind':<12} {'created_at':<26} {'size_bytes':>12} {'quick_check':<10} path")
+    for s in snapshots:
+        print(
+            f"{s.get('kind', ''):<12} {s.get('created_at', ''):<26} "
+            f"{s.get('db_size_bytes', 0):>12} {s.get('quick_check', '-'):<10} {s.get('db_path', '')}"
+        )
+    return 0
+
+
+def _cmd_take(args: argparse.Namespace) -> int:
+    from src.db import get_db_path
+
+    db_path = args.db_path or get_db_path()
+    path = take_snapshot(db_path, kind=args.kind)
+    print(f"取得完了: {path}")
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    result = verify_snapshot(args.path)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+def _cmd_restore(args: argparse.Namespace) -> int:
+    from src.db import get_db_path
+
+    db_path = args.db_path or get_db_path()
+
+    if args.latest:
+        snapshots = list_snapshots(db_path)
+        if not snapshots:
+            print("スナップショットが見つかりません", file=sys.stderr)
+            return 1
+        snapshot_path = snapshots[0]["db_path"]
+    elif args.path:
+        snapshot_path = args.path
+    else:
+        print("復元元を指定してください（<path> または --latest）", file=sys.stderr)
+        return 1
+
+    try:
+        result = restore_snapshot(
+            snapshot_path,
+            db_path,
+            force=args.force,
+            file_copy=args.file_copy,
+            yes=args.yes,
+        )
+    except (RestoreBlockedError, FileNotFoundError) as e:
+        print(f"復元エラー: {e}", file=sys.stderr)
+        return 1
+
+    print(f"復元完了: {result.restored_from} -> {result.db_path}")
+    if result.compatibility_note:
+        print(f"ℹ {result.compatibility_note}")
+    if result.prerestore_path:
+        print(f"復元前の状態を退避: {result.prerestore_path}")
+
+    print("行数の変化 (復元前 -> 復元後):")
+    tables = sorted(set(result.prerestore_row_counts) | set(result.restored_row_counts))
+    for table in tables:
+        before = result.prerestore_row_counts.get(table, "-")
+        after = result.restored_row_counts.get(table, "-")
+        print(f"  {table:<20} {before!s:>8} -> {after!s:>8}")
+    return 0
+
+
+def main() -> None:
+    """CLI: list / take / verify / restore サブコマンド"""
+    parser = argparse.ArgumentParser(description="cc-memory DBスナップショット管理CLI")
+    parser.add_argument("--db-path", dest="db_path", default=None, help="対象DBのパス（省略時はCCM_DB_PATH等から解決）")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="全kind横断のスナップショット一覧を表示する")
+
+    p_take = sub.add_parser("take", help="スナップショットを取得する")
+    p_take.add_argument("--kind", choices=list(get_args(SnapshotKind)), default="manual")
+
+    p_verify = sub.add_parser("verify", help="スナップショットの整合性を検証する")
+    p_verify.add_argument("path")
+
+    p_restore = sub.add_parser("restore", help="スナップショットから復元する")
+    p_restore.add_argument("path", nargs="?", default=None, help="復元元スナップショットのDBファイルパス")
+    p_restore.add_argument("--latest", action="store_true", help="全kind横断で最新のスナップショットを使う")
+    p_restore.add_argument("--force", action="store_true", help="サーバー稼働中チェックを無視して続行する")
+    p_restore.add_argument("--file-copy", dest="file_copy", action="store_true", help="DBファイルを直接置換する（-wal/-shmを削除）")
+    p_restore.add_argument("--yes", action="store_true", help="schema互換性警告を承知の上で続行する")
+
+    args = parser.parse_args()
+
+    handlers = {
+        "list": _cmd_list,
+        "take": _cmd_take,
+        "verify": _cmd_verify,
+        "restore": _cmd_restore,
+    }
+    sys.exit(handlers[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_snapshot.py
+++ b/tests/e2e/test_snapshot.py
@@ -1,25 +1,24 @@
-"""scripts/snapshot.py の E2E テスト
+"""scripts/snapshot.py (backup_service) の E2E テスト
 
-スナップショット取得・ヘルスチェック・ローテーション・復元、
-および session_start_hook.py との統合テスト。
+スナップショット取得・ヘルスチェック・ローテーション、
+session_start_hook.py との統合、CLIエントリポイントの疎通テスト。
+
+restore_snapshot() の安全装置（サーバー稼働中チェック・互換性警告等）を
+含む詳細な検証は tests/unit/test_backup_service.py で行う。
 """
 import json
 import os
 import subprocess
 import sys
-import tempfile
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from src.db import init_database
-from scripts.snapshot import (
-    get_row_counts,
+from src.services.backup_service import (
     health_check,
     should_take_snapshot,
     take_snapshot,
-    restore_snapshot,
     HealthCheckResult,
     SNAPSHOT_PREFIX,
     SNAPSHOT_JSON_SUFFIX,
@@ -27,21 +26,6 @@ from scripts.snapshot import (
 
 # プロジェクトルート
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-
-
-@pytest.fixture
-def temp_db():
-    """テスト用の一時的なデータベースを作成する"""
-    import src.config
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        os.environ["DISCUSSION_DB_PATH"] = db_path
-        src.config.DB_PATH = db_path
-        init_database()
-        yield db_path
-        if "DISCUSSION_DB_PATH" in os.environ:
-            del os.environ["DISCUSSION_DB_PATH"]
-        src.config.DB_PATH = None
 
 
 def _seed_rows(db_path: str, table: str, count: int) -> None:
@@ -238,39 +222,46 @@ class TestShouldTakeSnapshot:
         assert should_take_snapshot(snapshot_dir, interval_hours=12) is True
 
 
-class TestRestoreSnapshot:
-    """復元のテスト"""
+class TestSnapshotCLI:
+    """scripts/snapshot.py CLIエントリポイントの疎通テスト（list/take/verify）。
 
-    def test_restore_snapshot(self, temp_db):
-        """復元後にデータが戻る"""
-        snapshot_dir = Path(temp_db).parent / "snapshots"
+    restoreは安全装置（サーバー稼働中チェック等）が実機の状態に左右されるため
+    tests/unit/test_backup_service.py で関数レベルに隔離して検証する。
+    """
 
-        # データを追加してスナップショット取得
-        _seed_rows(temp_db, "activities", 50)
-        snapshot_path = take_snapshot(temp_db, snapshot_dir)
+    def _run_cli(self, db_path: str, *cli_args: str) -> subprocess.CompletedProcess:
+        env = {**os.environ, "DISCUSSION_DB_PATH": db_path}
+        return subprocess.run(
+            [sys.executable, "scripts/snapshot.py", *cli_args],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+        )
 
-        # 取得時の行数を記録
-        original_counts = get_row_counts(temp_db)
+    def test_list_empty(self, temp_db):
+        result = self._run_cli(temp_db, "list")
+        assert result.returncode == 0
+        assert "スナップショットはありません" in result.stdout
 
-        # データを削除
-        import sqlite3
-        conn = sqlite3.connect(temp_db)
-        try:
-            conn.execute("DELETE FROM activities")
-            conn.commit()
-        finally:
-            conn.close()
+    def test_take_then_list_then_verify(self, temp_db):
+        take_result = self._run_cli(temp_db, "take", "--kind", "manual")
+        assert take_result.returncode == 0, take_result.stderr
+        assert "取得完了" in take_result.stdout
 
-        # 削除後の行数確認
-        deleted_counts = get_row_counts(temp_db)
-        assert deleted_counts["activities"] == 0
+        list_result = self._run_cli(temp_db, "list")
+        assert list_result.returncode == 0
+        assert "manual" in list_result.stdout
 
-        # 復元
-        restore_snapshot(str(snapshot_path), temp_db)
+        # list出力からスナップショットのdbパスを抜き出してverifyする
+        snapshot_dir = Path(temp_db).parent / "snapshots" / "manual"
+        db_files = list(snapshot_dir.glob(f"{SNAPSHOT_PREFIX}*.db"))
+        assert len(db_files) == 1
 
-        # 復元後の行数確認
-        restored_counts = get_row_counts(temp_db)
-        assert restored_counts["activities"] == original_counts["activities"]
+        verify_result = self._run_cli(temp_db, "verify", str(db_files[0]))
+        assert verify_result.returncode == 0
+        payload = json.loads(verify_result.stdout)
+        assert payload["ok"] is True
 
 
 def _run_session_start_hook(db_path: str) -> dict:

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -265,6 +265,32 @@ class TestRestoreRoundTrip:
         bs.restore_snapshot(result.prerestore_path, temp_db)
         assert bs.get_row_counts(temp_db)["activities"] == 0
 
+    def test_repeated_restore_from_prerestore_survives_quota_rotation(self, temp_db):
+        """prerestore退避のquota超過ローテーションが復元元を消してDBを空にしないこと。
+
+        prerestore quota=2。同一prerestoreスナップショットからの復元を3回続けると、
+        3回目の退避で古いprerestoreが1件ローテーション削除される。復元元がその最古と
+        一致する場合、削除直後にそのファイルから復元しようとして空DBで上書きされうる。
+        復元元をローテーションから保護することで、復元後も行数が保たれることを検証する。
+        """
+        _seed_activities(temp_db, 5)
+        manual_snapshot = bs.take_snapshot(temp_db, kind="manual")
+
+        # 1回目: prerestore P1（5件の状態）を生成
+        result1 = bs.restore_snapshot(str(manual_snapshot), temp_db)
+        p1 = result1.prerestore_path
+        assert p1 is not None
+
+        # 2回目: P1から復元 → prerestore P2 生成（prerestoreは2件、quota内）
+        bs.restore_snapshot(p1, temp_db)
+        assert bs.get_row_counts(temp_db)["activities"] == 5
+
+        # 3回目: P1から復元 → prerestore P3 生成で最古(=P1)がローテーション対象になる。
+        # 保護が無いとP1が消え、空DBで現行DBが上書きされ0件になる。
+        bs.restore_snapshot(p1, temp_db)
+        assert Path(p1).exists()  # 復元元は保護され生存している
+        assert bs.get_row_counts(temp_db)["activities"] == 5  # 無警告のデータ消失が起きていない
+
 
 class TestRestoreServerRunningGuard:
     def test_blocked_when_lock_file_shows_alive_process(self, temp_db):
@@ -355,6 +381,49 @@ class TestRestorePrerestoreFallback:
         assert prerestore_bytes.startswith(b"corrupted-not-a-db")
         # 復元後は正常なDBに戻っている
         assert isinstance(bs.get_row_counts(temp_db), dict)
+
+    def test_fallback_copy_writes_json_and_is_listed(self, temp_db):
+        """破損DBフォールバック退避にもJSONが添えられ、list_snapshotsから可視になること。
+
+        JSONが無いとlist_snapshots()（.json起点で列挙）から漏れ、破損時の唯一の退避先が
+        ユーザーに見えなくなる。フォールバックコピーがメタデータJSON付きで作られ、
+        一覧にfallbackフラグ付きで現れることを検証する。
+        """
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+
+        Path(temp_db).write_bytes(b"corrupted-not-a-db" * 20)
+
+        result = bs.restore_snapshot(str(snapshot_path), temp_db, file_copy=True)
+        fallback_db = Path(result.prerestore_path)
+        fallback_json = fallback_db.with_suffix(".json")
+
+        assert fallback_json.exists()
+        meta = json.loads(fallback_json.read_text(encoding="utf-8"))
+        assert meta["kind"] == "prerestore"
+        assert meta["fallback"] is True
+
+        listed = bs.list_snapshots(temp_db)
+        listed_db_paths = {entry["db_path"] for entry in listed}
+        assert str(fallback_db) in listed_db_paths
+
+
+class TestUniqueSnapshotPaths:
+    def test_reserves_db_atomically_to_avoid_collision(self, tmp_path):
+        """_unique_snapshot_pathsが.dbをその場で確保し、連続呼び出しで別名を返すこと。
+
+        名前を計算するだけで確保しないと、同一秒内の複数プロセス/連続呼び出しが同じ名前を
+        選び片方の書き込みが失われうる。呼び出し即座に.dbを排他作成することで衝突を防ぐ。
+        """
+        snapshot_dir = tmp_path / "snaps"
+
+        first_db, first_json = bs._unique_snapshot_paths(snapshot_dir)
+        assert first_db.exists()  # 呼び出し時点で.dbが確保済み
+        assert first_db.suffix == ".db"
+        assert first_json.suffix == ".json"
+
+        second_db, _second_json = bs._unique_snapshot_paths(snapshot_dir)
+        assert second_db.exists()
+        assert second_db != first_db  # 確保済みの第1と衝突しない別名
 
 
 class TestCLIHandlers:

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -1,0 +1,401 @@
+"""backup_service のユニットテスト
+
+kind別ディレクトリ・daily昇格ローテーション・整合性検証・防護つき復元
+（サーバー稼働中チェック・互換性警告・prerestore退避・--file-copy）を検証する。
+
+restore_snapshot() の稼働中チェックは実機のポート52837 lock file /
+HTTPヘルスエンドポイントに依存するため、autouseフィクスチャで隔離する
+（開発機上で実サーバーが稼働していてもテストは決定論的に振る舞う）。
+"""
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.services import backup_service as bs
+from src.services import lock_file
+
+
+@pytest.fixture(autouse=True)
+def isolate_server_running_check(tmp_path, monkeypatch):
+    """restore()の稼働中チェックを実機の状態から隔離する。"""
+    lock_dir = tmp_path / ".cc-memory-lock-isolated"
+    lock_dir.mkdir()
+    monkeypatch.setattr(lock_file, "LOCK_DIR", lock_dir)
+    monkeypatch.setattr(lock_file, "LOCK_FILE", lock_dir / "server.lock")
+    monkeypatch.setattr(bs, "_check_health_endpoint", lambda timeout=2.0: False)
+
+
+def _seed_activities(db_path: str, count: int) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        for i in range(count):
+            conn.execute(
+                "INSERT INTO activities (title, description, status) VALUES (?, ?, ?)",
+                (f"activity_{i}", "desc", "pending"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _delete_activities(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DELETE FROM activities")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _touch_snapshot(dir_path: Path, stem: str, created_at: str, kind: str = "periodic") -> tuple[Path, Path]:
+    """ローテーション・一覧ロジックのテスト用に、内容を問わないダミーのスナップショットペアを置く。"""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    db_path = dir_path / f"{stem}.db"
+    json_path = dir_path / f"{stem}.json"
+    db_path.write_bytes(b"")
+    json_path.write_text(
+        json.dumps({
+            "created_at": created_at,
+            "db_size_bytes": 0,
+            "row_counts": {},
+            "kind": kind,
+            "schema_head": None,
+            "quick_check": "ok",
+        }),
+        encoding="utf-8",
+    )
+    return db_path, json_path
+
+
+class TestSnapshotDirFor:
+    def test_periodic_is_top_level(self, temp_db):
+        base = Path(temp_db).parent / "snapshots"
+        assert bs.snapshot_dir_for(temp_db, "periodic") == base
+
+    def test_other_kinds_are_subdirectories(self, temp_db):
+        base = Path(temp_db).parent / "snapshots"
+        for kind in ("premigration", "prerestore", "manual", "daily"):
+            assert bs.snapshot_dir_for(temp_db, kind) == base / kind
+
+
+class TestTakeSnapshotMetadata:
+    def test_metadata_has_kind_schema_head_quick_check(self, temp_db):
+        path = bs.take_snapshot(temp_db, kind="manual")
+        meta = json.loads(path.with_suffix(".json").read_text(encoding="utf-8"))
+
+        assert meta["kind"] == "manual"
+        assert meta["schema_head"]  # init_databaseでyoyo適用済みなのでNoneではない
+        assert meta["quick_check"] == "ok"
+        assert "row_counts" in meta
+        assert "discussion_topics" in meta["row_counts"]
+
+    def test_db_and_json_always_paired(self, temp_db):
+        path = bs.take_snapshot(temp_db, kind="manual")
+        assert path.exists()
+        assert path.with_suffix(".json").exists()
+
+    def test_extra_metadata_is_merged(self, temp_db):
+        path = bs.take_snapshot(
+            temp_db, kind="premigration", extra_metadata={"pending_migrations": ["0049_x"]}
+        )
+        meta = json.loads(path.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["pending_migrations"] == ["0049_x"]
+        assert meta["kind"] == "premigration"
+
+
+class TestKindIndependentRotation:
+    def test_periodic_rotation_does_not_touch_other_kinds(self, temp_db):
+        premigration_dir = bs.snapshot_dir_for(temp_db, "premigration")
+        bs.take_snapshot(temp_db, kind="premigration", max_snapshots=5)
+        assert len(list(premigration_dir.glob("discussion_*.db"))) == 1
+
+        periodic_dir = bs.snapshot_dir_for(temp_db, "periodic")
+        _touch_snapshot(periodic_dir, "discussion_20260101_0000", "2026-01-01T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260102_0000", "2026-01-02T00:00:00+00:00")
+        bs.take_snapshot(temp_db, kind="periodic", max_snapshots=2)
+
+        # premigrationは無傷のまま
+        assert len(list(premigration_dir.glob("discussion_*.db"))) == 1
+
+
+class TestDailyPromotion:
+    """periodicのローテーション時のdaily/への昇格ロジック（§3.1.3）"""
+
+    def test_promotes_when_no_daily_exists_for_date(self, temp_db):
+        periodic_dir = bs.snapshot_dir_for(temp_db, "periodic")
+        daily_dir = bs.snapshot_dir_for(temp_db, "daily")
+        _touch_snapshot(periodic_dir, "discussion_20260101_0000", "2026-01-01T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260102_0000", "2026-01-02T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260103_0000", "2026-01-03T00:00:00+00:00")
+
+        bs._rotate_periodic_with_promotion(temp_db, periodic_dir, max_snapshots=2)
+
+        # 最古(0101)は削除ではなくdaily/へ移動している
+        assert not (periodic_dir / "discussion_20260101_0000.db").exists()
+        assert (daily_dir / "discussion_20260101_0000.db").exists()
+        assert (daily_dir / "discussion_20260101_0000.json").exists()
+
+        remaining = sorted(p.name for p in periodic_dir.glob("discussion_*.db"))
+        assert remaining == ["discussion_20260102_0000.db", "discussion_20260103_0000.db"]
+
+    def test_deletes_when_daily_already_has_date(self, temp_db):
+        periodic_dir = bs.snapshot_dir_for(temp_db, "periodic")
+        daily_dir = bs.snapshot_dir_for(temp_db, "daily")
+        _touch_snapshot(daily_dir, "discussion_20260101_1200", "2026-01-01T12:00:00+00:00", kind="daily")
+        _touch_snapshot(periodic_dir, "discussion_20260101_0000", "2026-01-01T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260102_0000", "2026-01-02T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260103_0000", "2026-01-03T00:00:00+00:00")
+
+        bs._rotate_periodic_with_promotion(temp_db, periodic_dir, max_snapshots=2)
+
+        assert not (periodic_dir / "discussion_20260101_0000.db").exists()
+        assert not (daily_dir / "discussion_20260101_0000.db").exists()
+        assert len(list(daily_dir.glob("discussion_*.db"))) == 1  # 元からの1件のみ
+
+    def test_daily_does_not_exceed_own_quota(self, temp_db):
+        periodic_dir = bs.snapshot_dir_for(temp_db, "periodic")
+        daily_dir = bs.snapshot_dir_for(temp_db, "daily")
+        for i in range(bs.KIND_QUOTAS["daily"]):
+            _touch_snapshot(
+                daily_dir, f"discussion_202601{i:02d}_0000", f"2026-01-{i + 1:02d}T00:00:00+00:00", kind="daily"
+            )
+        assert len(list(daily_dir.glob("discussion_*.db"))) == bs.KIND_QUOTAS["daily"]
+
+        _touch_snapshot(periodic_dir, "discussion_20260201_0000", "2026-02-01T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260202_0000", "2026-02-02T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260203_0000", "2026-02-03T00:00:00+00:00")
+
+        bs._rotate_periodic_with_promotion(temp_db, periodic_dir, max_snapshots=2)
+
+        assert len(list(daily_dir.glob("discussion_*.db"))) == bs.KIND_QUOTAS["daily"]
+
+
+class TestListSnapshots:
+    def test_lists_across_all_kinds(self, temp_db):
+        bs.take_snapshot(temp_db, kind="manual")
+        bs.take_snapshot(temp_db, kind="premigration")
+
+        results = bs.list_snapshots(temp_db)
+        kinds = {r["kind"] for r in results}
+        assert {"manual", "premigration"} <= kinds
+
+    def test_sorted_by_created_at_desc(self, temp_db):
+        periodic_dir = bs.snapshot_dir_for(temp_db, "periodic")
+        _touch_snapshot(periodic_dir, "discussion_20260101_0000", "2026-01-01T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260103_0000", "2026-01-03T00:00:00+00:00")
+        _touch_snapshot(periodic_dir, "discussion_20260102_0000", "2026-01-02T00:00:00+00:00")
+
+        created_ats = [r["created_at"] for r in bs.list_snapshots(temp_db)]
+        assert created_ats == sorted(created_ats, reverse=True)
+
+
+class TestVerifySnapshot:
+    def test_valid_snapshot_is_ok(self, temp_db):
+        path = bs.take_snapshot(temp_db, kind="manual")
+        result = bs.verify_snapshot(str(path))
+
+        assert result["ok"] is True
+        assert result["integrity_check"] == "ok"
+        assert "row_counts" in result
+
+    def test_missing_file_is_not_ok(self, tmp_path):
+        result = bs.verify_snapshot(str(tmp_path / "nope.db"))
+        assert result["ok"] is False
+
+    def test_truncated_file_is_detected_as_corrupt(self, temp_db, tmp_path):
+        path = bs.take_snapshot(temp_db, kind="manual")
+        original = path.read_bytes()
+        truncated = tmp_path / "truncated.db"
+        truncated.write_bytes(original[: max(1, len(original) // 4)])
+
+        result = bs.verify_snapshot(str(truncated))
+        assert result["ok"] is False
+
+    def test_garbage_file_is_detected_as_corrupt(self, tmp_path):
+        garbage = tmp_path / "garbage.db"
+        garbage.write_bytes(b"not a sqlite database" * 100)
+
+        result = bs.verify_snapshot(str(garbage))
+        assert result["ok"] is False
+
+
+class TestSchemaCompatibility:
+    def test_none_schema_head_gives_note_only(self):
+        result = bs._check_schema_compatibility(None)
+        assert result.warning is None
+        assert result.note is not None
+
+    def test_current_head_gives_no_message(self):
+        current = bs._current_migration_ids()
+        result = bs._check_schema_compatibility(current[-1])
+        assert result.warning is None
+        assert result.note is None
+
+    def test_older_head_gives_note_not_warning(self):
+        current = bs._current_migration_ids()
+        assert len(current) >= 2
+        result = bs._check_schema_compatibility(current[0])
+        assert result.warning is None
+        assert result.note is not None
+
+    def test_unknown_head_gives_blocking_warning(self):
+        result = bs._check_schema_compatibility("9999_does_not_exist")
+        assert result.warning is not None
+
+
+class TestRestoreRoundTrip:
+    def test_restore_recovers_deleted_rows_and_round_trips(self, temp_db):
+        _seed_activities(temp_db, 5)
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        before_counts = bs.get_row_counts(temp_db)
+
+        _delete_activities(temp_db)
+        assert bs.get_row_counts(temp_db)["activities"] == 0
+
+        result = bs.restore_snapshot(str(snapshot_path), temp_db)
+
+        assert bs.get_row_counts(temp_db)["activities"] == before_counts["activities"]
+        assert result.prerestore_path is not None
+        assert Path(result.prerestore_path).exists()
+
+        # prerestoreは「削除直後(0件)」の状態を退避しているので、そこへ戻すと0件に戻る
+        bs.restore_snapshot(result.prerestore_path, temp_db)
+        assert bs.get_row_counts(temp_db)["activities"] == 0
+
+
+class TestRestoreServerRunningGuard:
+    def test_blocked_when_lock_file_shows_alive_process(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        lock_file.acquire(52837)  # 自プロセスPIDなのでis_process_alive=True
+
+        with pytest.raises(bs.RestoreBlockedError):
+            bs.restore_snapshot(str(snapshot_path), temp_db)
+
+    def test_force_bypasses_running_check(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        lock_file.acquire(52837)
+
+        result = bs.restore_snapshot(str(snapshot_path), temp_db, force=True)
+        assert result.forced is True
+
+    def test_blocked_when_health_endpoint_responds(self, temp_db, monkeypatch):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        monkeypatch.setattr(bs, "_check_health_endpoint", lambda timeout=2.0: True)
+
+        with pytest.raises(bs.RestoreBlockedError):
+            bs.restore_snapshot(str(snapshot_path), temp_db)
+
+
+class TestRestoreVerificationGuard:
+    def test_blocked_on_corrupt_snapshot(self, temp_db, tmp_path):
+        garbage = tmp_path / "discussion_20260101_0000.db"
+        garbage.write_bytes(b"not a sqlite database" * 50)
+        garbage.with_suffix(".json").write_text(json.dumps({"schema_head": None}), encoding="utf-8")
+
+        with pytest.raises(bs.RestoreBlockedError):
+            bs.restore_snapshot(str(garbage), temp_db)
+
+    def test_missing_snapshot_file_raises(self, temp_db, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            bs.restore_snapshot(str(tmp_path / "nope.db"), temp_db)
+
+
+class TestRestoreCompatibilityGuard:
+    def test_blocked_without_yes_for_unknown_schema_head(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        meta_path = snapshot_path.with_suffix(".json")
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["schema_head"] = "9999_does_not_exist"
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+        with pytest.raises(bs.RestoreBlockedError):
+            bs.restore_snapshot(str(snapshot_path), temp_db)
+
+    def test_yes_bypasses_compatibility_guard(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+        meta_path = snapshot_path.with_suffix(".json")
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["schema_head"] = "9999_does_not_exist"
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+        result = bs.restore_snapshot(str(snapshot_path), temp_db, yes=True)
+        assert result.restored_from == str(snapshot_path)
+
+
+class TestRestoreFileCopy:
+    def test_file_copy_replaces_db_and_removes_wal_shm(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+
+        wal = Path(f"{temp_db}-wal")
+        shm = Path(f"{temp_db}-shm")
+        wal.write_bytes(b"dummy-wal")
+        shm.write_bytes(b"dummy-shm")
+
+        bs.restore_snapshot(str(snapshot_path), temp_db, file_copy=True)
+
+        assert not wal.exists()
+        assert not shm.exists()
+        assert bs.get_row_counts(temp_db) is not None
+
+
+class TestRestorePrerestoreFallback:
+    def test_falls_back_to_raw_file_copy_when_current_db_unreadable(self, temp_db):
+        snapshot_path = bs.take_snapshot(temp_db, kind="manual")
+
+        # backup APIで読めない状態まで現行DBを破損させる
+        Path(temp_db).write_bytes(b"corrupted-not-a-db" * 20)
+
+        result = bs.restore_snapshot(str(snapshot_path), temp_db, file_copy=True)
+
+        assert result.prerestore_path is not None
+        prerestore_bytes = Path(result.prerestore_path).read_bytes()
+        assert prerestore_bytes.startswith(b"corrupted-not-a-db")
+        # 復元後は正常なDBに戻っている
+        assert isinstance(bs.get_row_counts(temp_db), dict)
+
+
+class TestCLIHandlers:
+    def test_cmd_list_reports_no_snapshots(self, temp_db, capsys):
+        assert bs._cmd_list(argparse.Namespace(db_path=temp_db)) == 0
+        assert "スナップショットはありません" in capsys.readouterr().out
+
+    def test_cmd_take_then_list(self, temp_db, capsys):
+        assert bs._cmd_take(argparse.Namespace(db_path=temp_db, kind="manual")) == 0
+        capsys.readouterr()
+
+        assert bs._cmd_list(argparse.Namespace(db_path=temp_db)) == 0
+        assert "manual" in capsys.readouterr().out
+
+    def test_cmd_verify_ok_and_ng_exit_codes(self, temp_db, tmp_path):
+        good_path = bs.take_snapshot(temp_db, kind="manual")
+        assert bs._cmd_verify(argparse.Namespace(path=str(good_path))) == 0
+
+        garbage = tmp_path / "garbage.db"
+        garbage.write_bytes(b"nope" * 50)
+        assert bs._cmd_verify(argparse.Namespace(path=str(garbage))) == 1
+
+    def test_cmd_restore_latest_picks_newest_across_kinds(self, temp_db):
+        _seed_activities(temp_db, 3)
+        old_snapshot = bs.take_snapshot(temp_db, kind="manual")
+        old_meta_path = old_snapshot.with_suffix(".json")
+        old_meta = json.loads(old_meta_path.read_text(encoding="utf-8"))
+        old_meta["created_at"] = "2020-01-01T00:00:00+00:00"
+        old_meta_path.write_text(json.dumps(old_meta), encoding="utf-8")
+
+        _seed_activities(temp_db, 7)  # 合計10件
+        new_snapshot = bs.take_snapshot(temp_db, kind="premigration")
+        new_meta_path = new_snapshot.with_suffix(".json")
+        new_meta = json.loads(new_meta_path.read_text(encoding="utf-8"))
+        new_meta["created_at"] = "2030-01-01T00:00:00+00:00"
+        new_meta_path.write_text(json.dumps(new_meta), encoding="utf-8")
+
+        _delete_activities(temp_db)
+
+        args = argparse.Namespace(
+            db_path=temp_db, latest=True, path=None, force=False, file_copy=False, yes=False,
+        )
+        assert bs._cmd_restore(args) == 0
+        assert bs.get_row_counts(temp_db)["activities"] == 10


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

DBスナップショット機構（取得・ヘルスチェック・ローテーション・復元）の実装本体を `scripts/snapshot.py` から `src/services/backup_service.py` に移設し、以下を拡張した。

**種別（kind）別の保存先とローテーション**: これまで全スナップショットが単一のディレクトリ・単一の保持世代数（5世代）で管理されていたが、用途別（periodic/premigration/prerestore/manual/daily）にディレクトリと保持世代数を分離した。periodicのローテーションは、削除する代わりにその日最初のスナップショットをdaily/へ昇格させる。これにより保持ウィンドウが「直近2.5日は12時間粒度、それより前は7日分を1日粒度」の2段階になり、気づくのが遅れたデータ消失にも対応できるようになる。

**復元コマンドの防護強化**: これまでの復元は「サーバー稼働中でも実行できてしまう」「復元前の現状態を保存しない（不可逆）」「スナップショット自体の破損を検知しない」という弱点があった。今回、復元前にサーバー稼働チェック（プロセスの生存確認 + ヘルスエンドポイント疎通の両方）を行い稼働中なら拒否する、復元元スナップショットの整合性検証（PRAGMA integrity_check）を行う、復元前の現状態を自動的に退避してから書き換える、を追加した。誤った復元をしても退避データから元に戻せる。

**スナップショット取得時の破損検知**: 取得直後にPRAGMA quick_checkを実行し、結果をメタデータに記録するようにした。破損したDBを「正常なバックアップ」として世代管理に積み、破損に気づかないまま正常な世代が入れ替わっていくという事故を防ぐ。

## 補足

- 依存PRなし。origin/mainから単体で切っている
- 実装中に、復元の安全装置が短時間に連続実行されるケース（誤った復元に気づいてすぐ退避データから再復元する等）で、スナップショットのファイル名が分単位のタイムスタンプに依存していたため同一分内での複数回取得が衝突しうる不具合を見つけて修正した。秒単位に変更した上で、なお衝突する場合は連番を付与して回避する
- schema互換性チェック（復元元のスキーマがコード側のmigrations/に存在するか）は、コード側が巻き戻された場合の検知が主目的。判定できない場合（旧形式のスナップショット等）は警告なしで進める
- スナップショット取得時のquick_check失敗は、故障シグナルの記録先となる仕組みがこのリポジトリにまだ無いため、現時点ではログ出力のみ行いメタデータに結果を残す。その仕組みが入った際に記録経路を追加する余地がある
- CLIの`scripts/snapshot.py`は後方互換のためre-exportとエントリポイントのみを持つ薄いモジュールにした。既存の呼び出し元（session_start_hook.py）は直接`backup_service`をimportするよう更新した

## テスト計画

新規テスト（`tests/unit/test_backup_service.py`）で以下を検証している:

- kind別ディレクトリへの取得と、kindごとに独立したローテーション（periodicの世代整理が他kindのスナップショットを消さないこと）
- periodicの世代整理でdaily/への昇格が正しく行われること（同日分が既にdaily/にあれば削除、無ければ移動、daily/自体は自分のクォータを超えないこと）
- スナップショットのメタデータにkind・schema_head・quick_check結果が正しく記録されること
- verify_snapshotが破損ファイル（切断コピー・不正な内容）を検出すること
- restoreがサーバー稼働中を検知して拒否し、`--force`で続行できること（プロセス生存側・ヘルスエンドポイント側の両検知経路）
- restoreが復元前に必ず現状態を退避し、退避データからのラウンドトリップ復元ができること
- 現行DBがbackup APIで読めないほど壊れている場合に、生ファイルコピーへのフォールバックが機能すること
- schema互換性チェックが未知のschema_headをブロックし、`--yes`で続行できること
- `--latest`が全kind横断で最新のスナップショットを選ぶこと、`--file-copy`が`-wal`/`-shm`を除去すること

既存のスナップショット関連e2eテスト（取得・ヘルスチェック・ローテーション・SessionStart hook統合）は移設後もそのまま通ることを確認済み。CLIの`list`/`take`/`verify`サブコマンドのサブプロセス実行による疎通テストも追加した。restoreのCLI疎通は、実機のポート52837の稼働状態に結果が左右されるため、関数レベル（サーバー稼働チェックをモックで隔離）で検証している。

テストスイート全体（unit/integration/e2e）を実行し、既存分を含めて回帰がないことを確認した。