### PR TITLE
docs: pull_precedentsのopenapi記載欠落とgo-gate.mdの誤記を修正

### DIFF
--- a/docs/spec/go-gate.md
+++ b/docs/spec/go-gate.md
@@ -10,12 +10,12 @@
 ## 現状の実装範囲
 
 現時点でリポジトリに存在するのは検出器本体(`scripts/gate_check.py`、`scripts/gate_check.sh`)、
-GO判定パッケージツール(`scripts/go_package.py`)、CI ワークフロー(`.github/workflows/gate.yml`)、
-このドキュメントである。以下は未実装である:
+GO判定パッケージツール(`scripts/go_package.py`)、判例 pull 機構(`pull_precedents` ツール)、
+CI ワークフロー(`.github/workflows/gate.yml`)、このドキュメントである。以下は未実装である:
 
 - plan.md / task-plan・task-execute skill への組み込み(分類予測欄、パッケージ生成手順)
-- 判例 pull 機構(`pull_precedents` ツール)本体。`go_package.py new --pull-json` は
-  その応答 JSON を受け取る入力口のみを用意している
+- `go_package.py new --pull-json` から `pull_precedents` を自動実行する配線。現状は
+  応答 JSON を受け取る入力口のみを用意しており、実行と保存は手動で行う
 
 検出器は手元で `uv run python3 scripts/gate_check.py --base <ref> --head <ref>` として、
 CI では PR ごとに `.github/workflows/gate.yml` から自動で呼び出せる状態にある。
@@ -296,7 +296,7 @@ pyyaml のみで動く。
 | L5 | `strictness(gate.effective) >= strictness(gate.machine)`(pre_go=2 > gray=1 > post_veto_candidate=0)。厳格化方向(effectiveの方が強い)は `gate.escalated_by` 必須。唯一の緩和例外は `machine: gray` から `gray_resolution.resolved_to: post_veto_candidate` かつ `basis` が非空かつ各基底判例が `precedents` にstance付きで存在する場合のみ | エラー |
 | L6 | `--mode shadow` のとき `shadow` ブロックが必須(`--allow-placeholder` で必須チェックのみ緩和)。存在する場合は `shadow.human` が妥当な値で、`shadow.divergence` が下表の対応表から正しく導出されている | エラー |
 | L7 | `gate.predicted` と `gate.machine` が乖離している | 警告のみ |
-| L8 | `--mode live` のとき `pull.presented: unavailable` はエラー(pull_precedents 稼働後の実行漏れ検知) | エラー |
+| L8 | `--mode live` のとき `pull.presented: unavailable` はエラー(pull_precedents の実行漏れ検知) | エラー |
 
 divergence対応表(3-7、`expected_divergence()` が単一ソース):
 
@@ -310,7 +310,7 @@ divergence対応表(3-7、`expected_divergence()` が単一ソース):
 
 ### 運用フロー(想定)
 
-1. 設計着手時に `pull_precedents` を実行し、応答JSONを保存する(pull稼働後。稼働前は省略可)
+1. 設計着手時に `pull_precedents` を実行し、応答JSONを保存する
 2. PR作成時に `go_package.py new --activity <id> --pull-json <保存した応答>` でパッケージ雛形を生成する
 3. 人間が1-a判例引用・判例が無かった論点・1-b・1-cを記入する
 4. shadow期は `shadow.human` / `shadow.divergence` を追記する

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -460,7 +460,7 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 | budget_chars | int | no | null | 本文展開の文字数予算。省略時はconfig既定値（`get_config()`の`precedent_budget_chars`で確認可） |
 | include_materials | bool | no | true | decision/topicに紐づくmaterialカタログを同時展開する（30件で打ち切り、超過時`materials_truncated=true`） |
 
-**返り値**: `{guarantee, routing, topics, budget, truncated, materials_truncated}`。`guarantee`は`enumerated`（routing成立・全件列挙完了）/ `routing_miss`（近傍topicなし）/ `routing_unavailable`（embeddingサーバー停止）のいずれか。`topics[].decisions`各要素は`detail="full"`（本文展開）または`detail="index"`（id/title等のみ、`get_by_ids`で本文追補可）。
+**返り値**: `{guarantee, routing, topics, budget, truncated, materials_truncated}`。`guarantee`は`enumerated`（routing成立・全件列挙完了）/ `routing_miss`（近傍topicなし）/ `routing_unavailable`（embeddingサーバー停止）のいずれか。`routing.mode`は`vector`（embedding routingで解決）/ `explicit`（topic_ids指定でrouting skip）/ `unavailable`（embeddingサーバー停止でrouting不能）。`routing.candidates`は各`{topic_id_raw, title, distance, selected}`（topic_ids指定時はdistanceなし。存在しないtopic_idを指定した場合は`{topic_id_raw, error: "not_found"}`）。`topics[].decisions`各要素は`detail="full"`（本文展開）または`detail="index"`（id/title等のみ、`get_by_ids`で本文追補可）。
 **動作**: `search`がランクtop-Nの確率的発見であるのに対し、本ツールは選ばれたtopicの非retract decisionを全件（最低でも索引粒度で）応答に含めることを保証する。read-only（statusを更新する副作用なし）。
 **関連**: 設計・裁定の前に近傍topicの判例を網羅確認したい場面で`get_decisions`/`check_in`のChoose節から参照される。
 

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -252,6 +252,72 @@ paths:
                     type: array
                     items: { $ref: '#/components/schemas/Decision' }
 
