### PR TITLE
fix: embedding serverの多重spawn競合とMCPセッション残留によるメモリリークを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,5 +34,5 @@ cc-memoryはローカルディレクトリをmarketplaceとして登録してお
 4. ローカルブランチを削除: `git branch -D <branch>`
 5. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
 6. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
-7. 既存のhttpサーバーを停止・再起動: `lsof -ti :52837 | xargs kill; uv run python -m src.launcher &`
+7. 既存のhttpサーバーを停止・再起動: `lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &`（`-sTCP:LISTEN` を付けないと :52837 に接続中のブリッジプロセスまで巻き添えで kill され、生存セッションの再接続競争を誘発する）
 8. Claude Codeセッションを再起動（個別でOK、全セッション同時に落とす必要なし）

--- a/src/infra/embedding_server.py
+++ b/src/infra/embedding_server.py
@@ -87,6 +87,17 @@ def _load_model():
         sys.exit(1)
 
 
+class EmbeddingHTTPServer(ThreadingHTTPServer):
+    """backlog を拡張した ThreadingHTTPServer。
+
+    bind はモデルロード前に行うため（main() 参照）、ロード中（accept 開始前）の
+    ヘルスチェック接続が listen backlog に溜まる。既定値 5 では数十秒のロード中に
+    枯渇して SYN がドロップされ、クライアント側から「ポート未 bind」と区別が
+    つかなくなるため余裕を持たせる。
+    """
+    request_queue_size = 128
+
+
 class EmbeddingHandler(BaseHTTPRequestHandler):
     """HTTPリクエストハンドラ"""
 
@@ -200,13 +211,19 @@ def _watchdog(server: ThreadingHTTPServer):
 
 def main():
     _setup_logging()
-    _load_model()
 
+    # bind をモデルロードより先に行う。多重起動の敗者判定は bind 失敗で行われるため、
+    # ロードを先にすると敗者も数百MBのモデルをロードし終えてから退場することになり、
+    # 並行 spawn 時にロード分のメモリが spawn 数だけ積み上がる。bind 済み・ロード中の
+    # 接続は backlog に溜まり、serve_forever 開始後に処理される（/health はロード完了
+    # まで応答しないので、クライアントは起動待ちを継続する）。
     try:
-        server = ThreadingHTTPServer((HOST, PORT), EmbeddingHandler)
+        server = EmbeddingHTTPServer((HOST, PORT), EmbeddingHandler)
     except OSError as e:
         logger.error(f"server_bind failed: {e}")
         sys.exit(1)
+
+    _load_model()
 
     logger.info(f"Embedding server listening on {HOST}:{PORT}")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -244,9 +244,14 @@ async def _bridge() -> None:
     # サーバー切断: server_to_stdoutが先に終了 → stdin_eofがFalse → ServerDisconnected
     stdin_eof = False
 
+    # terminate_on_close=True: 切断時に DELETE でMCPセッションを終了させる。
+    # ブリッジは再接続時にセッションを再利用せず毎回新規に張るため、DELETE を
+    # 送らないとサーバー側の StreamableHTTPSessionManager が旧セッション
+    # （タスク+トランスポート）をサーバー停止まで保持し続けてメモリが単調増加する。
+    # サーバー側切断が原因で閉じる場合の DELETE 失敗は SDK 内で握りつぶされる。
     async with streamable_http_client(
         url=MCP_ENDPOINT,
-        terminate_on_close=False,
+        terminate_on_close=True,
     ) as (read_stream, write_stream, _get_session_id):
 
         async def stdin_to_server() -> None:

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -72,6 +72,13 @@ _project_root_cache: Optional[str] = None
 # spawn する（各子プロセスがモデルロード分のメモリを確保する）。
 _spawn_lock = threading.Lock()
 
