### PR TITLE
feat: relay招待URLのredeem CLIとcredentialファイルfallback追加

### DIFF
--- a/docs/ops/relay-server.md
+++ b/docs/ops/relay-server.md
@@ -8,7 +8,21 @@ relay v2 サーバー（`uvicorn relay.app:app`）は cc-memory から独立し�
 - relay リポジトリ（`git@github.com:isizono/relay.git`）が cwd から見えていること
 - `relay` パッケージが install 済み（`uv sync` 済み）
 
-## 起動コマンド（開発環境）
+## Bearer token 配布方式
+
+cc-memory が relay へ接続するための Bearer token は、**招待URL方式**で配布する。
+
+1. relay 側で招待URLを1つ発行する（`python -m relay.invite new`）。
+2. 人間が招待URLをコピーする。
+3. cc-memory 側でその招待URLを redeem する（`python -m src.services.relay.redeem`）。redeem に成功すると `~/.cc-memory/relay/credential.json`（0600）が生成され、以後 cc-memory はこのファイルから token / base_url / identity を読む。
+
+招待URLは `<base>/invitations/redeem#v=1&t=it_<token>` の形式で、secret（`t=`）は URL の fragment に置かれる。fragment は HTTP GET でサーバーへ送信されないため、チャットやメールの link-preview bot に URL を踏まれても招待は消費されない。招待URLは 15 分・一回限りで失効する。
+
+環境変数 `RELAY_BEARER_TOKEN` / `RELAY_BASE_URL` / `RELAY_IDENTITY` による直接設定は残っている（下記「cc-memory 側の設定」）。これは break-glass 用の代替経路で、通常運用では招待URL方式を使う。env が設定されていると credential.json より優先される。
+
+## 起動コマンド（開発環境・break-glass）
+
+招待URL方式を使わずに素早く動作確認したい場合の経路。
 
 ```bash
 export RELAY_AUTH_TOKENS='{"<bearer-token>": "cc-memory"}'
@@ -18,21 +32,22 @@ uv run uvicorn relay.app:app --host 127.0.0.1 --port 8770
 ```
 
 - `RELAY_AUTH_TOKENS` は `{"<token>": "<identity>"}` の JSON。cc-memory server は `RELAY_BEARER_TOKEN` に `<token>` を、`RELAY_IDENTITY` に `<identity>`（省略時は `cc-memory`）を設定する。
-- `RELAY_DB_PATH` は outbox / publish_log / agent_cards の永続化先。subscription / stream registry は in-memory なので server 再起動で消える（cc-memory 側の B-2 lease loop が自己修復する）。
+- `RELAY_DB_PATH` は outbox / publish_log / agent_cards（および招待URL方式導入後は invitations / credentials）の永続化先。subscription / stream registry は in-memory なので server 再起動で消える（cc-memory 側の B-2 lease loop が自己修復する）。
 - ポート番号は他プロセスと衝突しない値を選ぶ。上例では 8770 を使う。
+- 常駐運用（launchd）では `RELAY_DB_PATH` を `~/.local/state/relay/relay.db` に統一する（下記「macOS launchd で常駐化する例」）。git / worktree の churn から独立させるため。
 
 ## cc-memory 側の設定
 
-cc-memory server（`python -m src.main --transport http`）は以下の env を認識する:
+cc-memory server（`python -m src.main --transport http`）は以下の env を認識する。値は env → `credential.json` → 既定 の順で解決される。
 
 | 環境変数 | 説明 | 既定値 |
 |---|---|---|
-| `RELAY_BASE_URL` | relay サーバーの base URL | `http://localhost:8770` |
-| `RELAY_BEARER_TOKEN` | Bearer token（未設定なら relay v2 は未導入扱い） | なし |
-| `RELAY_IDENTITY` | subscribe 時の subscriber、stream の名前空間 | `cc-memory` |
-| `RELAY_STATE_DIR` | declaration / inbox / cursor の置き場 | `~/.cc-memory/relay` |
+| `RELAY_BASE_URL` | relay サーバーの base URL | `http://localhost:8770`（credential.json があれば redeem 時の URL の scheme+host） |
+| `RELAY_BEARER_TOKEN` | Bearer token（env・credential.json とも未設定なら relay v2 は未導入扱い） | なし |
+| `RELAY_IDENTITY` | subscribe 時の subscriber、stream の名前空間 | `cc-memory`（credential.json があればそこに書かれた identity） |
+| `RELAY_STATE_DIR` | declaration / inbox / cursor / **credential.json** の置き場 | `~/.cc-memory/relay` |
 
-`RELAY_BEARER_TOKEN` が未設定のとき cc-memory は常駐 3 系統 thread を起動しない（log 1 行のみで縮退）。この状態でも server 本体の起動と既存機能は影響を受けない。relay を使う MCP tool（`relay_post` / `relay_publish` / `relay_subscribe` / `relay_receive`）は明示的な `config_missing` エラーを返す。
+`get_token()` が env・credential.json のいずれからも token を得られないとき、cc-memory は常駐 3 系統 thread を起動しない（log 1 行のみで縮退）。この状態でも server 本体の起動と既存機能は影響を受けない。relay を使う MCP tool（`relay_post` / `relay_publish` / `relay_subscribe` / `relay_receive`）は明示的な `config_missing` エラーを返す。**招待URL redeem 前のこの縮退は初回ブートの正常な挙動であり、誤報ではない。**
 
 ### outbox dispatcher の retry 既定値
 
