### PR TITLE
fix: relay配達のretry既定値強化と429エラー分離

### DIFF
--- a/docs/ops/relay-server.md
+++ b/docs/ops/relay-server.md
@@ -34,6 +34,18 @@ cc-memory server（`python -m src.main --transport http`）は以下の env を�
 
 `RELAY_BEARER_TOKEN` が未設定のとき cc-memory は常駐 3 系統 thread を起動しない（log 1 行のみで縮退）。この状態でも server 本体の起動と既存機能は影響を受けない。relay を使う MCP tool（`relay_post` / `relay_publish` / `relay_subscribe` / `relay_receive`）は明示的な `config_missing` エラーを返す。
 
+### outbox dispatcher の retry 既定値
+
+`relay_publish` の配達は outbox 経由の非同期 retry で行われる。以下の環境変数で retry 挙動を調整できる。
+
+| 環境変数 | 説明 | 既定値（cc-memory組み込み） | 既定値（スタンドアロンCLI） |
+| --- | --- | --- | --- |
+| `RELAY_OUTBOX_MAX_RETRY` | outbox 行 1 件あたりの retry 上限回数 | `10` | `5` |
+| `RELAY_OUTBOX_INITIAL_BACKOFF_MS` | retry 初回バックオフ（ミリ秒） | `1000` | `100` |
+| `RELAY_OUTBOX_BACKOFF_FACTOR` | retry 指数バックオフ係数 | `2.0` | `2.0` |
+
+`RELAY_OUTBOX_*` は cc-memory 組み込みの dispatcher（`RelayRuntime`）にも、スタンドアロン CLI（`python -m src.relay_sdk.outbox`）にも同じ環境変数名で効く。ただし未設定時のフォールバック既定値は異なる。cc-memory 組み込み経路は relay server の手動再起動断絶を生き延びる目的でスタンドアロン CLI より長い既定値（合計約 8.5 分）を持つ。
+
 ## macOS launchd で常駐化する例
 
 `~/Library/LaunchAgents/com.isizono.relay-v2.plist`:

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -487,7 +487,7 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 
 **返り値**: `{stream_id: string, publish_id: int, matched_members: int}`。
 **動作**: 投函先streamが未存在（404）なら自動作成し、自identityを`read_write` memberに設定して1回だけ再投函する。作成の同時競合（409）も1回の再投函で解消する。自server名義のstreamのみ扱う。
-**エラー処理**: `RELAY_BEARER_TOKEN`未設定は設定方法を含む明示エラー（`config_missing`）。認証エラー（401）・close済みstream（410）・rate limit（429）はそのまま明示エラーとして返す（silent fallbackしない）。
+**エラー処理**: `RELAY_BEARER_TOKEN`未設定は設定方法を含む明示エラー（`config_missing`）。認証エラー（401）・close済みstream（410）はそのまま明示エラーとして返す（silent fallbackしない）。rate limit（429）は専用コード`rate_limited`で返し、`retry_after`（秒、`Retry-After`ヘッダ未提供時は`null`）を構造化フィールドで付与する。呼び出し側はこの秒数だけ待ってからリトライすること。
 
 ### 2.39 relay_publish
 
@@ -509,7 +509,7 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 
 **返り値**: `{subscription_id: string, labels: list[string], lease_expires_at: string, handle: string, reused: bool}`。
 **動作**: 自sessionの`handle:` labelを自動付与し、subscription declaration file（`~/.cc-memory/relay/subscriptions/session-<session_id>.json`）とrelayの購読登録を同期する。同一labels集合の再呼び出しは冪等で、leaseが有効なら既存購読を返し（`reused: true`）、失効・不明なら新規購読してdeclaration fileのidを差し替える。lease更新・再購読・購読解除はserver側常駐処理が自動管理する。
-**エラー処理**: `RELAY_BEARER_TOKEN`未設定・session_id未解決は明示エラー。relayエラー時はdeclaration fileを更新しない。
+**エラー処理**: `RELAY_BEARER_TOKEN`未設定・session_id未解決は明示エラー。relayエラー時はdeclaration fileを更新しない。rate limit（429）は専用コード`rate_limited`で返し、`retry_after`（秒、`Retry-After`ヘッダ未提供時は`null`）を構造化フィールドで付与する。呼び出し側はこの秒数だけ待ってからリトライすること。
 
 ### 2.41 relay_receive
 

