### PR TITLE
feat: SessionStart時にrelay inbox未読件数を通知する

### DIFF
--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -370,6 +370,34 @@ def _build_signals_section(conn, session_id: str | None = None) -> str:  # conn,
     return f"未トリアージのシグナル: {total}件 ({breakdown}) → get_signals で確認\n"
 
 
+def _build_relay_inbox_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
+    """relay inboxの未読件数を1行表示する。
+
+    identity解決はsrc.services.relay.identity.get_relay_identity()に委ねる。
+    この関数はMCPリクエストのHTTPヘッダ（X-CC-Memory-Bridge-Session-Id）を
+    読んで識別子を得るが、本hookはClaude Code CLIが起動する独立プロセスで
+    あり、実行中はMCPリクエストコンテキストを一切持たない。そのためここから
+    呼ぶとヘッダ・ctx.session_idのいずれも解決できずNoneが返り、本セクションは
+    常に空文字（コンテキスト消費ゼロ）になる。get_relay_identity()自体は
+    コンテキスト外呼び出しで例外を投げない実装であり、それに依存して安全に
+    無出力へフォールバックしている。identityが解決できた場合のみ
+    count_unreadで未読件数を数えて表示する。
+    """
+    from src.services.relay.identity import get_relay_identity
+
+    identity = get_relay_identity()
+    if not identity:
+        return ""
+
+    from src.services.relay.inbox import count_unread
+
+    count = count_unread(identity)
+    if count <= 0:
+        return ""
+
+    return f"relay inbox 未読: {count}件 → relay_receive で確認\n"
+
+
 def _build_snapshot_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
     """スナップショット取得＋ヘルスチェック。異常検知時のみ警告を返す。
 
@@ -451,6 +479,7 @@ def _build_session_context(session_id: str | None = None) -> str:
             _build_habits_section,
             _build_sync_policy_section,
             _build_signals_section,
+            _build_relay_inbox_section,
         ]
         for builder in builders:
             try:

--- a/src/services/relay/identity.py
+++ b/src/services/relay/identity.py
@@ -27,15 +27,18 @@ def get_relay_identity() -> Optional[str]:
 
     launcher.py 経由（X-CC-Memory-Bridge-Session-Id ヘッダ）の呼び出しは、
     cc-memory server の再起動をまたいで不変な識別子を返す。ヘッダが無い
-    呼び出し元（本ヘッダを付与しない MCP クライアント）は、従来通り
-    ctx.session_id（ephemeral、MCP 接続単位）にフォールバックする。
+    呼び出し元（本ヘッダを付与しない MCP クライアント）、および HTTP
+    リクエストコンテキスト外からの呼び出し（import失敗・get_http_headers()
+    自体の失敗を含む）は、従来通り ctx.session_id（ephemeral、MCP 接続単位）
+    にフォールバックする。
     """
     try:
         from fastmcp.server.dependencies import get_http_headers
+
+        headers = get_http_headers()
     except Exception:
         return get_caller_session_id()
 
-    headers = get_http_headers()
     stable_id = headers.get(BRIDGE_SESSION_HEADER)
     if isinstance(stable_id, str) and stable_id.strip():
         return stable_id.strip()

--- a/src/services/relay/inbox.py
+++ b/src/services/relay/inbox.py
@@ -127,8 +127,10 @@ def count_unread(session_id: str) -> int:
     """未読メッセージ数を非破壊に数える（drain()と異なりcursorを前進させない）。
 
     inbox file 不在、または cursor が末尾に達している場合は 0。
-    末尾の改行未達（書きかけ）行は数えない。flock(LOCK_SH) で読み取り中の
-    append() と排他し、書きかけの途中状態を読まないようにする。
+    末尾の改行未達（書きかけ）行は数えない。JSON として読めない行・dict でない
+    行は drain() 同様に数えない（drain() で実際に受け取れる件数と一致させる）。
+    flock(LOCK_SH) で読み取り中の append() と排他し、書きかけの途中状態を
+    読まないようにする。
     """
     path = inbox_path(session_id)
     try:
@@ -149,4 +151,13 @@ def count_unread(session_id: str) -> int:
             tail = f.read()
         finally:
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-    return tail.count(b"\n")
+
+    count = 0
+    for line in tail.split(b"\n")[:-1]:
+        try:
+            record = json.loads(line.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(record, dict):
+            count += 1
+    return count

--- a/src/services/relay/inbox.py
+++ b/src/services/relay/inbox.py
@@ -6,6 +6,10 @@ cursor は「どこまで読んだか」のバイトオフセットで、対に�
 配達契約は at-least-once。cursor の欠落・巻き戻りは「重複して返す」側に倒す
 （取りこぼす側には倒さない）。append と drain は inbox ファイルの flock で相互排他し、
 別プロセスの書き手（server 側 intake）と安全に共存する。
+
+count_unread() は drain() と同じファイルを読むが、cursor は前進させない
+（peek専用）。SessionStart hook 等、実際に受信するかどうかをまだ決めていない
+呼び出し元のための軽量な件数確認手段。
 """
 from __future__ import annotations
 
@@ -117,3 +121,32 @@ def drain(session_id: str, limit: Optional[int] = None) -> list[dict]:
         finally:
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
     return records
+
+
+def count_unread(session_id: str) -> int:
+    """未読メッセージ数を非破壊に数える（drain()と異なりcursorを前進させない）。
+
+    inbox file 不在、または cursor が末尾に達している場合は 0。
+    末尾の改行未達（書きかけ）行は数えない。flock(LOCK_SH) で読み取り中の
+    append() と排他し、書きかけの途中状態を読まないようにする。
+    """
+    path = inbox_path(session_id)
+    try:
+        f = open(path, "rb")
+    except FileNotFoundError:
+        return 0
+    with f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        try:
+            size = os.fstat(f.fileno()).st_size
+            offset = read_cursor(session_id)
+            if offset > size:
+                # drain() と同じ規約: 不整合時は先頭からとみなす
+                offset = 0
+            if offset >= size:
+                return 0
+            f.seek(offset)
+            tail = f.read()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    return tail.count(b"\n")

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -1173,4 +1173,43 @@ class TestSessionStartHookSignals:
         result = _run_session_start_hook(temp_db)
         context = result["hookSpecificOutput"]["additionalContext"]
 
+
+class TestSessionStartHookRelayInbox:
+    """relay inbox未読件数の1行表示テスト
+
+    hookは実プロセスとしてsubprocess経由で起動され、MCPリクエストコンテキストを
+    一切持たない。そのためget_relay_identity()は常にNoneへ解決し、実際に未読が
+    存在してもこのセクションは常に空文字（ゼロコスト）になる。
+    """
+
+    def test_no_relay_section_when_no_unread(self, temp_db):
+        """relay状態が何もない通常時はセクション自体が出ない"""
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "relay inbox 未読" not in context
+
+    def test_relay_section_absent_even_with_real_unread_backlog(
+        self, temp_db, tmp_path
+    ):
+        """実在のinboxに未読が積まれていても、hookプロセスはidentityを解決
+        できないためセクションは表示されない（今回のバッチが対応する範囲では
+        SessionStart側は常に無出力）。
+        """
+        state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(state_dir)
+        try:
+            relay_inbox.append("some-identity", {"body": "hello"})
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_session_start_hook(
+            temp_db, extra_env={"RELAY_STATE_DIR": str(state_dir)}
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "relay inbox 未読" not in context
+
         assert "未トリアージのシグナル" not in context

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -1173,6 +1173,8 @@ class TestSessionStartHookSignals:
         result = _run_session_start_hook(temp_db)
         context = result["hookSpecificOutput"]["additionalContext"]
 
+        assert "未トリアージのシグナル" not in context
+
 
 class TestSessionStartHookRelayInbox:
     """relay inbox未読件数の1行表示テスト
@@ -1211,5 +1213,3 @@ class TestSessionStartHookRelayInbox:
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "relay inbox 未読" not in context
-
-        assert "未トリアージのシグナル" not in context

--- a/tests/unit/test_relay_identity.py
+++ b/tests/unit/test_relay_identity.py
@@ -60,6 +60,22 @@ class TestGetRelayIdentity:
         )
         assert relay_identity.get_relay_identity() == "ephemeral-session-id"
 