+# 起動失敗後の spawn 再試行クールダウン。モデルロードが恒久的に失敗する環境
+# （ネットワーク遮断等）で encode 呼び出しごとに spawn→即死ループになるのを防ぐ。
+# 子プロセスは失敗までに sentence_transformers の import 分のメモリを毎回確保する
+# ため、失敗直後の再 spawn は許可しない。_spawn_lock 保持中のみ読み書きする。
+_SPAWN_RETRY_COOLDOWN_SEC = 30.0
+_last_spawn_failed_at: Optional[float] = None
+
 
 def _get_project_root() -> str:
     """`_resolve_project_root()` の lazy + cache wrapper。
@@ -126,30 +133,40 @@ def _ensure_server_running() -> bool:
     spawn は _spawn_lock でプロセス内直列化する。ロック取得後の再チェックで
     先行スレッドが起動済みなら spawn しない。
     """
+    global _last_spawn_failed_at
     if _is_server_running():
         return True
     with _spawn_lock:
         # ロック待ちの間に別スレッドが起動を完了しているケース
         if _is_server_running():
             return True
+        if (
+            _last_spawn_failed_at is not None
+            and time.time() - _last_spawn_failed_at < _SPAWN_RETRY_COOLDOWN_SEC
+        ):
+            return False
         proc = _start_server()
         if proc is None:
+            _last_spawn_failed_at = time.time()
             return False
         # 最大30秒待機（0.5秒間隔 × 60回）
         for _ in range(60):
             time.sleep(0.5)
             if _is_server_running():
                 logger.info("Embedding server is ready")
+                _last_spawn_failed_at = None
                 return True
             if proc.poll() is not None:
                 # 子が終了済み。別プロセス起点のサーバーにbind負けした直後なら
                 # health が通るはずなので、最後にもう一度だけ確認してから諦める
                 if _is_server_running():
                     logger.info("Embedding server is ready")
+                    _last_spawn_failed_at = None
                     return True
                 logger.warning(
                     f"Embedding server exited early (returncode={proc.returncode})"
                 )
+                _last_spawn_failed_at = time.time()
                 return False
         # タイムアウト。bind 済み（= ロード進行中で、完了すれば応答する）なら生かし、
         # bind 前に固まっている子は回収する。放置すると stdout/stderr が DEVNULL の
@@ -167,6 +184,7 @@ def _ensure_server_running() -> bool:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+        _last_spawn_failed_at = time.time()
         return False
 
 

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from pathlib import Path
@@ -12,6 +13,7 @@ from typing import Optional
 from sqlite_vec import serialize_float32
 
 from src.db import execute_query, get_connection
+from src.infra.lock_file import is_port_listening
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +67,11 @@ _server_initialized = False
 _backfill_done = False
 _project_root_cache: Optional[str] = None
 
