### PR TITLE
migration番号0049/0050の衝突を解消

### DIFF
--- a/migrations/0050_add_topic_vec.sql
+++ b/migrations/0050_add_topic_vec.sql
@@ -1,4 +1,4 @@
--- Migration 0049: topic_vec 仮想テーブル追加（topic 専用ベクトル索引）
+-- Migration 0050: topic_vec 仮想テーブル追加（topic 専用ベクトル索引）
 --
 -- depends: 0048_session_identity
 --

--- a/migrations/0051_add_precedent_telemetry.sql
+++ b/migrations/0051_add_precedent_telemetry.sql
@@ -1,6 +1,6 @@
--- Migration 0050: precedent_telemetry テーブル追加
+-- Migration 0051: precedent_telemetry テーブル追加
 --
--- depends: 0049_add_topic_vec
+-- depends: 0050_add_topic_vec
 --
 -- 背景:
 --   判例（decision）を topic 単位で網羅列挙して提示する機能のための計測テーブル。

--- a/migrations/0052_add_tag_junction_indexes.sql
+++ b/migrations/0052_add_tag_junction_indexes.sql
@@ -1,4 +1,4 @@
--- Migration 049: タグjunctionテーブルへのtag_id逆引きindex + search_index.created_atのindex
+-- Migration 0052: タグjunctionテーブルへのtag_id逆引きindex + search_index.created_atのindex
 --
 -- depends: 0048_session_identity
 --

--- a/migrations/0053_cleanup_vec_orphans.sql
+++ b/migrations/0053_cleanup_vec_orphans.sql
@@ -1,6 +1,6 @@
--- Migration 050: vec_index孤児行の掃除
+-- Migration 0053: vec_index孤児行の掃除
 --
--- depends: 0049_add_tag_junction_indexes
+-- depends: 0052_add_tag_junction_indexes
 --
 -- 背景:
 --   vec_indexはsearch_indexのidと同値のrowidで運用される仮想テーブルだが、

--- a/migrations/0054_extend_search_telemetry.sql
+++ b/migrations/0054_extend_search_telemetry.sql
@@ -1,4 +1,4 @@
--- Migration 0049: search_telemetry に results_json / diagnostics_json を追加 + fetch_telemetry 新設
+-- Migration 0054: search_telemetry に results_json / diagnostics_json を追加 + fetch_telemetry 新設
 --
 -- depends: 0048_session_identity
 --

--- a/tests/test_migrations/test_0050_add_topic_vec.py
+++ b/tests/test_migrations/test_0050_add_topic_vec.py
@@ -1,6 +1,6 @@
-"""migration 0049_add_topic_vec のテスト
+"""migration 0050_add_topic_vec のテスト
 
-0049 適用後に topic_vec 仮想テーブルが作成され、rowid をキーにした
+0050 適用後に topic_vec 仮想テーブルが作成され、rowid をキーにした
 ベクトルの INSERT / KNN 検索ができることを確認する。
 """
 import os
@@ -21,7 +21,7 @@ EMBEDDING_DIM = 384
 
 @pytest.fixture
 def migrated_db():
-    """全 migration（0049 含む）を適用済みのテスト用 DB を提供する。"""
+    """全 migration（0050 含む）を適用済みのテスト用 DB を提供する。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -33,8 +33,8 @@ def migrated_db():
 
 
 @pytest.fixture
