### PR TITLE
fix: title docstring案内を35字に下げ安全マージンを設ける

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -274,7 +274,7 @@ def add_topic(
 ) -> dict:
     """新しい議論トピックを追加する。
 
-    title: トピックのタイトル（40字以内）
+    title: トピックのタイトル（35字以内）
     tags: タグ配列(必須、1個以上)。domain:タグに加えて内容を表すタグも付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "error-handling", "validation", "stdin"]
     related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]。作成と同時にリレーションを張る
 
@@ -326,7 +326,7 @@ def add_decisions(items: list[dict], ctx: Context) -> dict:
           防ぐための情報。検証行が無いdecisionは「決定のみ・実測未確認」を意味する（実装状態を本文に
           書かず、検証行の有無で表す）。節はすべて任意で、「該当なし」を埋めるための空項目・ダミー項目は
           書かないこと。
-        - title (str, optional): 決定の要点を表す1行（40字以内）。**付けることを強く推奨**。check-in・timeline・search等の一覧表示でdecision本文の代わりに見出しとして使われ、可読性が大きく上がる。省略時はdecision本文にfallbackする。tagsに layer:direction を含む場合は必須（省略・空文字はエラー）
+        - title (str, optional): 決定の要点を表す1行（35字以内）。**付けることを強く推奨**。check-in・timeline・search等の一覧表示でdecision本文の代わりに見出しとして使われ、可読性が大きく上がる。省略時はdecision本文にfallbackする。tagsに layer:direction を含む場合は必須（省略・空文字はエラー）
         - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。内容を表すタグを積極的に追加すること。namespace: domain:(プロジェクト)/intent:(意図)/layer:direction(判例が効かない前例なし領域での人間の抽象方向性判断であることを明示するタグ。少数・明示の原則により付けた場合はtitle必須)/素タグ(キーワード)。例: ["intent:design", "naming-convention", "backward-compat"]
         - propagate_to (dict, optional): 決定事項を注入先に伝搬する。
             - type: "habit" | "tag_note"
@@ -798,7 +798,7 @@ def add_activity(
     - orchが管理するアクティビティとして作成: add_activity("...", "...", [...], orch_managed=True)
 
     Args:
-        title: アクティビティのタイトル（40字以内）
+        title: アクティビティのタイトル（35字以内）
         description: アクティビティの詳細説明（必須）。スコアリングに活用されるため、以下の情報があれば記載を推奨: 締め切り、ブロッカー（自分が/外部）、影響度・緊急度
         tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
         related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1]}, {"type": "decision", "ids": [10, 11]}]。作成と同時にリレーションを張る。intent:implementタグを含む場合、relatedにtype='decision'のエントリを最低1件含めないとIMPLEMENT_WORKFLOW_GUARDエラーで弾かれる（議論・設計フェーズで合意したdecisionか、いきなりimplementする理由を記録したdecisionをrelateする）
@@ -901,7 +901,7 @@ def update_activity(
     Args:
         activity_id: アクティビティID
         status: 新しいステータス（pending/in_progress/completed/snoozed/shelved）
-        title: 新しいタイトル（40字以内）
+        title: 新しいタイトル（35字以内）
         description: 新しい説明
         tags: 新しいタグ配列（指定時は全置換。1個以上必須）
         orch_managed: orchが管理するアクティビティかを切り替える（True/False/None）。Noneなら変更しない
@@ -928,7 +928,7 @@ def add_material(
     呼び出し前に recording skill の判断ガイドを通すこと。
 
     Args:
-        title: 資材のタイトル（40字以内）
+        title: 資材のタイトル（35字以内）
         content: 資材の本文（マークダウン形式推奨）。先頭1-2文は内容の説明・要約を書くこと（check-in時にsnippetとして表示される）
         tags: タグ配列（必須、1個以上）。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)
         source: データの出自。典型的なソース種類: ユーザー発言、公式ドキュメント、コード調査、計測結果、外部記事、チーム議事録など
@@ -971,7 +971,7 @@ def update_material(
     Args:
         material_id: 資材のID
         content: 新しい本文（optional）。先頭1-2文は内容の説明・要約を書くこと（check-inやsearchのsnippetに使われるため）
-        title: 新しいタイトル（optional、40字以内）
+        title: 新しいタイトル（optional、35字以内）
         tags: 新しいタグ配列（指定時は全置換。1個以上必須。optional）
         source: 新しいソース（optional）
         mode: content指定時の結合動作。"overwrite"=上書き(既定、後方互換)、"prepend"=新+"\n\n"+既存、"append"=既存+"\n\n"+新

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -124,7 +124,7 @@ def add_activity(
     アクティビティを作成してIDを返す
 
     Args:
-        title: アクティビティのタイトル（40字以内）
+        title: アクティビティのタイトル（35字以内）
         description: アクティビティの説明
         tags: タグ配列（必須、1個以上）
         related: 関連エンティティ（optional）。
@@ -556,7 +556,7 @@ def update_activity(
     Args:
         activity_id: アクティビティID
         status: 新しいステータス（optional）
-        title: 新しいタイトル（optional、40字以内）
+        title: 新しいタイトル（optional、35字以内）
         description: 新しい説明（optional）
         tags: 新しいタグ配列（optional、指定時は全置換。1個以上必須）
         orch_managed: orch が管理する activity かどうかを切り替える（optional）。

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -41,7 +41,7 @@ def add_decisions(items: list[dict], caller_session_id: Optional[str] = None) ->
             - topic_id (int, 必須): 関連するトピックのID
             - decision (str, 必須): 決定内容
             - reason (str, 必須): 決定の理由
-            - title (str, optional): 決定の要点を表す1行（40字以内）。省略時はNULL（表示はdecision本文にfallback）。
+            - title (str, optional): 決定の要点を表す1行（35字以内）。省略時はNULL（表示はdecision本文にfallback）。
               tagsに layer:direction を含む場合は必須（省略・空文字はエラー）
             - tags (list[str], optional): 追加タグ。省略時はtopicのタグを継承。layer:direction は
               人間の抽象方向性判断であることを明示するタグ（付けた場合はtitle必須）

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -48,7 +48,7 @@ def add_material(title: str, content: str, tags: list[str], source: str, related
     資材を追加する
 
     Args:
-        title: 資材のタイトル（40字以内）
+        title: 資材のタイトル（35字以内）
         content: 資材の本文
         tags: タグ配列（必須、1個以上）
         source: データの出自
@@ -208,7 +208,7 @@ def update_material(
     Args:
         material_id: ID of the material to update
         content: New content (optional)
-        title: New title (optional, 40 chars or less)
+        title: New title (optional, 35 chars or less)
         tags: New tags (full replace, optional. At least 1 required when specified)
         source: New source (optional)
         mode: content指定時の結合動作。"overwrite"=既定で上書き、"prepend"=新+区切り+既存、

--- a/src/services/title_validation.py
+++ b/src/services/title_validation.py
@@ -4,6 +4,9 @@ cc-memory の add/update ツール群で title 引数を TITLE_MAX_LEN 字以内
 docstring 明記と validation の両輪で AI 側に制約を伝える。
 """
 