+# spawn 直列化ロック。FastMCP は sync ツールを threadpool で並行実行するため、
+# ロックなしだとサーバー停止中の並行呼び出しが全スレッド分の embedding_server を
+# spawn する（各子プロセスがモデルロード分のメモリを確保する）。
+_spawn_lock = threading.Lock()
+
 
 def _get_project_root() -> str:
     """`_resolve_project_root()` の lazy + cache wrapper。
@@ -88,18 +95,18 @@ def _is_server_running() -> bool:
         return False
 
 
-def _start_server() -> bool:
-    """embedding_server.pyをdetachedプロセスとして起動する。成功でTrue。"""
+def _start_server() -> Optional[subprocess.Popen]:
+    """embedding_server.pyをdetachedプロセスとして起動する。成功でPopen、失敗でNone。"""
     try:
         cwd = _get_project_root()
     except (RuntimeError, OSError) as e:
-        # project_root が解決できなければ起動も不可能。例外を握って False で返す
+        # project_root が解決できなければ起動も不可能。例外を握って None で返す
         # （呼び出し側 `_ensure_initialized` は False を graceful degradation として扱う）。
         logger.warning(f"Failed to resolve project root for embedding server: {e}")
-        return False
+        return None
     server_path = os.path.join(cwd, "src", "infra", "embedding_server.py")
     try:
-        subprocess.Popen(
+        proc = subprocess.Popen(
             [sys.executable, server_path],
             start_new_session=True,
             stdout=subprocess.DEVNULL,
@@ -108,25 +115,59 @@ def _start_server() -> bool:
         )
     except OSError as e:
         logger.warning(f"Failed to start embedding server: {e}")
-        return False
+        return None
     logger.info("Embedding server process started")
-    return True
+    return proc
 
 
 def _ensure_server_running() -> bool:
-    """ヘルスチェック→起動→待機のフロー。成功でTrue、タイムアウトでFalse。"""
+    """ヘルスチェック→起動→待機のフロー。成功でTrue、タイムアウトでFalse。
+
+    spawn は _spawn_lock でプロセス内直列化する。ロック取得後の再チェックで
+    先行スレッドが起動済みなら spawn しない。
+    """
     if _is_server_running():
         return True
-    if not _start_server():
-        return False
-    # 最大30秒待機（0.5秒間隔 × 60回）
-    for _ in range(60):
-        time.sleep(0.5)
+    with _spawn_lock:
+        # ロック待ちの間に別スレッドが起動を完了しているケース
         if _is_server_running():
-            logger.info("Embedding server is ready")
             return True
-    logger.warning("Embedding server failed to start within 30 seconds")
-    return False
+        proc = _start_server()
+        if proc is None:
+            return False
+        # 最大30秒待機（0.5秒間隔 × 60回）
+        for _ in range(60):
+            time.sleep(0.5)
+            if _is_server_running():
+                logger.info("Embedding server is ready")
+                return True
+            if proc.poll() is not None:
+                # 子が終了済み。別プロセス起点のサーバーにbind負けした直後なら
+                # health が通るはずなので、最後にもう一度だけ確認してから諦める
+                if _is_server_running():
+                    logger.info("Embedding server is ready")
+                    return True
+                logger.warning(
+                    f"Embedding server exited early (returncode={proc.returncode})"
+                )
+                return False
+        # タイムアウト。bind 済み（= ロード進行中で、完了すれば応答する）なら生かし、
+        # bind 前に固まっている子は回収する。放置すると stdout/stderr が DEVNULL の
+        # 不可視プロセスとしてモデルロード分のメモリを抱えたまま残留するため。
+        if is_port_listening(PORT):
+            logger.warning(
+                "Embedding server not ready within 30 seconds (port bound, still loading)"
+            )
+        else:
+            logger.warning(
+                "Embedding server failed to start within 30 seconds, terminating child"
+            )
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        return False
 
 
 def _encode_batch(texts: list[str], prefix: str) -> Optional[list[list[float]]]:

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1025,7 +1025,11 @@ def get_available_intents() -> list[dict]:
 # ========================================
 
 # セッション別の注入済みタグ追跡（ctx.session_idキー）
+# セッション終了はこのモジュールに通知されないため、上限超過時に挿入順の
+# 最古セッションから追い出す（放置するとセッション数ぶん永久に成長する）。
+# 追い出された長寿セッションは同じタグの notes を再度受け取るだけで実害はない。
 _injected_tags: dict[str, set[str]] = {}
+_INJECTED_TAGS_MAX_SESSIONS = 256
 
 
 def collect_tag_notes_for_injection(
@@ -1067,6 +1071,9 @@ def collect_tag_notes_for_injection(
             normal_parsed.append((ns, name))
 
     if mark:
+        if session_key not in _injected_tags:
+            while len(_injected_tags) >= _INJECTED_TAGS_MAX_SESSIONS:
+                del _injected_tags[next(iter(_injected_tags))]
         session_set = _injected_tags.setdefault(session_key, set())
         new_normal = [
             (t, p) for t, p in zip(normal_tags, normal_parsed)

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1,5 +1,6 @@
 """タグ管理ユーティリティ"""
 import sqlite3
+import threading
 from typing import Optional, Union
 
 from src.db import execute_query, get_connection, row_to_dict
@@ -1028,7 +1029,10 @@ def get_available_intents() -> list[dict]:
 # セッション終了はこのモジュールに通知されないため、上限超過時に挿入順の
 # 最古セッションから追い出す（放置するとセッション数ぶん永久に成長する）。
 # 追い出された長寿セッションは同じタグの notes を再度受け取るだけで実害はない。
+# 追い出しは check-then-act（len 判定 → del）でGILのアトミック性に頼れないため、
+# ツール並行実行下の同時到達を _injected_tags_lock で直列化する。
 _injected_tags: dict[str, set[str]] = {}
+_injected_tags_lock = threading.Lock()
 _INJECTED_TAGS_MAX_SESSIONS = 256
 
 
@@ -1071,15 +1075,16 @@ def collect_tag_notes_for_injection(
             normal_parsed.append((ns, name))
 
     if mark:
-        if session_key not in _injected_tags:
-            while len(_injected_tags) >= _INJECTED_TAGS_MAX_SESSIONS:
-                del _injected_tags[next(iter(_injected_tags))]
-        session_set = _injected_tags.setdefault(session_key, set())
-        new_normal = [
-            (t, p) for t, p in zip(normal_tags, normal_parsed)
-            if t not in session_set
-        ]
-        session_set.update(t for t, _ in new_normal)
+        with _injected_tags_lock:
+            if session_key not in _injected_tags:
+                while len(_injected_tags) >= _INJECTED_TAGS_MAX_SESSIONS:
+                    del _injected_tags[next(iter(_injected_tags))]
+            session_set = _injected_tags.setdefault(session_key, set())
+            new_normal = [
+                (t, p) for t, p in zip(normal_tags, normal_parsed)
+                if t not in session_set
+            ]
+            session_set.update(t for t, _ in new_normal)
     else:
         # mark=False: 全タグをクエリ対象にし、_injected_tags は更新しない
         new_normal = list(zip(normal_tags, normal_parsed))

--- a/tests/services/test_embedding_server_startup.py
+++ b/tests/services/test_embedding_server_startup.py
@@ -1,0 +1,49 @@
+"""embedding_server 起動順序のテスト。
+
+多重起動の敗者判定（bind 失敗 → exit）をモデルロードより前に走らせるため、
+main() は bind → モデルロードの順で進む必要がある（並行 spawn 時に敗者が
+モデルロード分のメモリを重複確保しないための順序）。
+"""
+import socket
+
+import pytest
+
+from src.infra import embedding_server
+from src.infra.lock_file import is_port_listening
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+def test_main_binds_port_before_model_load(monkeypatch):
+    """main(): モデルロード時点でポートが既に bind されている"""
+    port = _find_free_port()
+    created = {}
+
+    class RecordingServer(embedding_server.EmbeddingHTTPServer):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created["server"] = self
+
+    load_observed = {}
+
+    def fake_load():
+        load_observed["port_bound"] = is_port_listening(port)
+        raise SystemExit(0)  # serve_forever に進まず main を打ち切る
+
+    monkeypatch.setattr(embedding_server, "PORT", port)
+    monkeypatch.setattr(embedding_server, "_setup_logging", lambda: None)
+    monkeypatch.setattr(embedding_server, "_load_model", fake_load)
+    monkeypatch.setattr(embedding_server, "EmbeddingHTTPServer", RecordingServer)
+
+    try:
+        with pytest.raises(SystemExit):
+            embedding_server.main()
+    finally:
+        if "server" in created:
+            created["server"].server_close()
+
+    assert load_observed["port_bound"] is True

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -29,6 +29,12 @@ def temp_db():
             del os.environ["DISCUSSION_DB_PATH"]
 
 
+@pytest.fixture(autouse=True)
+def reset_spawn_cooldown(monkeypatch):
+    """テスト間でspawn失敗クールダウンが持ち越されないようリセットする"""
+    monkeypatch.setattr(emb, "_last_spawn_failed_at", None)
+
+
 @pytest.fixture
 def mock_embedding_server(monkeypatch):
     """embedding_serverへのHTTPリクエストをモック化"""
@@ -651,6 +657,58 @@ def test_ensure_server_running_gives_up_when_child_exits_early(temp_db, monkeypa
 
     assert emb._ensure_server_running() is False
     assert sleep_count["n"] < 60  # 60回ループを使い切らず早期リターン
+
+
+def test_ensure_server_running_cooldown_blocks_respawn_after_failure(temp_db, monkeypatch):
+    """_ensure_server_running: 起動失敗直後はクールダウンで再spawnしない"""
+    import time as time_mod
+
+    spawns = {"n": 0}
+
+    def counting_start():
+        spawns["n"] += 1
+        return _FakeProc(returncode=1)  # 即死する子（モデルロード失敗等）
+
+    monkeypatch.setattr(emb, "_is_server_running", lambda: False)
+    monkeypatch.setattr(emb, "_start_server", counting_start)
+    monkeypatch.setattr(time_mod, "sleep", lambda s: None)
+
+    assert emb._ensure_server_running() is False
+    assert spawns["n"] == 1
+    # クールダウン中の再呼び出しはspawnせずFalse
+    assert emb._ensure_server_running() is False
+    assert spawns["n"] == 1
+    # クールダウン経過後は再spawnを試みる
+    monkeypatch.setattr(
+        emb, "_last_spawn_failed_at",
+        time_mod.time() - emb._SPAWN_RETRY_COOLDOWN_SEC - 1,
+    )
+    assert emb._ensure_server_running() is False
+    assert spawns["n"] == 2
+
+
+def test_ensure_server_running_success_clears_cooldown(temp_db, monkeypatch):
+    """_ensure_server_running: 起動成功でクールダウンがクリアされる"""
+    import time as time_mod
+
+    monkeypatch.setattr(emb, "_is_server_running", lambda: False)
+    monkeypatch.setattr(emb, "_start_server", lambda: _FakeProc(returncode=1))
+    monkeypatch.setattr(time_mod, "sleep", lambda s: None)
+    assert emb._ensure_server_running() is False
+    assert emb._last_spawn_failed_at is not None
+
+    # 次のspawnが成功するケース（1回目のhealth checkで即ready）
+    monkeypatch.setattr(emb, "_last_spawn_failed_at", None)
+    calls = {"n": 0}
+
+    def health_after_start():
+        calls["n"] += 1
+        return calls["n"] > 2  # 事前チェック・ロック内再チェックはFalse、以降True
+
+    monkeypatch.setattr(emb, "_is_server_running", health_after_start)
+    monkeypatch.setattr(emb, "_start_server", lambda: _FakeProc(returncode=None))
+    assert emb._ensure_server_running() is True
+    assert emb._last_spawn_failed_at is None
 
 
 # ========================================

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -496,8 +496,8 @@ def test_recovery_after_encode_batch_failure(temp_db, monkeypatch):
 # ========================================
 
 
-def test_start_server_failure_returns_false(temp_db, monkeypatch):
-    """_start_server: subprocess.Popen失敗時にFalseを返す"""
+def test_start_server_failure_returns_none(temp_db, monkeypatch):
+    """_start_server: subprocess.Popen失敗時にNoneを返す"""
     import subprocess
 
     def failing_popen(*args, **kwargs):
@@ -506,7 +506,7 @@ def test_start_server_failure_returns_false(temp_db, monkeypatch):
     monkeypatch.setattr(subprocess, 'Popen', failing_popen)
 
     result = emb._start_server()
-    assert result is False
+    assert result is None
 
 
 def test_start_server_uses_existing_infra_path(temp_db, monkeypatch):
@@ -514,10 +514,11 @@ def test_start_server_uses_existing_infra_path(temp_db, monkeypatch):
     import subprocess
 
     captured = {}
+    sentinel = object()
 
     def capturing_popen(args, **kwargs):
         captured["args"] = args
-        return object()  # _start_serverは返り値を使わない
+        return sentinel  # _start_serverは子プロセスハンドルをそのまま返す
 
     # project rootをこのチェックアウト自身に固定する。
     # emb.__file__ = <root>/src/services/embedding_service.py なので parents[2] が <root>。
@@ -526,7 +527,7 @@ def test_start_server_uses_existing_infra_path(temp_db, monkeypatch):
     monkeypatch.setattr(emb, "_project_root_cache", None)  # env反映のためキャッシュをクリア
     monkeypatch.setattr(subprocess, "Popen", capturing_popen)
 
-    assert emb._start_server() is True
+    assert emb._start_server() is sentinel
 
     server_path = captured["args"][1]
     assert server_path == os.path.join(str(root), "src", "infra", "embedding_server.py")
@@ -536,10 +537,120 @@ def test_start_server_uses_existing_infra_path(temp_db, monkeypatch):
 def test_ensure_server_running_handles_start_failure(temp_db, monkeypatch):
     """_ensure_server_running: _start_server失敗時にFalseを返す"""
     monkeypatch.setattr(emb, '_is_server_running', lambda: False)
-    monkeypatch.setattr(emb, '_start_server', lambda: False)
+    monkeypatch.setattr(emb, '_start_server', lambda: None)
 
     result = emb._ensure_server_running()
     assert result is False
+
+
+# ========================================
+# spawn 直列化・タイムアウト回収テスト
+# ========================================
+
+
+class _FakeProc:
+    """Popen の poll/terminate/wait/kill だけを模したスタブ。"""
+
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+
+def test_ensure_server_running_single_spawn_under_concurrency(temp_db, monkeypatch):
+    """_ensure_server_running: 並行呼び出しでも spawn は1回に直列化される"""
+    import threading
+    import time as time_mod
+
+    state = {"running": False, "spawns": 0}
+    spawn_entered = threading.Event()
+    spawn_release = threading.Event()
+
+    def fake_start():
+        state["spawns"] += 1
+        spawn_entered.set()
+        spawn_release.wait(timeout=5)
+        state["running"] = True
+        return _FakeProc()
+
+    monkeypatch.setattr(emb, "_is_server_running", lambda: state["running"])
+    monkeypatch.setattr(emb, "_start_server", fake_start)
+    monkeypatch.setattr(time_mod, "sleep", lambda s: None)
+
+    results = []
+    t1 = threading.Thread(target=lambda: results.append(emb._ensure_server_running()))
+    t1.start()
+    assert spawn_entered.wait(timeout=5)  # t1 がロック内で spawn 中
+
+    # t2 は事前チェック（未起動）を通過後、ロック待ちに入る
+    t2 = threading.Thread(target=lambda: results.append(emb._ensure_server_running()))
+    t2.start()
+    time_mod.sleep(0)  # 明示 yield（sleepはno-op化済みのため実質即時）
+    spawn_release.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert results == [True, True]
+    assert state["spawns"] == 1  # t2 はロック取得後の再チェックで spawn せず復帰
+
+
+def test_ensure_server_running_kills_hung_child_on_timeout(temp_db, monkeypatch):
+    """_ensure_server_running: bind前に固まった子はタイムアウト時に回収される"""
+    import time as time_mod
+
+    fake = _FakeProc(returncode=None)
+    monkeypatch.setattr(emb, "_is_server_running", lambda: False)
+    monkeypatch.setattr(emb, "_start_server", lambda: fake)
+    monkeypatch.setattr(emb, "is_port_listening", lambda port: False)
+    monkeypatch.setattr(time_mod, "sleep", lambda s: None)
+
+    assert emb._ensure_server_running() is False
+    assert fake.terminated is True
+
+
+def test_ensure_server_running_spares_child_still_loading(temp_db, monkeypatch):
+    """_ensure_server_running: bind済み（ロード進行中）の子はタイムアウトでも殺さない"""
+    import time as time_mod
+
+    fake = _FakeProc(returncode=None)
+    monkeypatch.setattr(emb, "_is_server_running", lambda: False)
+    monkeypatch.setattr(emb, "_start_server", lambda: fake)
+    monkeypatch.setattr(emb, "is_port_listening", lambda port: True)
+    monkeypatch.setattr(time_mod, "sleep", lambda s: None)
+
+    assert emb._ensure_server_running() is False
+    assert fake.terminated is False
+    assert fake.killed is False
+
+
+def test_ensure_server_running_gives_up_when_child_exits_early(temp_db, monkeypatch):
+    """_ensure_server_running: 子が即終了し health も通らなければ30秒待たずFalse"""
+    import time as time_mod
+
+    sleep_count = {"n": 0}
+
+    def counting_sleep(s):
+        sleep_count["n"] += 1
+
+    fake = _FakeProc(returncode=1)  # bind負け等で終了済み
+    monkeypatch.setattr(emb, "_is_server_running", lambda: False)
+    monkeypatch.setattr(emb, "_start_server", lambda: fake)
+    monkeypatch.setattr(time_mod, "sleep", counting_sleep)
+
+    assert emb._ensure_server_running() is False
+    assert sleep_count["n"] < 60  # 60回ループを使い切らず早期リターン
 
 
 # ========================================

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -317,6 +317,41 @@ class TestProjectRoot:
         assert os.path.isfile(os.path.join(launcher._PROJECT_ROOT, "pyproject.toml"))
 
 
+class TestBridgeSessionTermination:
+    def test_bridge_passes_terminate_on_close_true(self, monkeypatch):
+        """_bridge: streamable_http_clientにterminate_on_close=Trueを渡す
+
+        DELETEを送らないとサーバー側のStreamableHTTPSessionManagerが
+        切断済みセッションを保持し続けるため、この値の回帰を検知する。
+        """
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        import mcp.client.streamable_http as streamable_http_module
+
+        captured = {}
+
+        class _Abort(Exception):
+            """接続確立前にブリッジを打ち切るためのセンチネル例外"""
+
+        @asynccontextmanager
+        async def fake_client(**kwargs):
+            captured.update(kwargs)
+            raise _Abort()
+            yield  # pragma: no cover
+
+        # _bridge内の遅延import（from mcp.client.streamable_http import ...）が
+        # 参照するモジュール属性を差し替える
+        monkeypatch.setattr(
+            streamable_http_module, "streamable_http_client", fake_client
+        )
+
+        with pytest.raises(_Abort):
+            asyncio.run(launcher._bridge())
+
+        assert captured["terminate_on_close"] is True
+
+
 class TestServerDisconnected:
     def test_is_exception(self):
         """ServerDisconnectedがExceptionのサブクラスである"""

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -135,6 +135,29 @@ class TestTagNotesInjection:
         finally:
             conn.close()
 
+    def test_session_eviction_caps_tracked_sessions(self, temp_db):
+        """セッション追跡数が上限に達したら最古セッションから追い出される"""
+        from src.services import tag_service
+
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "重要な教訓")
+
+        conn = get_connection()
+        try:
+            for i in range(tag_service._INJECTED_TAGS_MAX_SESSIONS + 10):
+                collect_tag_notes_for_injection(
+                    conn, ["domain:test"], session_id=f"session-{i}"
+                )
+            assert len(_injected_tags) == tag_service._INJECTED_TAGS_MAX_SESSIONS
+            # 最古セッションは追い出され、再遭遇時には再度注入される
+            assert "session-0" not in _injected_tags
+            result = collect_tag_notes_for_injection(
+                conn, ["domain:test"], session_id="session-0"
+            )
+            assert result is not None
+        finally:
+            conn.close()
+
     def test_no_notes_returns_none(self, temp_db):
         """notes がないタグでは None が返る"""
         add_topic(title="Test", description="Desc", tags=["domain:test"])

--- a/tests/unit/test_tag_notes.py
+++ b/tests/unit/test_tag_notes.py
@@ -158,6 +158,52 @@ class TestTagNotesInjection:
         finally:
             conn.close()
 
+    def test_session_eviction_concurrent_new_sessions(self, temp_db):
+        """上限到達状態で複数スレッドが同時に新規セッションを登録しても例外が出ない"""
+        import threading
+        from src.services import tag_service
+
+        add_topic(title="Test", description="Desc", tags=["domain:test"])
+        update_tag("domain:test", "重要な教訓")
+
+        conn = get_connection()
+        try:
+            # 上限まで埋める
+            for i in range(tag_service._INJECTED_TAGS_MAX_SESSIONS):
+                collect_tag_notes_for_injection(
+                    conn, ["domain:test"], session_id=f"warmup-{i}"
+                )
+        finally:
+            conn.close()
+
+        errors = []
+        barrier = threading.Barrier(8)
+
+        def worker(i):
+            # スレッドごとに独立したDB接続を使う
+            worker_conn = get_connection()
+            try:
+                barrier.wait(timeout=5)
+                for j in range(20):
+                    collect_tag_notes_for_injection(
+                        worker_conn,
+                        ["domain:test"],
+                        session_id=f"concurrent-{i}-{j}",
+                    )
+            except Exception as e:  # KeyError等の競合起因の例外を捕捉
+                errors.append(e)
+            finally:
+                worker_conn.close()
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == []
+        assert len(_injected_tags) <= tag_service._INJECTED_TAGS_MAX_SESSIONS
+
     def test_no_notes_returns_none(self, temp_db):
         """notes がないタグでは None が返る"""
         add_topic(title="Test", description="Desc", tags=["domain:test"])


### PR DESCRIPTION
## 概要

「embedding serverがごくたまにメモリリークする（手動再起動後に起こりやすい）」の調査で特定した2つの原因と増幅要因を修正する。

**原因1: embedding server（:52836）の多重spawn競合。** サーバー停止中に並行ツール呼び出しが来ると、全スレッドがそれぞれembedding_serverをspawnしていた（再現実験: 6並行呼び出し→6プロセス）。さらに多重起動の敗者判定（bind失敗→exit）がモデルロード**後**に走るため、敗者も数百MBのモデルをロードし終えてから退場し、その間メモリがspawn数ぶん積み上がる。加えてspawnはfire-and-forgetで、ロード中に固まった子はDEVNULLの不可視プロセスとして恒久残留し得た。修正後は、bind先行化で敗者がロード前に退場し、spawnはプロセス内で直列化され、タイムアウトした未bindの子は回収され、起動失敗後30秒はspawnを再試行しない（再現実験: 6並行呼び出し→1プロセス）。クールダウンは、モデルロードが恒久的に失敗する環境（ネットワーク遮断等）でencode呼び出しごとにspawn→即死ループになるのを防ぐ（検証環境で失敗spawnが1343回連鎖するのを実測）。

**原因2: 本体サーバー（:52837）のMCPセッション永久残留。** ブリッジが切断時にDELETEを送らないため、サーバー側のStreamableHTTPSessionManagerが切断済みセッションを停止まで保持し続ける（再現実験: 30接続断→30セッション+約90 asyncioタスクが永久残留、約80KB/セッション）。ブリッジは再接続時にセッションを再利用しないためDELETE送信に副作用はない。同根の`_injected_tags`（session_idキーのモジュールdict）にも上限evictを入れた（evictのcheck-then-actはロックで直列化）。

**増幅要因:** CLAUDE.mdの再起動コマンド`lsof -ti :52837`は接続中のブリッジまで巻き添えでkillし、再接続・多重spawn競争を誘発していたため、LISTENソケット限定に修正。

## 補足

- 「手動再起動後に起こりやすい」との相関: 再起動手順で全セッションが再起動→初回検索とbackfillがほぼ同時に到着し、TTL(1時間)で自滅していることの多いembedding serverへspawn競争が発生する、という連鎖だった
- クールダウンの副作用: 起動失敗後は最大30秒間encodeが縮退（None）で返る。従来もタイムアウト失敗時は30秒待ちだったため、リカバリ体感は同等かそれ以上
- 本体サーバー側の複数ブリッジによるspawn雷群（lock file+port checkで敗者は退場するが、import+init_database後に判定される）は今回スコープ外。必要なら別PRで判定の前倒しを検討
- 調査レポート全文はセッション成果物として別途保存予定（cc-memory MCPが本セッションから認証不可のため未保存）

## テスト計画

- 新規テストで保証する振る舞い:
  - 並行呼び出しでもembedding serverのspawnは1回に直列化される
  - bind前に固まった子はタイムアウト時にterminate/killで回収される
  - bind済み（ロード進行中）の子はタイムアウトでも殺さない
  - 子が即終了しhealthも通らない場合は30秒待たず早期リターンする
  - 起動失敗後のクールダウン中は再spawnせず、経過後に再試行し、起動成功で解除される
  - main()はモデルロード時点でポートをbind済み（敗者の早期退場の前提）
  - `_injected_tags`は上限到達で最古セッションから追い出され、追い出されたセッションは再遭遇時にnotesを再受信する。上限到達状態での並行新規セッション登録でも例外が出ない
  - `_bridge`はstreamable_http_clientにterminate_on_close=Trueを渡す
- 再現実験（本物のfastmcp 3.2.0 / mcp 1.25.0、モデルロードのみ5秒スリープのフェイク）で修正前後を比較: spawn数 6→1、セッション残留 30→0（terminate_on_close=True時はサーバー側タスク増加ゼロ）
- モデル取得不能環境（HFへの通信が403）での実地観察: 修正前はdecision作成のたびにspawn→即死が連鎖しテストがtimeout、クールダウン導入後は同テスト群が全パス（67件が54分→90秒）

## Revert

R1: migration 非接触。revert commit のみで戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016egDroeC8KLaRotXWNUBJS