--- a/src/main.py
+++ b/src/main.py
@@ -1608,7 +1608,9 @@ def relay_post(stream_name: str, body: str, ttl: int | None = None) -> dict:
 
     Returns:
         成功時: {"stream_id": str, "publish_id": int, "matched_members": int}
-        失敗時: {"error": {"code": str, "message": str}}
+        失敗時: {"error": {"code": str, "message": str, "retry_after"?: float | None}}
+                （code == "rate_limited"（429）のときのみ retry_after が付与される。
+                 Retry-After ヘッダ未提供時は null。この秒数だけ待ってからリトライすること）
     """
     guard_service.check_capability("relay_post")
     return relay_session_service.relay_post(stream_name, body, ttl=ttl)
@@ -1655,7 +1657,9 @@ def relay_subscribe(labels: list[str]) -> dict:
     Returns:
         成功時: {"subscription_id": str, "labels": [str], "lease_expires_at": str,
                  "handle": str, "reused": bool}
-        失敗時: {"error": {"code": str, "message": str}}
+        失敗時: {"error": {"code": str, "message": str, "retry_after"?: float | None}}
+                （code == "rate_limited"（429）のときのみ retry_after が付与される。
+                 Retry-After ヘッダ未提供時は null。この秒数だけ待ってからリトライすること）
     """
     guard_service.check_capability("relay_subscribe")
     caller_session_id = get_caller_session_id()

--- a/src/services/relay/runtime.py
+++ b/src/services/relay/runtime.py
@@ -25,12 +25,44 @@ RELAY_BASE_URL / RELAY_BEARER_TOKEN が未設定の環境では 3 系統を全�
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import Callable, Optional
 
 from src.services.relay import config, intake, lease_loop
 
 logger = logging.getLogger(__name__)
+
+
+# --- cc-memory 組み込み dispatcher 専用の既定値 -----------------------------------
+#
+# vendored SDK 自体の既定値（max_retry=5, initial_backoff_seconds=0.1,
+# backoff_factor=2.0）は TransientError に対して合計約 1.5 秒で dead 化する。relay
+# server は cc-memory とは独立に手動 kill/再起動されるプロセスであり、この秒数を
+# 超える再起動断絶は珍しくない。cc-memory 組み込み経路（このモジュール）専用の
+# 既定値をここに持つ。
+#
+# src/relay_sdk/config.py の DEFAULT_* は変更しない。src/relay_sdk/ 配下は
+# vendoring 物であり、VENDORED.md が定める「差分は import 書き換えのみ」という
+# 再同期不変条件がある。
+_EMBEDDED_DEFAULT_MAX_RETRY = 10
+_EMBEDDED_DEFAULT_INITIAL_BACKOFF_SECONDS = 1.0
+_EMBEDDED_DEFAULT_BACKOFF_FACTOR = 2.0
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw not in (None, "") else default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw not in (None, "") else default
+
+
+def _env_ms_as_seconds(name: str, default_seconds: float) -> float:
+    raw = os.environ.get(name)
+    return int(raw) / 1000.0 if raw not in (None, "") else default_seconds
 
 
 class RelayRuntime:
@@ -140,11 +172,22 @@ class RelayRuntime:
     def _run_dispatcher(self) -> None:
         """SDK 付属の `run_dispatcher` を thread で起動する薄い wrapper。
 
+        `RELAY_OUTBOX_MAX_RETRY` / `RELAY_OUTBOX_INITIAL_BACKOFF_MS` /
+        `RELAY_OUTBOX_BACKOFF_FACTOR` を明示的に解決して渡す（省略すると SDK 側の
+        ハードコード既定値にフォールバックし、これらの env var が一切効かなくなる
+        ため）。未設定時のフォールバック先は `_EMBEDDED_DEFAULT_*`（cc-memory 組み込み
+        経路専用、SDK 自身の既定値より粘り強い）。
+
+        `poll_interval_seconds` / `dlq_gc_interval_seconds` / `http_timeout_seconds`
+        は cc-memory 固有の既定値を持たず、SDK 側の env 解決ヘルパー（`sdk_config.env_*`）
+        をそのまま使う。
+
         二重起動は SDK 側 file lock（`<db_path>.dispatcher.lock`）で拒否される
         （`DispatcherAlreadyRunning`）。dispatcher プロセスは他にもいる（例:
         ユーザーが手動で `python -m relay_sdk.outbox` を起動している）ケースに
         備え、取得失敗はエラーではなく log のみで縮退する。
         """
+        from src.relay_sdk import config as sdk_config
         from src.relay_sdk.outbox import DispatcherAlreadyRunning, run_dispatcher
 
         db_path = self._outbox_db_path
