### PR TITLE
fix: check-in系4スキルのactivity取得にorch_managed除外を追加

### DIFF
--- a/skills/check-in/SKILL.md
+++ b/skills/check-in/SKILL.md
@@ -12,7 +12,7 @@ description: アクティビティにcheck-inして関連情報を集約取得�
 1. 引数で `activity_id` が指定されていればそのまま使う
 2. 指定されていなければ、SessionStart hookで注入済みのトピック別アクティビティ一覧を提示する:
    a. SessionStart hookの出力にトピック別グルーピングが含まれていればそのまま使う
-   b. グルーピングがなければ `get_activities()` でフラットに取得しフォールバック表示する
+   b. グルーピングがなければ `get_activities(orch_managed=False)` でフラットに取得しフォールバック表示する
    c. IDは一切表示しない（トピックID・アクティビティIDともに非表示）。トピック名とアクティビティ名のみ
    d. ユーザーが名前やキーワードで選択したら、対応するactivity_idでステップ3へ進む
 3. `check_in(activity_id=...)` を呼び出す

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -10,7 +10,7 @@ completedアクティビティの行動を時系列で振り返り、ユーザ�
 ## 1. 対象アクティビティの選択
 
 1. 引数で `activity_id` が指定されていればそのまま使う
-2. 指定されていなければ `get_activities(status="completed", limit=15)` で一覧を表示し、ユーザーに選んでもらう
+2. 指定されていなければ `get_activities(status="completed", limit=15, orch_managed=False)` で一覧を表示し、ユーザーに選んでもらう
 
 ## 2. ポストモーテムアクティビティの作成
 

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -10,7 +10,7 @@ cc-memoryの記録（decisions, logs, materials）を元に、外部共有可能
 ## 1. 対象アクティビティの選択
 
 1. 引数で `activity_id` が指定されていればそのまま使う
-2. 指定されていなければ `get_activities(status="completed")` で候補を表示し、ユーザーに選んでもらう
+2. 指定されていなければ `get_activities(status="completed", orch_managed=False)` で候補を表示し、ユーザーに選んでもらう
 3. 複数のアクティビティをまとめて1つのドキュメントにすることもできる。ユーザーに確認する
 
 ## 2. [執筆]アクティビティの作成

--- a/skills/sync-memory/SKILL.md
+++ b/skills/sync-memory/SKILL.md
@@ -22,7 +22,7 @@ description: セッション終了前にtranscriptを解析し、トピック・
 
 **アクション:**
 - セッション中に使ったトピックの `get_decisions(topic_id=...)` と `get_logs(topic_id=...)` を実行し、直近の決定事項・ログを取得
-- `get_activities(status="active")` で未完了アクティビティを取得（pending + in_progress）
+- `get_activities(status="active", orch_managed=False)` で未完了アクティビティを取得（pending + in_progress）
 - 取得した既存データと会話内容を照合し、**既に記録済みの内容は記録しない**
 
 **重複の判定基準:**


### PR DESCRIPTION
## Summary
- SessionStart hookの一覧表示は2026-06-23からorch_managed=1の活動を全階層で除外しているが、check-inのフォールバック経路・postmortem・scribe・sync-memoryの4スキルは同じ`get_activities()`をフィルタなしで呼んでおり、運用管理系の活動が候補一覧に混入する経路として残っていた
- 4箇所に`orch_managed=False`を明示し、これらの経路をhookの挙動に揃える

## Test plan
- SKILL.mdはLLM向けの指示文（プロンプト）であり実行コードを持たないため、既存のpytestスイートへの影響なし
- 対象4ファイルを直接参照・検証するテストが無いことをgrepで確認済み