-def db_before_0049():
-    """0048 までの migration を適用した DB を提供する。0049 の挙動を分離検証するために使う。"""
+def db_before_0050():
+    """0048 までの migration を適用した DB を提供する。0050 の挙動を分離検証するために使う。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -43,9 +43,9 @@ def db_before_0049():
         backend = _VecSQLiteBackend(parsed, default_migration_table)
         backend.init_database()
         all_migs = read_migrations(str(MIGRATIONS_DIR))
-        pre_0049 = MigrationList([m for m in all_migs if m.id < "0049"])
+        pre_0050 = MigrationList([m for m in all_migs if m.id < "0050"])
         with backend.lock():
-            backend.apply_migrations(pre_0049)
+            backend.apply_migrations(pre_0050)
 
         _injected_tags.clear()
         yield db_path
@@ -53,33 +53,33 @@ def db_before_0049():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
-def _apply_migration_0049(db_path: str) -> None:
-    """db_path に対して migration 0049 のみを適用する。"""
+def _apply_migration_0050(db_path: str) -> None:
+    """db_path に対して migration 0050 のみを適用する。"""
     parsed = parse_uri(f"sqlite:///{db_path}")
     backend = _VecSQLiteBackend(parsed, default_migration_table)
     all_migs = read_migrations(str(MIGRATIONS_DIR))
-    only_0049 = MigrationList([m for m in all_migs if m.id.startswith("0049")])
+    only_0050 = MigrationList([m for m in all_migs if m.id.startswith("0050")])
     with backend.lock():
-        backend.apply_migrations(only_0049)
+        backend.apply_migrations(only_0050)
 
 
 class TestTopicVecTableCreated:
-    def test_topic_vec_table_exists_after_0049(self, migrated_db):
-        """migration 0049 適用後、topic_vec テーブルが存在する"""
+    def test_topic_vec_table_exists_after_0050(self, migrated_db):
+        """migration 0050 適用後、topic_vec テーブルが存在する"""
         conn = get_connection()
         try:
             assert table_exists(conn, "topic_vec"), (
-                "topic_vec テーブルが 0049 適用後に存在しない"
+                "topic_vec テーブルが 0050 適用後に存在しない"
             )
         finally:
             conn.close()
 
-    def test_topic_vec_table_not_exists_before_0049(self, db_before_0049):
-        """0049 適用前は topic_vec テーブルが存在しない（前提確認）"""
+    def test_topic_vec_table_not_exists_before_0050(self, db_before_0050):
+        """0050 適用前は topic_vec テーブルが存在しない（前提確認）"""
         conn = get_connection()
         try:
             assert not table_exists(conn, "topic_vec"), (
-                "0049 適用前に topic_vec テーブルが既に存在している"
+                "0050 適用前に topic_vec テーブルが既に存在している"
             )
         finally:
             conn.close()

--- a/tests/test_migrations/test_0051_add_precedent_telemetry.py
+++ b/tests/test_migrations/test_0051_add_precedent_telemetry.py
@@ -1,6 +1,6 @@
-"""migration 0050_add_precedent_telemetry のテスト
+"""migration 0051_add_precedent_telemetry のテスト
 
-0050 適用後に precedent_telemetry テーブルとタイムスタンプ index が作成され、
+0051 適用後に precedent_telemetry テーブルとタイムスタンプ index が作成され、
 NOT NULL 制約とデフォルト timestamp が機能することを確認する。
 """
 import os
@@ -19,7 +19,7 @@ from test_migrations.conftest import get_column_names, index_names, table_exists
 
 @pytest.fixture
 def migrated_db():
-    """全 migration（0050 含む）を適用済みのテスト用 DB を提供する。"""
+    """全 migration（0051 含む）を適用済みのテスト用 DB を提供する。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -31,8 +31,8 @@ def migrated_db():
 
 
 @pytest.fixture
-def db_before_0050():
-    """0049 までの migration を適用した DB を提供する。0050 の挙動を分離検証するために使う。"""
+def db_before_0051():
+    """0050 までの migration を適用した DB を提供する。0051 の挙動を分離検証するために使う。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -41,9 +41,9 @@ def db_before_0050():
         backend = _VecSQLiteBackend(parsed, default_migration_table)
         backend.init_database()
         all_migs = read_migrations(str(MIGRATIONS_DIR))
-        pre_0050 = MigrationList([m for m in all_migs if m.id < "0050"])
+        pre_0051 = MigrationList([m for m in all_migs if m.id < "0051"])
         with backend.lock():
-            backend.apply_migrations(pre_0050)
+            backend.apply_migrations(pre_0051)
 
         _injected_tags.clear()
         yield db_path
@@ -52,28 +52,28 @@ def db_before_0050():
 
 
 class TestPrecedentTelemetryTableCreated:
-    def test_table_exists_after_0050(self, migrated_db):
-        """migration 0050 適用後、precedent_telemetry テーブルが存在する"""
+    def test_table_exists_after_0051(self, migrated_db):
+        """migration 0051 適用後、precedent_telemetry テーブルが存在する"""
         conn = get_connection()
         try:
             assert table_exists(conn, "precedent_telemetry"), (
-                "precedent_telemetry テーブルが 0050 適用後に存在しない"
+                "precedent_telemetry テーブルが 0051 適用後に存在しない"
             )
         finally:
             conn.close()
 