@@ -159,6 +202,19 @@ class RelayRuntime:
                 db_path=db_path,
                 relay_base_url=base_url,
                 bearer_token=token,
+                poll_interval_seconds=sdk_config.env_poll_interval_seconds(),
+                max_retry=_env_int(
+                    "RELAY_OUTBOX_MAX_RETRY", _EMBEDDED_DEFAULT_MAX_RETRY
+                ),
+                initial_backoff_seconds=_env_ms_as_seconds(
+                    "RELAY_OUTBOX_INITIAL_BACKOFF_MS",
+                    _EMBEDDED_DEFAULT_INITIAL_BACKOFF_SECONDS,
+                ),
+                backoff_factor=_env_float(
+                    "RELAY_OUTBOX_BACKOFF_FACTOR", _EMBEDDED_DEFAULT_BACKOFF_FACTOR
+                ),
+                dlq_gc_interval_seconds=sdk_config.env_dlq_gc_interval_seconds(),
+                http_timeout_seconds=sdk_config.env_http_timeout_seconds(),
                 stop_event=self._stop_event,
             )
         except DispatcherAlreadyRunning as exc:

--- a/src/services/relay/service.py
+++ b/src/services/relay/service.py
@@ -47,14 +47,29 @@ SESSION_UNRESOLVED_MESSAGE = (
 )
 
 
-def _error(code: str, message: str) -> dict:
-    return {"error": {"code": code, "message": message}}
+def _error(code: str, message: str, **extra: Any) -> dict:
+    """{"error": {"code", "message", ...extra}} を組み立てる。
+
+    extra に渡したキーは error dict にそのまま展開される（例: retry_after）。
+    """
+    payload: dict[str, Any] = {"code": code, "message": message}
+    payload.update(extra)
+    return {"error": payload}
 
 
 def _relay_error(exc: Exception) -> dict:
+    """relay_sdk の 3 例外を呼び出し元向けのエラー dict に翻訳する。
+
+    TransientError のうち 429（rate limit）は `rate_limited` として他の transient
+    failure（5xx・timeout・接続不能）と区別し、`retry_after`（秒、Retry-After
+    ヘッダが無ければ null）を構造化フィールドで返す。429 以外の TransientError は
+    従来通り `relay_unavailable`（`retry_after` フィールドなし）。
+    """
     if isinstance(exc, RelayProtocolError):
         return _error(exc.code or "relay_protocol_error", str(exc))
     if isinstance(exc, TransientError):
+        if exc.status_code == 429:
+            return _error("rate_limited", str(exc), retry_after=exc.retry_after)
         return _error("relay_unavailable", str(exc))
     if isinstance(exc, PermanentError):
         return _error("relay_gone", str(exc))

--- a/tests/unit/test_relay_runtime.py
+++ b/tests/unit/test_relay_runtime.py
@@ -4,6 +4,8 @@
 - 二重 start 防止
 - SDK 側 file lock が既に取られていた場合の B-3 縮退（DispatcherAlreadyRunning 握り潰し）
 - supervisor が例外後に再起動し、stop で終了すること