+    def test_falls_back_when_get_http_headers_call_raises(self, monkeypatch):
+        """import自体は成功しても、HTTPリクエストコンテキスト外呼び出し等で
+        get_http_headers()の呼び出しが例外を投げた場合もフォールバックする"""
+
+        def raising_get_http_headers():
+            raise RuntimeError("no active HTTP request context")
+
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers",
+            raising_get_http_headers,
+        )
+        monkeypatch.setattr(
+            relay_identity, "get_caller_session_id", lambda: "ephemeral-session-id"
+        )
+        assert relay_identity.get_relay_identity() == "ephemeral-session-id"
+
     def test_strips_whitespace_from_header_value(self, monkeypatch):
         """ヘッダ値の前後空白は取り除いて返す"""
         monkeypatch.setattr(

--- a/tests/unit/test_relay_inbox.py
+++ b/tests/unit/test_relay_inbox.py
@@ -125,3 +125,12 @@ class TestCountUnread:
         inbox.append("s1", {"n": 1})
         inbox._write_cursor("s1", 10_000)
         assert inbox.count_unread("s1") == 1
+
+    def test_malformed_line_is_not_counted(self):
+        """drain()が実際に返す件数と一致させるため、壊れた行はcountに含めない"""
+        inbox.append("s1", {"n": 1})
+        with open(inbox.inbox_path("s1"), "ab") as f:
+            f.write(b"{broken json\n")
+        inbox.append("s1", {"n": 2})
+        assert inbox.count_unread("s1") == 2
+        assert [r["n"] for r in inbox.drain("s1")] == [1, 2]

--- a/tests/unit/test_relay_inbox.py
+++ b/tests/unit/test_relay_inbox.py
@@ -82,3 +82,46 @@ class TestDrainRobustness:
         lines = inbox.inbox_path("s1").read_bytes().splitlines()
         assert len(lines) == 2
         assert json.loads(lines[0]) == {"a": 1}
+
+
+class TestCountUnread:
+    def test_missing_inbox_returns_zero(self):
+        assert inbox.count_unread("never-subscribed") == 0
+
+    def test_fully_drained_inbox_returns_zero(self):
+        inbox.append("s1", {"n": 1})
+        inbox.drain("s1")
+        assert inbox.count_unread("s1") == 0
+
+    def test_counts_unread_records(self):
+        inbox.append("s1", {"n": 1})
+        inbox.append("s1", {"n": 2})
+        inbox.append("s1", {"n": 3})
+        assert inbox.count_unread("s1") == 3
+
+    def test_counts_only_records_after_cursor(self):
+        inbox.append("s1", {"n": 1})
+        inbox.drain("s1")
+        inbox.append("s1", {"n": 2})
+        inbox.append("s1", {"n": 3})
+        assert inbox.count_unread("s1") == 2
+
+    def test_partial_trailing_line_is_not_counted(self):
+        inbox.append("s1", {"n": 1})
+        with open(inbox.inbox_path("s1"), "ab") as f:
+            f.write(b'{"n": 2')
+        assert inbox.count_unread("s1") == 1
+
+    def test_does_not_advance_cursor(self):
+        inbox.append("s1", {"n": 1})
+        inbox.append("s1", {"n": 2})
+        cursor_before = inbox.read_cursor("s1")
+        assert inbox.count_unread("s1") == 2
+        assert inbox.read_cursor("s1") == cursor_before
+        # drain後も同じ2件が読めることでcursorが前進していないことを確認する
+        assert [r["n"] for r in inbox.drain("s1")] == [1, 2]
+
+    def test_cursor_beyond_file_size_rereads_from_start(self):
+        inbox.append("s1", {"n": 1})
+        inbox._write_cursor("s1", 10_000)
+        assert inbox.count_unread("s1") == 1

--- a/tests/unit/test_session_start_relay_inbox_section.py
+++ b/tests/unit/test_session_start_relay_inbox_section.py
@@ -1,0 +1,87 @@
+"""_build_relay_inbox_section（hooks/session_start_hook.py）のユニットテスト。
+
+subprocess経由のE2E（tests/e2e/test_session_start_hook.py）はhookプロセスが
+実際のMCPリクエストコンテキストを持たないため、identity解決が常にNoneになる
+「ゼロコスト」経路しか検証できない。ここでは関数を直接importして
+get_relay_identity/count_unreadをmonkeypatchし、identityが解決できた場合の
+表示ロジックを検証する。
+"""
+import os
+import tempfile
+
+import pytest
+
+import src.services.relay.identity as relay_identity
+import src.services.relay.inbox as relay_inbox
+from src.db import init_database
+from hooks.session_start_hook import _build_relay_inbox_section, _build_session_context
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+class TestIdentityUnresolved:
+    def test_returns_empty_when_identity_unresolved(self, monkeypatch):
+        """get_relay_identity()がNoneを返すとき、count_unreadを呼ばず空文字を返す"""
+        monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: None)
+        called = {"count_unread": False}
+        monkeypatch.setattr(
+            relay_inbox,
+            "count_unread",
+            lambda session_id: called.__setitem__("count_unread", True) or 5,
+        )
+        assert _build_relay_inbox_section(None) == ""
+        assert called["count_unread"] is False
+
+
+class TestIdentityResolved:
+    def test_returns_empty_when_unread_is_zero(self, monkeypatch):
+        monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: "stable-id-1")
+        monkeypatch.setattr(relay_inbox, "count_unread", lambda session_id: 0)
+        assert _build_relay_inbox_section(None) == ""
+
+    def test_shows_count_when_unread_is_positive(self, monkeypatch):
+        monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: "stable-id-1")
+        monkeypatch.setattr(relay_inbox, "count_unread", lambda session_id: 3)
+        assert (
+            _build_relay_inbox_section(None)
+            == "relay inbox 未読: 3件 → relay_receive で確認\n"
+        )
+
+    def test_passes_resolved_identity_to_count_unread(self, monkeypatch):
+        """count_unreadに渡される引数がget_relay_identity()の返り値と一致する"""
+        received = {}
+        monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: "stable-id-42")
+
+        def fake_count_unread(session_id):
+            received["session_id"] = session_id
+            return 1
+
+        monkeypatch.setattr(relay_inbox, "count_unread", fake_count_unread)
+        _build_relay_inbox_section(None)
+        assert received["session_id"] == "stable-id-42"
+
+
+class TestSessionContextProtection:
+    def test_relay_section_exception_does_not_break_other_sections(
+        self, temp_db, monkeypatch
+    ):
+        """本セクションが例外を投げても、buildersループの他セクション（静的
+        セクション含む）の出力は失われない（per-builder try/exceptの保護範囲）。
+        """
+
+        def boom():
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(relay_identity, "get_relay_identity", boom)
+        context = _build_session_context()
+        assert "# コンテキスト取得フロー" in context