-    def test_table_not_exists_before_0050(self, db_before_0050):
-        """0050 適用前は precedent_telemetry テーブルが存在しない（前提確認）"""
+    def test_table_not_exists_before_0051(self, db_before_0051):
+        """0051 適用前は precedent_telemetry テーブルが存在しない（前提確認）"""
         conn = get_connection()
         try:
             assert not table_exists(conn, "precedent_telemetry"), (
-                "0050 適用前に precedent_telemetry テーブルが既に存在している"
+                "0051 適用前に precedent_telemetry テーブルが既に存在している"
             )
         finally:
             conn.close()
 
     def test_required_columns_exist(self, migrated_db):
-        """0050 適用後、precedent_telemetry テーブルに必須カラムが全部存在する"""
+        """0051 適用後、precedent_telemetry テーブルに必須カラムが全部存在する"""
         conn = get_connection()
         try:
             column_names = get_column_names(conn, "precedent_telemetry")
@@ -89,13 +89,13 @@ class TestPrecedentTelemetryTableCreated:
             }
             for col in required:
                 assert col in column_names, (
-                    f"precedent_telemetry.{col} が 0050 適用後に存在しない"
+                    f"precedent_telemetry.{col} が 0051 適用後に存在しない"
                 )
         finally:
             conn.close()
 
     def test_timestamp_index_created(self, migrated_db):
-        """0050 適用後、timestamp に index が作成されている"""
+        """0051 適用後、timestamp に index が作成されている"""
         conn = get_connection()
         try:
             idx_names = index_names(conn, "idx_precedent_telemetry_%")

--- a/tests/test_migrations/test_0052_add_tag_junction_indexes.py
+++ b/tests/test_migrations/test_0052_add_tag_junction_indexes.py
@@ -1,6 +1,6 @@
-"""migration 0049_add_tag_junction_indexes のテスト
+"""migration 0052_add_tag_junction_indexes のテスト
 
-0049 適用後に topic_tags / activity_tags / decision_tags / log_tags への
+0052 適用後に topic_tags / activity_tags / decision_tags / log_tags への
 tag_id 逆引き index と search_index(created_at) の index が作成され、
 既存データ・タグフィルタ結果が変わらないことを確認する。
 """
@@ -19,7 +19,7 @@ from test_migrations.conftest import index_names
 
 @pytest.fixture
 def migrated_db():
-    """全 migration（0049 含む）を適用済みのテスト用 DB を提供する。"""
+    """全 migration（0052 含む）を適用済みのテスト用 DB を提供する。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -31,8 +31,8 @@ def migrated_db():
 
 
 @pytest.fixture
