### PR TITLE
entity write→relay publish配線とentity namespace購読解禁

### DIFF
--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -491,7 +491,7 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 
 | 名前 | 型 | 必須 | デフォルト | 説明 |
 | --- | --- | --- | --- | --- |
-| labels | list[string] | yes | - | 配送先マッチング用labels（1個以上）。routing系（`handle:`/`room:`/`task:`）とtag namespace（`domain:`/`intent:`等）を併用可。これらのみでも有効。未知prefixは不透明labelとして受理。`role:`（廃止済みnamespace）と中核entity namespace（`topic:`/`activity:`/`decision:`/`log:`/`material:`。実在チェックなしの不透明文字列にしかならないため予約済み）はエラー |
+| labels | list[string] | yes | - | 配送先マッチング用labels（1個以上、1個あたり200字以内）。routing系（`handle:`/`room:`/`task:`）とtag namespace（`domain:`/`intent:`等）を併用可。これらのみでも有効。未知prefixは不透明labelとして受理。`role:`（廃止済みnamespace）とcc-memoryの予約namespace（`entity:`/`event:`/`topic:`/`activity:`/`decision:`/`log:`/`material:`/`tag:`/`habit:`。entity更新のrelay publishが使うnamespaceで、実在チェックなしの不透明文字列にしかならないため予約済み）はエラー |
 | body | string | yes | - | メッセージ本文（非空） |
 | title | string | no | null | 一覧表示用の見出し（200字以内） |
 
@@ -504,7 +504,7 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 
 | 名前 | 型 | 必須 | デフォルト | 説明 |
 | --- | --- | --- | --- | --- |
-| labels | list[string] | yes | - | 購読条件labels（publish側labelsをすべて含む発話が届く）。空配列なら自handle宛のみの購読。`role:`と中核entity namespace（`topic:`/`activity:`/`decision:`/`log:`/`material:`）はエラー |
+| labels | list[string] | yes | - | 購読条件labels（publish側labelsをすべて含む発話が届く）。空配列なら自handle宛のみの購読。`role:`はエラー。cc-memoryの予約namespace（`entity:`/`event:`/`topic:`/`activity:`/`decision:`/`log:`/`material:`/`tag:`/`habit:`）はrelay_publishと異なりここでは許可（entity更新のrelay publishを購読するために必要。例: `["activity:1183", "event:updated"]`） |
 
 **返り値**: `{subscription_id: string, labels: list[string], lease_expires_at: string, handle: string, reused: bool, identity: string}`。
 **動作**: 自sessionの`handle:` labelを自動付与し、subscription declaration file（`~/.cc-memory/relay/subscriptions/session-<session_id>.json`）とrelayの購読登録を同期する。同一labels集合の再呼び出しは冪等で、leaseが有効なら既存購読を返し（`reused: true`）、失効・不明なら新規購読してdeclaration fileのidを差し替える。lease更新・再購読・購読解除はserver側常駐処理が自動管理する。新規購読（`reused: false`）が成立すると、server内の常駐SSE受信スレッドへ即座に反映指示を送る。反映は次にSSEフレーム（実メッセージだけでなくkeepaliveのコメントフレーム到達でも判定される）が届いた時点で完了し、既定設定では上限概ね60秒に収まる。この間に届いたメッセージはrelay側のsubscription outboxに保持されるため取りこぼされない。`identity`は呼び出し元セッションの識別子（cc-memory server再起動をまたいで安定。`scripts/relay/watch_inbox.sh`等に渡す値として使える）。

--- a/src/main.py
+++ b/src/main.py
@@ -1660,9 +1660,10 @@ def relay_publish(labels: list[str], body: str, title: str | None = None) -> dic
 
     送信者の handle: label が自動付与される。labels には routing 系（handle:/room:/task:）と
     cc-memory の tag namespace（domain:/intent: 等）を併用でき、これらのみでも有効。未知
-    prefix も不透明 label として受理する。role:（廃止済み namespace）と cc-memory の中核
-    entity namespace（topic:/activity:/decision:/log:/material:。実在チェックなしの不透明
-    文字列にしかならないため予約済み）は指定するとエラー。
+    prefix も不透明 label として受理する。role:（廃止済み namespace）と cc-memory の予約
+    namespace（entity:/event:/topic:/activity:/decision:/log:/material:/tag:/habit:。
+    entity 更新の relay publish が使う namespace で、実在チェックなしの不透明文字列に
+    しかならないため予約済み）は指定するとエラー。
 
     配布した内容は cc-memory 本体（search/get_timeline/pull_precedents 等）には自動で
     反映されない。受信側が後から参照できる形で残したい場合は、受信後に add_logs/
@@ -1699,8 +1700,11 @@ def relay_subscribe(labels: list[str]) -> dict:
     （直接メッセージ）のみの購読になる。同一 labels 集合での再呼び出しは冪等で、lease が
     有効なら既存の購読をそのまま返し、失効していれば新規に購読し直して差し替える。
     lease 更新・再接続・購読解除は server 側で自動管理される（呼び出し側の操作は不要）。