+# 実際の上限は40のまま。AIエージェント向けdocstringでは安全マージンとして
+# 「35字以内」と案内している（AIは字数を数え間違えやすく、40字ちょうど狙いだと
+# 実際に超過することがあるため）。
 TITLE_MAX_LEN = 40
 
 

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -145,7 +145,7 @@ def add_topic(
     新しい議論トピックを追加する。
 
     Args:
-        title: トピックのタイトル（40字以内）
+        title: トピックのタイトル（35字以内）
         description: トピックの説明（必須）
         tags: タグ配列（必須、1個以上）
         related: 関連エンティティ（optional）。

--- a/tests/unit/test_mcp_tool_title_docstrings.py
+++ b/tests/unit/test_mcp_tool_title_docstrings.py
@@ -1,8 +1,11 @@
-"""MCP tool description (ToolSearch/エージェントから見える文面) の title 40字上限明記テスト。
+"""MCP tool description (ToolSearch/エージェントから見える文面) の title 35字案内明記テスト。
 
-src.services.* 側の docstring には既に「40字以内」が明記されているが（test_title_validation.py が担保）、
-実際にエージェントへ配信される MCP tool description は src.main の @mcp.tool() 関数の docstring から
-生成されるため、そちらへの転記漏れは別途この層で検証する必要がある。
+実際のバリデーション上限は40字のままだが（test_title_validation.py が担保）、
+AIエージェントが字数を数え間違えて超過することを防ぐため、docstring上の案内は
+安全マージンとして35字以内としている。src.services.* 側の docstring には既に
+「35字以内」が明記されているが、実際にエージェントへ配信される MCP tool description は
+src.main の @mcp.tool() 関数の docstring から生成されるため、そちらへの転記漏れは
+別途この層で検証する必要がある。
 """
 from tests.helpers import all_tool_descriptions as _all_tool_descriptions
 
@@ -18,11 +21,11 @@ TITLE_TOOLS = [
 
 
 class TestToolDescriptionMentionsTitleLimit:
-    def test_all_title_tools_mention_40_char_limit(self):
+    def test_all_title_tools_mention_35_char_limit(self):
         descriptions = _all_tool_descriptions()
         missing = [
             name
             for name in TITLE_TOOLS
-            if "40字以内" not in descriptions.get(name, "")
+            if "35字以内" not in descriptions.get(name, "")
         ]
-        assert not missing, f"MCP tool description に「40字以内」が欠落: {missing}"
+        assert not missing, f"MCP tool description に「35字以内」が欠落: {missing}"


### PR DESCRIPTION
## Summary

AIエージェント（Claude等）がtitle引数を生成する際、40字ちょうど狙いだと文字数を数え間違えて実際には41字などになり、`VALIDATION_ERROR`で弾かれることが頻発していた。実際のバリデーション上限（`TITLE_MAX_LEN = 40`）は変更せず、AIエージェント向けdocstringおよびMCP tool descriptionの案内文言のみを「35字以内」に下げ、多少数え間違えても実際の上限を超えにくい安全マージンを設けた。

対象は `add_topic` / `add_decisions` / `add_activity` / `update_activity` / `add_material` / `update_material` の title 引数を案内する docstring 群（`src/main.py` の `@mcp.tool()` 関数、および `src/services/*.py` の対応する service 関数）。

## Test plan

- 既存のtitle文字数バリデーション動作（実際の上限は40字のまま）に変化がないことを確認
- MCP tool descriptionのtitle案内が全対象ツールで「35字以内」表記に揃ったことを確認するテストを更新し、pass することを確認
- 上記2点を検証する既存テストスイート（`tests/unit/test_title_validation.py`、`tests/unit/test_mcp_tool_title_docstrings.py`）が全件passすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)