@@ -46,7 +61,102 @@ cc-memory server（`python -m src.main --transport http`）は以下の env を�
 
 `RELAY_OUTBOX_*` は cc-memory 組み込みの dispatcher（`RelayRuntime`）にも、スタンドアロン CLI（`python -m src.relay_sdk.outbox`）にも同じ環境変数名で効く。ただし未設定時のフォールバック既定値は異なる。cc-memory 組み込み経路は relay server の手動再起動断絶を生き延びる目的でスタンドアロン CLI より長い既定値（合計約 8.5 分）を持つ。
 
-## macOS launchd で常駐化する例
+## 招待URL発行・redeem 手順（推奨経路）
+
+### 初回セットアップ
+
+1. **relay 側で招待URLを発行する**（relay リポジトリの cwd で）:
+
+   ```bash
+   python -m relay.invite new --identity cc-memory
+   ```
+
+   標準出力に招待URLが1行出る（例: `http://127.0.0.1:8770/invitations/redeem#v=1&t=it_...`）。DB の場所は `--db` 明示 → env `RELAY_DB_PATH` → 既定の canonical 絶対パス `~/.local/state/relay/relay.db` の順で解決される。対話 shell に `RELAY_DB_PATH` を export する必要はない（launchd が起動時に設定する env は対話 shell には伝播しないため、CLI 側は cwd 相対パスへフォールバックせずこの canonical パスを既定にしている）。
+
+2. **招待URLをコピーする。**
+
+3. **cc-memory 側で redeem する**（cc-memory リポジトリの cwd で）:
+
+   ```bash
+   pbpaste | python -m src.services.relay.redeem
+   ```
+
+   `echo '<URL>' | python -m src.services.relay.redeem` は使わない。`echo` は builtin でもコマンドライン全体が `~/.zsh_history` に平文で残り、招待URL（＝capability）がシェル履歴に永続してしまう。`pbpaste` でクリップボードから直接渡す。
+
+   成功すると `~/.cc-memory/relay/credential.json`（0600、親 dir 0700）が生成され、identity と expires_at が標準出力に表示される。
+
+4. **cc-memory の relay クライアントを再起動して credential を拾わせる。** relay に接続するのは **ローカル http プロセス（port 52837、`src.launcher` が起動する `src.main --transport http`）ただ1個**である。
+
+   ```bash
+   lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &
+   ```
+
+   **remote プロセス（port 8001, `com.isizono.cc-memory-remote`）は relay クライアントを一切起動しないため、再起動しても relay 接続には無関係。** relay を有効化する手段として remote 再起動を代用しないこと（サイレントに繋がらないまま気づかない事故になる）。
+
+5. 疎通確認: cc-memory の relay tool（`relay_post` 等）が `config_missing` を返さないこと、relay ログに `invite_redeemed` が出ていること。
+
+### 失効・再発行
+
+- **失効**: relay 側で
+
+  ```bash
+  python -m relay.invite revoke --identity cc-memory
+  ```
+
+  ただし revoke は DB に `revoked_at` をセットするだけで、稼働中 relay の in-memory 認証テーブルは変えない。**revoke 単独では失効しない。** 反映には relay 再起動（`launchctl kickstart -k gui/$(id -u)/com.isizono.relay-v2`）まで含めて1手順である。
+
+- **再発行A（credential.json の紛失・破損からの復旧、漏洩なし）**: 新 credential を追加発行するだけでよい。**旧 credential は無効化されない**（既定無期限のため自然失効もしない）。定期入替（rotation）や「旧鍵を殺す」目的には使えない — その場合は必ず再発行Bを使う。relay 再起動は不要。
+
+  ```bash
+  # relay 側
+  python -m relay.invite new --identity cc-memory
+  ```
+  ```bash
+  # cc-memory 側（招待URLをコピー後）
+  pbpaste | python -m src.services.relay.redeem
+  lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &
+  ```
+
+- **再発行B（credential 漏洩時、失効が必須）**: 漏洩した bearer を確実に無効化する。**relay 再起動を省くと漏洩 bearer が認証テーブルに残り、認証を通し続ける**（revoke は `revoked_at` 列を立てるだけで、稼働中プロセスの照合ロジックはその列を見ない）。
+
+  ```bash
+  # 1. relay 側: revoke
+  python -m relay.invite revoke --identity cc-memory
+
+  # 2. relay 再起動（漏洩 token を in-memory 認証テーブルから除去。省略厳禁）
+  launchctl kickstart -k gui/$(id -u)/com.isizono.relay-v2
+
+  # 3. relay 側: 新規招待発行
+  python -m relay.invite new --identity cc-memory
+  ```
+  ```bash
+  # 4. cc-memory 側（招待URLをコピー後）
+  pbpaste | python -m src.services.relay.redeem
+  lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &
+  ```
+
+## macOS launchd で常駐化する例（秘密ゼロ plist）
+
+credential は relay の DB 側と cc-memory の credential.json 側にのみ存在させ、plist / 起動スクリプトには一切 secret を書かない。
+
+`~/.local/bin/relay-v2.sh`:
+
+```sh
+#!/bin/sh
+# relay-v2.sh — 秘密を一切持たない。credential は DB 側に置く。
+# umask 077: SQLite が open のたびに再生成する -wal/-shm を含め、新規生成ファイル
+# 全てを 0600 相当に強制する（一回きりの chmod では再起動ごとに 0644 の窓が開く）。
+umask 077
+cd "$HOME/workspace/relay"
+install -m 700 -d "$HOME/.local/state/relay"
+export RELAY_DB_PATH="$HOME/.local/state/relay/relay.db"
+export RELAY_SERVER_LOG_PATH="$HOME/.local/state/relay/relay-server.jsonl"
+exec uv run uvicorn relay.app:app --host 127.0.0.1 --port 8770
+```
+
+```bash
+chmod +x ~/.local/bin/relay-v2.sh
+```
 
 `~/Library/LaunchAgents/com.isizono.relay-v2.plist`:
 