-    role:（廃止済み namespace）と cc-memory の中核 entity namespace
-    （topic:/activity:/decision:/log:/material:）は relay_publish と同様に指定するとエラー。
+    role:（廃止済み namespace）は relay_publish と同様に指定するとエラー。cc-memory の
+    予約 namespace（entity:/event:/topic:/activity:/decision:/log:/material:/tag:/
+    habit:）は relay_publish と異なりここでは許可される（entity 更新の relay publish を
+    購読するために必要。例: ["activity:1183", "event:updated"] で activity 1183 の
+    状態遷移を購読、["entity:decision", "event:retracted"] で全 decision の retract を購読）。
 
     新規に購読が作られた場合（reused: false）、server 内の常駐 SSE 接続へ即座に反映指示を
     送る。実際の反映は次に SSE フレーム（実メッセージだけでなく keepalive のコメント

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -643,7 +643,7 @@ def update_activity(
         if status is None and old_status == "snoozed":
             status = "pending"
 
-        # publish判定（decision 3076）: statusはold_status != new_statusの遷移時のみ、
+        # publish判定: statusはold_status != new_statusの遷移時のみ、
         # 他フィールド（title/description/tags/orch_managed）はno-op含めて無条件でpublish対象。
         # statusはsnoozed自動復活後の値（上のブロック）で判定するため、自動復活も遷移として拾う。
         should_publish = (

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -9,6 +9,7 @@ from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.title_validation import validate_title
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -182,6 +183,10 @@ def add_activity(
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(
             conn, "activity", activity_id, title=title, description=description
+        )
+
+        publish_entity_event_with_conn(
+            conn, entity_type="activity", entity_id=activity_id, event="created"
         )
 
         conn.commit()
@@ -634,8 +639,20 @@ def update_activity(
             }
 
         # snoozed中にstatus指定なしでフィールド更新 → 自動復活
-        if status is None and row["status"] == "snoozed":
+        old_status = row["status"]
+        if status is None and old_status == "snoozed":
             status = "pending"
+
+        # publish判定（decision 3076）: statusはold_status != new_statusの遷移時のみ、
+        # 他フィールド（title/description/tags/orch_managed）はno-op含めて無条件でpublish対象。
+        # statusはsnoozed自動復活後の値（上のブロック）で判定するため、自動復活も遷移として拾う。
+        should_publish = (
+            title is not None
+            or description is not None
+            or parsed_tags is not None
+            or orch_managed is not None
+            or (status is not None and status != old_status)
+        )
 
         # 動的SQL構築: 指定されたフィールドのみUPDATEする
         set_parts = []
@@ -680,6 +697,11 @@ def update_activity(
             conn, "activity", activity_id,
             title=new_title, description=new_description,
         )
+
+        if should_publish:
+            publish_entity_event_with_conn(
+                conn, entity_type="activity", entity_id=activity_id, event="updated"
+            )
 
         conn.commit()
 

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -23,6 +23,7 @@ from src.services.direction_service import (
 from src.services.habit_service import _add_habit_with_conn
 from src.services.precedent_pure import attach_precedent, parse_precedent_sections, summarize_precedent
 from src.services.relation_service import _add_relation_with_conn
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.supersede_service import compute_supersede_info_batch
 from src.services.title_validation import validate_title
 
@@ -144,6 +145,10 @@ def add_decisions(items: list[dict]) -> dict:
                 # 本文中の {{cite:X#NNN}} を citations テーブルに保存
                 upsert_citations_for_owner_with_conn(
                     conn, "decision", decision_id, decision=decision, reason=reason
+                )
+
+                publish_entity_event_with_conn(
+                    conn, entity_type="decision", entity_id=decision_id, event="created"
                 )
 
                 # propagate_to 処理

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -14,6 +14,7 @@ from src.services.tag_service import (
     get_effective_tags_batch_by_ids,
 )
 from src.services.relation_service import _add_relation_with_conn
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 
 
 def _auto_generate_title(content: str) -> str | None:
@@ -115,6 +116,10 @@ def add_logs(items: list[dict]) -> dict:
                 # 本文中の {{cite:X#NNN}} を citations テーブルに保存
                 upsert_citations_for_owner_with_conn(
                     conn, "log", log_id, content=content
+                )
+
+                publish_entity_event_with_conn(
+                    conn, entity_type="log", entity_id=log_id, event="created"
                 )
 
                 conn.execute(f"RELEASE SAVEPOINT item_{i}")

--- a/src/services/habit_service.py
+++ b/src/services/habit_service.py
@@ -2,6 +2,7 @@
 import logging
 
 from src.db import get_connection, row_to_dict
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,9 @@ def _add_habit_with_conn(conn, content: str) -> int:
         "INSERT INTO habits (content) VALUES (?)",
         (content,),
     )
-    return cursor.lastrowid
+    habit_id = cursor.lastrowid
+    publish_entity_event_with_conn(conn, entity_type="habit", entity_id=habit_id, event="created")
+    return habit_id
 
 
 def add_habit(content: str) -> dict:
@@ -48,11 +51,7 @@ def add_habit(content: str) -> dict:
 
     conn = get_connection()
     try:
-        cursor = conn.execute(
-            "INSERT INTO habits (content) VALUES (?)",
-            (content,),
-        )
-        habit_id = cursor.lastrowid
+        habit_id = _add_habit_with_conn(conn, content)
         conn.commit()
 
         return {"habit_id": habit_id}
@@ -176,6 +175,7 @@ def update_habit(habit_id: int, content: str | None = None, active: bool | None 
             f"UPDATE habits SET {set_clause} WHERE id = ?",
             tuple(values),
         )
+        publish_entity_event_with_conn(conn, entity_type="habit", entity_id=habit_id, event="updated")
         conn.commit()
 
         # 更新後の振る舞いを取得

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -12,6 +12,7 @@ from src.services.readable_id import apply_readable_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.title_validation import validate_title
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -125,6 +126,10 @@ def add_material(title: str, content: str, tags: list[str], source: str, related
 
         # タグを取得（commit前）
         tag_strings = get_entity_tags(conn, "material_tags", "material_id", material_id)
+
+        publish_entity_event_with_conn(
+            conn, entity_type="material", entity_id=material_id, event="created"
+        )
 
         conn.commit()
 
@@ -333,6 +338,10 @@ def update_material(
         new_content = effective_content if content is not None else row["content"]
         upsert_citations_for_owner_with_conn(
             conn, "material", material_id, title=new_title, content=new_content
+        )
+
+        publish_entity_event_with_conn(
+            conn, entity_type="material", entity_id=material_id, event="updated"
         )
 
         conn.commit()

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -218,7 +218,7 @@ def add_pin(
             (source_type, source_id, target_type, target_id),
         )
         # 実際に新規追加された（冪等な再呼び出しでない）ときのみ、pin自体は独立
-        # publishせずsource/target両entityをevent:updatedでpublishする（decision 3065）
+        # publishせずsource/target両entityをevent:updatedでpublishする
         if conn.execute("SELECT changes()").fetchone()[0] > 0:
             bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
             bump_updated_at_and_publish_with_conn(conn, target_type, target_id)

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -4,6 +4,7 @@ import sqlite3
 from typing import Optional, Union
 
 from src.db import get_connection
+from src.services.relay.entity_publish import bump_updated_at_and_publish_with_conn
 from src.services.supersede_service import get_superseded_by_batch
 from src.services.tag_service import parse_tag, resolve_tag_ids
 
@@ -216,6 +217,11 @@ def add_pin(
             "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
             (source_type, source_id, target_type, target_id),
         )
+        # 実際に新規追加された（冪等な再呼び出しでない）ときのみ、pin自体は独立
+        # publishせずsource/target両entityをevent:updatedでpublishする（decision 3065）
+        if conn.execute("SELECT changes()").fetchone()[0] > 0:
+            bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
+            bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
         conn.commit()
 
         result = {
@@ -316,6 +322,9 @@ def remove_pin(
             "DELETE FROM pins WHERE source_type=? AND source_id=? AND target_type=? AND target_id=?",
             (source_type, source_id, target_type, target_id),
         )
+        if cursor.rowcount > 0:
+            bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
+            bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
         conn.commit()
 
         return {"removed": cursor.rowcount}

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -390,7 +390,7 @@ def _remove_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, targe
 def _bump_and_publish_endpoints_with_conn(
     conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]
 ) -> None:
-    """add_relation/remove_relationのsource + target各entityをbump+publishする（decision 3065）。
+    """add_relation/remove_relationのsource + target各entityをbump+publishする。
 
     relation自体は独立publishせず、source/target両方のentityのupdated_atを進めて
     event:updatedとしてpublishすることで代替する。呼び出し元が実際に変化があった

--- a/src/services/relation_service.py
+++ b/src/services/relation_service.py
@@ -4,6 +4,7 @@ import sqlite3
 
 from src.db import get_connection
 from src.services.readable_id import apply_readable_id_inplace
+from src.services.relay.entity_publish import bump_updated_at_and_publish_with_conn
 from src.services.tag_service import (
     get_entity_tags_batch,
 )
@@ -386,6 +387,27 @@ def _remove_supersedes_with_conn(conn: sqlite3.Connection, source_id: int, targe
     return removed
 
 
+def _bump_and_publish_endpoints_with_conn(
+    conn: sqlite3.Connection, source_type: str, source_id: int, targets: list[dict]
+) -> None:
+    """add_relation/remove_relationのsource + target各entityをbump+publishする（decision 3065）。
+
+    relation自体は独立publishせず、source/target両方のentityのupdated_atを進めて
+    event:updatedとしてpublishすることで代替する。呼び出し元が実際に変化があった
+    （added/removed > 0）ときのみ呼ぶこと。
+    """
+    bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
+    seen = set()
+    for target in targets:
+        target_type = target["type"]
+        for target_id in target["ids"]:
+            key = (target_type, target_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
+
+
 def add_relation(source_type: str, source_id: int, targets: list[dict], relation_type: str = "related") -> dict:
     """リレーションを追加する。
 
@@ -440,6 +462,8 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
             added = 0
             for target in targets:
                 added += _add_depends_on_with_conn(conn, source_id, target["ids"])
+            if added > 0:
+                _bump_and_publish_endpoints_with_conn(conn, source_type, source_id, targets)
             conn.commit()
             return {"added": added}
         elif relation_type == "supersedes":
@@ -449,6 +473,8 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
                 a, p = _add_supersedes_with_conn(conn, source_id, target["ids"])
                 added += a
                 pins_transferred += p
+            if added > 0:
+                _bump_and_publish_endpoints_with_conn(conn, source_type, source_id, targets)
             conn.commit()
             result: dict = {"added": added}
             if pins_transferred > 0:
@@ -460,6 +486,8 @@ def add_relation(source_type: str, source_id: int, targets: list[dict], relation
             return result
         else:
             added = _add_relation_with_conn(conn, source_type, source_id, targets, relation_type)
+            if added > 0:
+                _bump_and_publish_endpoints_with_conn(conn, source_type, source_id, targets)
         conn.commit()
         return {"added": added}
     except ValueError as e:
@@ -534,6 +562,8 @@ def remove_relation(source_type: str, source_id: int, targets: list[dict], relat
                 removed += _remove_supersedes_with_conn(conn, source_id, target["ids"])
         else:
             removed = _remove_relation_with_conn(conn, source_type, source_id, targets)
+        if removed > 0:
+            _bump_and_publish_endpoints_with_conn(conn, source_type, source_id, targets)
         conn.commit()
         return {"removed": removed}
     except Exception as e:

--- a/src/services/relay/entity_publish.py
+++ b/src/services/relay/entity_publish.py
@@ -60,7 +60,8 @@ def _one_hop_parent_labels(conn: sqlite3.Connection, entity_type: str, entity_id
     placeholders = ",".join("?" * len(_ONE_HOP_PARENT_TARGET_TYPES))
     rows = conn.execute(
         f"SELECT DISTINCT target_type, target_id FROM relations_view "
-        f"WHERE source_type = ? AND source_id = ? AND target_type IN ({placeholders})",
+        f"WHERE source_type = ? AND source_id = ? AND relation_type = 'belongs_to' "
+        f"AND target_type IN ({placeholders})",
         (entity_type, entity_id, *_ONE_HOP_PARENT_TARGET_TYPES),
     ).fetchall()
     return [f"{row['target_type']}:{row['target_id']}" for row in rows]

--- a/src/services/relay/entity_publish.py
+++ b/src/services/relay/entity_publish.py
@@ -1,0 +1,182 @@
+"""entity write（add_*/update_*/retract/relation/pin）→ relay outbox の core 内部 publish。
+
+relay_publish（セッション向け4動詞の1つ、src.services.relay.service）とは独立した
+内部専用 API で、write 系サービス関数の commit 直前に `publish_entity_event_with_conn`
+を1行呼ぶだけで完結する。RELAY_BEARER_TOKEN 未設定（relay 未接続）環境では静かに
+no-op し、outbox が無限に積もるのを防ぐ。
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Literal, Optional
+
+from src.relay_sdk.config import MAX_TITLE_CHARS
+from src.relay_sdk.outbox import publish as outbox_publish
+from src.services.relay import config as relay_config
+from src.services.relay.service import PUBLISH_ENTITY_TYPES, validate_labels
+from src.services.tag_service import get_entity_tags
+
+logger = logging.getLogger(__name__)
+
+EventType = Literal["created", "updated", "retracted"]
+
+# ref.type として publish 対象になる entity 種別と、対応する DB テーブル名
+# （decision 3065 A.2、cc-memory 内呼称と完全一致）。
+ENTITY_TABLE_MAP: dict[str, str] = {
+    "decision": "decisions",
+    "log": "discussion_logs",
+    "material": "materials",
+    "activity": "activities",
+    "topic": "discussion_topics",
+    "tag": "tags",
+    "habit": "habits",
+}
+assert set(ENTITY_TABLE_MAP) == set(PUBLISH_ENTITY_TYPES)
+
+# entity 自身の tags 取得に使う junction table（topic/activity/decision/log/material のみ。
+# tag/habit 自身は tag 付けされない entity のため対象外）。
+_TAG_JUNCTION: dict[str, tuple[str, str]] = {
+    "topic": ("topic_tags", "topic_id"),
+    "activity": ("activity_tags", "activity_id"),
+    "decision": ("decision_tags", "decision_id"),
+    "log": ("log_tags", "log_id"),
+    "material": ("material_tags", "material_id"),
+}
+
+# 1 hop 親方向の ID 参照（decision 3058 A.4.3）を relations 経由で引く対象。
+# topic は階層の最上位で親を持たないため除外する（除外しないと relations_view の
+# 対称展開で「この topic に属する全 entity」を親扱いしてしまい、publish のたびに
+# 件数が entity 数に比例して膨張する）。tag/habit は relations テーブルに現れない
+# ため、そもそも対象外。
+_ONE_HOP_PARENT_LOOKUP_TYPES = frozenset({"activity", "material", "decision", "log"})
+_ONE_HOP_PARENT_TARGET_TYPES = ("topic", "activity", "material", "decision", "log")
+
+
+def _one_hop_parent_labels(conn: sqlite3.Connection, entity_type: str, entity_id: int) -> list[str]:
+    """1 hop 親方向の ID を labels として返す（N hop transitive は含めない、decision 3058）。"""
+    if entity_type not in _ONE_HOP_PARENT_LOOKUP_TYPES:
+        return []
+    placeholders = ",".join("?" * len(_ONE_HOP_PARENT_TARGET_TYPES))
+    rows = conn.execute(
+        f"SELECT DISTINCT target_type, target_id FROM relations_view "
+        f"WHERE source_type = ? AND source_id = ? AND target_type IN ({placeholders})",
+        (entity_type, entity_id, *_ONE_HOP_PARENT_TARGET_TYPES),
+    ).fetchall()
+    return [f"{row['target_type']}:{row['target_id']}" for row in rows]
+
+
+def _build_title(conn: sqlite3.Connection, entity_type: str, entity_id: int) -> Optional[str]:
+    """A.4.4 の表に従い title を組み立てる（200 UTF-8 chars で truncate、publisher 側責務）。"""
+    if entity_type == "tag":
+        row = conn.execute(
+            "SELECT namespace, name FROM tags WHERE id = ?", (entity_id,)
+        ).fetchone()
+        if not row:
+            return None
+        raw = f"{row['namespace']}:{row['name']}" if row["namespace"] else row["name"]
+    elif entity_type == "habit":
+        row = conn.execute("SELECT content FROM habits WHERE id = ?", (entity_id,)).fetchone()
+        if not row:
+            return None
+        raw = row["content"] or ""
+    elif entity_type == "decision":
+        row = conn.execute(
+            "SELECT title, decision FROM decisions WHERE id = ?", (entity_id,)
+        ).fetchone()
+        if not row:
+            return None
+        raw = row["title"] or row["decision"] or ""
+    elif entity_type == "log":
+        row = conn.execute(
+            "SELECT title, content FROM discussion_logs WHERE id = ?", (entity_id,)
+        ).fetchone()
+        if not row:
+            return None
+        raw = row["title"] or (row["content"] or "")[:50]
+    else:
+        table = ENTITY_TABLE_MAP[entity_type]
+        row = conn.execute(f"SELECT title FROM {table} WHERE id = ?", (entity_id,)).fetchone()
+        if not row:
+            return None
+        raw = row["title"] or ""
+    return raw[:MAX_TITLE_CHARS]
+
+
+def publish_entity_event_with_conn(
+    conn: sqlite3.Connection,
+    *,
+    entity_type: str,
+    entity_id: int,
+    event: EventType,
+) -> Optional[int]:
+    """entity write の commit 直前に呼ぶ、relay outbox への core 内部 publish フック。
+
+    呼び出し元の transaction に乗って outbox 行を INSERT する（commit はしない、
+    呼び出し元の commit に委ねる。cc-memory 業務 write と outbox INSERT が同一 tx に
+    乗ることで dual-write 問題を構造的に回避する）。
+
+    RELAY_BEARER_TOKEN 未設定（relay 未接続）の環境では静かに no-op する
+    （outbox が無限に積もるのを防ぐ。既存の RelayConfigError 判定と同じ config.get_token()
+    を使う）。
+
+    Returns:
+        outbox 行の id（no-op 時・防御的スキップ時は None）
+    """
+    if not relay_config.get_token():
+        return None
+    if entity_type not in ENTITY_TABLE_MAP:
+        raise ValueError(f"Unsupported entity_type for entity publish: {entity_type!r}")
+
+    own_tags: list[str] = []
+    junction = _TAG_JUNCTION.get(entity_type)
+    if junction is not None:
+        junction_table, id_column = junction
+        own_tags = get_entity_tags(conn, junction_table, id_column, entity_id)
+
+    labels = list(dict.fromkeys(
+        own_tags
+        + [f"entity:{entity_type}", f"event:{event}"]
+        + _one_hop_parent_labels(conn, entity_type, entity_id)
+    ))
+
+    message = validate_labels(labels, check_reserved=False)
+    if message:
+        # labels は内部で組み立てているため通常起こり得ない。write本体を巻き込まない
+        # よう、publish だけ諦めてログに残す（防御的フォールバック）。
+        logger.error(
+            "entity publish labels invalid, skipping publish (entity_type=%s, entity_id=%s): %s",
+            entity_type, entity_id, message,
+        )
+        return None
+
+    title = _build_title(conn, entity_type, entity_id)
+
+    return outbox_publish(conn, ref_type=entity_type, ref_id=entity_id, labels=labels, title=title)
+
+
+# updated_at カラムを実際に持つ entity 種別。2026-07 時点で activities / materials の
+# 2 テーブルのみが該当し、decisions / discussion_logs / discussion_topics / tags /
+# habits には updated_at カラムが無い。
+_HAS_UPDATED_AT_COLUMN = frozenset({"activity", "material"})
+
+
+def bump_updated_at_and_publish_with_conn(
+    conn: sqlite3.Connection, entity_type: str, entity_id: int
+) -> Optional[int]:
+    """relation/pin の add/remove 用: entity の updated_at を（カラムがあれば）進めて
+    event:updated を publish する（decision 3065: relation/pin 自体は独立 publish
+    せず、source/target 両方の entity 側で表現する）。
+
+    updated_at カラムを持たない entity 種別（decisions/discussion_logs/
+    discussion_topics/tags/habits）は UPDATE 文をスキップし publish のみ行う
+    （該当テーブルに存在しないカラムへの UPDATE はできないための縮退）。
+    """
+    if entity_type in _HAS_UPDATED_AT_COLUMN:
+        table = ENTITY_TABLE_MAP[entity_type]
+        conn.execute(
+            f"UPDATE {table} SET updated_at = CURRENT_TIMESTAMP WHERE id = ?", (entity_id,)
+        )
+    return publish_entity_event_with_conn(
+        conn, entity_type=entity_type, entity_id=entity_id, event="updated"
+    )

--- a/src/services/relay/entity_publish.py
+++ b/src/services/relay/entity_publish.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 EventType = Literal["created", "updated", "retracted"]
 
 # ref.type として publish 対象になる entity 種別と、対応する DB テーブル名
-# （decision 3065 A.2、cc-memory 内呼称と完全一致）。
+# （cc-memory 内呼称と完全一致）。
 ENTITY_TABLE_MAP: dict[str, str] = {
     "decision": "decisions",
     "log": "discussion_logs",
@@ -44,7 +44,7 @@ _TAG_JUNCTION: dict[str, tuple[str, str]] = {
     "material": ("material_tags", "material_id"),
 }
 
-# 1 hop 親方向の ID 参照（decision 3058 A.4.3）を relations 経由で引く対象。
+# 1 hop 親方向の ID 参照を relations 経由で引く対象。
 # topic は階層の最上位で親を持たないため除外する（除外しないと relations_view の
 # 対称展開で「この topic に属する全 entity」を親扱いしてしまい、publish のたびに
 # 件数が entity 数に比例して膨張する）。tag/habit は relations テーブルに現れない
@@ -54,7 +54,7 @@ _ONE_HOP_PARENT_TARGET_TYPES = ("topic", "activity", "material", "decision", "lo
 
 
 def _one_hop_parent_labels(conn: sqlite3.Connection, entity_type: str, entity_id: int) -> list[str]:
-    """1 hop 親方向の ID を labels として返す（N hop transitive は含めない、decision 3058）。"""
+    """1 hop 親方向の ID を labels として返す（N hop transitive は含めない）。"""
     if entity_type not in _ONE_HOP_PARENT_LOOKUP_TYPES:
         return []
     placeholders = ",".join("?" * len(_ONE_HOP_PARENT_TARGET_TYPES))
@@ -67,7 +67,7 @@ def _one_hop_parent_labels(conn: sqlite3.Connection, entity_type: str, entity_id
 
 
 def _build_title(conn: sqlite3.Connection, entity_type: str, entity_id: int) -> Optional[str]:
-    """A.4.4 の表に従い title を組み立てる（200 UTF-8 chars で truncate、publisher 側責務）。"""
+    """entity 種別ごとの取得元から title を組み立てる（200 UTF-8 chars で truncate、publisher 側責務）。"""
     if entity_type == "tag":
         row = conn.execute(
             "SELECT namespace, name FROM tags WHERE id = ?", (entity_id,)
@@ -165,12 +165,10 @@ def bump_updated_at_and_publish_with_conn(
     conn: sqlite3.Connection, entity_type: str, entity_id: int
 ) -> Optional[int]:
     """relation/pin の add/remove 用: entity の updated_at を（カラムがあれば）進めて
-    event:updated を publish する（decision 3065: relation/pin 自体は独立 publish
-    せず、source/target 両方の entity 側で表現する）。
+    event:updated を publish する。
 
-    updated_at カラムを持たない entity 種別（decisions/discussion_logs/
-    discussion_topics/tags/habits）は UPDATE 文をスキップし publish のみ行う
-    （該当テーブルに存在しないカラムへの UPDATE はできないための縮退）。
+    updated_at カラムは activities/materials にしか存在しないため、他の entity
+    種別は UPDATE 文をスキップし publish のみ行う。
     """
     if entity_type in _HAS_UPDATED_AT_COLUMN:
         table = ENTITY_TABLE_MAP[entity_type]

--- a/src/services/relay/service.py
+++ b/src/services/relay/service.py
@@ -44,7 +44,7 @@ _RESERVED_LABEL_PREFIXES = tuple(
     sorted(f"{entity_type}:" for entity_type in PUBLISH_ENTITY_TYPES) + ["entity:", "event:"]
 )
 
-# 1 つの label string の上限文字数（decision 3074 D.1）。
+# 1 つの label string の上限文字数。
 MAX_LABEL_CHARS = 200
 
 # relay_post の ttl 許容範囲（秒）。

--- a/src/services/relay/service.py
+++ b/src/services/relay/service.py
@@ -24,7 +24,6 @@ from src.relay_sdk.http.request import (
     raise_for_relay_status,
 )
 from src.relay_sdk.outbox import publish as outbox_publish
-from src.services.relation_service import VALID_ENTITY_TYPES
 from src.services.relay import config, declarations, inbox
 from src.services.relay.config import RelayConfigError
 
@@ -33,10 +32,20 @@ logger = logging.getLogger(__name__)
 _ROLE_PREFIX = "role:"
 _HANDLE_PREFIX = "handle:"
 
-# cc-memory の中核 entity 種別（relation_service.VALID_ENTITY_TYPES と同一集合）を
-# label prefix として予約する。relay label は実在チェックを行わない不透明文字列の
-# ため、これらの語彙と衝突すると存在しない/未検証の entity への関連付けを誤認させる。
-_RESERVED_ENTITY_PREFIXES = tuple(sorted(f"{entity_type}:" for entity_type in VALID_ENTITY_TYPES))
+# entity 更新 → relay publish（core内部専用、src.services.relay.entity_publish）が
+# ref.type として使う 7 種類（cc-memory 内呼称と完全一致）。
+PUBLISH_ENTITY_TYPES = ("decision", "log", "material", "activity", "topic", "tag", "habit")
+
+# labels の予約 namespace。cc-memory の中核 entity 種別 7 つ（PUBLISH_ENTITY_TYPES）に
+# 加えて、entity 種別そのものを表す `entity:` と write event 種別を表す `event:` も
+# 予約する。relay label は実在チェックを行わない不透明文字列のため、これらの語彙と
+# 衝突すると存在しない/未検証の entity への関連付けを誤認させる。
+_RESERVED_LABEL_PREFIXES = tuple(
+    sorted(f"{entity_type}:" for entity_type in PUBLISH_ENTITY_TYPES) + ["entity:", "event:"]
+)
+
+# 1 つの label string の上限文字数（decision 3074 D.1）。
+MAX_LABEL_CHARS = 200
 
 # relay_post の ttl 許容範囲（秒）。
 TTL_MIN_SECONDS = 60
@@ -91,13 +100,20 @@ def _relay_error(exc: Exception) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def validate_labels(labels: Any, *, allow_empty: bool = False) -> Optional[str]:
+def validate_labels(
+    labels: Any, *, allow_empty: bool = False, check_reserved: bool = True
+) -> Optional[str]:
     """labels の妥当性を検査し、問題があればエラーメッセージを返す（正常は None）。
 
-    role:（廃止済み namespace）と、cc-memory の中核 entity namespace
-    （topic:/activity:/decision:/log:/material:）を予約済みとして拒否する。
-    handle:/room:/task:・domain:/intent: 等の tag namespace・その他未知 prefix は
-    不透明 label として受理する。
+    型・非空文字列・200 chars 上限（MAX_LABEL_CHARS）は 3 モード共通の基礎検証。
+    role:（廃止済み namespace）は常に拒否する。
+
+    check_reserved=True（既定、relay_publish/relay_subscribe の中核 entity
+    予約 namespace チェック用）のときは、cc-memory の予約 namespace
+    （entity:/event:/topic:/activity:/decision:/log:/material:/tag:/habit:）も
+    拒否する。entity write → relay outbox の core 内部 publish
+    （src.services.relay.entity_publish）はこれらの namespace を自ら組み立てる
+    ため check_reserved=False で呼ぶ。
     """
     if not isinstance(labels, list):
         return "labels は文字列の配列で指定してください"
@@ -106,19 +122,22 @@ def validate_labels(labels: Any, *, allow_empty: bool = False) -> Optional[str]:
     for label in labels:
         if not isinstance(label, str) or not label:
             return "labels の各要素は非空文字列で指定してください"
+        if len(label) > MAX_LABEL_CHARS:
+            return f"label は {MAX_LABEL_CHARS} chars 以内にしてください: '{label[:50]}...'"
         if label.startswith(_ROLE_PREFIX):
             return (
                 f"label '{label}' は使用できません。"
                 "role: namespace は廃止済みです（routing には handle:/room:/task: を使う）"
             )
-        for prefix in _RESERVED_ENTITY_PREFIXES:
-            if label.startswith(prefix):
-                return (
-                    f"label '{label}' は使用できません。"
-                    f"'{prefix}' は cc-memory の中核 entity namespace として予約されています。"
-                    "relay label は実在チェックを行わない不透明文字列のため、"
-                    "実 entity と関連付けたい場合は body に記述してください"
-                )
+        if check_reserved:
+            for prefix in _RESERVED_LABEL_PREFIXES:
+                if label.startswith(prefix):
+                    return (
+                        f"label '{label}' は使用できません。"
+                        f"'{prefix}' は cc-memory の中核 entity namespace として予約されています。"
+                        "relay label は実在チェックを行わない不透明文字列のため、"
+                        "実 entity と関連付けたい場合は body に記述してください"
+                    )
     return None
 
 
@@ -296,10 +315,15 @@ def relay_subscribe(
 
     lease が有効な既存宣言はそのまま返し、失効・不明なら新規に subscribe して
     declaration file の subscription_id を差し替える。
+
+    cc-memory の予約 namespace（entity:/event:/topic:/activity:/decision:/log:/
+    material:/tag:/habit:）は relay_publish（メッセージ配布）とは異なり許可する。
+    entity 更新 → relay publish の labels（例: ["activity:1183", "event:updated"]）を
+    購読するのに必要なため。role:（廃止済み namespace）は引き続き拒否する。
     """
     if not caller_session_id:
         return _error("session_unresolved", SESSION_UNRESOLVED_MESSAGE)
-    message = validate_labels(labels, allow_empty=True)
+    message = validate_labels(labels, allow_empty=True, check_reserved=False)
     if message:
         return _error("validation", message)
 

--- a/src/services/retract_service.py
+++ b/src/services/retract_service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from src.db import get_connection
 from src.services import embedding_service
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,9 @@ def retract(entity_type: str, ids: list[int], undo: bool = False) -> dict:
                         )
                         _delete_search_index_entry(
                             conn, _SEARCH_INDEX_SOURCE_TYPE[entity_type], entity_id
+                        )
+                        publish_entity_event_with_conn(
+                            conn, entity_type=entity_type, entity_id=entity_id, event="retracted"
                         )
 
                 conn.execute(f"RELEASE SAVEPOINT retract_{i}")

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -115,25 +115,46 @@ def ensure_tag_ids(conn: sqlite3.Connection, parsed_tags: list[tuple[str, str]])
 
     connを受け取り、呼び出し元のトランザクション内で動作する。
     エイリアスタグの場合はcanonical側のIDを返す。
+    新規にINSERTされたタグ（未使用だったnamespace:name）はrelay publish
+    （entity:tag, event:created）の対象にする（decision 3075）。
     """
     if not parsed_tags:
         return []
-    conn.executemany(
-        "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
-        parsed_tags,
-    )
     placeholders = " OR ".join(
         "(namespace = ? AND name = ?)" for _ in parsed_tags
     )
     flat_params = [v for pair in parsed_tags for v in pair]
+
+    # INSERT前に既存タグを控えておき、INSERT OR IGNORE後との差分で新規作成分を判定する
+    # （executemanyのINSERT OR IGNOREは行単位の成否を返さないため）。
+    existing_before = conn.execute(
+        f"SELECT namespace, name FROM tags WHERE {placeholders}", flat_params
+    ).fetchall()
+    existing_keys = {(row["namespace"], row["name"]) for row in existing_before}
+
+    conn.executemany(
+        "INSERT OR IGNORE INTO tags (namespace, name) VALUES (?, ?)",
+        parsed_tags,
+    )
     rows = conn.execute(
         f"SELECT id, namespace, name, canonical_id FROM tags WHERE {placeholders}",
         flat_params,
     ).fetchall()
     id_map = {}
+    newly_created_ids = []
     for row in rows:
+        key = (row["namespace"], row["name"])
         effective_id = row["canonical_id"] if row["canonical_id"] is not None else row["id"]
-        id_map[(row["namespace"], row["name"])] = effective_id
+        id_map[key] = effective_id
+        if key not in existing_keys:
+            newly_created_ids.append(row["id"])
+
+    if newly_created_ids:
+        # entity_publishがtag_serviceを import するため、循環import回避のためlocal import
+        from src.services.relay.entity_publish import publish_entity_event_with_conn
+        for tag_id in newly_created_ids:
+            publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="created")
+
     return [id_map[(ns, name)] for ns, name in parsed_tags]
 
 
@@ -754,6 +775,10 @@ def update_tag(
                 {"tag": str, "description": str | None, "updated": True} (description更新時)
         失敗時: {"error": {"code": ..., "message": ...}}
     """
+    # entity_publishがtag_serviceをimportするため、循環import回避のためlocal import
+    # （モジュールtopでのimportはこのモジュールがロードされる時点で循環になる）
+    from src.services.relay.entity_publish import publish_entity_event_with_conn
+
     # バリデーション: 相互排他（notes, canonical, rename, description は1つだけ指定可能）
     specified = [p for p in (notes, canonical, rename, description) if p is not None]
     if len(specified) > 1:
@@ -838,6 +863,7 @@ def update_tag(
                 "UPDATE tags SET namespace = ?, name = ? WHERE id = ?",
                 (new_namespace, new_name, tag_id),
             )
+            publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="updated")
             conn.commit()
             new_tag_str = f"{new_namespace}:{new_name}" if new_namespace else new_name
             return {"tag": tag_str, "renamed_to": new_tag_str, "updated": True}
@@ -851,6 +877,7 @@ def update_tag(
                 "UPDATE tags SET description = ? WHERE id = ?",
                 (description, tag_id),
             )
+            publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="updated")
             conn.commit()
             return {"tag": tag_str, "description": description, "updated": True}
 
@@ -860,6 +887,7 @@ def update_tag(
                 "UPDATE tags SET notes = ? WHERE id = ?",
                 (notes, tag_id),
             )
+            publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="updated")
             conn.commit()
             return {"tag": tag_str, "notes": notes, "updated": True}
 
@@ -870,6 +898,7 @@ def update_tag(
                 "UPDATE tags SET canonical_id = NULL WHERE id = ?",
                 (tag_id,),
             )
+            publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="updated")
             conn.commit()
             return {"tag": tag_str, "canonical": None, "updated": True}
 
@@ -980,6 +1009,7 @@ def update_tag(
                 (canonical_id, tag_id),
             )
 
+        publish_entity_event_with_conn(conn, entity_type="tag", entity_id=tag_id, event="updated")
         conn.commit()
 
         # タグ変更に伴うembedding再生成（コミット後に同期的に実行）

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -116,7 +116,7 @@ def ensure_tag_ids(conn: sqlite3.Connection, parsed_tags: list[tuple[str, str]])
     connを受け取り、呼び出し元のトランザクション内で動作する。
     エイリアスタグの場合はcanonical側のIDを返す。
     新規にINSERTされたタグ（未使用だったnamespace:name）はrelay publish
-    （entity:tag, event:created）の対象にする（decision 3075）。
+    （entity:tag, event:created）の対象にする。
     """
     if not parsed_tags:
         return []

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -10,6 +10,7 @@ from src.services.embedding_service import (
     insert_topic_embedding_with_conn,
 )
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
+from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.search_service import find_similar_topics
 from src.services.title_validation import validate_title
 from src.services.tag_service import (
@@ -189,6 +190,10 @@ def add_topic(
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(
             conn, "topic", topic_id, title=title, description=description
+        )
+
+        publish_entity_event_with_conn(
+            conn, entity_type="topic", entity_id=topic_id, event="created"
         )
 
         conn.commit()

--- a/tests/unit/test_relay_entity_publish.py
+++ b/tests/unit/test_relay_entity_publish.py
@@ -1,0 +1,373 @@
+"""entity write（add_*/update_*/retract/relation/pin）→ relay outbox の
+core内部publish（src.services.relay.entity_publish）の unit test。
+
+relay_publish（セッション向け4動詞、tests/unit/test_relay_service_publish.py）とは
+別物で、entity write のcommit直前にoutbox行を1件INSERTするフックを検証する。
+"""
+import json
+
+import pytest
+
+from src.db import get_connection
+from src.services.activity_service import add_activity, update_activity
+from src.services.decision_service import add_decisions
+from src.services.discussion_log_service import add_logs
+from src.services.habit_service import add_habit, update_habit
+from src.services.material_service import add_material, update_material
+from src.services.pin_service import add_pin, remove_pin
+from src.services.relation_service import add_relation
+from src.services.retract_service import retract
+from src.services.tag_service import _injected_tags, update_tag
+from src.services.topic_service import add_topic
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture(autouse=True)
+def relay_connected(tmp_path, monkeypatch):
+    """relay接続済み（RELAY_BEARER_TOKEN設定済み）環境をデフォルトにする。
+
+    autouse かつ temp_db に依存しないため、temp_db（init_database() 経由で
+    db.py の seed 投入 ensure_tag_ids(conn, [("domain", "default")]) を含む）より
+    先に実行される。これにより、"domain:default" タグの event:created が
+    outbox に1件紛れ込む（token設定済み環境の副作用として無害・許容）。
+
+    未接続時no-op挙動を検証するTestNoOpWhenRelayNotConfiguredは、この
+    fixtureを同名でオーバーライドしtokenを一切設定しない。
+    """
+    monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path / "relay-state"))
+    monkeypatch.setenv("RELAY_BEARER_TOKEN", "test-token")
+    monkeypatch.delenv("RELAY_BASE_URL", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_injected_tags():
+    _injected_tags.clear()
+
+
+def _outbox_rows() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute("SELECT * FROM relay_outbox ORDER BY id").fetchall()
+        result = []
+        for row in rows:
+            item = dict(row)
+            item["labels"] = json.loads(item["labels"])
+            result.append(item)
+        return result
+    finally:
+        conn.close()
+
+
+def _rows_for(ref_type: str, ref_id) -> list[dict]:
+    return [r for r in _outbox_rows() if r["ref_type"] == ref_type and r["ref_id"] == str(ref_id)]
+
+
+class TestNoOpWhenRelayNotConfigured:
+    """RELAY_BEARER_TOKEN未設定（relay未接続）環境ではoutboxが積まれない。"""
+
+    @pytest.fixture(autouse=True)
+    def relay_connected(self, tmp_path, monkeypatch):
+        """モジュールレベルのrelay_connectedを同名でオーバーライドし、tokenを
+        一切設定しない（RELAY_STATE_DIRは隔離し、init_database()のseed投入が
+        実マシンの ~/.cc-memory/relay/credential.json にフォールバックしない
+        ようにする）。autouseかつtemp_dbに依存しないため、init_database()より
+        先に実行される。
+        """
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path / "relay-state"))
+        monkeypatch.delenv("RELAY_BEARER_TOKEN", raising=False)
+        monkeypatch.delenv("RELAY_BASE_URL", raising=False)
+
+    def test_add_decisions_is_noop_without_token(self, temp_db, disable_embedding):
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "d1", "reason": "r1"}
+        ])
+        assert not result["errors"]
+        assert _outbox_rows() == []
+
+    def test_add_material_is_noop_without_token(self, temp_db, disable_embedding):
+        result = add_material(
+            title="m1", content="c1", tags=DEFAULT_TAGS, source="test"
+        )
+        assert "error" not in result
+        assert _outbox_rows() == []
+
+
+class TestCreatedEventOnRepresentativeWritePaths:
+    """代表write経路（add_*）でoutbox行が1件生成され、ref_type/event/entity:が正しいこと。"""
+
+    def test_add_topic_publishes_created(self, temp_db, disable_embedding):
+        topic = add_topic(title="トピック", description="説明", tags=DEFAULT_TAGS)
+        rows = _rows_for("topic", topic["topic_id"])
+        assert len(rows) == 1
+        assert "entity:topic" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+        assert "domain:test" in rows[0]["labels"]
+        assert rows[0]["title"] == "トピック"
+
+    def test_add_activity_publishes_created(self, temp_db, disable_embedding):
+        activity = add_activity(
+            title="アクティビティ", description="説明", tags=DEFAULT_TAGS, check_in=False
+        )
+        rows = _rows_for("activity", activity["activity_id"])
+        assert len(rows) == 1
+        assert "entity:activity" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+
+    def test_add_material_publishes_created(self, temp_db, disable_embedding):
+        material = add_material(title="資材", content="本文", tags=DEFAULT_TAGS, source="test")
+        rows = _rows_for("material", material["material_id"])
+        assert len(rows) == 1
+        assert "entity:material" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+
+    def test_add_decisions_publishes_created_with_topic_parent_label(self, temp_db, disable_embedding):
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "d1", "reason": "r1", "tags": DEFAULT_TAGS}
+        ])
+        decision_id = result["created"][0]["decision_id"]
+        rows = _rows_for("decision", decision_id)
+        assert len(rows) == 1
+        assert "entity:decision" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+        assert f"topic:{topic['topic_id']}" in rows[0]["labels"]
+        assert "domain:test" in rows[0]["labels"]
+
+    def test_decision_title_falls_back_to_decision_text(self, temp_db, disable_embedding):
+        """titleを省略したdecisionは、A.4.4のCOALESCE(title, decision)通りdecision本文がtitleになる。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "タイトル省略時の本文", "reason": "r1"}
+        ])
+        decision_id = result["created"][0]["decision_id"]
+        rows = _rows_for("decision", decision_id)
+        assert rows[0]["title"] == "タイトル省略時の本文"
+
+    def test_add_logs_publishes_created(self, temp_db, disable_embedding):
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        result = add_logs([{"topic_id": topic["topic_id"], "content": "ログ本文"}])
+        log_id = result["created"][0]["log_id"]
+        rows = _rows_for("log", log_id)
+        assert len(rows) == 1
+        assert "entity:log" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+        assert f"topic:{topic['topic_id']}" in rows[0]["labels"]
+
+    def test_add_habit_publishes_created(self, temp_db):
+        result = add_habit("振る舞い")
+        rows = _rows_for("habit", result["habit_id"])
+        assert len(rows) == 1
+        assert "entity:habit" in rows[0]["labels"]
+        assert "event:created" in rows[0]["labels"]
+        assert rows[0]["title"] == "振る舞い"
+
+    def test_new_tag_use_publishes_created(self, temp_db, disable_embedding):
+        """add_decisionsで初めて使われるタグ文字列は、decisionのcreatedとは別にtagのcreatedも積む。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        add_decisions([
+            {
+                "topic_id": topic["topic_id"],
+                "decision": "d1",
+                "reason": "r1",
+                "tags": ["glossary:brand-new-tag-xyz"],
+            }
+        ])
+        rows = [r for r in _outbox_rows() if r["ref_type"] == "tag"]
+        assert any("event:created" in r["labels"] and "entity:tag" in r["labels"] for r in rows)
+
+    def test_topic_has_no_one_hop_parent_labels(self, temp_db, disable_embedding):
+        """topicは階層の最上位で親を持たないため、自身に属する子の数に関わらずlabelsは
+        自身のtags + entity:/event:のみ（子をparent-labelとして巻き込まない）。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        add_decisions([
+            {"topic_id": topic["topic_id"], "decision": f"d{i}", "reason": "r"}
+            for i in range(3)
+        ])
+        rows = _rows_for("topic", topic["topic_id"])
+        assert len(rows) == 1
+        assert set(rows[0]["labels"]) == {"entity:topic", "event:created", "domain:test"}
+
+
+class TestUpdatedEventOnRepresentativeWritePaths:
+    def test_update_material_publishes_updated(self, temp_db, disable_embedding):
+        material = add_material(title="資材", content="本文", tags=DEFAULT_TAGS, source="test")
+        update_material(material["material_id"], content="更新後本文")
+        rows = _rows_for("material", material["material_id"])
+        assert len(rows) == 2
+        assert "event:created" in rows[0]["labels"]
+        assert "event:updated" in rows[1]["labels"]
+
+    def test_update_habit_publishes_updated(self, temp_db):
+        habit = add_habit("振る舞い")
+        update_habit(habit["habit_id"], content="更新後")
+        rows = _rows_for("habit", habit["habit_id"])
+        assert len(rows) == 2
+        assert "event:updated" in rows[1]["labels"]
+
+    def test_update_tag_publishes_updated(self, temp_db, disable_embedding):
+        topic = add_topic(title="t", description="d", tags=["glossary:existing-tag"])
+        update_tag("glossary:existing-tag", notes="教訓")
+        rows = [r for r in _outbox_rows() if r["ref_type"] == "tag"]
+        assert any("event:updated" in r["labels"] for r in rows)
+
+
+class TestActivityStatusDiffDetection:
+    """update_activityはdecision 3076に基づきstatus遷移のみ厳密化する。"""
+
+    def test_status_transition_publishes(self, temp_db, disable_embedding):
+        activity = add_activity(
+            title="a", description="d", tags=DEFAULT_TAGS, check_in=False
+        )
+        before = len(_rows_for("activity", activity["activity_id"]))
+        update_activity(activity["activity_id"], status="in_progress")
+        after = _rows_for("activity", activity["activity_id"])
+        assert len(after) == before + 1
+        assert "event:updated" in after[-1]["labels"]
+
+    def test_status_no_op_does_not_publish(self, temp_db, disable_embedding):
+        activity = add_activity(
+            title="a", description="d", tags=DEFAULT_TAGS, check_in=False
+        )
+        before = len(_rows_for("activity", activity["activity_id"]))
+        # activityは作成直後 status="pending"。同じ値を指定 = 実質no-op
+        update_activity(activity["activity_id"], status="pending")
+        after = _rows_for("activity", activity["activity_id"])
+        assert len(after) == before
+
+    def test_non_status_field_publishes_even_without_status_change(self, temp_db, disable_embedding):
+        activity = add_activity(
+            title="a", description="d", tags=DEFAULT_TAGS, check_in=False
+        )
+        before = len(_rows_for("activity", activity["activity_id"]))
+        update_activity(activity["activity_id"], title="新タイトル")
+        after = _rows_for("activity", activity["activity_id"])
+        assert len(after) == before + 1
+
+
+class TestRetract:
+    def test_retract_publishes_retracted(self, temp_db, disable_embedding):
+        material = add_material(title="資材", content="本文", tags=DEFAULT_TAGS, source="test")
+        retract("material", [material["material_id"]])
+        rows = _rows_for("material", material["material_id"])
+        assert len(rows) == 2
+        assert "event:retracted" in rows[-1]["labels"]
+
+    def test_undo_does_not_publish(self, temp_db, disable_embedding):
+        material = add_material(title="資材", content="本文", tags=DEFAULT_TAGS, source="test")
+        retract("material", [material["material_id"]])
+        before = len(_rows_for("material", material["material_id"]))
+        retract("material", [material["material_id"]], undo=True)
+        after = _rows_for("material", material["material_id"])
+        assert len(after) == before
+
+    def test_already_retracted_is_idempotent_no_extra_publish(self, temp_db, disable_embedding):
+        material = add_material(title="資材", content="本文", tags=DEFAULT_TAGS, source="test")
+        retract("material", [material["material_id"]])
+        before = len(_rows_for("material", material["material_id"]))
+        retract("material", [material["material_id"]])
+        after = _rows_for("material", material["material_id"])
+        assert len(after) == before
+
+
+class TestRelationPublish:
+    """add_relation/remove_relationはrelation自体を独立publishせず、source/target
+    両方のentityをevent:updatedでpublishする（decision 3065）。"""
+
+    def test_add_relation_publishes_both_endpoints(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+
+        before_material = len(_rows_for("material", material["material_id"]))
+        before_activity = len(_rows_for("activity", activity["activity_id"]))
+
+        result = add_relation(
+            "activity", activity["activity_id"],
+            [{"type": "material", "ids": [material["material_id"]]}],
+        )
+        assert result["added"] == 1
+
+        after_material = _rows_for("material", material["material_id"])
+        after_activity = _rows_for("activity", activity["activity_id"])
+        assert len(after_material) == before_material + 1
+        assert len(after_activity) == before_activity + 1
+        assert "event:updated" in after_material[-1]["labels"]
+        assert "event:updated" in after_activity[-1]["labels"]
+
+    def test_idempotent_add_relation_does_not_republish(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+        add_relation(
+            "activity", activity["activity_id"],
+            [{"type": "material", "ids": [material["material_id"]]}],
+        )
+        before = len(_rows_for("material", material["material_id"]))
+        result = add_relation(
+            "activity", activity["activity_id"],
+            [{"type": "material", "ids": [material["material_id"]]}],
+        )
+        assert result["added"] == 0
+        after = len(_rows_for("material", material["material_id"]))
+        assert after == before
+
+    def test_relation_to_entity_without_updated_at_column_still_publishes(self, temp_db, disable_embedding):
+        """decision/log/topic/tag/habitはupdated_atカラムを持たないため、UPDATE文は
+        スキップされるがpublish自体は行われる（暫定の縮退、decision 3065参照）。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        decision_result = add_decisions([
+            {"topic_id": topic["topic_id"], "decision": "d1", "reason": "r1"}
+        ])
+        decision_id = decision_result["created"][0]["decision_id"]
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+
+        before = len(_rows_for("decision", decision_id))
+        result = add_relation(
+            "activity", activity["activity_id"],
+            [{"type": "decision", "ids": [decision_id]}],
+        )
+        assert result["added"] == 1
+        after = _rows_for("decision", decision_id)
+        assert len(after) == before + 1
+        assert "event:updated" in after[-1]["labels"]
+
+
+class TestPinPublish:
+    def test_add_pin_publishes_both_endpoints(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+
+        before_material = len(_rows_for("material", material["material_id"]))
+        before_activity = len(_rows_for("activity", activity["activity_id"]))
+
+        result = add_pin("activity", activity["activity_id"], "material", material["material_id"])
+        assert "error" not in result
+
+        assert len(_rows_for("material", material["material_id"])) == before_material + 1
+        assert len(_rows_for("activity", activity["activity_id"])) == before_activity + 1
+
+    def test_remove_pin_publishes_both_endpoints(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+        add_pin("activity", activity["activity_id"], "material", material["material_id"])
+
+        before_material = len(_rows_for("material", material["material_id"]))
+        before_activity = len(_rows_for("activity", activity["activity_id"]))
+
+        result = remove_pin("activity", activity["activity_id"], "material", material["material_id"])
+        assert result["removed"] == 1
+
+        assert len(_rows_for("material", material["material_id"])) == before_material + 1
+        assert len(_rows_for("activity", activity["activity_id"])) == before_activity + 1
+
+    def test_idempotent_remove_pin_does_not_republish(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+        add_pin("activity", activity["activity_id"], "material", material["material_id"])
+        remove_pin("activity", activity["activity_id"], "material", material["material_id"])
+
+        before = len(_rows_for("material", material["material_id"]))
+        result = remove_pin("activity", activity["activity_id"], "material", material["material_id"])
+        assert result["removed"] == 0
+        after = len(_rows_for("material", material["material_id"]))
+        assert after == before

--- a/tests/unit/test_relay_entity_publish.py
+++ b/tests/unit/test_relay_entity_publish.py
@@ -331,6 +331,73 @@ class TestRelationPublish:
         assert len(after) == before + 1
         assert "event:updated" in after[-1]["labels"]
 
+    def test_related_relation_does_not_add_parent_label(self, temp_db, disable_embedding):
+        """relation_type='related'（デフォルト）はどちらの向きにも親帰属を表さないため、
+        source/target双方のpublishに相手をparent labelとして混入させない。"""
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        activity = add_activity(title="a", description="d", tags=DEFAULT_TAGS, check_in=False)
+
+        result = add_relation(
+            "activity", activity["activity_id"],
+            [{"type": "material", "ids": [material["material_id"]]}],
+        )
+        assert result["added"] == 1
+
+        activity_rows = _rows_for("activity", activity["activity_id"])
+        material_rows = _rows_for("material", material["material_id"])
+        assert f"material:{material['material_id']}" not in activity_rows[-1]["labels"]
+        assert f"activity:{activity['activity_id']}" not in material_rows[-1]["labels"]
+
+    def test_depends_on_relation_does_not_add_parent_label(self, temp_db, disable_embedding):
+        """depends_onはactivity同士の依存関係であり、親帰属ではないため
+        依存先をparent labelとして混入させない。"""
+        dependency = add_activity(title="dependency", description="d", tags=DEFAULT_TAGS, check_in=False)
+        dependent = add_activity(title="dependent", description="d", tags=DEFAULT_TAGS, check_in=False)
+
+        result = add_relation(
+            "activity", dependent["activity_id"],
+            [{"type": "activity", "ids": [dependency["activity_id"]]}],
+            relation_type="depends_on",
+        )
+        assert result["added"] == 1
+
+        dependent_rows = _rows_for("activity", dependent["activity_id"])
+        assert f"activity:{dependency['activity_id']}" not in dependent_rows[-1]["labels"]
+
+    def test_supersedes_relation_does_not_add_parent_label(self, temp_db, disable_embedding):
+        """supersedesはdecision同士の置き換え関係であり、親帰属ではないため
+        置き換え先(旧decision)をparent labelとして混入させない。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        old = add_decisions([{"topic_id": topic["topic_id"], "decision": "old", "reason": "r"}])
+        new = add_decisions([{"topic_id": topic["topic_id"], "decision": "new", "reason": "r"}])
+        old_id = old["created"][0]["decision_id"]
+        new_id = new["created"][0]["decision_id"]
+
+        result = add_relation(
+            "decision", new_id,
+            [{"type": "decision", "ids": [old_id]}],
+            relation_type="supersedes",
+        )
+        assert result["added"] == 1
+
+        new_rows = _rows_for("decision", new_id)
+        assert f"decision:{old_id}" not in new_rows[-1]["labels"]
+
+    def test_belongs_to_relation_adds_parent_label(self, temp_db, disable_embedding):
+        """親帰属パターン（子→topic）はrelation_type='related'指定でも内部でbelongs_toに
+        自動格上げされ、この場合のみparent labelが付く。"""
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+
+        result = add_relation(
+            "material", material["material_id"],
+            [{"type": "topic", "ids": [topic["topic_id"]]}],
+        )
+        assert result["added"] == 1
+
+        material_rows = _rows_for("material", material["material_id"])
+        assert f"topic:{topic['topic_id']}" in material_rows[-1]["labels"]
+
 
 class TestPinPublish:
     def test_add_pin_publishes_both_endpoints(self, temp_db, disable_embedding):

--- a/tests/unit/test_relay_service_publish.py
+++ b/tests/unit/test_relay_service_publish.py
@@ -103,18 +103,26 @@ class TestPublishValidation:
 
 
 class TestReservedEntityNamespace:
-    """cc-memory の中核 entity namespace（topic:/activity:/decision:/log:/material:）は
-    label として使えず拒否される。relay label は実在チェックを行わない不透明文字列のため、
-    これらの語彙をそのまま許すと存在しない/未検証の entity への関連付けを誤認させる。
+    """cc-memory の予約 namespace（entity:/event:/topic:/activity:/decision:/log:/
+    material:/tag:/habit:）は label として使えず拒否される。relay label は実在
+    チェックを行わない不透明文字列のため、これらの語彙をそのまま許すと存在しない/
+    未検証の entity への関連付けを誤認させる。
     """
 
     @pytest.mark.parametrize(
-        "entity_type", ["topic", "activity", "decision", "log", "material"]
+        "entity_type",
+        ["topic", "activity", "decision", "log", "material", "tag", "habit"],
     )
     def test_core_entity_prefix_rejected(self, conn, entity_type):
         result = _publish(conn, ["task:build", f"{entity_type}:1"])
         assert result["error"]["code"] == "validation"
         assert f"{entity_type}:" in result["error"]["message"]
+
+    @pytest.mark.parametrize("meta_namespace", ["entity", "event"])
+    def test_meta_namespace_rejected(self, conn, meta_namespace):
+        result = _publish(conn, ["task:build", f"{meta_namespace}:decision"])
+        assert result["error"]["code"] == "validation"
+        assert f"{meta_namespace}:" in result["error"]["message"]
 
     def test_core_entity_prefix_blocks_call_even_with_other_valid_labels(self, conn):
         """中核 entity prefix が1つでも含まれれば、他の label が有効でも呼び出し全体を拒否する（部分成功しない）。"""
@@ -124,6 +132,18 @@ class TestReservedEntityNamespace:
     def test_no_row_inserted_when_entity_prefix_rejected(self, conn):
         _publish(conn, ["decision:1"])
         assert conn.execute("SELECT COUNT(*) FROM relay_outbox").fetchone()[0] == 0
+
+
+class TestLabelLengthCap:
+    """1 つの label string は 200 chars 以内（decision 3074 D.1）。"""
+
+    def test_label_within_cap_is_accepted(self, conn):
+        result = _publish(conn, ["x" * 200])
+        assert "error" not in result
+
+    def test_overlong_label_rejected(self, conn):
+        result = _publish(conn, ["x" * 201])
+        assert result["error"]["code"] == "validation"
 
 
 class TestPublishPreconditions:
@@ -136,3 +156,33 @@ class TestPublishPreconditions:
     def test_unresolved_session_returns_explicit_error(self, conn):
         result = _publish(conn, ["task:1"], session_id=None)
         assert result["error"]["code"] == "session_unresolved"
+
+
+class TestValidateLabelsCoreMode:
+    """check_reserved=False（entity write → relay outbox の core内部 publish 専用）の
+    検証モード。予約 namespace を許可しつつ、role: と200字capは維持する。
+    """
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "entity:decision", "event:created", "event:updated", "event:retracted",
+            "topic:1", "activity:1", "decision:1", "log:1", "material:1",
+            "tag:1", "habit:1",
+        ],
+    )
+    def test_reserved_namespace_is_accepted(self, label):
+        from src.services.relay.service import validate_labels
+        assert validate_labels([label], check_reserved=False) is None
+
+    def test_role_prefix_still_rejected(self):
+        from src.services.relay.service import validate_labels
+        message = validate_labels(["role:navigator"], check_reserved=False)
+        assert message is not None
+        assert "role:" in message
+
+    def test_label_length_cap_still_enforced(self):
+        from src.services.relay.service import validate_labels
+        assert validate_labels(["entity:decision"], check_reserved=False) is None
+        message = validate_labels(["x" * 201], check_reserved=False)
+        assert message is not None

--- a/tests/unit/test_relay_service_subscribe.py
+++ b/tests/unit/test_relay_service_subscribe.py
@@ -124,18 +124,43 @@ class TestSubscribe:
         assert stub.counter == 0
 
     @pytest.mark.parametrize(
-        "entity_type", ["topic", "activity", "decision", "log", "material"]
+        "entity_type",
+        ["topic", "activity", "decision", "log", "material", "tag", "habit"],
     )
-    def test_core_entity_prefix_rejected(self, monkeypatch, entity_type):
-        """cc-memory の中核 entity namespace は relay_publish と同様に拒否される。"""
+    def test_core_entity_prefix_is_accepted(self, monkeypatch, entity_type):
+        """cc-memory の予約 namespace は relay_publish と異なり subscribe では許可される。
+
+        entity 更新 → relay publish の labels（例: ["activity:1183", "event:updated"]）を
+        購読するのに必要（material 522 D.5）。
+        """
         stub = SubscriptionStub()
         stub.install(monkeypatch)
         result = service.relay_subscribe(
             ["task:build", f"{entity_type}:1"], caller_session_id="sess-1"
         )
-        assert result["error"]["code"] == "validation"
-        assert f"{entity_type}:" in result["error"]["message"]
-        assert stub.counter == 0
+        assert "error" not in result
+        assert stub.counter == 1
+
+    @pytest.mark.parametrize("meta_namespace", ["entity", "event"])
+    def test_meta_namespace_is_accepted(self, monkeypatch, meta_namespace):
+        stub = SubscriptionStub()
+        stub.install(monkeypatch)
+        result = service.relay_subscribe(
+            [f"{meta_namespace}:decision"], caller_session_id="sess-1"
+        )
+        assert "error" not in result
+
+    def test_entity_publish_subscribe_examples_from_spec(self, monkeypatch):
+        """material 522 D.5 の購読例が通ることを確認する。"""
+        stub = SubscriptionStub()
+        stub.install(monkeypatch)
+        for labels in (
+            ["activity:1183", "event:updated"],
+            ["domain:cc-memory", "entity:activity", "event:updated"],
+            ["entity:decision", "event:retracted"],
+        ):
+            result = service.relay_subscribe(labels, caller_session_id="sess-1")
+            assert "error" not in result, result
 
     def test_missing_token_returns_explicit_error(self, monkeypatch):
         stub = SubscriptionStub()


### PR DESCRIPTION
## Summary

- cc-memory の entity write（decision/log/material/activity/topic/tag/habit の add_*/update_*/retract、および relation/pin の add/remove）が commit 直前に relay outbox へ 1 行 publish するようになった。これまで entity 更新は cc-memory 内に閉じており、他セッションが購読して能動的に気づく手段がなかった。
- labels は entity 自身の tags + `entity:<type>` + `event:<created|updated|retracted>` + 1 hop 親 ID（`topic:<id>` / `activity:<id>` 等）で構成する。N hop の transitive な関係は載せない（write 経路のコスト増を避けるため）。
- `update_activity` は status 遷移（old != new）のときのみ publish する差分検出を入れた。他フィールド（title/description/tags/orch_managed）の更新は no-op を含めて無条件で publish する。
- relation/pin の add/remove は「リレーション自体」を独立に publish せず、source/target 両方の entity を `event:updated` として publish することで表現する。ただし `updated_at` カラムを持つのは `activities`/`materials` の 2 テーブルのみで、`decisions`/`discussion_logs`/`discussion_topics`/`tags`/`habits` には無いため、後者は updated_at の UPDATE 文だけスキップし publish 自体は実行する（暫定の縮退。詳細は下記「実装判断・確認したいこと」参照）。
- `RELAY_BEARER_TOKEN` 未設定（relay 未接続）の環境では静かに no-op し、outbox が無限に積もらないようにした。

## labels 検証の3モード分離

`relay_publish`（セッション間の任意メッセージ配布）と、今回追加した entity publish は用途が異なるため、`validate_labels` の予約 namespace チェックを用途別に分離した。

- `relay_publish`（メッセージ配布）: 予約 namespace（`entity:`/`event:`/`topic:`/`activity:`/`decision:`/`log:`/`material:`/`tag:`/`habit:`）を引き続き拒否する。従来は5種類（`topic:`/`activity:`/`decision:`/`log:`/`material:`）のみの拒否だったが、tag/habit が publish 対象 entity に加わったことに合わせて `tag:`/`habit:`/`entity:`/`event:` も拒否対象に広げた。
- entity publish（内部専用）: 上記の予約 namespace を自ら組み立てるため、検証をスキップする。
- `relay_subscribe`（購読宣言）: 逆に予約 namespace を許可するよう変更した。`["activity:1183", "event:updated"]` のような labels で entity 更新を購読できるようにするため。

label 1個あたり200字の上限チェックも今回追加した（従来は未実装だった）。

## 実装判断・確認したいこと

- **tag の `event:created`**: 実際にタグ行が新規作成されるのは `update_tag` ではなく、tag 解決の共通ヘルパー `ensure_tag_ids`（decision/log/material/activity/topic の各 add 系から呼ばれる）だったため、publish フックはそちらに置いた。
- **1 hop 親の対象**: topic は階層の最上位で親を持たないため、topic 自身の publish には 1 hop 親ラベルを付けない（つけると「この topic に属する全 entity」を親扱いしてしまい、entity 数に比例して labels が膨張するため）。activity/material/decision/log は relations テーブル上の直接の関連（belongs_to や related）を 1 hop 親として載せる。
- **relation/pin の updated_at 縮退**: 上述の通り、decisions/discussion_logs/discussion_topics/tags/habits には updated_at カラムが無い。今回は publish（event:updated）だけ行い updated_at の更新はスキップする形にした。スキーマ変更（5テーブルへの updated_at 追加）は本 PR のスコープ（publish 配線）を超えると判断し見送ったが、この判断で問題ないか確認したい。

## Test plan

- labels 構築: entity 自身の tags + `entity:<type>` + `event:<type>` + 1 hop 親 ID が正しく組み立つこと（decision/log/material/activity/topic/tag/habit 各種別）
- topic は自身に属する子 entity の数に関わらず 1 hop 親ラベルを持たないこと（親を持たないための除外ロジックの確認）
- labels 検証の3モード分離: `relay_publish` は予約 namespace（tag:/habit:/entity:/event: 含む）を拒否、`relay_subscribe` は許可、entity publish 内部呼び出しは許可
- label 200字上限のバリデーション
- 代表的な write 経路（add_topic/add_activity/add_material/add_decisions/add_logs/add_habit、および新規タグ初回使用時）で outbox 行が1件生成されること
- `update_activity` の status 差分検出: 遷移時のみ publish、no-op（同値指定）では publish しない、他フィールド更新は status 変化がなくても publish すること
- `retract` は publish、`undo` は publish しない、既に retract 済みへの再 retract は publish しない（冪等）こと
- `add_relation`/`remove_relation`/`add_pin`/`remove_pin` で source/target 両方に `event:updated` が publish されること（2件）、冪等な再呼び出しでは追加 publish されないこと、updated_at カラムを持たない entity 種別でも publish 自体は行われること
- `RELAY_BEARER_TOKEN` 未設定環境で outbox に何も積まれないこと（no-op）
- 既存テスト全 pass を維持（pre-existing の無関係な失敗5件はこのブランチでも origin/main でも同様に発生することを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)