### PR TITLE
docs: サーバー再起動手順にmcp reconnectステップを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,5 +34,5 @@ cc-memoryはローカルディレクトリをmarketplaceとして登録してお
 4. ローカルブランチを削除: `git branch -D <branch>`
 5. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
 6. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
-7. 既存のhttpサーバーを停止・再起動: `lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &`（`-sTCP:LISTEN` を付けないと :52837 に接続中のブリッジプロセスまで巻き添えで kill され、生存セッションの再接続競争を誘発する）
-8. Claude Codeセッションを再起動（個別でOK、全セッション同時に落とす必要なし）
+7. 既存のhttpサーバーを停止・再起動: `lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &`（`-sTCP:LISTEN` を付けないと :52837 に接続中のブリッジプロセスまで巻き添えで kill され、生存セッションの再接続競争を誘発する。多数のセッションが同時接続している状態でkillすると、再接続待ちのブリッジ全部が同時に起動リトライを行い、起動が失敗することがある）
+8. 生存している全Claude Codeセッションで `/mcp` からreconnectを実行する（個別でOK、全セッション同時に落とす必要なし）。reconnectで復旧しない場合はそのセッションを再起動する


### PR DESCRIPTION
## Summary
- 複数セッション同時接続下でMCPサーバーを再起動すると、待機中のブリッジ全部が同時に起動リトライを行い失敗することがある。失敗するとブリッジプロセスが終了し、Claude Code側は自動的に再接続しない
- フルセッション再起動より軽量な `/mcp` reconnectで復旧できることを実機で確認したため、手順のステップ8を「セッション再起動」から「`/mcp` reconnect（ダメならセッション再起動）」に変更した
- ステップ7の注記に、多数セッション同時接続時の再起動リスクを追記した

## Test plan
- 実機検証: 13セッション以上が同時接続している状態でローカルMCPサーバーをkill→再起動したところ、複数ブリッジが起動リトライに失敗してプロセス終了、Claude Code側は自動復旧せず。`/mcp` reconnectで復旧することを確認（ブリッジ生存・死亡の両ケースで有効）