### PR TITLE
backup_serviceのlock_file参照をsrc.infra配下に追従させる

### DIFF
--- a/src/services/backup_service.py
+++ b/src/services/backup_service.py
@@ -556,8 +556,8 @@ def _check_health_endpoint(timeout: float = 2.0) -> bool:
 
 def _server_appears_running() -> tuple[bool, str]:
     """lock file生存 または /healthエンドポイント応答のいずれかでrunningと判定する。"""
-    from src.services.lock_file import is_process_alive
-    from src.services.lock_file import read as read_lock
+    from src.infra.lock_file import is_process_alive
+    from src.infra.lock_file import read as read_lock
 
     reasons = []
     running = False

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from src.infra import lock_file
 from src.services import backup_service as bs
-from src.services import lock_file
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- サービス層の物理配置整理（#475）で `lock_file.py` が `src/services` から `src/infra` へ移動したが、`backup_service.py` の遅延import（`_server_appears_running`内）と `test_backup_service.py` のimportが旧パスのままだった
- `test_backup_service.py` は現在のmain上でpytest collection自体が失敗する状態（Test workflowがpull_request専用でmainへのマージ後に再実行されないため見逃されていた）

## Test plan
- [x] `tests/unit/test_backup_service.py` `tests/unit/test_lock_file.py` が通ることを確認（53 passed）
- [x] リポジトリ全体で他に `src.services.lock_file` / `src.services.session_manager` / `src.services.embedding_server` への古い参照が残っていないことを確認