### PR TITLE
feat: signal_events テーブルとシグナル記録ツール3本を追加

### DIFF
--- a/migrations/0049_add_signal_events.sql
+++ b/migrations/0049_add_signal_events.sql
@@ -1,0 +1,64 @@
+-- Migration 0049: signal_events テーブル追加
+--
+-- depends: 0048_session_identity
+--
+-- 背景:
+--   cc-memory 自身の故障報告・使用感不満・矛盾検出・運用計測イベントの統一記録先。
+--   decision / log と混ぜない理由: シグナルは「双方の合意」も文脈タグ体系も要らない
+--   生の観測データであり、量が多く、状態遷移（トリアージ）を持つ。既存エンティティへ
+--   の昇格は明示的な promote (status='promoted' + promoted_type/promoted_id) で行う。
+--
+--   本テーブルは体制全体のシグナル・運用計測イベントの唯一の記録先とする。他コンポ
+--   ーネント（ops_metrics 集計・境界ゲートの shadow 突合ミラー）も本テーブルを共有し、
+--   独自テーブルは作らない。
+--
+-- スキーマ:
+--   id               主キー
+--   kind             シグナル種別。妥当性は DB 制約ではなく Python 層の
+--                    signal_service.KNOWN_KINDS で検証する（種別追加を migration 不要
+--                    にするため）
+--   source           発生源。'tool:<name>' / 'hook:<name>' / 'migration' / 'backup' /
+--                    'agent' / 'user' / 'gate' 等の自由文字列
+--   summary          1行要約
+--   detail           traceback・引数ダイジェスト・自由記述（任意）
+--   refs             JSON配列: [{"type":"decision","id":123}, ...]（任意）
+--   context          JSON: kind ごとの構造化ペイロード（任意）
+--   fingerprint      sha256(kind|source|正規化summary) 先頭16hex。dedup のキー
+--   occurrence_count 同一fingerprintの再発回数
+--   first_seen_at    初回記録時刻
+--   last_seen_at     最終記録時刻（dedup 時に更新）
+--   session_id       記録元セッションID（任意）
+--   status           トリアージ状態。new → triaged / promoted / dismissed
+--   promoted_type    promote先エンティティ種別（'topic'|'activity'|'decision'|'log'|'material'）
+--   promoted_id      promote先エンティティID
+--
+-- dedup:
+--   status='new' の行に限り fingerprint を UNIQUE とする部分インデックスを張る。
+--   同一 fingerprint の new 行が既存なら INSERT は競合し、アプリ層は
+--   ON CONFLICT(fingerprint) WHERE status='new' DO UPDATE で occurrence_count を
+--   加算する（この部分 UNIQUE index 自体が並行書き込みの競合検知を担う）。
+--   トリアージ済み（status が new 以外）の同型イベント再発は新規行になる。
+
+CREATE TABLE signal_events (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind             TEXT NOT NULL,
+    source           TEXT NOT NULL,
+    summary          TEXT NOT NULL,
+    detail           TEXT,
+    refs             TEXT,
+    context          TEXT,
+    fingerprint      TEXT NOT NULL,
+    occurrence_count INTEGER NOT NULL DEFAULT 1,
+    first_seen_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    session_id       TEXT,
+    status           TEXT NOT NULL DEFAULT 'new'
+                     CHECK (status IN ('new', 'triaged', 'promoted', 'dismissed')),
+    promoted_type    TEXT,
+    promoted_id      INTEGER,
+    CHECK ((promoted_type IS NULL) = (promoted_id IS NULL))
+);
+
+CREATE UNIQUE INDEX idx_signal_fingerprint_new ON signal_events(fingerprint) WHERE status = 'new';
+CREATE INDEX idx_signal_status ON signal_events(status, last_seen_at);
+CREATE INDEX idx_signal_kind ON signal_events(kind, last_seen_at);

--- a/migrations/0049_add_signal_events.sql
+++ b/migrations/0049_add_signal_events.sql
@@ -26,7 +26,8 @@
 --   fingerprint      sha256(kind|source|正規化summary) 先頭16hex。dedup のキー
 --   occurrence_count 同一fingerprintの再発回数
 --   first_seen_at    初回記録時刻
