### PR TITLE
fix: recompose提案hintに別セッション実施の許容と自発実行禁止を明記

### DIFF
--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -133,11 +133,19 @@ HINT_LOGS_SPARSE_MESSAGE = (
 )
 
 
+RECOMPOSE_AUTOTRIGGER_GUARD = (
+    "別セッションで実施しても構わない旨をユーザーに伝えてください。"
+    "ユーザーがこのセッションでの実施を明示的に求めない限り、"
+    "このセッションでrecompose-context skillを自発的に実行してはいけません。"
+)
+
+
 def _recompose_bootstrap_message(tag_name: str, total_count: int) -> str:
     return (
         f"tag「{tag_name}」にdecisionが{total_count}件蓄積していますが、"
         f"統合material（recomposed material）がありません。"
         f"recompose-context skillでの初回整理をユーザーに提案してください。"
+        f"{RECOMPOSE_AUTOTRIGGER_GUARD}"
         f"今は都合が悪い場合、tag notesに"
         f"「{MARKER_RECOMPOSE_BOOTSTRAP}-until:YYYY-MM-DD」（任意の未来日）を"
         f"追記すると、その日まで一時的に黙らせられます。恒久的に不要なら日付なしの"
@@ -150,6 +158,7 @@ def _recompose_delta_message(tag_name: str, delta_count: int) -> str:
         f"tag「{tag_name}」はrecomposed materialの最終更新以降にdecisionが"
         f"{delta_count}件増えています。recompose-context skillでのメンテを"
         f"ユーザーに提案してください。"
+        f"{RECOMPOSE_AUTOTRIGGER_GUARD}"
         f"今は都合が悪い場合、tag notesに"
         f"「{MARKER_RECOMPOSE_DELTA}-until:YYYY-MM-DD」（任意の未来日）を"
         f"追記すると、その日まで一時的に黙らせられます。恒久的に不要なら日付なしの"

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -17,6 +17,7 @@ from src.services.hint_service import (
     MARKER_RECOMPOSE_BOOTSTRAP,
     MARKER_RECOMPOSE_DELTA,
     MARKER_RECOMPOSE_GENERIC,
+    RECOMPOSE_AUTOTRIGGER_GUARD,
     RECOMPOSE_BOOTSTRAP_THRESHOLD,
     RECOMPOSE_DELTA_THRESHOLD,
     _is_marker_active,
@@ -105,6 +106,14 @@ class TestRecomposeBootstrap:
         assert hints[0]["severity"] == "info"
         assert str(RECOMPOSE_BOOTSTRAP_THRESHOLD) in hints[0]["message"]
 
+    def test_message_includes_autotrigger_guard(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert RECOMPOSE_AUTOTRIGGER_GUARD in hints[0]["message"]
+
     def test_silent_below_threshold(self, temp_db):
         topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
         for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD - 1):
@@ -158,6 +167,21 @@ class TestRecomposeDelta:
         assert hints[0]["type"] == "recompose_delta"
         assert hints[0]["delivery_hint"] == "immediate"
         assert str(RECOMPOSE_DELTA_THRESHOLD) in hints[0]["message"]
+
+    def test_message_includes_autotrigger_guard(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        mat = add_material(
+            title="m", content="c", tags=[DOMAIN_TAG], source="s",
+        )
+        add_pin("tag", DOMAIN_TAG, "material", mat["material_id"])
+        _set_material_updated_at(mat["material_id"], "2024-06-01 00:00:00")
+
+        for i in range(RECOMPOSE_DELTA_THRESHOLD):
+            d = add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+            _set_decision_created_at(d["decision_id"], "2024-07-01 00:00:00")
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert RECOMPOSE_AUTOTRIGGER_GUARD in hints[0]["message"]
 
     def test_silent_below_threshold(self, temp_db):
         topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])


### PR DESCRIPTION
## Summary
- recompose_bootstrap / recompose_delta hint文言に、別セッションで実施しても構わない旨と、hintだけを根拠にrecompose-context skillを自発的に実行してはいけない旨を追加した
- 従来の文言はrecompose-context skillでの整理を提案するよう促すのみで、実施タイミングやこのセッション内での自動実行を抑止する言及がなかった

## Test plan
- `_recompose_bootstrap_message` / `_recompose_delta_message` それぞれについて、追加した guard 文言がhint messageに含まれることを確認するテストを追加
- 既存テスト39件 + 追加テスト2件、計41件pass