-def db_before_0049():
-    """0048 までの migration を適用した DB を提供する。0049 の挙動を分離検証するために使う。"""
+def db_before_0052():
+    """0048 までの migration を適用した DB を提供する。0052 の挙動を分離検証するために使う。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -41,9 +41,9 @@ def db_before_0049():
         backend = _VecSQLiteBackend(parsed, default_migration_table)
         backend.init_database()
         all_migs = read_migrations(str(MIGRATIONS_DIR))
-        pre_0049 = MigrationList([m for m in all_migs if m.id < "0049"])
+        pre_0052 = MigrationList([m for m in all_migs if m.id < "0052"])
         with backend.lock():
-            backend.apply_migrations(pre_0049)
+            backend.apply_migrations(pre_0052)
 
         _injected_tags.clear()
         yield db_path
@@ -51,18 +51,18 @@ def db_before_0049():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
-def _apply_migration_0049(db_path: str) -> None:
-    """db_path に対して migration 0049 のみを適用する。"""
+def _apply_migration_0052(db_path: str) -> None:
+    """db_path に対して migration 0052 のみを適用する。"""
     parsed = parse_uri(f"sqlite:///{db_path}")
     backend = _VecSQLiteBackend(parsed, default_migration_table)
     all_migs = read_migrations(str(MIGRATIONS_DIR))
-    only_0049 = MigrationList([m for m in all_migs if m.id.startswith("0049")])
+    only_0052 = MigrationList([m for m in all_migs if m.id.startswith("0052")])
     with backend.lock():
-        backend.apply_migrations(only_0049)
+        backend.apply_migrations(only_0052)
 
 
 class TestIndexesCreated:
-    """0049 適用後に 5 本の index が作成されることの確認"""
+    """0052 適用後に 5 本の index が作成されることの確認"""
 
     EXPECTED_INDEXES = {
         "idx_topic_tags_tag",
@@ -72,8 +72,8 @@ class TestIndexesCreated:
         "idx_search_index_created_at",
     }
 
-    def test_indexes_exist_after_0049(self, migrated_db):
-        """0049 適用後、5 本の index すべてが sqlite_master に存在する"""
+    def test_indexes_exist_after_0052(self, migrated_db):
+        """0052 適用後、5 本の index すべてが sqlite_master に存在する"""
         conn = get_connection()
         try:
             existing = set()
@@ -82,12 +82,12 @@ class TestIndexesCreated:
                              "idx_search_index_created_at"]:
                 existing |= index_names(conn, pattern)
             for idx in self.EXPECTED_INDEXES:
-                assert idx in existing, f"インデックス {idx} が 0049 適用後に存在しない"
+                assert idx in existing, f"インデックス {idx} が 0052 適用後に存在しない"
         finally:
             conn.close()
 
-    def test_indexes_not_exist_before_0049(self, db_before_0049):
-        """0049 適用前は 5 本の index がいずれも存在しない（前提確認）"""
+    def test_indexes_not_exist_before_0052(self, db_before_0052):
+        """0052 適用前は 5 本の index がいずれも存在しない（前提確認）"""
         conn = get_connection()
         try:
             existing = set()
@@ -96,7 +96,7 @@ class TestIndexesCreated:
                              "idx_search_index_created_at"]:
                 existing |= index_names(conn, pattern)
             assert existing.isdisjoint(self.EXPECTED_INDEXES), (
-                "0049 適用前に対象インデックスが既に存在している"
+                "0052 適用前に対象インデックスが既に存在している"
             )
         finally:
             conn.close()
@@ -133,10 +133,10 @@ class TestIndexesCreated:
 
 
 class TestExistingDataPreserved:
-    """0049 適用前に投入したタグ紐付けデータが、適用後も破壊されないことの確認"""
+    """0052 適用前に投入したタグ紐付けデータが、適用後も破壊されないことの確認"""
 
-    def test_existing_tag_links_preserved(self, db_before_0049):
-        """0049 適用前の topic_tags / activity_tags / decision_tags / log_tags 行は
+    def test_existing_tag_links_preserved(self, db_before_0052):
+        """0052 適用前の topic_tags / activity_tags / decision_tags / log_tags 行は
         適用後も残る"""
         conn = get_connection()
         try:
@@ -171,7 +171,7 @@ class TestExistingDataPreserved:
         finally:
             conn.close()
 
-        _apply_migration_0049(db_before_0049)
+        _apply_migration_0052(db_before_0052)
 
         conn = get_connection()
         try:

--- a/tests/test_migrations/test_0053_cleanup_vec_orphans.py
+++ b/tests/test_migrations/test_0053_cleanup_vec_orphans.py
@@ -1,6 +1,6 @@
-"""migration 0050_cleanup_vec_orphans のテスト
+"""migration 0053_cleanup_vec_orphans のテスト
 
-0050 適用後に、対応する search_index 行を持たない vec_index の孤児行が削除され、
+0053 適用後に、対応する search_index 行を持たない vec_index の孤児行が削除され、
 対応行を持つ vec_index 行は 1 行も消えないことを確認する。
 """
 import os
@@ -19,8 +19,8 @@ EMBEDDING_DIM = 384
 
 
 @pytest.fixture
-def db_before_0050():
-    """0049 までの migration を適用した DB を提供する。0050 の挙動を分離検証するために使う。"""
+def db_before_0053():
+    """0052 までの migration を適用した DB を提供する。0053 の挙動を分離検証するために使う。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         os.environ["DISCUSSION_DB_PATH"] = db_path
@@ -29,9 +29,9 @@ def db_before_0050():
         backend = _VecSQLiteBackend(parsed, default_migration_table)
         backend.init_database()
         all_migs = read_migrations(str(MIGRATIONS_DIR))
-        pre_0050 = MigrationList([m for m in all_migs if m.id < "0050"])
+        pre_0053 = MigrationList([m for m in all_migs if m.id < "0053"])
         with backend.lock():
