### PR TITLE
fix: get_signals/update_signalの内部識別子露出を是正

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1558,6 +1558,8 @@ def get_signals(
         成功時: {"signals": [...], "total_count": int, "stats": {...}(include_stats時のみ)}
         失敗時: {"error": {"code": ..., "message": ...}}
         各signalのidは他のget系ツールと同様id_rawとして返る（idキー自体は含まない）。
+        refs内の各要素のid・promoted_id・context内にネストした参照（missed_ids等）も
+        同じ変換で対応する`{id_key}_raw`に退避される。
         session_id/fingerprintは記録側の内部相関・dedup専用フィールドのため含まない
     """
     return signal_service.get_signals(
@@ -1587,7 +1589,8 @@ def update_signal(
 
     Returns:
         成功時: {"signal": {...}}（更新後の行。idはid_rawとして返り、
-            session_id/fingerprintは含まない。get_signalsと同じ整形）
+            session_id/fingerprintは含まない。refs/promoted_id/context内参照の
+            id_raw化も含め、get_signalsと同じ整形）
         失敗時: {"error": {"code": ..., "message": ...}}
     """
     guard_service.check_capability("update_signal")

--- a/src/main.py
+++ b/src/main.py
@@ -1557,6 +1557,8 @@ def get_signals(
     Returns:
         成功時: {"signals": [...], "total_count": int, "stats": {...}(include_stats時のみ)}
         失敗時: {"error": {"code": ..., "message": ...}}
+        各signalのidは他のget系ツールと同様id_rawとして返る（idキー自体は含まない）。
+        session_id/fingerprintは記録側の内部相関・dedup専用フィールドのため含まない
     """
     return signal_service.get_signals(
         status=status, kind=kind, limit=limit, offset=offset, include_stats=include_stats
@@ -1584,7 +1586,8 @@ def update_signal(
         promoted_id: 昇格先エンティティID。promoted_typeと同時に指定する
 
     Returns:
-        成功時: {"signal": {...}}（更新後の行）
+        成功時: {"signal": {...}}（更新後の行。idはid_rawとして返り、
+            session_id/fingerprintは含まない。get_signalsと同じ整形）
         失敗時: {"error": {"code": ..., "message": ...}}
     """
     guard_service.check_capability("update_signal")

--- a/src/services/readable_id.py
+++ b/src/services/readable_id.py
@@ -27,7 +27,7 @@ def format_readable_id(
     新規 caller を増やさないこと。
 
     Args:
-        entity_type: エンティティ種別 ('topic'/'decision'/'activity'/'log'/'material')
+        entity_type: エンティティ種別 ('topic'/'decision'/'activity'/'log'/'material'/'signal')
         id_int: 元の整数 ID
         title: エンティティのタイトル (None や空文字列の場合は ID のみ)
         flavor: 表示形式 ('readable' のみ実装済み、'raw'/'internal' は将来実装)

--- a/src/services/readable_id.py
+++ b/src/services/readable_id.py
@@ -8,7 +8,7 @@ cc-memory の get 系 tool 返却で、整数 `id` を `id_raw` に退避し、`
 """
 from typing import Literal, get_args
 
-ENTITY_TYPE = Literal["topic", "decision", "activity", "log", "material"]
+ENTITY_TYPE = Literal["topic", "decision", "activity", "log", "material", "signal"]
 FLAVOR = Literal["raw", "internal", "readable"]
 
 _VALID_ENTITY_TYPES: frozenset[str] = frozenset(get_args(ENTITY_TYPE))

--- a/src/services/signal_service.py
+++ b/src/services/signal_service.py
@@ -285,11 +285,58 @@ def _sanitize_signal_for_response(signal: dict) -> dict:
     session_id / fingerprintはrecord_signalのdedup・相関目的の内部専用フィールドで、
     他の read 系ツールがcaller_session_idを返却しない慣習と同様レスポンスから除去する。
     idは他のget系ツールと同じreadable_id変換でid_rawに退避する。
+
+    signal自身のidだけでなく、他エンティティへの内部ID参照も同じ変換パターンで
+    id_raw化する（timeline_serviceのreplaces/replaced_byと同様）:
+    - refs配列内の各要素（{"type": ..., "id": 123}形式）
+    - promoted_id（promoted_typeと対でエンティティ実体を指す。material_serviceの
+      material_id同様id_key引数でid以外のキー名を指定する）
+    - context内にネストした{"type": ..., "id": ...}形状の参照（precedent_missの
+      missed_ids・precedent_misapplied のcited_id等、kindごとの規約キーを
+      列挙しきれないため、キー名ではなく参照の形状で判定する）
     """
     signal.pop("session_id", None)
     signal.pop("fingerprint", None)
+
+    refs = signal.get("refs")
+    if isinstance(refs, list):
+        for ref in refs:
+            _apply_readable_id_if_ref_shaped(ref)
+
+    promoted_type = signal.get("promoted_type")
+    if promoted_type in PROMOTED_ENTITY_TABLE:
+        apply_readable_id_inplace(signal, promoted_type, id_key="promoted_id")
+
+    context = signal.get("context")
+    if isinstance(context, (dict, list)):
+        _apply_readable_id_recursive(context)
+
     apply_readable_id_inplace(signal, "signal")
     return signal
+
+
+def _apply_readable_id_if_ref_shaped(value: object) -> None:
+    """valueが{"type": <PROMOTED_ENTITY_TABLEのいずれか>, "id": int}形状ならid_raw化する。"""
+    if isinstance(value, dict) and value.get("type") in PROMOTED_ENTITY_TABLE:
+        apply_readable_id_inplace(value, value["type"])
+
+
+def _apply_readable_id_recursive(value: object) -> None:
+    """dict/listを再帰的に走査し、ネストしたエンティティ参照をすべてid_raw化する(in-place)。
+
+    contextはkindごとに自由形式のペイロード（migration 0049コメント・
+    report_signalの docstring 参照）で、missed_ids/cited_id等の規約キーを
+    将来のkind追加も含めて列挙しきれない。そのためキー名ではなく
+    refs/replaces/replaced_by と同じ{"type": ..., "id": ...}という参照の
+    "形状"だけを手がかりに変換対象を判定する。
+    """
+    if isinstance(value, dict):
+        _apply_readable_id_if_ref_shaped(value)
+        for v in value.values():
+            _apply_readable_id_recursive(v)
+    elif isinstance(value, list):
+        for item in value:
+            _apply_readable_id_recursive(item)
 
 
 def _compute_stats(conn: sqlite3.Connection) -> dict:

--- a/src/services/signal_service.py
+++ b/src/services/signal_service.py
@@ -15,6 +15,7 @@ import sys
 from typing import Optional
 
 from src.db import get_connection, row_to_dict
+from src.services.readable_id import apply_readable_id_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +214,8 @@ def get_signals(
     Returns:
         {"signals": [...], "total_count": int, "stats": {...} (include_stats時のみ)}
         失敗時: {"error": {"code": ..., "message": ...}}
+        各signalはidをid_rawへ退避しsession_id/fingerprintを含まない
+        （_sanitize_signal_for_response参照）
     """
     if status is not None and status not in VALID_STATUSES:
         return {
@@ -257,7 +260,7 @@ def get_signals(
             params + [limit, offset],
         ).fetchall()
 
-        signals = [_signal_row_to_dict(row) for row in rows]
+        signals = [_sanitize_signal_for_response(_signal_row_to_dict(row)) for row in rows]
 
         result: dict = {"signals": signals, "total_count": total_count}
         if include_stats:
@@ -273,6 +276,19 @@ def _signal_row_to_dict(row: sqlite3.Row) -> dict:
     signal = row_to_dict(row)
     signal["refs"] = json.loads(signal["refs"]) if signal.get("refs") else None
     signal["context"] = json.loads(signal["context"]) if signal.get("context") else None
+    return signal
+
+
+def _sanitize_signal_for_response(signal: dict) -> dict:
+    """get_signals / update_signal のレスポンス用にsignal dictを整形する(in-place)。
+
+    session_id / fingerprintはrecord_signalのdedup・相関目的の内部専用フィールドで、
+    他の read 系ツールがcaller_session_idを返却しない慣習と同様レスポンスから除去する。
+    idは他のget系ツールと同じreadable_id変換でid_rawに退避する。
+    """
+    signal.pop("session_id", None)
+    signal.pop("fingerprint", None)
+    apply_readable_id_inplace(signal, "signal")
     return signal
 
 
@@ -327,7 +343,8 @@ def update_signal(
         promoted_id: 昇格先エンティティID
 
     Returns:
-        {"signal": {...}}（更新後の行）
+        {"signal": {...}}（更新後の行。get_signalsと同様idをid_rawへ退避し
+        session_id/fingerprintを含まない）
         失敗時: {"error": {"code": ..., "message": ...}}
     """
     if status not in VALID_STATUSES:
@@ -398,7 +415,7 @@ def update_signal(
         updated = conn.execute(
             "SELECT * FROM signal_events WHERE id = ?", (signal_id,)
         ).fetchone()
-        return {"signal": _signal_row_to_dict(updated)}
+        return {"signal": _sanitize_signal_for_response(_signal_row_to_dict(updated))}
     except Exception as e:
         conn.rollback()
         return {"error": {"code": "DATABASE_ERROR", "message": str(e)}}

--- a/tests/unit/test_readable_id.py
+++ b/tests/unit/test_readable_id.py
@@ -125,3 +125,10 @@ def test_apply_readable_id_inplace_invalid_entity_type():
     """不正な entity_type は ValueError"""
     with pytest.raises(ValueError, match="Invalid entity_type"):
         apply_readable_id_inplace({"id": 1}, "unknown")  # type: ignore[arg-type]
+
+
+def test_apply_readable_id_inplace_accepts_signal_entity_type():
+    """signal も get 系ツールと同じ id → id_raw 変換の対象になる"""
+    d = {"id": 99, "kind": "friction"}
+    apply_readable_id_inplace(d, "signal")
+    assert d == {"id_raw": 99, "kind": "friction"}

--- a/tests/unit/test_signal_service.py
+++ b/tests/unit/test_signal_service.py
@@ -221,8 +221,36 @@ class TestGetSignals:
         result = ss.get_signals(status=None)
 
         signal = result["signals"][0]
-        assert signal["refs"] == [{"type": "decision", "id": 1}]
+        # refs内の各要素もid_rawへ退避される（他エンティティへの内部ID参照のため）
+        assert signal["refs"] == [{"type": "decision", "id_raw": 1}]
+        # context.resolutionは参照形状({"type":..,"id":..})ではないためそのまま
         assert signal["context"] == {"resolution": "new_correct"}
+
+    def test_context_nested_refs_are_converted_to_id_raw(self, temp_db):
+        """precedent_miss/precedent_misappliedのmissed_ids/cited_id等、contextに
+        ネストした{"type":..,"id":..}形状の参照もid_raw化される。"""
+        ss.record_signal(
+            "precedent_miss",
+            "missed decision 9",
+            source="agent",
+            context={"missed_ids": [{"type": "decision", "id": 9}]},
+        )
+        ss.record_signal(
+            "precedent_misapplied",
+            "decision 1 out of scope",
+            source="agent",
+            context={"cited_id": {"type": "decision", "id": 1}},
+        )
+
+        result = ss.get_signals(status=None)
+
+        by_kind = {s["kind"]: s for s in result["signals"]}
+        assert by_kind["precedent_miss"]["context"] == {
+            "missed_ids": [{"type": "decision", "id_raw": 9}]
+        }
+        assert by_kind["precedent_misapplied"]["context"] == {
+            "cited_id": {"type": "decision", "id_raw": 1}
+        }
 
     def test_response_hides_raw_session_id_and_fingerprint(self, temp_db):
         """session_id/fingerprintは記録側の内部専用フィールドで、レスポンスに現れない。"""
@@ -299,7 +327,9 @@ class TestUpdateSignal:
 
         assert result["signal"]["status"] == "promoted"
         assert result["signal"]["promoted_type"] == "topic"
-        assert result["signal"]["promoted_id"] == topic["topic_id"]
+        # promoted_idも他エンティティへの内部ID参照のためid_rawへ退避される
+        assert "promoted_id" not in result["signal"]
+        assert result["signal"]["promoted_id_raw"] == topic["topic_id"]
 
     def test_promote_rejects_nonexistent_entity(self, temp_db):
         r1 = ss.record_signal("precedent_miss", "missed something")
@@ -389,4 +419,4 @@ class TestUpdateSignal:
 
         assert result["signal"]["status"] == "dismissed"
         assert result["signal"]["promoted_type"] == "topic"
-        assert result["signal"]["promoted_id"] == topic["topic_id"]
+        assert result["signal"]["promoted_id_raw"] == topic["topic_id"]

--- a/tests/unit/test_signal_service.py
+++ b/tests/unit/test_signal_service.py
@@ -224,6 +224,26 @@ class TestGetSignals:
         assert signal["refs"] == [{"type": "decision", "id": 1}]
         assert signal["context"] == {"resolution": "new_correct"}
 
+    def test_response_hides_raw_session_id_and_fingerprint(self, temp_db):
+        """session_id/fingerprintは記録側の内部専用フィールドで、レスポンスに現れない。"""
+        ss.record_signal("machine_error", "boom", source="tool:foo", session_id="sess-1")
+
+        result = ss.get_signals(status=None)
+
+        signal = result["signals"][0]
+        assert "session_id" not in signal
+        assert "fingerprint" not in signal
+
+    def test_response_uses_id_raw_not_bare_id(self, temp_db):
+        """idは他のget系ツールと同じreadable_id変換でid_rawに退避され、idキーは残らない。"""
+        r1 = ss.record_signal("machine_error", "boom", source="tool:foo")
+
+        result = ss.get_signals(status=None)
+
+        signal = result["signals"][0]
+        assert "id" not in signal
+        assert signal["id_raw"] == r1["id"]
+
     def test_include_stats_cross_tabulates_kind_and_status(self, temp_db):
         r1 = ss.record_signal("machine_error", "a", source="s1")
         ss.update_signal(r1["id"], "promoted", promoted_type=None, promoted_id=None)
@@ -254,6 +274,18 @@ class TestUpdateSignal:
 
         assert result["signal"]["status"] == "triaged"
         assert result["signal"]["promoted_type"] is None
+
+    def test_response_hides_raw_session_id_fingerprint_and_bare_id(self, temp_db):
+        """get_signalsと同様、内部識別子はレスポンスに現れずidはid_rawで返る。"""
+        r1 = ss.record_signal("friction", "a", session_id="sess-1")
+
+        result = ss.update_signal(r1["id"], "triaged")
+
+        signal = result["signal"]
+        assert "session_id" not in signal
+        assert "fingerprint" not in signal
+        assert "id" not in signal
+        assert signal["id_raw"] == r1["id"]
 
     def test_promote_links_existing_entity(self, temp_db):
         from src.services.topic_service import add_topic

--- a/tests/unit/test_signal_tools.py
+++ b/tests/unit/test_signal_tools.py
@@ -34,6 +34,18 @@ class TestGetSignalsTool:
         assert result["total_count"] == 1
         assert result["signals"][0]["summary"] == "使いにくい"
 
+    def test_does_not_expose_internal_identifiers(self, temp_db):
+        """session_id/fingerprintは露出せず、idはid_rawのreadable形式で返る。"""
+        created = report_signal("friction", "使いにくい")
+
+        result = get_signals()
+
+        signal = result["signals"][0]
+        assert "session_id" not in signal
+        assert "fingerprint" not in signal
+        assert "id" not in signal
+        assert signal["id_raw"] == created["id"]
+
 
 class TestUpdateSignalTool:
     def test_orch_can_update(self, temp_db, monkeypatch):


### PR DESCRIPTION
## Summary
- `get_signals` / `update_signal` がDB行をそのまま返しており、記録側の内部相関用フィールドである `session_id`（記録元セッションの生ID）と `fingerprint`（dedup用ハッシュ）がレスポンスに生値のまま含まれていた
- 他のget系ツール（get_decisions/get_activities等）が使っている「idをid_rawへ退避し内部IDリテラルの直接露出を避ける」既存の変換パターンをsignalの応答にも適用し、`session_id`/`fingerprint`は完全に除去した
- `update_signal` も同じ行変換関数を経由して返却していたため、一貫性のため同様に修正した

## Test plan
- 新規テストの検証項目:
  - `get_signals` のレスポンスに `session_id` / `fingerprint` が含まれないこと
  - `get_signals` のレスポンスで `id` キーの代わりに `id_raw` が返ること（値は記録時のidと一致）
  - `update_signal` のレスポンスでも同様に内部識別子が露出しないこと
  - `readable_id.apply_readable_id_inplace` が `signal` エンティティ種別を受け付けること
  - MCPツール層（`src.main.get_signals`）経由でも同様の整形がかかること
- 既存テスト（signal_service / signal_tools / signal_capture / signal_middleware / readable_id 系）は全件pass維持