+  /tools/pull_precedents:
+    post:
+      tags: [decision]
+      summary: 設計判断前に近傍topicの決定事項を網羅列挙（判例pull）
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context]
+              properties:
+                context:
+                  type: string
+                  description: これから決めようとしている論点の記述（自由記述、2文字以上）。routingのクエリ兼telemetry用（topic_ids指定時も必須）
+                topic_ids:
+                  type: array
+                  items: { type: integer }
+                  nullable: true
+                  description: 対象topicを明示指定してroutingをスキップする（embeddingサーバー停止時でも動作する）
+                k:
+                  type: integer
+                  default: 3
+                  description: routingで採用するtopic数の上限（1〜5にclamp）
+                budget_chars:
+                  type: integer
+                  nullable: true
+                  description: 本文展開の文字数予算。省略時はconfig既定値
+                include_materials:
+                  type: boolean
+                  default: true
+                  description: decision/topicに紐づくmaterialカタログを同時展開する（30件で打ち切り、超過時materials_truncated=true）
+                flavor:
+                  type: string
+                  enum: [raw, internal, readable]
+                  default: internal
+      responses:
+        '200':
+          description: routingが当たったtopicの非retract decisionを全件（最低でも索引粒度で）列挙
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  guarantee:
+                    type: string
+                    enum: [enumerated, routing_miss, routing_unavailable]
+                  routing:
+                    type: object
+                    properties:
+                      candidates:
+                        type: array
+                        items: { type: object }
+                  topics:
+                    type: array
+                    items: { $ref: '#/components/schemas/PrecedentTopic' }
+                  budget:
+                    type: object
+                    properties:
+                      limit: { type: integer, nullable: true }
+                      used: { type: integer }
+                      full: { type: integer }
+                      index_only: { type: integer }
+                  truncated: { type: boolean }
+                  materials_truncated: { type: boolean }
+
   /tools/search:
     post:
       tags: [search]
@@ -1159,3 +1225,16 @@ components:
           items: { $ref: '#/components/schemas/DiscussionLog' }
         catalog: { type: object }
         summary: { type: string }
+
+    PrecedentTopic:
+      type: object
+      properties:
+        topic_id_raw: { type: integer }
+        title: { type: string, nullable: true }
+        decisions_total: { type: integer }
+        decisions:
+          type: array
+          items: { type: object }
+        materials:
+          type: array
+          items: { type: object }

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -309,7 +309,7 @@ paths:
                       candidates:
                         type: array
                         items: { type: object }
-                        description: 各要素は{topic_id, title, distance, selected}（explicit時はdistanceなし）。topic_ids指定時に存在しないtopic_idを指定した場合は{topic_id, error:"not_found"}になる
+                        description: 各要素は{topic_id_raw, title, distance, selected}（explicit時はdistanceなし）。topic_ids指定時に存在しないtopic_idを指定した場合は{topic_id_raw, error:"not_found"}になる
                   topics:
                     type: array
                     items: { $ref: '#/components/schemas/PrecedentTopic' }

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -302,9 +302,14 @@ paths:
                   routing:
                     type: object
                     properties:
+                      mode:
+                        type: string
+                        enum: [vector, explicit, unavailable]
+                        description: vector=embedding routingで解決 / explicit=topic_ids指定でrouting skip / unavailable=embeddingサーバー停止でrouting不能
                       candidates:
                         type: array
                         items: { type: object }
+                        description: 各要素は{topic_id, title, distance, selected}（explicit時はdistanceなし）。topic_ids指定時に存在しないtopic_idを指定した場合は{topic_id, error:"not_found"}になる
                   topics:
                     type: array
                     items: { $ref: '#/components/schemas/PrecedentTopic' }


### PR DESCRIPTION
## Summary
- `pull_precedents` ツールが `docs/spec/openapi.yaml` に定義されておらず、機械可読仕様から参照できない状態だった。`src/main.py` の実装（引数・レスポンス形状）に合わせてリクエスト/レスポンススキーマを追加した
- `docs/spec/go-gate.md` に `pull_precedents` ツール本体が「未実装」と記載されたままだったが、実際には実装済み（`docs/spec/mcp-tools.md` にも既に記載済み）。未実装として残るのは `go_package.py new --pull-json` が `pull_precedents` を自動実行しない（応答JSONを受け取る入力口のみを持ち、実行・保存は手動）という点のみなので、実態に合わせて文言を修正した。付随して同ドキュメント内の「pull稼働後/稼働前」という運用フロー・lintルールの記述も、ツールが常時稼働中である前提に揃えた

## Test plan
- ドキュメントのみの変更（コード変更なし）
- `docs/spec/openapi.yaml` がYAMLとしてparseできること、`pull_precedents` パスと `PrecedentTopic` スキーマが追加されていることを確認済み