-            backend.apply_migrations(pre_0050)
+            backend.apply_migrations(pre_0053)
 
         _injected_tags.clear()
         yield db_path
@@ -39,14 +39,14 @@ def db_before_0050():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
-def _apply_migration_0050(db_path: str) -> None:
-    """db_path に対して migration 0050 のみを適用する。"""
+def _apply_migration_0053(db_path: str) -> None:
+    """db_path に対して migration 0053 のみを適用する。"""
     parsed = parse_uri(f"sqlite:///{db_path}")
     backend = _VecSQLiteBackend(parsed, default_migration_table)
     all_migs = read_migrations(str(MIGRATIONS_DIR))
-    only_0050 = MigrationList([m for m in all_migs if m.id.startswith("0050")])
+    only_0053 = MigrationList([m for m in all_migs if m.id.startswith("0053")])
     with backend.lock():
-        backend.apply_migrations(only_0050)
+        backend.apply_migrations(only_0053)
 
 
 def _make_embedding(seed: float) -> bytes:
@@ -54,10 +54,10 @@ def _make_embedding(seed: float) -> bytes:
 
 
 class TestOrphanRowsRemoved:
-    """search_index に対応行の無い vec_index 行が 0050 適用で削除されることの確認"""
+    """search_index に対応行の無い vec_index 行が 0053 適用で削除されることの確認"""
 
-    def test_orphan_vec_rows_deleted_after_0050(self, db_before_0050):
-        """search_index に無い rowid を持つ vec_index 行は 0050 適用後に消える"""
+    def test_orphan_vec_rows_deleted_after_0053(self, db_before_0053):
+        """search_index に無い rowid を持つ vec_index 行は 0053 適用後に消える"""
         conn = get_connection()
         try:
             # 実エンティティ（search_indexに行がある）
@@ -93,7 +93,7 @@ class TestOrphanRowsRemoved:
         finally:
             conn.close()
 
-        _apply_migration_0050(db_before_0050)
+        _apply_migration_0053(db_before_0053)
 
         conn = get_connection()
         try:
@@ -102,7 +102,7 @@ class TestOrphanRowsRemoved:
                 for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
             }
             assert orphan_rowid not in rowids_after, (
-                "search_index に対応行の無い孤児 vec_index 行が 0050 適用後も残っている"
+                "search_index に対応行の無い孤児 vec_index 行が 0053 適用後も残っている"
             )
             assert real_search_id in rowids_after, (
                 "search_index に対応行のある vec_index 行が誤って削除された"
@@ -110,7 +110,7 @@ class TestOrphanRowsRemoved:
         finally:
             conn.close()
 
-    def test_multiple_orphans_all_removed(self, db_before_0050):
+    def test_multiple_orphans_all_removed(self, db_before_0053):
         """複数の孤児行がすべて削除される"""
         conn = get_connection()
         try:
@@ -124,7 +124,7 @@ class TestOrphanRowsRemoved:
         finally:
             conn.close()
 
-        _apply_migration_0050(db_before_0050)
+        _apply_migration_0053(db_before_0053)
 
         conn = get_connection()
         try:
@@ -141,8 +141,8 @@ class TestOrphanRowsRemoved:
 class TestNonOrphanRowsPreserved:
     """search_index に対応行を持つ vec_index 行が 1 行も消えないことの確認"""
 
-    def test_all_valid_vec_rows_survive_migration(self, db_before_0050):
-        """search_index の全行に対応する vec_index 行を作った状態で 0050 を適用しても、
+    def test_all_valid_vec_rows_survive_migration(self, db_before_0053):
+        """search_index の全行に対応する vec_index 行を作った状態で 0053 を適用しても、
         1 行も消えない"""
         conn = get_connection()
         try:
@@ -172,7 +172,7 @@ class TestNonOrphanRowsPreserved:
         finally:
             conn.close()
 
-        _apply_migration_0050(db_before_0050)
+        _apply_migration_0053(db_before_0053)
 
         conn = get_connection()
         try:
@@ -180,7 +180,7 @@ class TestNonOrphanRowsPreserved:
                 "SELECT COUNT(*) AS c FROM vec_index"
             ).fetchone()["c"]
             assert after_count == before_count, (
-                "search_index に対応行を持つ vec_index 行が 0050 適用で減ってしまった"
+                "search_index に対応行を持つ vec_index 行が 0053 適用で減ってしまった"
             )
             remaining = {
                 row["rowid"]
@@ -190,9 +190,9 @@ class TestNonOrphanRowsPreserved:
         finally:
             conn.close()
 
-    def test_no_orphans_no_op(self, db_before_0050):
+    def test_no_orphans_no_op(self, db_before_0053):
         """孤児が 1 行も無い状態（vec_index の全行が search_index の行に対応）で
-        0050 を適用しても、vec_index の行は 1 行も削除されないことを確認する。
+        0053 を適用しても、vec_index の行は 1 行も削除されないことを確認する。
 
         search_index には行があるが vec_index には対応行が無いエントリを混在させ、
         それらが誤って削除の巻き添えにならないことも合わせて確認する。
@@ -231,7 +231,7 @@ class TestNonOrphanRowsPreserved:
         finally:
             conn.close()
 
-        _apply_migration_0050(db_before_0050)
+        _apply_migration_0053(db_before_0053)
 
         conn = get_connection()
         try:
@@ -240,7 +240,7 @@ class TestNonOrphanRowsPreserved:
                 for row in conn.execute("SELECT rowid FROM vec_index").fetchall()
             }
             assert after == before, (
-                "孤児が 1 行も無い状態で 0050 が vec_index の行を削除してしまった"
+                "孤児が 1 行も無い状態で 0053 が vec_index の行を削除してしまった"
             )
         finally:
             conn.close()