### PR DESCRIPTION
## 概要

relay inboxに未読メッセージが溜まっていても、これまではセッション側が能動的にrelay_receiveを呼ばない限りその存在に気づく手段がなかった（送った側は成功と思っているが受け手は気づかない、というすれ違いの温床）。本PRはSessionStart時に「relay inbox 未読: N件 → relay_receive で確認」の1行をsystem-reminder注入し、受信のきっかけを作る。

安定identityのPR #518の後続。**#518マージ後にbaseをmainへ付け替えてからマージすること**（stacked PRのため同一ターンでの連続squash mergeは避ける）。

## 挙動

- inbox側に、cursorを前進させないpeek専用の未読カウント手段を追加（既読管理には一切影響しない。書き込み中のプロセスとはflockで排他）
- 未読0件・identity未解決時は完全に無出力で、セッションのコンテキストを1文字も消費しない（既存の未トリアージsignal表示と同じパターン）
- 制約の明示: SessionStart hookはMCPリクエストコンテキストを持たない独立プロセスのため、現状この表示は常に無出力側に倒れる。launcherが保持する安定識別子をhookプロセスから解決する経路が今後の課題として残っており、それが繋がった時点でこの表示が実効化する
- 受信中メッセージをリアルタイムで追いたい用途には、relay各toolの返り値のidentityをscripts/relay/watch_inbox.shに渡す既存経路が使える（本PRでの変更なし）

## テスト計画

- 未読カウントの非破壊性: カウント後にdrainしても全件返る（cursor不変）
- 境界条件: inboxファイル不在→0、cursor末尾到達→0、cursor不整合（ファイルサイズ超過）→先頭からの再カウント、書きかけ行（末尾改行なし）は数えない
- 表示ロジック: identity解決成功+未読ありのときだけ1行出力、0件・identity未解決では空文字
- hookプロセス経路（E2E）: 実プロセス起動でidentity未解決→無出力かつ他セクションに影響しないこと
- 既存unit全2447件pass（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)