@@ -59,43 +169,51 @@ cc-memory server（`python -m src.main --transport http`）は以下の env を�
     <string>com.isizono.relay-v2</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/sh</string>
         <string>/Users/YOU/.local/bin/relay-v2.sh</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>RELAY_AUTH_TOKENS</key>
-        <string>{"REPLACE_ME": "cc-memory"}</string>
-        <key>RELAY_DB_PATH</key>
-        <string>/Users/YOU/.cc-memory/relay/relay-server.db</string>
+        <key>PATH</key>
+        <string>/Users/YOU/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/Users/YOU/.cc-memory/relay/relay-server.log</string>
+    <string>/Users/YOU/.local/state/relay/relay-v2.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/YOU/.cc-memory/relay/relay-server.log</string>
+    <string>/Users/YOU/.local/state/relay/relay-v2.err.log</string>
 </dict>
 </plist>
 ```
 
-`~/.local/bin/relay-v2.sh`:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-cd /Users/YOU/workspace/relay
-exec uv run uvicorn relay.app:app --host 127.0.0.1 --port 8770
-```
+- `RELAY_AUTH_TOKENS` は plist に置かない（動的 credential は DB から起動時に読み込まれる）。
+- `EnvironmentVariables` の `PATH` に `uv` の場所とツールチェーンを明示すること。launchd の最小 PATH には `uv` が含まれず、無いと `uv run` が not found で起動失敗する。
+- bind は `127.0.0.1`（ネットワーク非露出。最重要かつ無償の一次制御）。
 
 登録・起動:
 
 ```bash
-chmod +x ~/.local/bin/relay-v2.sh
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.isizono.relay-v2.plist
 launchctl kickstart -k gui/$(id -u)/com.isizono.relay-v2
 ```
+
+起動直後に `ls -l ~/.local/state/relay/` で `relay.db` 系ファイルが 0600 になっていることを確認する（`umask 077` が効いていれば追加操作は不要。0644 が見えたら `chmod 600 ~/.local/state/relay/relay.db*` で是正する）。
+
+### 既存プロセスからの切り替え（cutover）時の注意
+
+- 新旧の relay は同一 port を bind するため同時起動できない。切り替え前に旧プロセスの listener を確実に停止し、port を解放してから launchd を bootstrap すること。`kill <PID>` を `uv run` ラッパの PID に対して行っても、実 listener が子プロセスとして port を保持し続けることがある。listener は次のように特定して落とす:
+
+  ```bash
+  lsof -ti tcp:8770 -sTCP:LISTEN | xargs kill
+  lsof -ti tcp:8770 -sTCP:LISTEN   # 空になったことを確認してから次へ進む
+  ```
+
+  port が空かないまま `launchctl bootstrap` すると bind 失敗（`Address already in use`）→ `KeepAlive=true` で crash-loop する。
+
+- 旧構成が環境変数 `RELAY_AUTH_TOKENS` の静的表（例: `claude-main` identity）で認証していた場合、新構成（`RELAY_AUTH_TOKENS` 未設定・新 DB は空）へ切り替えると、その identity で接続中の全クライアントが無警告で 401 になる。切り替え前に静的表利用の全 identity を棚卸しし、各々について「招待URLで DB credential として再発行する」「break-glass として plist に温存する」「明示的に破棄する」のいずれかを決めること。
 
 ## セッション側 watcher
 
@@ -118,6 +236,10 @@ inbox path は `RELAY_STATE_DIR`（未設定なら `~/.cc-memory/relay`）配下
 
 ## トラブルシューティング
 