---   last_seen_at     最終記録時刻（dedup 時に更新）
+--   last_seen_at     最後に実際に再発した時刻（新規記録・dedup 時のみ更新。
+--                    トリアージ状態遷移では更新しない）
 --   session_id       記録元セッションID（任意）
 --   status           トリアージ状態。new → triaged / promoted / dismissed
 --   promoted_type    promote先エンティティ種別（'topic'|'activity'|'decision'|'log'|'material'）

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ from src.services import (
     timeline_service,
     ow_service,
     guard_service,
+    signal_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.tag_service import search_tags as _search_tags, update_tag as _update_tag, collect_tag_notes_for_injection
@@ -244,6 +245,10 @@ mcp = FastMCP("cc-memory", instructions=build_instructions())
 # role 別の tools/list 可視性を制御する middleware を登録する
 from src.services.visibility_middleware import CapabilityVisibilityMiddleware
 mcp.add_middleware(CapabilityVisibilityMiddleware())
+
+# tool呼び出し中の未捕捉例外を signal_events へ自動捕捉する middleware を登録する
+from src.services.signal_middleware import SignalCaptureMiddleware
+mcp.add_middleware(SignalCaptureMiddleware())
 
 # サーバー起動時刻（/health で uptime 算出に使用）
 _SERVER_STARTED_AT = datetime.now(timezone.utc)
@@ -1259,6 +1264,118 @@ def get_config() -> dict:
 def roll_dice(sides: int = 10) -> dict:
     """指定面数のダイスを振る。デフォルト1d10。"""
     return {"result": random.randint(1, sides)}
+
+
+# ----------------------------
+# シグナル吸い上げ
+# ----------------------------
+
+
+@mcp.tool()
+def report_signal(
+    kind: str,
+    summary: str,
+    detail: str | None = None,
+    refs: list[dict] | None = None,
+    context: dict | None = None,
+) -> dict:
+    """cc-memory 自身への故障報告・使用感不満・矛盾検出・運用計測イベントの統一入口。
+
+    kind（7種類、いずれか必須）:
+      - "machine_error": ツールエラー・hook 失敗・サーバー異常を観察した
+      - "friction": cc-memory の使い勝手への不満・違和感（ユーザー発話由来を含む）
+      - "contradiction": 既存記録(decision/material/log)と矛盾する結論を出した/検出した。
+        refs に矛盾の両側の id を必ず含めること。summary は
+        「<新しい結論の要旨> ↔ <矛盾する既存記録の title>」形式。
+        detail にはどちらの検証アンカー(コミット・日付・検証手段)が強いかの観察を書く。
+        context.resolution に existing_correct / new_correct / unresolved を書く
+      - "precedent_miss" / "precedent_misapplied": 判例参照の見落とし・誤類推の事後発覚。
+        context に missed_ids / cited_id 等の規約キーを書く
+      - "boundary_case" / "rollback": 運用上の案件記録。summary に PR 番号等の
+        案件識別子を含める（dedup の集約単位を案件ごとに分けるため）
+
+    同一内容の再報告は自動で集約される(occurrence_count)。
+
+    Args:
+        kind: 上記7種のいずれか
+        summary: 1行要約（空文字不可）
+        detail: traceback・引数ダイジェスト・自由記述（optional）
+        refs: [{"type": "decision", "id": 123}, ...] 形式の参照リスト（optional）
+        context: kind ごとの構造化ペイロード（optional）
+
+    Returns:
+        成功時: {"id": int, "deduped": bool, "occurrence_count": int}
+        失敗時: {"error": {"code": "VALIDATION_ERROR", "message": ...}}
+    """
+    caller_session_id = get_caller_session_id()
+    try:
+        return signal_service.record_signal(
+            kind,
+            summary,
+            detail=detail,
+            refs=refs,
+            context=context,
+            session_id=caller_session_id,
+        )
+    except ValueError as e:
+        return {"error": {"code": "VALIDATION_ERROR", "message": str(e)}}
+
+
+@mcp.tool()
+def get_signals(
+    status: str | None = "new",
+    kind: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    include_stats: bool = False,
+) -> dict:
+    """report_signal で記録されたシグナルを一覧・集計する。
+
+    Args:
+        status: フィルタ対象のstatus（"new"|"triaged"|"promoted"|"dismissed"）。
+            null指定で全status横断。デフォルトは未トリアージの"new"のみ
+        kind: フィルタ対象のkind。null指定で全kind横断
+        limit: 取得件数上限（最大100件、デフォルト20）
+        offset: 取得開始位置（ページネーション用）
+        include_stats: Trueのとき kind×status のクロス集計と直近30日サマリを付与
+
+    Returns:
+        成功時: {"signals": [...], "total_count": int, "stats": {...}(include_stats時のみ)}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    return signal_service.get_signals(
+        status=status, kind=kind, limit=limit, offset=offset, include_stats=include_stats
+    )
+
+
+@mcp.tool()
+def update_signal(
+    signal_id: int,
+    status: str,
+    promoted_type: str | None = None,
+    promoted_id: int | None = None,
+) -> dict:
+    """シグナルのトリアージ状態を遷移する（orch/親セッション専用）。
+
+    promoted_type/promoted_id は既存エンティティ（topic/activity/decision/log/material）
+    への参照であり、両方指定時のみ実在チェックの上でリンクする。実体の作成は行わない
+    （昇格実体は既存の add 系ツールで別途作成する）。
+
+    Args:
+        signal_id: 対象シグナルID
+        status: 遷移先status（"new"|"triaged"|"promoted"|"dismissed"）
+        promoted_type: 昇格先エンティティ種別（"topic"|"activity"|"decision"|"log"|"material"）。
+            省略時は既存の紐付けを変更しない
+        promoted_id: 昇格先エンティティID。promoted_typeと同時に指定する
+
+    Returns:
+        成功時: {"signal": {...}}（更新後の行）
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    guard_service.check_capability("update_signal")
+    return signal_service.update_signal(
+        signal_id, status, promoted_type=promoted_type, promoted_id=promoted_id
+    )
 
 
 # ----------------------------

--- a/src/services/capability_matrix.py
+++ b/src/services/capability_matrix.py
@@ -64,6 +64,11 @@ CAPABILITY_MATRIX: CapabilityMatrix = {
     "get_by_ids":        {"orch": True,  "dispatcher": True,  "worker": True},
     "get_config":        {"orch": True,  "dispatcher": True,  "worker": True},
 
+    # シグナル吸い上げ（機械エラー・使用感不満・矛盾検出・運用計測イベント）
+    "report_signal":     {"orch": True,  "dispatcher": True,  "worker": True},   # 入口は全開放
+    "get_signals":       {"orch": True,  "dispatcher": True,  "worker": True},
+    "update_signal":     {"orch": True,  "dispatcher": False, "worker": False},  # トリアージはorch/親のみ
+
     # その他
     "roll_dice":         {"orch": True,  "dispatcher": True,  "worker": True},
 }

--- a/src/services/signal_middleware.py
+++ b/src/services/signal_middleware.py
@@ -1,0 +1,71 @@
+"""MCP ツール呼び出し中の未捕捉例外を signal_events へ自動捕捉する middleware。
+
+例外はそのまま re-raise するため、呼び出し元から見た挙動は不変。記録は
+ベストエフォート（capture_signal_safe 経由でいかなる例外も外に漏らさない）で
+あり、記録自体の失敗がツール呼び出しを壊すことはない。
+"""
+from __future__ import annotations
+
+import traceback
+from typing import Any
+
+import mcp.types as mt
+
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+from src.services import signal_service
+from src.services.guard_service import CapabilityError
+
+# detail に書き込む traceback + 引数ダイジェストの最大文字数。値そのものは含めず
+# key と型のみを記録する（機密情報混入の回避）。DB カラムに上限は無いが、
+# detail が肥大化しないよう妥当な長さで切る。
+_DETAIL_MAX_LEN = 500
+
+
+class SignalCaptureMiddleware(Middleware):
+    """role guard による正常な拒否 (CapabilityError) を除く全ての例外を machine_error として記録する。"""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        try:
+            return await call_next(context)
+        except CapabilityError:
+            raise  # ガードによる正常な拒否は故障ではない
+        except Exception as e:
+            signal_service.capture_signal_safe(
+                kind="machine_error",
+                summary=f"{type(e).__name__}: {str(e)[:200]}",
+                source=f"tool:{context.message.name}",
+                detail=_traceback_and_args_digest(e, context),
+                session_id=_safe_session_id(context),
+            )
+            raise
+
+
+def _traceback_and_args_digest(exc: Exception, context: MiddlewareContext) -> str:
+    """例外の traceback と呼び出し引数の (key, 型) ダイジェストを生成する。
+
+    引数の値そのものは含めない。全体を _DETAIL_MAX_LEN 文字に切り詰める際は
+    末尾（例外メッセージ・直近フレーム）を優先して残すため、末尾から切り出す。
+    """
+    tb_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    args_summary = ""
+    try:
+        arguments = context.message.arguments or {}
+        args_summary = ", ".join(f"{k}:{type(v).__name__}" for k, v in arguments.items())
+    except Exception:
+        pass
+
+    digest = f"{tb_text}\nargs: {args_summary}"
+    return digest[-_DETAIL_MAX_LEN:]
+
+
+def _safe_session_id(context: MiddlewareContext) -> str | None:
+    try:
+        return context.fastmcp_context.session_id if context.fastmcp_context else None
+    except Exception:
+        return None

--- a/src/services/signal_middleware.py
+++ b/src/services/signal_middleware.py
@@ -16,9 +16,15 @@ from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from src.services import signal_service
 from src.services.guard_service import CapabilityError
 
-# detail に書き込む traceback + 引数ダイジェストの最大文字数。値そのものは含めず
-# key と型のみを記録する（機密情報混入の回避）。DB カラムに上限は無いが、
-# detail が肥大化しないよう妥当な長さで切る。
+# detail に書き込む traceback + 引数ダイジェストの最大文字数。DB カラムに上限は
+# 無いが、detail が肥大化しないよう妥当な長さで切る。
+#
+# 注意（機密情報）: 「値そのものを含めない」保護は _traceback_and_args_digest が
+# 自前で組み立てる引数ダイジェスト（key:型 のみ）にしか効かない。実際に記録される
+# summary（str(e)）と detail 中の traceback 本文は例外オブジェクトの文字列表現
+# そのものであり、この保護の対象外。既存サービスには例外メッセージへ引数の実値を
+# 直接埋め込む箇所があるため（例: f"Tag {tag!r} not found"）、summary/detail は
+# 値を含みうる自由文字列として扱うこと。マスキングは未実装。
 _DETAIL_MAX_LEN = 500
 
 

--- a/src/services/signal_service.py
+++ b/src/services/signal_service.py
@@ -1,0 +1,395 @@
+"""cc-memory 自身の故障報告・使用感不満・矛盾検出・運用計測イベントの記録サービス。
+
+signal_events テーブルへの記録・取得・トリアージ状態遷移を担う。record_signal は
+検証あり・例外を投げる通常経路。capture_signal_safe はいかなる例外も外に漏らさない
+捕捉専用の薄いラッパで、middleware / hooks からの自動捕捉に使う。
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sqlite3
+import sys
+from typing import Optional
+
+from src.db import get_connection, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+KNOWN_KINDS = {
+    "machine_error",
+    "friction",
+    "contradiction",
+    "precedent_miss",
+    "precedent_misapplied",
+    "boundary_case",
+    "rollback",
+}
+
+VALID_STATUSES = {"new", "triaged", "promoted", "dismissed"}
+
+# promoted_type として許可するエンティティ種別とその実体テーブル。
+# pin_service.ENTITY_TABLE_MAP 等とは別に、signal_events の promoted_type CHECK
+# (§migration コメント) が想定する 5 種のみに絞って定義する ('tag' 等は対象外)。
+PROMOTED_ENTITY_TABLE = {
+    "topic": "discussion_topics",
+    "activity": "activities",
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "material": "materials",
+}
+
+# get_signals の limit 引数の上限。設計文書は上限を明記していないため、
+# 他の一覧系サービス (get_decisions/get_logs の 30件上限) より広めの値を
+# 実装判断で採用する (シグナルはトリアージ目的で多めに一覧したいケースがある)。
+_MAX_LIMIT = 100
+
+# stats.last_30d の集計期間。設計文書は「固定 vs 引数化」を実装者判断としており、
+# v1 は固定で開始する。
+_STATS_RECENT_DAYS = 30
+
+
+def _normalize_summary(summary: str) -> str:
+    """fingerprint計算用にsummaryを正規化する（前後空白除去 + 連続空白畳み込み + 小文字化）。"""
+    return re.sub(r"\s+", " ", summary.strip()).lower()
+
+
+def _compute_fingerprint(kind: str, source: str, summary: str) -> str:
+    """sha256(kind|source|正規化summary) の先頭16hexをfingerprintとして返す。"""
+    normalized = _normalize_summary(summary)
+    digest = hashlib.sha256(f"{kind}|{source}|{normalized}".encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _to_json_or_raise(value: Optional[object], field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"{field_name} is not JSON serializable: {e}") from e
+
+
+def record_signal(
+    kind: str,
+    summary: str,
+    *,
+    source: str = "agent",
+    detail: Optional[str] = None,
+    refs: Optional[list[dict]] = None,
+    context: Optional[dict] = None,
+    session_id: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> dict:
+    """検証あり・例外を投げる通常経路でシグナルを1件記録する。
+
+    kind が KNOWN_KINDS に含まれない場合、summary が空の場合、refs/context が
+    JSON serialize 不能な場合は ValueError を投げる。
+
+    同一 fingerprint (sha256(kind|source|正規化summary) 先頭16hex) の
+    status='new' 行が既存なら、新規行を作らず occurrence_count を +1 し
+    last_seen_at / detail を更新する（dedup）。トリアージ済み（new 以外）の
+    同型イベント再発は新規行になる。dedup 判定は idx_signal_fingerprint_new
+    (部分 UNIQUE index) を conflict target にした INSERT ... ON CONFLICT で
+    アトミックに行うため、並行書き込みでも競合が起きない。
+
+    Args:
+        kind: signal種別（machine_error/friction/contradiction/precedent_miss/
+            precedent_misapplied/boundary_case/rollback のいずれか）
+        summary: 1行要約（空文字不可）
+        source: 発生源。'tool:<name>' / 'hook:<name>' / 'migration' / 'backup' /
+            'agent' / 'user' / 'gate' 等
+        detail: traceback・引数ダイジェスト・自由記述
+        refs: [{"type": "decision", "id": 123}, ...] 形式の参照リスト
+        context: kind ごとの構造化ペイロード
+        session_id: 記録元セッションID
+        conn: 呼び出し元が既に開いている接続を再利用する場合に渡す
+            (二重接続を避けるための共有パターン)。省略時は自前で接続する
+
+    Returns:
+        {"id": int, "deduped": bool, "occurrence_count": int}
+    """
+    if kind not in KNOWN_KINDS:
+        raise ValueError(f"Invalid kind: {kind!r}. Must be one of {sorted(KNOWN_KINDS)}")
+    if not summary or not summary.strip():
+        raise ValueError("summary must not be empty")
+
+    refs_json = _to_json_or_raise(refs, "refs")
+    context_json = _to_json_or_raise(context, "context")
+    fingerprint = _compute_fingerprint(kind, source, summary)
+
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            INSERT INTO signal_events
+                (kind, source, summary, detail, refs, context, fingerprint, session_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(fingerprint) WHERE status = 'new'
+            DO UPDATE SET
+                occurrence_count = signal_events.occurrence_count + 1,
+                last_seen_at = CURRENT_TIMESTAMP,
+                detail = excluded.detail
+            RETURNING id, occurrence_count
+            """,
+            (kind, source, summary, detail, refs_json, context_json, fingerprint, session_id),
+        )
+        row = cursor.fetchone()
+        signal_id, occurrence_count = row[0], row[1]
+        if own_conn:
+            conn.commit()
+        # INSERT は常に occurrence_count=1 で始まるため、2 以上なら
+        # ON CONFLICT 側 (dedup) が発火したことを意味する。
+        return {
+            "id": signal_id,
+            "deduped": occurrence_count > 1,
+            "occurrence_count": occurrence_count,
+        }
+    except Exception:
+        if own_conn:
+            conn.rollback()
+        raise
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def capture_signal_safe(
+    kind: str,
+    summary: str,
+    *,
+    source: str = "agent",
+    detail: Optional[str] = None,
+    refs: Optional[list[dict]] = None,
+    context: Optional[dict] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """捕捉経路用。いかなる例外も外に漏らさない (stderr へ出すのみ)。
+
+    record_signal の validation エラー・DB 書き込み失敗を含め、あらゆる例外を
+    握りつぶす。middleware / hooks の例外捕捉フックから安全に呼べる。
+    """
+    try:
+        record_signal(
+            kind,
+            summary,
+            source=source,
+            detail=detail,
+            refs=refs,
+            context=context,
+            session_id=session_id,
+        )
+    except Exception as e:
+        print(f"capture_signal_safe failed: {type(e).__name__}: {e}", file=sys.stderr)
+
+
+def get_signals(
+    status: Optional[str] = "new",
+    kind: Optional[str] = None,
+    limit: int = 20,
+    offset: int = 0,
+    include_stats: bool = False,
+) -> dict:
+    """シグナル一覧を取得する。
+
+    Args:
+        status: フィルタ対象のstatus。None指定で全status横断
+        kind: フィルタ対象のkind。None指定で全kind横断
+        limit: 取得件数上限（最大100件）
+        offset: 取得開始位置
+        include_stats: Trueのとき kind×status のクロス集計と直近30日サマリを付与
+
+    Returns:
+        {"signals": [...], "total_count": int, "stats": {...} (include_stats時のみ)}
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    if status is not None and status not in VALID_STATUSES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid status: {status!r}. Must be one of {sorted(VALID_STATUSES)} or null",
+            }
+        }
+    if kind is not None and kind not in KNOWN_KINDS:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid kind: {kind!r}. Must be one of {sorted(KNOWN_KINDS)} or null",
+            }
+        }
+
+    limit = min(max(limit, 1), _MAX_LIMIT)
+    offset = max(offset, 0)
+
+    conn = get_connection()
+    try:
+        where_parts = []
+        params: list[object] = []
+        if status is not None:
+            where_parts.append("status = ?")
+            params.append(status)
+        if kind is not None:
+            where_parts.append("kind = ?")
+            params.append(kind)
+        where_clause = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+
+        total_count = conn.execute(
+            f"SELECT COUNT(*) FROM signal_events {where_clause}", params
+        ).fetchone()[0]
+
+        rows = conn.execute(
+            f"""
+            SELECT * FROM signal_events {where_clause}
+            ORDER BY last_seen_at DESC, id DESC
+            LIMIT ? OFFSET ?
+            """,
+            params + [limit, offset],
+        ).fetchall()
+
+        signals = [_signal_row_to_dict(row) for row in rows]
+
+        result: dict = {"signals": signals, "total_count": total_count}
+        if include_stats:
+            result["stats"] = _compute_stats(conn)
+        return result
+    except Exception as e:
+        return {"error": {"code": "DATABASE_ERROR", "message": str(e)}}
+    finally:
+        conn.close()
+
+
+def _signal_row_to_dict(row: sqlite3.Row) -> dict:
+    signal = row_to_dict(row)
+    signal["refs"] = json.loads(signal["refs"]) if signal.get("refs") else None
+    signal["context"] = json.loads(signal["context"]) if signal.get("context") else None
+    return signal
+
+
+def _compute_stats(conn: sqlite3.Connection) -> dict:
+    """kind×status のクロス件数と直近 _STATS_RECENT_DAYS 日サマリを返す。
+
+    フィルタ引数の影響を受けず、signal_events 全体を対象に集計する
+    (トリアージ担当が全体像を把握するための集計であるため)。
+    """
+    by_kind_status: dict[str, dict[str, int]] = {}
+    for row in conn.execute(
+        "SELECT kind, status, COUNT(*) AS c FROM signal_events GROUP BY kind, status"
+    ).fetchall():
+        by_kind_status.setdefault(row["kind"], {})[row["status"]] = row["c"]
+
+    last_period: dict[str, int] = {}
+    for row in conn.execute(
+        f"""
+        SELECT kind, COUNT(*) AS c FROM signal_events
+        WHERE first_seen_at >= datetime('now', '-{_STATS_RECENT_DAYS} days')
+        GROUP BY kind
+        """
+    ).fetchall():
+        last_period[row["kind"]] = row["c"]
+
+    return {
+        "by_kind_status": by_kind_status,
+        f"last_{_STATS_RECENT_DAYS}d": last_period,
+    }
+
+
+def update_signal(
+    signal_id: int,
+    status: str,
+    promoted_type: Optional[str] = None,
+    promoted_id: Optional[int] = None,
+) -> dict:
+    """シグナルのトリアージ状態を遷移する。
+
+    promoted_type/promoted_id は両方指定 or 両方省略のいずれかのみ許可する。
+    両方指定時は昇格先エンティティの実在チェックを行った上でリンクする。
+    省略時は既存の promoted_type/promoted_id を変更しない（status のみ更新）。
+
+    Args:
+        signal_id: 対象シグナルID
+        status: 遷移先status（new/triaged/promoted/dismissed）
+        promoted_type: 昇格先エンティティ種別（'topic'|'activity'|'decision'|'log'|'material'）
+        promoted_id: 昇格先エンティティID
+
+    Returns:
+        {"signal": {...}}（更新後の行）
+        失敗時: {"error": {"code": ..., "message": ...}}
+    """
+    if status not in VALID_STATUSES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Invalid status: {status!r}. Must be one of {sorted(VALID_STATUSES)}",
+            }
+        }
+    if (promoted_type is None) != (promoted_id is None):
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "promoted_type and promoted_id must be both set or both omitted",
+            }
+        }
+    if promoted_type is not None and promoted_type not in PROMOTED_ENTITY_TABLE:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": (
+                    f"Invalid promoted_type: {promoted_type!r}. "
+                    f"Must be one of {sorted(PROMOTED_ENTITY_TABLE)}"
+                ),
+            }
+        }
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id FROM signal_events WHERE id = ?", (signal_id,)
+        ).fetchone()
+        if row is None:
+            return {
+                "error": {
+                    "code": "NOT_FOUND",
+                    "message": f"signal_events id={signal_id} not found",
+                }
+            }
+
+        if promoted_type is not None:
+            table = PROMOTED_ENTITY_TABLE[promoted_type]
+            exists = conn.execute(
+                f"SELECT 1 FROM {table} WHERE id = ?", (promoted_id,)
+            ).fetchone()
+            if not exists:
+                return {
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": f"{promoted_type} id={promoted_id} does not exist",
+                    }
+                }
+            conn.execute(
+                """
+                UPDATE signal_events
+                SET status = ?, promoted_type = ?, promoted_id = ?, last_seen_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (status, promoted_type, promoted_id, signal_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE signal_events SET status = ?, last_seen_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (status, signal_id),
+            )
+        conn.commit()
+
+        updated = conn.execute(
+            "SELECT * FROM signal_events WHERE id = ?", (signal_id,)
+        ).fetchone()
+        return {"signal": _signal_row_to_dict(updated)}
+    except Exception as e:
+        conn.rollback()
+        return {"error": {"code": "DATABASE_ERROR", "message": str(e)}}
+    finally:
+        conn.close()

--- a/src/services/signal_service.py
+++ b/src/services/signal_service.py
@@ -90,7 +90,11 @@ def record_signal(
 
     同一 fingerprint (sha256(kind|source|正規化summary) 先頭16hex) の
     status='new' 行が既存なら、新規行を作らず occurrence_count を +1 し
-    last_seen_at / detail を更新する（dedup）。トリアージ済み（new 以外）の
+    last_seen_at / detail / refs / context / session_id を今回の値で上書きする
+    （dedup、last-write-wins）。refs/context/session_id を最新 occurrence の値で
+    更新するのは、contradiction のように refs で矛盾の両側を指す kind で
+    2 回目以降の参照が失われるのを防ぐため、および再発したセッションを追える
+    ようにするため。トリアージ済み（new 以外）の
     同型イベント再発は新規行になる。dedup 判定は idx_signal_fingerprint_new
     (部分 UNIQUE index) を conflict target にした INSERT ... ON CONFLICT で
     アトミックに行うため、並行書き込みでも競合が起きない。
@@ -133,7 +137,10 @@ def record_signal(
             DO UPDATE SET
                 occurrence_count = signal_events.occurrence_count + 1,
                 last_seen_at = CURRENT_TIMESTAMP,
-                detail = excluded.detail
+                detail = excluded.detail,
+                refs = excluded.refs,
+                context = excluded.context,
+                session_id = excluded.session_id
             RETURNING id, occurrence_count
             """,
             (kind, source, summary, detail, refs_json, context_json, fingerprint, session_id),
@@ -309,6 +316,10 @@ def update_signal(
     両方指定時は昇格先エンティティの実在チェックを行った上でリンクする。
     省略時は既存の promoted_type/promoted_id を変更しない（status のみ更新）。
 
+    last_seen_at は「最後に実際に再発した時刻」を表すため、トリアージ状態遷移では
+    更新しない（更新は新規記録・dedup のみ）。人手のトリアージで last_seen_at を
+    書き換えると get_signals のデフォルトソートが古いシグナルを上位へ押し上げる。
+
     Args:
         signal_id: 対象シグナルID
         status: 遷移先status（new/triaged/promoted/dismissed）
@@ -372,14 +383,14 @@ def update_signal(
             conn.execute(
                 """
                 UPDATE signal_events
-                SET status = ?, promoted_type = ?, promoted_id = ?, last_seen_at = CURRENT_TIMESTAMP
+                SET status = ?, promoted_type = ?, promoted_id = ?
                 WHERE id = ?
                 """,
                 (status, promoted_type, promoted_id, signal_id),
             )
         else:
             conn.execute(
-                "UPDATE signal_events SET status = ?, last_seen_at = CURRENT_TIMESTAMP WHERE id = ?",
+                "UPDATE signal_events SET status = ? WHERE id = ?",
                 (status, signal_id),
             )
         conn.commit()

--- a/tests/test_migrations/test_0049_add_signal_events.py
+++ b/tests/test_migrations/test_0049_add_signal_events.py
@@ -1,0 +1,195 @@
+"""migration 0049_add_signal_events のテスト
+
+0049 適用後に signal_events テーブルとその索引・CHECK 制約が期待通り
+存在することを、Python 層の signal_service を経由せず生 SQL で検証する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+from src.services.tag_service import _injected_tags
+from test_migrations.conftest import get_column_names, index_names, table_exists
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0049含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0049():
+    """0048までのmigrationを適用したDBを提供する。0049の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0049 = MigrationList([m for m in all_migs if m.id < "0049"])
+        with backend.lock():
+            backend.apply_migrations(pre_0049)
+
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _insert_signal(conn: sqlite3.Connection, **overrides) -> int:
+    fields = {
+        "kind": "machine_error",
+        "source": "tool:foo",
+        "summary": "boom",
+        "fingerprint": "deadbeefdeadbeef",
+    }
+    fields.update(overrides)
+    columns = ", ".join(fields.keys())
+    placeholders = ", ".join("?" for _ in fields)
+    cur = conn.execute(
+        f"INSERT INTO signal_events ({columns}) VALUES ({placeholders})",
+        tuple(fields.values()),
+    )
+    return cur.lastrowid
+
+
+class TestTableCreated:
+    def test_signal_events_does_not_exist_before_0049(self, db_before_0049):
+        conn = get_connection()
+        try:
+            assert not table_exists(conn, "signal_events")
+        finally:
+            conn.close()
+
+    def test_signal_events_exists_after_0049(self, migrated_db):
+        conn = get_connection()
+        try:
+            assert table_exists(conn, "signal_events")
+        finally:
+            conn.close()
+
+    def test_expected_columns(self, migrated_db):
+        conn = get_connection()
+        try:
+            columns = get_column_names(conn, "signal_events")
+        finally:
+            conn.close()
+        expected = {
+            "id", "kind", "source", "summary", "detail", "refs", "context",
+            "fingerprint", "occurrence_count", "first_seen_at", "last_seen_at",
+            "session_id", "status", "promoted_type", "promoted_id",
+        }
+        assert expected <= columns
+
+    def test_expected_indexes(self, migrated_db):
+        conn = get_connection()
+        try:
+            names = index_names(conn, "idx_signal_%")
+        finally:
+            conn.close()
+        assert {
+            "idx_signal_fingerprint_new",
+            "idx_signal_status",
+            "idx_signal_kind",
+        } <= names
+
+
+class TestDefaults:
+    def test_status_defaults_to_new(self, migrated_db):
+        conn = get_connection()
+        try:
+            signal_id = _insert_signal(conn)
+            conn.commit()
+            row = conn.execute(
+                "SELECT status, occurrence_count FROM signal_events WHERE id = ?",
+                (signal_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row["status"] == "new"
+        assert row["occurrence_count"] == 1
+
+
+class TestCheckConstraints:
+    def test_invalid_status_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_signal(conn, status="not_a_status")
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_promoted_type_without_id_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_signal(conn, promoted_type="topic")
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_promoted_id_without_type_rejected(self, migrated_db):
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_signal(conn, promoted_id=1)
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_promoted_type_and_id_together_accepted(self, migrated_db):
+        conn = get_connection()
+        try:
+            signal_id = _insert_signal(conn, promoted_type="topic", promoted_id=1)
+            conn.commit()
+            row = conn.execute(
+                "SELECT promoted_type, promoted_id FROM signal_events WHERE id = ?",
+                (signal_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row["promoted_type"] == "topic"
+        assert row["promoted_id"] == 1
+
+
+class TestPartialUniqueIndex:
+    def test_duplicate_fingerprint_rejected_while_status_new(self, migrated_db):
+        conn = get_connection()
+        try:
+            _insert_signal(conn, fingerprint="dup000000000000")
+            conn.commit()
+            with pytest.raises(sqlite3.IntegrityError):
+                _insert_signal(conn, fingerprint="dup000000000000")
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_duplicate_fingerprint_allowed_once_not_new(self, migrated_db):
+        conn = get_connection()
+        try:
+            first_id = _insert_signal(conn, fingerprint="dup111111111111")
+            conn.execute(
+                "UPDATE signal_events SET status = 'dismissed' WHERE id = ?",
+                (first_id,),
+            )
+            second_id = _insert_signal(conn, fingerprint="dup111111111111")
+            conn.commit()
+        finally:
+            conn.close()
+        assert first_id != second_id

--- a/tests/unit/test_signal_middleware.py
+++ b/tests/unit/test_signal_middleware.py
@@ -1,0 +1,146 @@
+"""SignalCaptureMiddleware の単体テスト
+
+tool呼び出し中の未捕捉例外が signal_events に machine_error として記録され、
+例外自体はそのまま呼び出し元に伝播すること（挙動不変）を検証する。
+CapabilityError は正常な拒否として記録対象から除外されること、signal記録自体の
+失敗がtool呼び出し結果を壊さないことも合わせて検証する。
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.db import get_connection
+from src.services.guard_service import CapabilityError
+from src.services.signal_middleware import SignalCaptureMiddleware
+
+
+def _make_call_context(tool_name="add_decisions", arguments=None, session_id="sess-1"):
+    message = MagicMock()
+    message.name = tool_name
+    message.arguments = arguments if arguments is not None else {"topic_id": 1, "decision": "x"}
+
+    fastmcp_ctx = MagicMock()
+    fastmcp_ctx.session_id = session_id
+
+    context = MagicMock()
+    context.message = message
+    context.fastmcp_context = fastmcp_ctx
+    return context
+
+
+@pytest.mark.asyncio
+async def test_records_machine_error_on_unhandled_exception(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context(tool_name="add_decisions")
+
+    async def _raise(_ctx):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await middleware.on_call_tool(context, _raise)
+
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT * FROM signal_events").fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["kind"] == "machine_error"
+    assert row["source"] == "tool:add_decisions"
+    assert "RuntimeError" in row["summary"]
+    assert row["session_id"] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_reraises_original_exception_unchanged(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context()
+    original = ValueError("specific message")
+
+    async def _raise(_ctx):
+        raise original
+
+    with pytest.raises(ValueError) as exc_info:
+        await middleware.on_call_tool(context, _raise)
+    assert exc_info.value is original
+
+
+@pytest.mark.asyncio
+async def test_capability_error_not_captured(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context()
+
+    async def _raise(_ctx):
+        raise CapabilityError("denied")
+
+    with pytest.raises(CapabilityError):
+        await middleware.on_call_tool(context, _raise)
+
+    conn = get_connection()
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM signal_events").fetchone()[0]
+    finally:
+        conn.close()
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_success_path_untouched(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context()
+    call_next = AsyncMock(return_value="ok")
+
+    result = await middleware.on_call_tool(context, call_next)
+
+    assert result == "ok"
+    call_next.assert_called_once_with(context)
+
+    conn = get_connection()
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM signal_events").fetchone()[0]
+    finally:
+        conn.close()
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_detail_excludes_raw_argument_values(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context(
+        tool_name="add_decisions",
+        arguments={"decision": "super secret content that must not leak"},
+    )
+
+    async def _raise(_ctx):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await middleware.on_call_tool(context, _raise)
+
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT detail FROM signal_events").fetchone()
+    finally:
+        conn.close()
+    assert "super secret content" not in row["detail"]
+    assert "decision:str" in row["detail"]
+
+
+@pytest.mark.asyncio
+async def test_missing_fastmcp_context_does_not_crash(temp_db):
+    middleware = SignalCaptureMiddleware()
+    context = _make_call_context()
+    context.fastmcp_context = None
+
+    async def _raise(_ctx):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await middleware.on_call_tool(context, _raise)
+
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT session_id FROM signal_events").fetchone()
+    finally:
+        conn.close()
+    assert row["session_id"] is None

--- a/tests/unit/test_signal_service.py
+++ b/tests/unit/test_signal_service.py
@@ -1,0 +1,271 @@
+"""signal_service の単体テスト
+
+signal_events テーブルへの record/dedup/get/update と、捕捉専用の
+capture_signal_safe が例外を外に漏らさないことを検証する。
+"""
+import sqlite3
+
+import pytest
+
+from src.db import get_connection
+from src.services import signal_service as ss
+
+
+def test_record_signal_creates_row(temp_db):
+    result = ss.record_signal("machine_error", "boom", source="tool:foo", detail="tb")
+    assert result["deduped"] is False
+    assert result["occurrence_count"] == 1
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM signal_events WHERE id = ?", (result["id"],)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["kind"] == "machine_error"
+    assert row["source"] == "tool:foo"
+    assert row["summary"] == "boom"
+    assert row["status"] == "new"
+    assert row["occurrence_count"] == 1
+
+
+def test_record_signal_rejects_unknown_kind(temp_db):
+    with pytest.raises(ValueError):
+        ss.record_signal("not_a_real_kind", "boom")
+
+
+def test_record_signal_rejects_empty_summary(temp_db):
+    with pytest.raises(ValueError):
+        ss.record_signal("friction", "   ")
+
+
+def test_record_signal_rejects_unserializable_refs(temp_db):
+    class Unserializable:
+        pass
+
+    with pytest.raises(ValueError):
+        ss.record_signal(
+            "contradiction", "x", refs=[{"type": "decision", "id": Unserializable()}]
+        )
+
+
+def test_record_signal_dedups_same_fingerprint(temp_db):
+    r1 = ss.record_signal("machine_error", "Something broke", source="tool:foo")
+    r2 = ss.record_signal("machine_error", "  something   BROKE  ", source="tool:foo", detail="second")
+
+    assert r2["id"] == r1["id"]
+    assert r2["deduped"] is True
+    assert r2["occurrence_count"] == 2
+
+    conn = get_connection()
+    try:
+        rows = conn.execute("SELECT * FROM signal_events").fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["occurrence_count"] == 2
+    assert rows[0]["detail"] == "second"
+
+
+def test_record_signal_does_not_dedup_after_triage(temp_db):
+    r1 = ss.record_signal("machine_error", "Something broke", source="tool:foo")
+    ss.update_signal(r1["id"], "triaged")
+
+    r2 = ss.record_signal("machine_error", "Something broke", source="tool:foo")
+
+    assert r2["id"] != r1["id"]
+    assert r2["deduped"] is False
+    assert r2["occurrence_count"] == 1
+
+    conn = get_connection()
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM signal_events").fetchone()[0]
+    finally:
+        conn.close()
+    assert total == 2
+
+
+def test_record_signal_different_kind_or_source_not_deduped(temp_db):
+    r1 = ss.record_signal("machine_error", "same text", source="tool:foo")
+    r2 = ss.record_signal("friction", "same text", source="tool:foo")
+    r3 = ss.record_signal("machine_error", "same text", source="tool:bar")
+
+    assert len({r1["id"], r2["id"], r3["id"]}) == 3
+
+
+def test_capture_signal_safe_never_raises_on_invalid_kind(temp_db):
+    ss.capture_signal_safe("not_a_real_kind", "boom")  # 例外を投げないことのみ検証
+
+    conn = get_connection()
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM signal_events").fetchone()[0]
+    finally:
+        conn.close()
+    assert total == 0
+
+
+def test_capture_signal_safe_writes_valid_signal(temp_db):
+    ss.capture_signal_safe("machine_error", "boom", source="hook:session_start")
+
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT * FROM signal_events").fetchone()
+    finally:
+        conn.close()
+    assert row["kind"] == "machine_error"
+    assert row["source"] == "hook:session_start"
+
+
+def test_capture_signal_safe_survives_db_failure(temp_db, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(ss, "record_signal", _boom)
+    ss.capture_signal_safe("machine_error", "boom")  # 例外を投げないことのみ検証
+
+
+class TestGetSignals:
+    def test_default_filters_to_new_status(self, temp_db):
+        r1 = ss.record_signal("machine_error", "a", source="s1")
+        ss.update_signal(r1["id"], "dismissed")
+        ss.record_signal("friction", "b", source="s2")
+
+        result = ss.get_signals()
+
+        assert result["total_count"] == 1
+        assert result["signals"][0]["kind"] == "friction"
+
+    def test_status_none_returns_all(self, temp_db):
+        r1 = ss.record_signal("machine_error", "a", source="s1")
+        ss.update_signal(r1["id"], "dismissed")
+        ss.record_signal("friction", "b", source="s2")
+
+        result = ss.get_signals(status=None)
+
+        assert result["total_count"] == 2
+
+    def test_kind_filter(self, temp_db):
+        ss.record_signal("machine_error", "a", source="s1")
+        ss.record_signal("friction", "b", source="s2")
+
+        result = ss.get_signals(status=None, kind="friction")
+
+        assert result["total_count"] == 1
+        assert result["signals"][0]["kind"] == "friction"
+
+    def test_invalid_status_returns_validation_error(self, temp_db):
+        result = ss.get_signals(status="not_a_status")
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_invalid_kind_returns_validation_error(self, temp_db):
+        result = ss.get_signals(kind="not_a_kind")
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_refs_and_context_are_deserialized(self, temp_db):
+        ss.record_signal(
+            "contradiction",
+            "x vs y",
+            refs=[{"type": "decision", "id": 1}],
+            context={"resolution": "new_correct"},
+        )
+
+        result = ss.get_signals(status=None)
+
+        signal = result["signals"][0]
+        assert signal["refs"] == [{"type": "decision", "id": 1}]
+        assert signal["context"] == {"resolution": "new_correct"}
+
+    def test_include_stats_cross_tabulates_kind_and_status(self, temp_db):
+        r1 = ss.record_signal("machine_error", "a", source="s1")
+        ss.update_signal(r1["id"], "promoted", promoted_type=None, promoted_id=None)
+        ss.record_signal("friction", "b", source="s2")
+        ss.record_signal("friction", "c", source="s3")
+
+        result = ss.get_signals(status=None, include_stats=True)
+
+        assert result["stats"]["by_kind_status"]["friction"]["new"] == 2
+        assert result["stats"]["by_kind_status"]["machine_error"]["promoted"] == 1
+        assert result["stats"]["last_30d"]["friction"] == 2
+
+    def test_limit_is_clamped_to_max(self, temp_db):
+        for i in range(3):
+            ss.record_signal("friction", f"item {i}", source=f"s{i}")
+
+        result = ss.get_signals(status=None, limit=99999)
+
+        assert result["total_count"] == 3
+        assert len(result["signals"]) == 3
+
+
+class TestUpdateSignal:
+    def test_status_transition_without_promotion(self, temp_db):
+        r1 = ss.record_signal("friction", "a")
+
+        result = ss.update_signal(r1["id"], "triaged")
+
+        assert result["signal"]["status"] == "triaged"
+        assert result["signal"]["promoted_type"] is None
+
+    def test_promote_links_existing_entity(self, temp_db):
+        from src.services.topic_service import add_topic
+
+        topic = add_topic(title="t", description="d", tags=["domain:test"])
+        r1 = ss.record_signal("precedent_miss", "missed something")
+
+        result = ss.update_signal(
+            r1["id"], "promoted", promoted_type="topic", promoted_id=topic["topic_id"]
+        )
+
+        assert result["signal"]["status"] == "promoted"
+        assert result["signal"]["promoted_type"] == "topic"
+        assert result["signal"]["promoted_id"] == topic["topic_id"]
+
+    def test_promote_rejects_nonexistent_entity(self, temp_db):
+        r1 = ss.record_signal("precedent_miss", "missed something")
+
+        result = ss.update_signal(
+            r1["id"], "promoted", promoted_type="topic", promoted_id=999999
+        )
+
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_partial_promoted_args_rejected(self, temp_db):
+        r1 = ss.record_signal("friction", "a")
+
+        result = ss.update_signal(r1["id"], "triaged", promoted_type="topic")
+
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_invalid_promoted_type_rejected(self, temp_db):
+        r1 = ss.record_signal("friction", "a")
+
+        result = ss.update_signal(
+            r1["id"], "triaged", promoted_type="tag", promoted_id=1
+        )
+
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_invalid_status_rejected(self, temp_db):
+        r1 = ss.record_signal("friction", "a")
+
+        result = ss.update_signal(r1["id"], "not_a_status")
+
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_nonexistent_signal_returns_not_found(self, temp_db):
+        result = ss.update_signal(999999, "triaged")
+        assert result["error"]["code"] == "NOT_FOUND"
+
+    def test_preserves_existing_promotion_when_omitted(self, temp_db):
+        from src.services.topic_service import add_topic
+
+        topic = add_topic(title="t", description="d", tags=["domain:test"])
+        r1 = ss.record_signal("precedent_miss", "missed something")
+        ss.update_signal(r1["id"], "promoted", promoted_type="topic", promoted_id=topic["topic_id"])
+
+        result = ss.update_signal(r1["id"], "dismissed")
+
+        assert result["signal"]["status"] == "dismissed"
+        assert result["signal"]["promoted_type"] == "topic"
+        assert result["signal"]["promoted_id"] == topic["topic_id"]

--- a/tests/unit/test_signal_service.py
+++ b/tests/unit/test_signal_service.py
@@ -68,6 +68,41 @@ def test_record_signal_dedups_same_fingerprint(temp_db):
     assert rows[0]["detail"] == "second"
 
 
+def test_record_signal_dedup_updates_refs_context_session_id(temp_db):
+    """dedup 時に refs / context / session_id が最新 occurrence の値で上書きされる。"""
+    r1 = ss.record_signal(
+        "contradiction",
+        "X contradicts Y",
+        source="agent",
+        refs=[{"type": "decision", "id": 1}, {"type": "decision", "id": 2}],
+        context={"resolution": "old_correct"},
+        session_id="sess-1",
+    )
+    r2 = ss.record_signal(
+        "contradiction",
+        "X contradicts Y",
+        source="agent",
+        refs=[{"type": "decision", "id": 1}, {"type": "decision", "id": 3}],
+        context={"resolution": "new_correct"},
+        session_id="sess-2",
+    )
+
+    assert r2["id"] == r1["id"]
+    assert r2["deduped"] is True
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM signal_events WHERE id = ?", (r1["id"],)
+        ).fetchone()
+    finally:
+        conn.close()
+    signal = ss._signal_row_to_dict(row)
+    assert signal["refs"] == [{"type": "decision", "id": 1}, {"type": "decision", "id": 3}]
+    assert signal["context"] == {"resolution": "new_correct"}
+    assert signal["session_id"] == "sess-2"
+
+
 def test_record_signal_does_not_dedup_after_triage(temp_db):
     r1 = ss.record_signal("machine_error", "Something broke", source="tool:foo")
     ss.update_signal(r1["id"], "triaged")
@@ -153,6 +188,19 @@ class TestGetSignals:
 
         assert result["total_count"] == 1
         assert result["signals"][0]["kind"] == "friction"
+
+    def test_status_and_kind_filter_combined(self, temp_db):
+        r1 = ss.record_signal("machine_error", "a", source="s1")
+        ss.update_signal(r1["id"], "dismissed")  # machine_error / dismissed
+        ss.record_signal("machine_error", "b", source="s2")  # machine_error / new
+        ss.record_signal("friction", "c", source="s3")  # friction / new
+
+        result = ss.get_signals(status="new", kind="machine_error")
+
+        assert result["total_count"] == 1
+        assert result["signals"][0]["summary"] == "b"
+        assert result["signals"][0]["kind"] == "machine_error"
+        assert result["signals"][0]["status"] == "new"
 
     def test_invalid_status_returns_validation_error(self, temp_db):
         result = ss.get_signals(status="not_a_status")
@@ -256,6 +304,47 @@ class TestUpdateSignal:
     def test_nonexistent_signal_returns_not_found(self, temp_db):
         result = ss.update_signal(999999, "triaged")
         assert result["error"]["code"] == "NOT_FOUND"
+
+    def _set_last_seen_at(self, signal_id, value):
+        conn = get_connection()
+        try:
+            conn.execute(
+                "UPDATE signal_events SET last_seen_at = ? WHERE id = ?",
+                (value, signal_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _read_last_seen_at(self, signal_id):
+        conn = get_connection()
+        try:
+            return conn.execute(
+                "SELECT last_seen_at FROM signal_events WHERE id = ?", (signal_id,)
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_status_transition_does_not_touch_last_seen_at(self, temp_db):
+        r1 = ss.record_signal("friction", "a")
+        self._set_last_seen_at(r1["id"], "2020-01-01 00:00:00")
+
+        ss.update_signal(r1["id"], "dismissed")
+
+        assert self._read_last_seen_at(r1["id"]) == "2020-01-01 00:00:00"
+
+    def test_promote_does_not_touch_last_seen_at(self, temp_db):
+        from src.services.topic_service import add_topic
+
+        topic = add_topic(title="t", description="d", tags=["domain:test"])
+        r1 = ss.record_signal("precedent_miss", "missed something")
+        self._set_last_seen_at(r1["id"], "2020-01-01 00:00:00")
+
+        ss.update_signal(
+            r1["id"], "promoted", promoted_type="topic", promoted_id=topic["topic_id"]
+        )
+
+        assert self._read_last_seen_at(r1["id"]) == "2020-01-01 00:00:00"
 
     def test_preserves_existing_promotion_when_omitted(self, temp_db):
         from src.services.topic_service import add_topic

--- a/tests/unit/test_signal_tools.py
+++ b/tests/unit/test_signal_tools.py
@@ -1,0 +1,67 @@
+"""report_signal / get_signals / update_signal MCPツールのユニットテスト
+
+src.main 経由の統合的な挙動 (validationエラーのdict化、capability gating) を
+検証する。record_signal/get_signals/update_signalの詳細な分岐は
+tests/unit/test_signal_service.py が担う。
+"""
+import pytest
+
+from src.main import report_signal, get_signals, update_signal
+from src.services.guard_service import CapabilityError
+
+
+class TestReportSignalTool:
+    def test_records_and_returns_id(self, temp_db):
+        result = report_signal("machine_error", "boom")
+        assert "id" in result
+        assert result["deduped"] is False
+
+    def test_invalid_kind_returns_validation_error_dict_not_raise(self, temp_db):
+        result = report_signal("not_a_kind", "boom")
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_empty_summary_returns_validation_error_dict_not_raise(self, temp_db):
+        result = report_signal("friction", "")
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestGetSignalsTool:
+    def test_returns_reported_signal(self, temp_db):
+        report_signal("friction", "使いにくい")
+
+        result = get_signals()
+
+        assert result["total_count"] == 1
+        assert result["signals"][0]["summary"] == "使いにくい"
+
+
+class TestUpdateSignalTool:
+    def test_orch_can_update(self, temp_db, monkeypatch):
+        monkeypatch.setenv("OW_ROLE", "orch")
+        created = report_signal("friction", "a")
+
+        result = update_signal(created["id"], "triaged")
+
+        assert result["signal"]["status"] == "triaged"
+
+    def test_worker_is_blocked(self, temp_db, monkeypatch):
+        created = report_signal("friction", "a")
+        monkeypatch.setenv("OW_ROLE", "worker")
+
+        with pytest.raises(CapabilityError):
+            update_signal(created["id"], "triaged")
+
+    def test_dispatcher_is_blocked(self, temp_db, monkeypatch):
+        created = report_signal("friction", "a")
+        monkeypatch.setenv("OW_ROLE", "dispatcher")
+
+        with pytest.raises(CapabilityError):
+            update_signal(created["id"], "triaged")
+
+    def test_non_ow_session_can_update(self, temp_db):
+        """非owセッション(role未解決)はcheck_capabilityのbackward compatで通過する。"""
+        created = report_signal("friction", "a")
+
+        result = update_signal(created["id"], "triaged")
+
+        assert result["signal"]["status"] == "triaged"


### PR DESCRIPTION
> 夜間自走実装（ユーザー不在中の自動実装）。レビュー前提、マージしないでください。

## 概要

cc-memory 自身の故障・使用感の不満・矛盾検出・運用計測イベントを記録する統一入口が存在せず、気づいた問題がその場で消えていた。`report_signal` / `get_signals` / `update_signal` の3ツールを追加し、これらのイベントを専用テーブル (`signal_events`) に記録・一覧・トリアージできるようにする。

- `report_signal` は machine_error / friction / contradiction / precedent_miss / precedent_misapplied / boundary_case / rollback の7種類のイベントを記録する。kind の妥当性は DB 制約ではなく Python 層で検証し、種別追加を migration 不要にしている
- 同一内容 (kind + source + 正規化summary のフィンガープリント) の再報告は自動集約され (`occurrence_count` 加算)、テーブルが際限なく伸びない。トリアージ済み (new 以外) になったイベントが再発した場合は新規行として記録される（直したはずの故障が再浮上したことが分かるようにするため）
- `report_signal` / `get_signals` は orch / dispatcher / worker の全 role に開放しており、worker セッションからも摩擦なく観測を書ける。`update_signal` によるトリアージ状態遷移のみ orch 専用に制限する
- 全 MCP ツール呼び出しに横断適用する middleware (`SignalCaptureMiddleware`) を追加した。ツール内で未捕捉例外が発生すると自動的に machine_error として記録した上で、例外はそのまま呼び出し元に返す（挙動不変）。role guard による正常な拒否 (CapabilityError) は記録対象から除外する。記録処理自体の失敗はツール呼び出しの結果に一切影響しない

## 補足

- 本 PR は品質投資コンポーネント設計における独立した1系列であり、依存 PR は無い。ただし今後別の複数 PR (運用計測イベント集計、境界判定の shadow 突合ミラー記録) がこのテーブルへの書き込みを前提にする想定になっている
- migration 番号は実装時点の最新 (0048) に対し 0049 を採番した。並行して進む他 PR も同じ番号を採番する可能性があるが、実際のマージ順で若い番号側が確定する運用のため許容している
- hooks からの自動捕捉・SessionStart への未トリアージ件数表示・サーバーログの永続化は本 PR のスコープ外（別 PR で対応予定）

## テスト計画

- migration: signal_events テーブルの列・索引が期待通り作成されること、CHECK 制約 (status の許容値、promoted_type/promoted_id の対称性) が DB レベルで機能すること、fingerprint の部分 UNIQUE インデックスが `status='new'` の行にのみ効くこと（`dismissed` 等に遷移した後は同一 fingerprint でも新規行を作れること）を検証
- signal_service: 不正な kind・空summary・JSON化不能な refs/context を拒否すること、同一フィンガープリントの新規重複が集約されること・kind/source が違えば集約されないこと、`get_signals` の status/kind フィルタと集計 (`include_stats`) が正しいこと、`update_signal` が昇格先エンティティの実在確認を行うこと・promoted_type/promoted_id を省略した場合は既存の紐付けを保持すること
- middleware: ツール呼び出し中の未捕捉例外が machine_error として記録されつつ元の例外がそのまま伝播すること、CapabilityError は記録対象外であること、記録に使う引数ダイジェストに生の引数値を含めず key と型のみが残ること
- MCP tool層: `report_signal` の validation エラーが例外ではなく通常のエラーレスポンスとして返ること、`update_signal` を worker/dispatcher role から呼ぶと拒否されること
- 既存テスト (`tests/unit` 全2052件、`tests/test_migrations`・`tests/services`・`tests/integration`・`tests/e2e`) が全てパスすることを確認し、既存挙動への影響が無いことを確認した