+- `_run_dispatcher` の retry 関連 kwargs 解決（env 明示設定時の反映、未設定時の
+  cc-memory 組み込み既定値へのフォールバック）
 """
 from __future__ import annotations
 
@@ -71,6 +73,92 @@ class TestDispatcherFallback:
         # 例外を上位まで漏らさないこと（RuntimeError にならず None が返る）。
         runtime._run_dispatcher()
         assert raised == ["called"]
+
+
+class TestDispatcherRetryTuning:
+    """`_run_dispatcher` が retry 関連 kwargs をどう解決するかの検証。"""
+
+    def _capture_kwargs(self, monkeypatch) -> dict:
+        captured: dict = {}
+
+        def fake_run_dispatcher(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "src.relay_sdk.outbox.run_dispatcher", fake_run_dispatcher
+        )
+        monkeypatch.setattr(
+            "src.relay_sdk.outbox.dispatcher.run_dispatcher", fake_run_dispatcher
+        )
+        return captured
+
+    def test_explicit_env_vars_are_forwarded(self, monkeypatch):
+        """RELAY_OUTBOX_* を明示設定すると、その値がそのまま run_dispatcher に渡る。"""
+        monkeypatch.setenv("RELAY_BEARER_TOKEN", "test-token")
+        monkeypatch.setenv("RELAY_OUTBOX_MAX_RETRY", "7")
+        monkeypatch.setenv("RELAY_OUTBOX_INITIAL_BACKOFF_MS", "500")
+        monkeypatch.setenv("RELAY_OUTBOX_BACKOFF_FACTOR", "3.0")
+        captured = self._capture_kwargs(monkeypatch)
+
+        runtime = RelayRuntime(
+            active_sessions_getter=lambda: set(), outbox_db_path=":memory:"
+        )
+        runtime._run_dispatcher()
+
+        assert captured["max_retry"] == 7
+        assert captured["initial_backoff_seconds"] == 0.5
+        assert captured["backoff_factor"] == 3.0
+
+    def test_unset_env_falls_back_to_embedded_defaults(self, monkeypatch):
+        """RELAY_OUTBOX_* 未設定時は cc-memory 組み込み既定値（10 / 1.0 / 2.0）を使い、
+        vendored SDK 自身の既定値（5 / 0.1 / 2.0）とは異なる値になる。
+        """
+        monkeypatch.setenv("RELAY_BEARER_TOKEN", "test-token")
+        monkeypatch.delenv("RELAY_OUTBOX_MAX_RETRY", raising=False)
+        monkeypatch.delenv("RELAY_OUTBOX_INITIAL_BACKOFF_MS", raising=False)
+        monkeypatch.delenv("RELAY_OUTBOX_BACKOFF_FACTOR", raising=False)
+        captured = self._capture_kwargs(monkeypatch)
+
+        runtime = RelayRuntime(
+            active_sessions_getter=lambda: set(), outbox_db_path=":memory:"
+        )
+        runtime._run_dispatcher()
+
+        assert captured["max_retry"] == 10
+        assert captured["initial_backoff_seconds"] == 1.0
+        assert captured["backoff_factor"] == 2.0
+        # vendored SDK 自身の既定値（DispatcherConfig 相当）とは異なることを明示確認する。
+        from src.relay_sdk import config as sdk_config
+
+        assert captured["max_retry"] != sdk_config.DEFAULT_MAX_RETRY
+        assert (
+            captured["initial_backoff_seconds"]
+            != sdk_config.DEFAULT_INITIAL_BACKOFF_SECONDS
+        )
+
+    def test_poll_and_timeout_use_sdk_env_defaults(self, monkeypatch):
+        """poll_interval / dlq_gc_interval / http_timeout は SDK 側の env 解決
+        ヘルパーがそのまま使われ、cc-memory 固有の既定値は持たない。
+        """
+        monkeypatch.setenv("RELAY_BEARER_TOKEN", "test-token")
+        monkeypatch.delenv("RELAY_OUTBOX_POLL_INTERVAL_MS", raising=False)
+        monkeypatch.delenv("RELAY_OUTBOX_DLQ_GC_INTERVAL_S", raising=False)
+        monkeypatch.delenv("RELAY_HTTP_TIMEOUT_S", raising=False)
+        captured = self._capture_kwargs(monkeypatch)
+
+        runtime = RelayRuntime(
+            active_sessions_getter=lambda: set(), outbox_db_path=":memory:"
+        )
+        runtime._run_dispatcher()
+
+        from src.relay_sdk import config as sdk_config
+
+        assert captured["poll_interval_seconds"] == sdk_config.DEFAULT_POLL_INTERVAL_SECONDS
+        assert (
+            captured["dlq_gc_interval_seconds"]
+            == sdk_config.DEFAULT_DLQ_GC_INTERVAL_SECONDS
+        )
+        assert captured["http_timeout_seconds"] == sdk_config.DEFAULT_HTTP_TIMEOUT_SECONDS
 
 
 class TestSupervisorRestart:

--- a/tests/unit/test_relay_service_post.py
+++ b/tests/unit/test_relay_service_post.py
@@ -230,3 +230,38 @@ class TestErrorPropagation:
         monkeypatch.setattr(service, "make_client", factory)
         result = service.relay_post("general", "hello")
         assert result["error"]["code"] == "relay_unavailable"
+        assert "retry_after" not in result["error"]
+
+
+class TestRateLimiting:
+    def test_429_with_retry_after_header_returns_rate_limited_code(self, monkeypatch):
+        stub = StubRelay()
+        stub.handlers[("POST", MESSAGES_PATH)] = lambda request: httpx.Response(
+            429,
+            json={"code": "RATE_LIMITED", "message": "しばらく待ってください"},
+            headers={"Retry-After": "12.5"},
+        )
+        stub.install(monkeypatch)
+        result = service.relay_post("general", "hello")
+        assert result["error"]["code"] == "rate_limited"
+        assert result["error"]["retry_after"] == 12.5
+
+    def test_429_without_retry_after_header_returns_null_retry_after(self, monkeypatch):
+        stub = StubRelay()
+        stub.handlers[("POST", MESSAGES_PATH)] = lambda request: httpx.Response(
+            429, json={"code": "RATE_LIMITED", "message": "しばらく待ってください"}
+        )
+        stub.install(monkeypatch)
+        result = service.relay_post("general", "hello")
+        assert result["error"]["code"] == "rate_limited"
+        assert result["error"]["retry_after"] is None
+
+    def test_non_rate_limit_errors_do_not_carry_retry_after_key(self, monkeypatch):
+        """validation 等、`_error()` に extra を渡さない既存呼び出しには
+        `retry_after` 等の余計なキーが混入しない。
+        """
+        stub = StubRelay()
+        stub.install(monkeypatch)
+        result = service.relay_post("general", "")
+        assert result["error"]["code"] == "validation"
+        assert "retry_after" not in result["error"]

--- a/tests/unit/test_relay_service_subscribe.py
+++ b/tests/unit/test_relay_service_subscribe.py
@@ -156,6 +156,26 @@ class TestSubscribe:
         decl = declarations.load("sess-1")
         assert decl is None or decl.get("subscriptions") == []
 
+    def test_429_returns_rate_limited_code_with_retry_after(self, monkeypatch):
+        """429 は relay_post と同様 `rate_limited` に分類され、retry_after が付与される。"""
+
+        def factory(base_url, **kwargs):
+            def rate_limited(request):
+                return httpx.Response(
+                    429,
+                    json={"code": "RATE_LIMITED", "message": "しばらく待ってください"},
+                    headers={"Retry-After": "3"},
+                )
+
+            return httpx.Client(
+                transport=httpx.MockTransport(rate_limited), base_url=base_url
+            )
+
+        monkeypatch.setattr(service, "make_client", factory)
+        result = service.relay_subscribe(["a"], caller_session_id="sess-1")
+        assert result["error"]["code"] == "rate_limited"
+        assert result["error"]["retry_after"] == 3.0
+
 
 class TestReceive:
     def test_no_inbox_returns_empty_list(self):


### PR DESCRIPTION
## Summary

- cc-memory組み込みのrelay outbox dispatcherがRELAY_OUTBOX_MAX_RETRY等の環境変数を一切参照しておらず、transient failure発生時に約1.5秒でDLQ行き（恒久喪失）になっていた。env値を明示的に解決してSDKへ渡すようにし、未設定時の既定値もcc-memory固有の値（合計約8.5分の粘り）に引き上げた。relay serverは手動kill/再起動される運用のため、この断絶を生き延びやすくする狙い。
- relay_post/relay_subscribeの429（rate limit）応答が5xx・timeout・接続不能と同じ`relay_unavailable`に一括分類されており、呼び出し元が「relayが落ちている」のか「レート制限で待てば復帰する」のかを区別できなかった。429を専用コード`rate_limited`に分離し、Retry-Afterヘッダの値を`retry_after`秒数として構造化フィールドで返すようにした。

## Test plan

- [x] `_run_dispatcher`がRELAY_OUTBOX_*環境変数を明示設定した値をそのままSDKへ渡すこと
- [x] 環境変数未設定時はcc-memory固有の既定値（max_retry=10, initial_backoff=1.0s, backoff_factor=2.0）が使われ、SDK自身の既定値（5/0.1/2.0）とは異なること
- [x] poll_interval/dlq_gc_interval/http_timeoutはSDK側のenv解決ヘルパーがそのまま使われること
- [x] 既存のDispatcherAlreadyRunning縮退テストが無修正で通ること
- [x] 429・Retry-Afterヘッダありは`rate_limited`+具体的な秒数を返すこと（relay_post/relay_subscribe両方）
- [x] 429・Retry-Afterヘッダなしは`rate_limited`+`retry_after: null`を返すこと
- [x] 5xx・timeout・接続不能は引き続き`relay_unavailable`（`retry_after`キーなし）を返し、既存テストが無修正で通ること
- [x] 401/410（RelayProtocolError）は本変更の影響を受けないこと
- [x] validation等、extraを渡さない既存エラー呼び出しに`retry_after`等の余計なキーが混入しないこと
- 既存テスト群（unit 2422件）に破壊なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)