-- **cc-memory 起動時のログに「RELAY_BEARER_TOKEN が未設定のため RelayRuntime を起動しません」と出る**: cc-memory を起動する launchd / shell に `RELAY_BEARER_TOKEN` を注入する。`launchctl setenv RELAY_BEARER_TOKEN <token>` は再起動で消えるため、`~/Library/LaunchAgents/com.isizono.cc-memory-remote.plist` の `EnvironmentVariables` に書く。
-- **relay 起動後も cc-memory が SSE 接続に失敗する**: `RELAY_BASE_URL` の port が relay server と一致しているか確認する。cc-memory 側の既定は 8770。
+- **cc-memory 起動時のログに token 未設定の縮退が出る（招待URL redeem 前）**: 初回ブートで credential.json がまだ無い状態のこの縮退は正常な挙動。`python -m relay.invite new` → `python -m src.services.relay.redeem` で credential を取得すれば解消する。
+- **redeem に成功した（`credential.json` は存在する）のに relay tool が `config_missing` を返し続ける**: credential.json の更新は cc-memory の再起動を挟まないと反映されない（`get_token()` は呼び出しごとに読むが、`RelayRuntime` の起動判定はプロセス起動時に一度だけ評価されるため）。`lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &` でローカル http プロセスを再起動する。
+- **credential.json はあるのに relay が 401 を返し続ける**: revoke 済みの bearer を掴んだままの状態（再発行Bの手順を最後まで完遂していない、または cc-memory の再起動を忘れている）。`RelayRuntime` の再接続ループは指数バックオフ（上限30秒）で無限に再試行し続けるため、プロセスは落ちないが noisy な縮退が続く。再発行A（redeem し直し）を行い、必ず cc-memory（ローカル http 52837）を再起動する。
+- **credential.json と runtime の参照先がずれて `config_missing` になる**: redeem CLI の書込先と runtime の読取先はどちらも `RELAY_STATE_DIR`（既定 `~/.cc-memory/relay`）に一致している前提。どちらか一方だけで `RELAY_STATE_DIR` を override すると発症が分かりにくいズレが生じる。既定のまま揃えることを推奨する。
+- **`python -m relay.invite new` で発行した招待を redeem すると常に 404 になる**: invite CLI と稼働中 relay server が別々の DB ファイルを見ている可能性が高い。invite CLI の DB 解決は `--db` → env `RELAY_DB_PATH` → canonical 絶対パス `~/.local/state/relay/relay.db` の順で、cwd 相対パスにはフォールバックしない。稼働中 relay の `RELAY_DB_PATH`（launchd plist または `relay-v2.sh` の設定）と一致していることを確認する。
+- **relay 起動後も cc-memory が SSE 接続に失敗する**: `RELAY_BASE_URL`（または credential.json の `base_url`）の port が relay server と一致しているか確認する。cc-memory 側の既定は 8770。
 - **declaration file が増え続ける**: cc-memory server の B-2 lease loop が「lease_expires_at の最大値が 24 時間以上前」の declaration file を定期的に削除する（起動時 1 回 + 1 時間毎）。それでも増える場合は該当 session が生存していて renew が回っている可能性がある（生存判定は `SessionManager.session_ids`。SIGKILL 等で launcher が異常終了した場合も `CC_MEMORY_SESSION_LIVENESS_TIMEOUT_SEC` 経過後に自動で対象から外れる）。

--- a/src/services/relay/config.py
+++ b/src/services/relay/config.py
@@ -2,9 +2,14 @@
 
 環境変数は呼び出し時に解決する（モジュール import 時に固定するとテスト・
 プロセス寿命中の設定変更を拾えないため）。
+
+base_url / identity / token はいずれも env → credential.json → 既定 の順で
+フォールバックする。env は override・break-glass 用に最優先を維持する。
+credential.json は招待URL redeem（src/services/relay/redeem.py）が生成する。
 """
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -14,10 +19,11 @@ DEFAULT_IDENTITY = "cc-memory"
 _TOKEN_ENV = "RELAY_BEARER_TOKEN"
 
 TOKEN_MISSING_MESSAGE = (
-    "RELAY_BEARER_TOKEN が未設定のため relay に接続できません。"
-    "relay サーバー側 RELAY_AUTH_TOKENS に登録済みの Bearer token を"
-    "環境変数 RELAY_BEARER_TOKEN に設定してください"
-    "（例: export RELAY_BEARER_TOKEN=<token>）。"
+    "relay の Bearer token が未設定のため接続できません。"
+    "relay 側で招待URLを発行し（`python -m relay.invite new --identity cc-memory`）、"
+    "cc-memory 側で `python -m src.services.relay.redeem` に招待URLを渡して"
+    "credential を取得してください（標準入力に招待URLを1行渡す）。"
+    "環境変数 RELAY_BEARER_TOKEN の直接設定は break-glass 用の代替経路です。"
 )
 
 
@@ -25,23 +31,55 @@ class RelayConfigError(RuntimeError):
     """relay 接続に必要な設定が不足しているときに raise される。"""
 
 
+def _read_credential_file() -> dict | None:
+    """credential.json を読む。欠落・壊れは None（fail-safe）。"""
+    path = get_state_dir() / "credential.json"
+    try:
+        with path.open() as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
 def get_base_url() -> str:
-    """relay サーバーの base URL（env RELAY_BASE_URL、既定 http://localhost:8770）。"""
-    return os.environ.get("RELAY_BASE_URL") or DEFAULT_BASE_URL
+    """relay サーバーの base URL（env RELAY_BASE_URL → credential.json → 既定）。"""
+    env = os.environ.get("RELAY_BASE_URL")
+    if env:
+        return env
+    cred = _read_credential_file()
+    if cred and cred.get("base_url"):
+        return str(cred["base_url"])
+    return DEFAULT_BASE_URL
 
 
 def get_identity() -> str:
-    """relay に対する自 identity 名（env RELAY_IDENTITY、既定 cc-memory）。
+    """relay に対する自 identity 名（env RELAY_IDENTITY → credential.json → 既定）。
 
     Bearer token が解決される identity 文字列と一致している必要がある
     （subscription の subscriber・stream の名前空間の両方がこの値でスコープされる）。
     """
-    return os.environ.get("RELAY_IDENTITY") or DEFAULT_IDENTITY
+    env = os.environ.get("RELAY_IDENTITY")
+    if env:
+        return env
+    cred = _read_credential_file()
+    if cred and cred.get("identity"):
+        return str(cred["identity"])
+    return DEFAULT_IDENTITY
 
 
 def get_token() -> str | None:
-    """Bearer token（env RELAY_BEARER_TOKEN）。未設定なら None。"""
-    return os.environ.get(_TOKEN_ENV) or None
+    """Bearer token（env RELAY_BEARER_TOKEN → credential.json → None）。
+
+    env は override / break-glass として最優先する。
+    """
+    env = os.environ.get(_TOKEN_ENV)
+    if env:
+        return env
+    cred = _read_credential_file()
+    if cred and cred.get("bearer_token"):
+        return str(cred["bearer_token"])
+    return None
 
 
 def require_token() -> str:

--- a/src/services/relay/redeem.py
+++ b/src/services/relay/redeem.py
@@ -1,0 +1,178 @@
+"""招待URL redeem CLI: `python -m src.services.relay.redeem`。
+
+標準入力から招待URLを1行受け取り、relay の `POST /invitations/redeem` へ
+POST して bearer credential を取得し、`config.get_state_dir()/credential.json`
+（0600、親 dir 0700）へ atomic に書き込む。
+
+招待URLは argv ではなく標準入力で受ける（shell 履歴への招待URL残留を避けるため）。
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import parse_qsl, urlsplit
+
+import httpx
+
+from src.services.relay import config
+
+CREDENTIAL_FILENAME = "credential.json"
+
+_REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+class RedeemError(RuntimeError):
+    """redeem 処理が失敗したときに raise される。メッセージはそのまま利用者へ表示する。"""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_invite_url(url: str) -> tuple[str, str, str]:
+    """招待URLを (redeem先エンドポイントURL, base_url, invite_token) に分解する。
+
+    招待URLの形式: `<scheme>://<host>[:<port>]/invitations/redeem#v=1&t=it_...`
+    - scheme+host+path が POST 先エンドポイント
+    - scheme+host が credential.json に保存する base_url
+    - fragment の `t=` が invite token
+    """
+    parsed = urlsplit(url.strip())
+    if not parsed.scheme or not parsed.netloc or not parsed.path:
+        raise RedeemError(f"招待URLの形式が不正です（scheme/host/pathが揃っていません）: {url!r}")
+    if not parsed.fragment:
+        raise RedeemError("招待URLに fragment（#v=1&t=...）がありません")
+
+    fragment_params = dict(parse_qsl(parsed.fragment))
+    token = fragment_params.get("t")
+    if not token:
+        raise RedeemError("招待URLの fragment に招待token（t=...）がありません")
+
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+    endpoint = f"{base_url}{parsed.path}"
+    return endpoint, base_url, token
+
+
+def _redeem(endpoint: str, invite_token: str) -> dict:
+    """redeem endpoint へ POST し、成功時の応答 body（dict）を返す。
+
+    HTTP 応答に至らない transport error（connection refused 等）は非200分岐と
+    区別し、relay の稼働確認を促すメッセージで RedeemError を送出する。
+    """
+    try:
+        response = httpx.post(
+            endpoint,
+            json={"invite_token": invite_token},
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.TransportError as exc:
+        raise RedeemError(
+            "relay に接続できませんでした。relay サーバーが起動しているか確認してください"
+            "（例: launchctl print gui/$(id -u)/com.isizono.relay-v2）。"
+            f" 詳細: {exc}"
+        ) from exc
+
+    if response.status_code != 200:
+        code = "?"
+        message = response.text
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if isinstance(body, dict):
+            code = body.get("code", code)
+            message = body.get("message", message)
+        raise RedeemError(f"redeem に失敗しました（HTTP {response.status_code} {code}）: {message}")
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise RedeemError("redeem 応答の JSON parse に失敗しました") from exc
+    if not isinstance(body, dict) or not body.get("bearer_token") or not body.get("identity"):
+        raise RedeemError(f"redeem 応答に bearer_token / identity がありません: {body!r}")
+    return body
+
+
+def _write_credential_file(state_dir: Path, credential: dict) -> None:
+    """credential.json を temp file → atomic rename で 0600 書込する。
+
+    temp file は最終 dir と同一 FS 上（`tempfile.mkstemp(dir=state_dir)`）に
+    作る。cross-FS だと rename が非 atomic な copy に fallback し、平文 bearer
+    が一時的に広い権限で露出し得るため。
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(state_dir, 0o700)
+
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(state_dir), prefix=".credential-", suffix=".tmp")
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(credential, f)
+        os.replace(tmp_path, state_dir / CREDENTIAL_FILENAME)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _report_write_failure(state_dir: Path, credential: dict, exc: OSError) -> None:
+    """credential ファイル書込失敗時、bearer を stderr に出して手動回復を促す。
+
+    invite は既に消費済み・bearer は relay 側に mint 済みだが client に届かない
+    孤児 credential が生じる（E4）。手動でファイルへ貼るか、revoke + 再発行で
+    孤児を無効化することを促す。
+    """
+    print(f"credential ファイルの書き込みに失敗しました: {exc}", file=sys.stderr)
+    print(
+        f"手動回復: 以下の bearer_token を {state_dir / CREDENTIAL_FILENAME} に"
+        "手貼りするか、"
+        f"`python -m relay.invite revoke --identity {credential.get('identity')}` の後に"
+        "再発行してください。",
+        file=sys.stderr,
+    )
+    print(f"bearer_token: {credential.get('bearer_token')}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    url = sys.stdin.readline().strip()
+    if not url:
+        print("標準入力から招待URLを受け取れませんでした。", file=sys.stderr)
+        return 1
+
+    try:
+        endpoint, base_url, invite_token = _parse_invite_url(url)
+    except RedeemError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    try:
+        body = _redeem(endpoint, invite_token)
+    except RedeemError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    credential = {
+        "base_url": base_url,
+        "identity": body["identity"],
+        "bearer_token": body["bearer_token"],
+        "issued_at": _now_iso(),
+        "expires_at": body.get("expires_at"),
+    }
+
+    state_dir = config.get_state_dir()
+    try:
+        _write_credential_file(state_dir, credential)
+    except OSError as exc:
+        _report_write_failure(state_dir, credential, exc)
+        return 1
+
+    print(f"credential を取得しました: identity={credential['identity']} expires_at={credential['expires_at']}")
+    print(f"保存先: {state_dir / CREDENTIAL_FILENAME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_relay_config.py
+++ b/tests/unit/test_relay_config.py
@@ -1,4 +1,6 @@
 """relay 接続設定（src/services/relay/config.py）の unit test。"""
+import json
+
 import pytest
 
 from src.services.relay import config
@@ -50,8 +52,79 @@ class TestToken:
     def test_require_token_raises_with_setup_instructions(self):
         with pytest.raises(RelayConfigError) as excinfo:
             config.require_token()
-        assert "RELAY_BEARER_TOKEN" in str(excinfo.value)
+        assert "redeem" in str(excinfo.value)
 
     def test_require_token_returns_value(self, monkeypatch):
         monkeypatch.setenv("RELAY_BEARER_TOKEN", "secret")
         assert config.require_token() == "secret"
+
+
+class TestCredentialFileFallback:
+    """env → credential.json → 既定 のフォールバック順を検証する。"""
+
+    def _write_credential(self, tmp_path, **overrides):
+        data = {
+            "base_url": "http://127.0.0.1:8770",
+            "identity": "cc-memory",
+            "bearer_token": "bt_from_file",
+            "issued_at": "2026-07-08T00:00:00Z",
+            "expires_at": None,
+        }
+        data.update(overrides)
+        (tmp_path / "credential.json").write_text(json.dumps(data))
+        return data
+
+    def test_get_token_reads_credential_file_when_env_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path)
+        assert config.get_token() == "bt_from_file"
+
+    def test_get_token_env_overrides_credential_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path)
+        monkeypatch.setenv("RELAY_BEARER_TOKEN", "bt_from_env")
+        assert config.get_token() == "bt_from_env"
+
+    def test_get_token_none_when_no_env_and_no_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        assert config.get_token() is None
+
+    def test_get_token_none_when_credential_file_missing_bearer_token(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path, bearer_token=None)
+        assert config.get_token() is None
+
+    def test_get_token_none_when_credential_file_malformed(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        (tmp_path / "credential.json").write_text("not valid json")
+        assert config.get_token() is None
+
+    def test_get_base_url_reads_credential_file_when_env_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path, base_url="http://127.0.0.1:8770")
+        assert config.get_base_url() == "http://127.0.0.1:8770"
+
+    def test_get_base_url_env_overrides_credential_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path, base_url="http://127.0.0.1:8770")
+        monkeypatch.setenv("RELAY_BASE_URL", "http://example.test:9999")
+        assert config.get_base_url() == "http://example.test:9999"
+
+    def test_get_base_url_default_when_no_env_and_no_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        assert config.get_base_url() == "http://localhost:8770"
+
+    def test_get_identity_reads_credential_file_when_env_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path, identity="my-agent")
+        assert config.get_identity() == "my-agent"
+
+    def test_get_identity_env_overrides_credential_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        self._write_credential(tmp_path, identity="my-agent")
+        monkeypatch.setenv("RELAY_IDENTITY", "env-agent")
+        assert config.get_identity() == "env-agent"
+
+    def test_get_identity_default_when_no_env_and_no_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path))
+        assert config.get_identity() == "cc-memory"

--- a/tests/unit/test_relay_redeem.py
+++ b/tests/unit/test_relay_redeem.py
@@ -1,0 +1,194 @@
+"""招待URL redeem CLI（src/services/relay/redeem.py）の unit test。"""
+import io
+import json
+import stat
+
+import httpx
+import pytest
+
+from src.services.relay import redeem
+
+VALID_URL = "http://127.0.0.1:8770/invitations/redeem#v=1&t=it_abc123"
+
+
+@pytest.fixture(autouse=True)
+def _clean_relay_env(monkeypatch):
+    for key in ("RELAY_BASE_URL", "RELAY_BEARER_TOKEN", "RELAY_STATE_DIR", "RELAY_IDENTITY"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture()
+def state_dir(tmp_path, monkeypatch):
+    d = tmp_path / "relay-state"
+    monkeypatch.setenv("RELAY_STATE_DIR", str(d))
+    return d
+
+
+class TestParseInviteUrl:
+    def test_valid_url(self):
+        endpoint, base_url, token = redeem._parse_invite_url(VALID_URL)
+        assert endpoint == "http://127.0.0.1:8770/invitations/redeem"
+        assert base_url == "http://127.0.0.1:8770"
+        assert token == "it_abc123"
+
+    def test_strips_surrounding_whitespace(self):
+        endpoint, base_url, token = redeem._parse_invite_url(f"  {VALID_URL}  \n")
+        assert token == "it_abc123"
+
+    def test_missing_fragment_rejected(self):
+        with pytest.raises(redeem.RedeemError):
+            redeem._parse_invite_url("http://127.0.0.1:8770/invitations/redeem")
+
+    def test_missing_token_in_fragment_rejected(self):
+        with pytest.raises(redeem.RedeemError):
+            redeem._parse_invite_url("http://127.0.0.1:8770/invitations/redeem#v=1")
+
+    def test_missing_scheme_rejected(self):
+        with pytest.raises(redeem.RedeemError):
+            redeem._parse_invite_url("127.0.0.1:8770/invitations/redeem#v=1&t=it_abc123")
+
+    def test_missing_path_rejected(self):
+        with pytest.raises(redeem.RedeemError):
+            redeem._parse_invite_url("http://127.0.0.1:8770#v=1&t=it_abc123")
+
+    def test_garbage_string_rejected(self):
+        with pytest.raises(redeem.RedeemError):
+            redeem._parse_invite_url("not a url at all")
+
+
+class TestMainHappyPath:
+    def test_reads_url_from_stdin_and_writes_credential_atomically(
+        self, monkeypatch, capsys, state_dir
+    ):
+        monkeypatch.setattr("sys.stdin", io.StringIO(VALID_URL + "\n"))
+
+        def fake_post(url, *, json, timeout):
+            assert url == "http://127.0.0.1:8770/invitations/redeem"
+            assert json == {"invite_token": "it_abc123"}
+            return httpx.Response(
+                200,
+                json={
+                    "bearer_token": "bt_secret",
+                    "identity": "cc-memory",
+                    "expires_at": None,
+                },
+            )
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        exit_code = redeem.main()
+
+        assert exit_code == 0
+        cred_path = state_dir / redeem.CREDENTIAL_FILENAME
+        assert cred_path.exists()
+        data = json.loads(cred_path.read_text())
+        assert data["bearer_token"] == "bt_secret"
+        assert data["identity"] == "cc-memory"
+        assert data["base_url"] == "http://127.0.0.1:8770"
+        assert data["expires_at"] is None
+        assert "issued_at" in data
+
+        # credential.json は 0600、親 dir は 0700。
+        file_mode = stat.S_IMODE(cred_path.stat().st_mode)
+        dir_mode = stat.S_IMODE(state_dir.stat().st_mode)
+        assert file_mode == 0o600
+        assert dir_mode == 0o700
+
+        out = capsys.readouterr().out
+        assert "cc-memory" in out
+
+    def test_no_leftover_temp_files(self, monkeypatch, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO(VALID_URL + "\n"))
+        monkeypatch.setattr(
+            httpx,
+            "post",
+            lambda url, *, json, timeout: httpx.Response(
+                200,
+                json={"bearer_token": "bt_secret", "identity": "cc-memory", "expires_at": None},
+            ),
+        )
+
+        redeem.main()
+
+        entries = list(state_dir.iterdir())
+        assert entries == [state_dir / redeem.CREDENTIAL_FILENAME]
+
+
+class TestMainRejectsMalformedUrl:
+    def test_malformed_url_nonzero_exit_no_file_written(self, monkeypatch, capsys, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO("not a url at all\n"))
+
+        exit_code = redeem.main()
+
+        assert exit_code != 0
+        assert not (state_dir / redeem.CREDENTIAL_FILENAME).exists()
+        assert capsys.readouterr().err
+
+    def test_empty_stdin_nonzero_exit(self, monkeypatch, capsys, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+        exit_code = redeem.main()
+
+        assert exit_code != 0
+        assert capsys.readouterr().err
+
+
+class TestMainHttpErrors:
+    def test_non_200_response_reports_code_and_message(self, monkeypatch, capsys, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO(VALID_URL + "\n"))
+        monkeypatch.setattr(
+            httpx,
+            "post",
+            lambda url, *, json, timeout: httpx.Response(
+                404,
+                json={"code": "InviteNotFoundError", "message": "unknown or expired invite"},
+            ),
+        )
+
+        exit_code = redeem.main()
+
+        assert exit_code != 0
+        err = capsys.readouterr().err
+        assert "InviteNotFoundError" in err
+        assert "unknown or expired invite" in err
+        assert not (state_dir / redeem.CREDENTIAL_FILENAME).exists()
+
+    def test_transport_error_reports_relay_liveness_hint(self, monkeypatch, capsys, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO(VALID_URL + "\n"))
+
+        def raise_connect_error(url, *, json, timeout):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "post", raise_connect_error)
+
+        exit_code = redeem.main()
+
+        assert exit_code != 0
+        err = capsys.readouterr().err
+        assert "起動しているか確認" in err
+        assert not (state_dir / redeem.CREDENTIAL_FILENAME).exists()
+
+
+class TestWriteFailureReportsBearer:
+    def test_write_failure_prints_bearer_to_stderr(self, monkeypatch, capsys, state_dir):
+        monkeypatch.setattr("sys.stdin", io.StringIO(VALID_URL + "\n"))
+        monkeypatch.setattr(
+            httpx,
+            "post",
+            lambda url, *, json, timeout: httpx.Response(
+                200,
+                json={"bearer_token": "bt_orphan", "identity": "cc-memory", "expires_at": None},
+            ),
+        )
+
+        def raise_replace(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("src.services.relay.redeem.os.replace", raise_replace)
+
+        exit_code = redeem.main()
+
+        assert exit_code != 0
+        err = capsys.readouterr().err
+        assert "bt_orphan" in err
+        assert "revoke" in err


### PR DESCRIPTION
## Summary

- relay 接続の Bearer token 取得を、env 直接設定に加えて「招待URLを redeem してファイルから読む」経路でも行えるようにする。`config.get_token()` / `get_base_url()` / `get_identity()` は env → `~/.cc-memory/relay/credential.json` → 既定値、の順でフォールバックする。env は break-glass 用の最優先経路として残す。
- 新規 CLI `python -m src.services.relay.redeem` を追加。標準入力から招待URL（`<base>/invitations/redeem#v=1&t=it_...` 形式）を1行受け取り、relay の redeem endpoint へ POST し、応答の bearer token / identity を `credential.json`（0600、親 dir 0700）へ temp file + atomic rename で書き込む。招待URLは argv ではなく stdin で受けるため、シェル履歴に残らない。
- redeem 失敗時の振る舞い: 非200応答は応答本文の code/message を表示して非ゼロ終了。relay へ到達できない transport error（connection refused 等）は別分岐で捕捉し、relay の起動確認を促すメッセージを出す。credential ファイルの書き込みに失敗した場合（invite は既に消費済みで bearer は発行済みだが保存できない状態）は bearer を標準エラーに出力し、手動保存または revoke + 再発行での回復を促す。
- 既存の relay クライアントランタイム（service.py / intake.py / runtime.py / lease_loop.py）は `config.*` 経由でのみ token/base_url/identity を取得しているため、この変更は config.py と新規 redeem.py に閉じており、クライアントランタイム側の改修は不要。
- `docs/ops/relay-server.md` に招待URL発行→redeem のセットアップ手順、失効・再発行手順（紛失復旧用と漏洩時失効用を区別）、秘密を一切含まない launchd plist 例、および関連トラブルシューティング項目を追記した。

## Test plan

`src/services/relay/config.py` の credential.json フォールバック:
- `get_token` が env → credential.json → None の順で解決する
- `get_base_url` / `get_identity` が env の次に credential.json を読み、両方未設定なら既定値に落ちる
- credential.json が欠落・壊れている場合は fail-safe に無視される

`src/services/relay/redeem.py`:
- 招待URLの fragment（`t=`）から invite token を抽出し、scheme+host+path を POST 先、scheme+host を保存する base_url として分解する
- scheme/host/path や fragment の token が欠けた不正な URL を拒否する
- 招待URLを標準入力から受け取る（argv を使わない）
- redeem 成功時に credential.json を 0600（親 dir 0700）で atomic に生成し、一時ファイルを残さない
- 非200応答時に応答の code/message を表示して非ゼロ終了する
- relay に接続できない transport error 時に別メッセージで非ゼロ終了する
- credential ファイルの書き込み失敗時に bearer_token を標準エラーへ出力する

既存テストへの影響: `tests/unit` 全件（2459件）pass、破壊的変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)