--- a/tests/unit/test_search_telemetry.py
+++ b/tests/unit/test_search_telemetry.py
@@ -113,7 +113,7 @@ def _fetch_all_fetch_telemetry():
 
 
 def test_search_telemetry_table_schema(temp_db):
-    """migration 0041 + 0049 で search_telemetry テーブルと必要なカラムが作られる"""
+    """migration 0041 + 0054 で search_telemetry テーブルと必要なカラムが作られる"""
     conn = get_connection()
     try:
         rows = conn.execute("PRAGMA table_info(search_telemetry)").fetchall()
@@ -149,7 +149,7 @@ def test_search_telemetry_index_on_timestamp(temp_db):
 
 
 def test_fetch_telemetry_table_schema(temp_db):
-    """migration 0049 で fetch_telemetry テーブルと必要なカラムが作られる"""
+    """migration 0054 で fetch_telemetry テーブルと必要なカラムが作られる"""
     conn = get_connection()
     try:
         rows = conn.execute("PRAGMA table_info(fetch_telemetry)").fetchall()


### PR DESCRIPTION
## 概要

夜間実装バッチで並行実装された複数PRが、`0048_session_identity` の直後を狙って独立にmigration番号を採番した結果、`0049` を4本、`0050` を2本のファイルが名乗る状態になっていた。ファイル名自体は別物のためmigrationフレームワーク（yoyo）の依存解決自体は壊れていなかったが、番号だけでは実際の適用順序を人間が追えず、以後の新規migrationも0051からで良いのか判断できない状態だった。

マージが完了した順に沿って `0050`〜`0054` へ振り直した。

- `0049_add_topic_vec.sql` → `0050_add_topic_vec.sql`
- `0050_add_precedent_telemetry.sql` → `0051_add_precedent_telemetry.sql`（depends を `0050_add_topic_vec` に更新）
- `0049_add_tag_junction_indexes.sql` → `0052_add_tag_junction_indexes.sql`
- `0050_cleanup_vec_orphans.sql` → `0053_cleanup_vec_orphans.sql`（depends を `0052_add_tag_junction_indexes` に更新）
- `0049_extend_search_telemetry.sql` → `0054_extend_search_telemetry.sql`

`0049_add_signal_events.sql` は最初にマージされた分のためそのまま。

対応するテストファイルもリネームし、ファイル内の比較文字列・docstringの番号言及を新番号に合わせて更新した。

## テスト計画

- 全migrationテスト（`tests/test_migrations/`）が新しい番号・依存関係で通ることを確認
- リネーム対象migrationに関連する `tests/unit/test_search_telemetry.py` / `tests/unit/test_topic_vec.py` も合わせて確認
- 既存のunitテスト全体（2430件、既存1件skip）を実行し、回帰がないことを確認