### PR TITLE
improvement-backlog未処理累積を検知するbacklog-reviewスキルを新設

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -186,7 +186,7 @@ Claude Code harnessのhookシグナルを受けてプロセスとして起動す
 ### 4.3 フロー層 service
 
 - `src/services/checkin_service.py`: check-inの本体実装。アクティビティに紐づく tag-notes・資材カタログ・pinned・関連decisions・recent logs を一括取得し、coverage と recompose hints を計算する (recompose hint は HintService 経由)
-- `src/services/hint_service.py`: hint一元化（`get_hints(scope, target_id) -> list[Hint]`）。recompose_bootstrap / recompose_delta / logs_sparse / follow_up_after_decision / record_missing を統一フォーマットで返す。delivery_hint で immediate (check_in 同期注入) と deferred (Stop hook → events.jsonl → UserPromptSubmit 注入) を分岐する
+- `src/services/hint_service.py`: hint一元化（`get_hints(scope, target_id) -> list[Hint]`）。recompose_bootstrap / recompose_delta / logs_sparse / follow_up_after_decision / record_missing / direction_overflow / backlog_review_due を統一フォーマットで返す。delivery_hint で immediate (check_in 同期注入) と deferred (Stop hook → events.jsonl → UserPromptSubmit 注入) を分岐する
 - `src/services/habit_service.py`: SessionStartでの全件注入対象
 
 ### 4.4 hookシグナルの流れ

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -373,18 +373,26 @@ def _build_signals_section(conn, session_id: str | None = None) -> str:  # conn,
 
 
 def _build_backlog_review_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
-    """improvement-backlog未処理累積のbacklog_review_due hintをSessionStartでも表示する。"""
-    from src.services.hint_service import get_hints_with_conn
+    """improvement-backlog未処理累積のbacklog_review_due hintをSessionStartでも表示する。
+
+    get_hints_with_conn(scope="tag")ではなくget_backlog_review_hintを直接呼ぶことで、
+    _get_hints_for_tagが行うrecompose/direction系の付随クエリ（本セクションでは使わ
+    ない）を回避する。SessionStartは毎セッション実行される経路のため、この差が効く。
+    """
+    from src.services.hint_service import (
+        BACKLOG_REVIEW_DOMAIN_NAME,
+        BACKLOG_REVIEW_DOMAIN_NAMESPACE,
+        get_backlog_review_hint,
+    )
 
     row = conn.execute(
-        "SELECT id FROM tags WHERE namespace = 'domain' AND name = 'cc-memory'"
+        "SELECT id FROM tags WHERE namespace = ? AND name = ?",
+        (BACKLOG_REVIEW_DOMAIN_NAMESPACE, BACKLOG_REVIEW_DOMAIN_NAME),
     ).fetchone()
     if row is None:
         return ""
-    for hint in get_hints_with_conn(conn, "tag", row["id"]):
-        if hint["type"] == "backlog_review_due":
-            return hint["message"] + "\n"
-    return ""
+    hint = get_backlog_review_hint(conn, row["id"])
+    return (hint["message"] + "\n") if hint is not None else ""
 
 
 def _build_relay_inbox_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -372,6 +372,21 @@ def _build_signals_section(conn, session_id: str | None = None) -> str:  # conn,
     return f"未トリアージのシグナル: {total}件 ({breakdown}) → get_signals で確認\n"
 
 
+def _build_backlog_review_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
+    """improvement-backlog未処理累積のbacklog_review_due hintをSessionStartでも表示する。"""
+    from src.services.hint_service import get_hints_with_conn
+
+    row = conn.execute(
+        "SELECT id FROM tags WHERE namespace = 'domain' AND name = 'cc-memory'"
+    ).fetchone()
+    if row is None:
+        return ""
+    for hint in get_hints_with_conn(conn, "tag", row["id"]):
+        if hint["type"] == "backlog_review_due":
+            return hint["message"] + "\n"
+    return ""
+
+
 def _build_relay_inbox_section(conn, session_id: str | None = None) -> str:  # conn, session_id: buildersループの統一シグネチャ
     """relay inboxの未読件数 + Monitor監視の指示を表示する。
 
@@ -508,6 +523,7 @@ def _build_session_context(session_id: str | None = None) -> str:
             _build_habits_section,
             _build_sync_policy_section,
             _build_signals_section,
+            _build_backlog_review_section,
             _build_relay_inbox_section,
         ]
         for builder in builders:

--- a/skills/backlog-review/SKILL.md
+++ b/skills/backlog-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: backlog-review
+description: 【必須】improvement-backlogタグ付きlog/materialの未処理累積が閾値に達した状況で発動する。SessionStartまたはcheck-inのhintで「要望会タイミングです（未処理N件）。/backlog-review で着手」を受け取りユーザーが着手を承認した状況、または「/backlog-review」「要望会やろう」「バックログレビューして」等ユーザーが直接要望した状況で発動する。このスキルを経由せずにimprovement-backlogタグ付き項目の一括判定（採用/却下/保留の分類・タグ付け）を行ってはいけない。TRIGGER: hint受領後にユーザーが着手を承認した／ユーザーが要望会・backlog-review着手を明示した、のいずれか。DO NOT TRIGGER: improvement-backlogタグ付き項目1件だけをその場で個別対応する場合／discomfort-protocolタグのみでまだimprovement-backlogに昇格していない違和感メモを扱う場合／緊急バグ調査中／設計上の大論点を議論している最中。
+---
+
+# backlog-review
+
+improvement-backlogタグが付いた未処理のlog/materialをまとめてレビューし、採用（設計activity化）/却下（decision記録）/保留（タグ付け）に振り分ける「要望会」を実行する。
+
+## 発動契機
+
+- **hint経由（主経路）**: SessionStartの表示、または`check_in`の`hints`フィールドに「要望会タイミングです（未処理N件）。/backlog-review で着手」が出た後、ユーザーが着手を承認した
+- **ユーザー明示**: 「/backlog-review」「要望会やろう」等の直接呼び出し
+
+いずれの経路でも、対象件数と概要を提示してユーザーの承認を取ってから本体フローに入る（自律発動 ≠ 全自動）。
+
+## 手順
+
+### 1. 未処理バックログの取得
+
+- `search(tags=["improvement-backlog"], entity_type="log", limit=50)` と `search(tags=["improvement-backlog"], entity_type="material", limit=50)` をそれぞれ呼ぶ
+- `search`の`tags`はAND条件のみでNOT条件がないため、`improvement-backlog-triaged`または`improvement-backlog-deferred`が付いているものは、返ってきた各アイテムの`tags`配列を見てクライアント側で除外する
+- 除外後に残った件数が今回のレビュー対象件数
+
+### 2. Edge case判定
+
+- **0件**: 「未処理バックログはありません」と伝えて終了する
+- **各searchの`total_count`が50件超**: 全件を一度に扱わず、「直近作成分」「特定タグ」等のサブセット選択肢を提示し、対象を絞ってから3へ進む
+- 上記以外はそのまま3へ
+
+### 3. SA事前トリアージ
+
+対象が6件以上の場合、Agentツール（`subagent_type: "scout"`, `mode: "auto"`, `run_in_background: true`）でSAに分類提案を委譲する。5件以下ならこのステップを省き自分で分類案を作ってよい。
+
+SAへの依頼に含めるもの:
+- 各アイテムのtitle/snippet/tags全文
+- 分類観点: 採用候補（具体的な設計/実装activityを起票する価値がある）／却下候補（対応不要と判断できる理由がある）／保留候補（今は判断材料が足りない）
+- 各アイテムに1行の分類提案+理由を返すよう指示
+
+SAの提案は「たたき台」であり、最終判断はユーザーのバッチ承認で行う。scoutの成果物は裏取り前提の生データとして扱い、そのまま実行に流さない。
+
+### 4. 5件バッチでユーザー承認
+
+5件ずつAskUserQuestionで提示する。1バッチの選択肢:
+- A: SA提案通り承認
+- B: 一部修正して承認（どのアイテムをどう変えるか自由記述）
+- C: このバッチは保留にして次へ
+
+**承認が得られたバッチから即座に実行する**（全バッチの承認を待たない）。これにより、ユーザーが途中で中断しても、それまでの承認済みバッチは処理済みとして残る。
+
+### 5. 実行（承認された分類ごと）
+
+- **採用**: `add_activity`でintent:designの`[設計]`activityを新規作成する。`related`に起点log/materialを紐づける。**作成成功を確認してから**起点log/materialに`improvement-backlog-triaged`タグを追加する（既存タグを保持したまま追記、全置換で消さないこと）
+- **却下**: `add_decisions`で却下decisionを記録する。`topic_id`は起点log/materialが既存で属するtopicがあればそれを使う（`get_by_ids`や`get_map`で確認）。属していなければ`search(keyword="improvement-backlog 要望会", entity_type="topic")`で該当topicを検索して使う。reasonに却下理由を明記する。**記録成功を確認してから**起点log/materialに`improvement-backlog-triaged`タグを追加する
+- **保留**: 起点log/materialのタグに`improvement-backlog-deferred`を追加する（`improvement-backlog-triaged`は付けない）
+
+**順序を厳守する**: 成果物（activity/decision）の作成が成功してから起点のタグを更新する。作成に失敗した場合はタグを変更せず、そのアイテムは未処理のまま次回に持ち越す（この順序が失敗時の一貫性を保証するため、別途ロールバック処理は不要）。
+
+### 6. 完了報告
+
+`add_material`で今回の要望会サマリを保存する。内容: 採用N件・却下M件・保留L件の内訳（各アイテムのタイトルと振り分け先）、次回しきい値到達までの未処理残数見込み。`related`で対象topicや今回作成したactivity/decisionと紐づける。
+
+ユーザーへの報告は「採用N件（新規activity一覧）・却下M件・保留L件、要望会完了」の簡潔な要約に留める。
+
+## discomfort-protocolとの境界
+
+- `improvement-backlog`タグが付いていない（discomfort-protocolタグのみの）log/materialは本スキルの対象外。まだ「育っていない」違和感の段階
+- discomfort-protocol → improvement-backlogへの昇格判定は別フロー。本スキルは既にimprovement-backlogが付いたものだけを扱う
+
+## 関連skillとの境界
+
+- 単発1件のimprovement-backlog対応（その場で判断がつく軽微な要望）は本スキルを介さず直接処理してよい。本スキルは「まとめて」の継続運用が対象
+- 記録の同期・棚卸し全般はsync-memoryの担当。本スキルはimprovement-backlogタグに限定したレビューに専念する
+
+## 注意
+
+- ユーザー承認なしにactivity/decisionを大量生成しない。5件バッチ承認を必ず経由する
+- 完了報告のmaterial保存はレビュー完了ごとに1件（複数回に分けて保存しない）

--- a/skills/tag-notes/SKILL.md
+++ b/skills/tag-notes/SKILL.md
@@ -14,9 +14,9 @@ description: タグのnotesを確認・更新する。「/tag-notes」「タグ�
 3. `search_tags` で対象タグを検索し、現在の notes を取得する（対象タグ名をqueryに、include_notes=Trueで呼ぶ）
 4. 既存の notes がある場合はその内容を保持しつつ、新しい内容をマージしたドラフトを作成する
 
-   recompose/direction系のhint抑制マーカー（`#recompose-skipped`, `#recompose-bootstrap-skipped`,
-   `#recompose-delta-skipped`, `#logs-sparse-ack`, `#direction-overflow-ack`）を追記・更新する
-   場合の書式は以下の通り:
+   recompose/direction/backlog-review系のhint抑制マーカー（`#recompose-skipped`,
+   `#recompose-bootstrap-skipped`, `#recompose-delta-skipped`, `#logs-sparse-ack`,
+   `#direction-overflow-ack`, `#backlog-review-ack`）を追記・更新する場合の書式は以下の通り:
    - マーカー単体（例: `#recompose-skipped`）は恒久抑制
    - `<マーカー>-until:YYYY-MM-DD`（例: `#recompose-skipped-until:2026-08-01`）を付けると、
      指定日当日まで有効な期限付き抑制になる

--- a/src/config.py
+++ b/src/config.py
@@ -35,6 +35,11 @@ SYNC_POLICY: str | None = os.environ.get("CCM_SYNC_POLICY") or None  # 空文字
 # direction_overflow hintを発火する（少数原則の維持を促す）
 DIRECTION_OVERFLOW_THRESHOLD: int = int(os.environ.get("CCM_DIRECTION_OVERFLOW_THRESHOLD", "8"))
 
+# --- Backlog Review ---
+# improvement-backlogタグ付きlog/materialのうちimprovement-backlog-triagedが
+# 付いていない(未処理)件数がこの値以上になったらbacklog_review_due hintを発火する
+BACKLOG_REVIEW_THRESHOLD: int = int(os.environ.get("CCM_BACKLOG_REVIEW_THRESHOLD", "10"))
+
 # --- Migration Safety ---
 # premigration スナップショット取得を無効化する緊急脱出弁（"0" で無効化）
 CCM_MIGRATION_SNAPSHOT: bool = os.environ.get("CCM_MIGRATION_SNAPSHOT", "1") != "0"

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -11,11 +11,13 @@ hintの種別と発火条件は仕様確定decisionに従う。
 - record_missing (deferred): 一定turn記録系ツール未呼出
 - direction_overflow (immediate): tag scope, domain: namespaceのみ,
   layer:direction decisionのactive件数 ≥ DIRECTION_OVERFLOW_THRESHOLD
+- backlog_review_due (immediate): tag scope, domain:cc-memory固定, improvement-backlog
+  タグ付きlog/materialの未処理(triaged無し)件数 ≥ BACKLOG_REVIEW_THRESHOLD
 
 抑制:
 - tag_notesに以下のハッシュタグマーカーがあれば該当hintをスキップ:
   #recompose-skipped, #recompose-bootstrap-skipped, #recompose-delta-skipped,
-  #logs-sparse-ack, #direction-overflow-ack
+  #logs-sparse-ack, #direction-overflow-ack, #backlog-review-ack
 - 各マーカーは素の形（恒久抑制）に加えて `<marker>-until:YYYY-MM-DD` の形式
   （指定日当日まで有効な期限付き抑制）も受け付ける。不正な日付形式は無視される
   （フェイルオープン、抑制しない側に倒す）。判定は_is_marker_activeに集約する
@@ -37,9 +39,10 @@ import sys
 from datetime import date
 from typing import Any, Literal, TypedDict
 
-from src.config import DIRECTION_OVERFLOW_THRESHOLD
+from src.config import BACKLOG_REVIEW_THRESHOLD, DIRECTION_OVERFLOW_THRESHOLD
 from src.db import get_connection
 from src.services.direction_service import count_direction_decisions
+from src.services.tag_service import resolve_tag_ids
 
 # --- 型定義 ---
 
@@ -50,6 +53,7 @@ HintType = Literal[
     "follow_up_after_decision",
     "record_missing",
     "direction_overflow",
+    "backlog_review_due",
 ]
 Severity = Literal["info", "warn"]
 DeliveryHint = Literal["immediate", "deferred"]
@@ -86,6 +90,7 @@ MARKER_RECOMPOSE_BOOTSTRAP = "#recompose-bootstrap-skipped"
 MARKER_RECOMPOSE_DELTA = "#recompose-delta-skipped"
 MARKER_LOGS_SPARSE = "#logs-sparse-ack"
 MARKER_DIRECTION_OVERFLOW = "#direction-overflow-ack"
+MARKER_BACKLOG_REVIEW = "#backlog-review-ack"
 
 # マーカーは素の形（恒久抑制）に加えて `<marker>-until:YYYY-MM-DD`（期限付き抑制、
 # 指定日当日まで有効）も受け付ける。判定は_is_marker_activeに集約する。
@@ -174,6 +179,16 @@ def _direction_overflow_message(tag_name: str, count: int) -> str:
         f"「{MARKER_DIRECTION_OVERFLOW}-until:YYYY-MM-DD」（任意の未来日）を"
         f"追記すると、その日まで一時的に黙らせられます。恒久的に不要なら日付なしの"
         f"「{MARKER_DIRECTION_OVERFLOW}」を追記してください。"
+    )
+
+
+def _backlog_review_message(count: int) -> str:
+    return (
+        f"要望会タイミングです（未処理{count}件）。/backlog-review で着手してください。"
+        f"今は都合が悪い場合、domain:cc-memoryのtag notesに"
+        f"「{MARKER_BACKLOG_REVIEW}-until:YYYY-MM-DD」（任意の未来日）を追記すると、"
+        f"その日まで一時的に黙らせられます。恒久的に不要なら日付なしの"
+        f"「{MARKER_BACKLOG_REVIEW}」を追記してください。"
     )
 
 
@@ -303,6 +318,24 @@ def _get_hints_for_tag(conn: sqlite3.Connection, tag_id: int) -> list[Hint]:
                 "delivery_hint": "immediate",
             })
 
+    if tag_name == "domain:cc-memory" and not _is_marker_active(notes, MARKER_BACKLOG_REVIEW):
+        untriaged = _count_untriaged_backlog_items(conn)
+        if untriaged >= BACKLOG_REVIEW_THRESHOLD:
+            hints.append({
+                "type": "backlog_review_due",
+                "severity": "info",
+                "message": _backlog_review_message(untriaged),
+                "suggested_action": {
+                    "skill": "backlog-review",
+                    "natural_language": (
+                        f"improvement-backlog未処理{untriaged}件の要望会着手を"
+                        "ユーザーに提案する"
+                    ),
+                },
+                "source": "backlog_review_due",
+                "delivery_hint": "immediate",
+            })
+
     return hints
 
 
@@ -357,6 +390,45 @@ def _count_tag_scope_decisions(
         params.append(after)
     row = conn.execute(sql, tuple(params)).fetchone()
     return row[0] if row else 0
+
+
+def _count_untriaged_backlog_items(conn: sqlite3.Connection) -> int:
+    """improvement-backlogタグ付きでimprovement-backlog-triagedが付いていない
+    log/material件数（retracted除外）。"""
+    backlog_ids = resolve_tag_ids(conn, [("", "improvement-backlog")])
+    if not backlog_ids:
+        return 0
+    backlog_id = backlog_ids[0]
+    triaged_ids = resolve_tag_ids(conn, [("", "improvement-backlog-triaged")])
+    triaged_id = triaged_ids[0] if triaged_ids else -1
+
+    log_count = conn.execute(
+        """
+        SELECT COUNT(*) FROM log_tags lt
+        JOIN discussion_logs dl ON dl.id = lt.log_id
+        WHERE lt.tag_id = ? AND dl.retracted_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM log_tags lt2
+              WHERE lt2.log_id = lt.log_id AND lt2.tag_id = ?
+          )
+        """,
+        (backlog_id, triaged_id),
+    ).fetchone()[0]
+
+    material_count = conn.execute(
+        """
+        SELECT COUNT(*) FROM material_tags mt
+        JOIN materials m ON m.id = mt.material_id
+        WHERE mt.tag_id = ? AND m.retracted_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM material_tags mt2
+              WHERE mt2.material_id = mt.material_id AND mt2.tag_id = ?
+          )
+        """,
+        (backlog_id, triaged_id),
+    ).fetchone()[0]
+
+    return log_count + material_count
 
 
 # --- scope=topic ---

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -83,6 +83,15 @@ RECOMPOSE_DELTA_THRESHOLD = 50
 LOGS_SPARSE_LOG_THRESHOLD = 5
 
 
+# --- backlog_review_due 固有のタグ識別子 ---
+
+BACKLOG_REVIEW_DOMAIN_NAMESPACE = "domain"
+BACKLOG_REVIEW_DOMAIN_NAME = "cc-memory"
+BACKLOG_REVIEW_DOMAIN_TAG = f"{BACKLOG_REVIEW_DOMAIN_NAMESPACE}:{BACKLOG_REVIEW_DOMAIN_NAME}"
+BACKLOG_TAG_NAME = "improvement-backlog"
+BACKLOG_TRIAGED_TAG_NAME = "improvement-backlog-triaged"
+
+
 # --- 抑制マーカー ---
 
 MARKER_RECOMPOSE_GENERIC = "#recompose-skipped"
@@ -185,7 +194,7 @@ def _direction_overflow_message(tag_name: str, count: int) -> str:
 def _backlog_review_message(count: int) -> str:
     return (
         f"要望会タイミングです（未処理{count}件）。/backlog-review で着手してください。"
-        f"今は都合が悪い場合、domain:cc-memoryのtag notesに"
+        f"今は都合が悪い場合、{BACKLOG_REVIEW_DOMAIN_TAG}のtag notesに"
         f"「{MARKER_BACKLOG_REVIEW}-until:YYYY-MM-DD」（任意の未来日）を追記すると、"
         f"その日まで一時的に黙らせられます。恒久的に不要なら日付なしの"
         f"「{MARKER_BACKLOG_REVIEW}」を追記してください。"
@@ -318,25 +327,54 @@ def _get_hints_for_tag(conn: sqlite3.Connection, tag_id: int) -> list[Hint]:
                 "delivery_hint": "immediate",
             })
 
-    if tag_name == "domain:cc-memory" and not _is_marker_active(notes, MARKER_BACKLOG_REVIEW):
-        untriaged = _count_untriaged_backlog_items(conn)
-        if untriaged >= BACKLOG_REVIEW_THRESHOLD:
-            hints.append({
-                "type": "backlog_review_due",
-                "severity": "info",
-                "message": _backlog_review_message(untriaged),
-                "suggested_action": {
-                    "skill": "backlog-review",
-                    "natural_language": (
-                        f"improvement-backlog未処理{untriaged}件の要望会着手を"
-                        "ユーザーに提案する"
-                    ),
-                },
-                "source": "backlog_review_due",
-                "delivery_hint": "immediate",
-            })
+    backlog_hint = get_backlog_review_hint(conn, tag_id)
+    if backlog_hint is not None:
+        hints.append(backlog_hint)
 
     return hints
+
+
+def get_backlog_review_hint(conn: sqlite3.Connection, tag_id: int) -> Hint | None:
+    """指定tag_idがdomain:cc-memoryの場合のみbacklog_review_due hintを判定する。
+
+    _get_hints_for_tagの内部判定に加えて、backlog_review_due単体だけが必要な経路
+    （session_start_hookなど）向けの軽量エントリポイントを兼ねる。tag_id以外の
+    引数を要求しないため、呼び出し側は_get_hints_for_tagが行うrecompose/direction系
+    の付随クエリ（pinned material時刻・tag scope decision件数・direction decision
+    件数の集計）を発生させずに済む。
+    """
+    tag_row = conn.execute(
+        "SELECT namespace, name, notes FROM tags WHERE id = ?", (tag_id,)
+    ).fetchone()
+    if tag_row is None:
+        return None
+    if (tag_row["namespace"], tag_row["name"]) != (
+        BACKLOG_REVIEW_DOMAIN_NAMESPACE, BACKLOG_REVIEW_DOMAIN_NAME
+    ):
+        return None
+
+    notes = tag_row["notes"] or ""
+    if _is_marker_active(notes, MARKER_BACKLOG_REVIEW):
+        return None
+
+    untriaged = _count_untriaged_backlog_items(conn, tag_id)
+    if untriaged < BACKLOG_REVIEW_THRESHOLD:
+        return None
+
+    return {
+        "type": "backlog_review_due",
+        "severity": "info",
+        "message": _backlog_review_message(untriaged),
+        "suggested_action": {
+            "skill": "backlog-review",
+            "natural_language": (
+                f"improvement-backlog未処理{untriaged}件の要望会着手を"
+                "ユーザーに提案する"
+            ),
+        },
+        "source": "backlog_review_due",
+        "delivery_hint": "immediate",
+    }
 
 
 def _get_pinned_material_max_time(
@@ -392,14 +430,20 @@ def _count_tag_scope_decisions(
     return row[0] if row else 0
 
 
-def _count_untriaged_backlog_items(conn: sqlite3.Connection) -> int:
-    """improvement-backlogタグ付きでimprovement-backlog-triagedが付いていない
-    log/material件数（retracted除外）。"""
-    backlog_ids = resolve_tag_ids(conn, [("", "improvement-backlog")])
+def _count_untriaged_backlog_items(conn: sqlite3.Connection, domain_tag_id: int) -> int:
+    """domain_tag_idにスコープした、improvement-backlogタグ付きで
+    improvement-backlog-triagedが付いていないlog/material件数（retracted除外）。
+
+    このDBは複数domainを横断して1つに格納する前提のため、domainでスコープしないと
+    別domainのimprovement-backlog項目が混入する。logはdecisionと同様、直付けタグ
+    OR 親topicからの継承タグのいずれかで判定する。materialはtopic継承を持たない
+    設計（get_effective_tagsの対象外）のため、直付けタグのみで判定する。
+    """
+    backlog_ids = resolve_tag_ids(conn, [("", BACKLOG_TAG_NAME)])
     if not backlog_ids:
         return 0
     backlog_id = backlog_ids[0]
-    triaged_ids = resolve_tag_ids(conn, [("", "improvement-backlog-triaged")])
+    triaged_ids = resolve_tag_ids(conn, [("", BACKLOG_TRIAGED_TAG_NAME)])
     triaged_id = triaged_ids[0] if triaged_ids else -1
 
     log_count = conn.execute(
@@ -411,8 +455,21 @@ def _count_untriaged_backlog_items(conn: sqlite3.Connection) -> int:
               SELECT 1 FROM log_tags lt2
               WHERE lt2.log_id = lt.log_id AND lt2.tag_id = ?
           )
+          AND (
+              EXISTS (
+                  SELECT 1 FROM log_tags lt3
+                  WHERE lt3.log_id = lt.log_id AND lt3.tag_id = ?
+              )
+              OR EXISTS (
+                  SELECT 1 FROM relations r
+                  JOIN topic_tags tt ON tt.topic_id = r.target_id
+                  WHERE r.source_type = 'log' AND r.source_id = lt.log_id
+                    AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                    AND tt.tag_id = ?
+              )
+          )
         """,
-        (backlog_id, triaged_id),
+        (backlog_id, triaged_id, domain_tag_id, domain_tag_id),
     ).fetchone()[0]
 
     material_count = conn.execute(
@@ -424,8 +481,12 @@ def _count_untriaged_backlog_items(conn: sqlite3.Connection) -> int:
               SELECT 1 FROM material_tags mt2
               WHERE mt2.material_id = mt.material_id AND mt2.tag_id = ?
           )
+          AND EXISTS (
+              SELECT 1 FROM material_tags mt3
+              WHERE mt3.material_id = mt.material_id AND mt3.tag_id = ?
+          )
         """,
-        (backlog_id, triaged_id),
+        (backlog_id, triaged_id, domain_tag_id),
     ).fetchone()[0]
 
     return log_count + material_count

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -1301,3 +1301,60 @@ class TestSessionStartHookRelayInbox:
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "relay inbox 未読" not in context
+
+
+class TestSessionStartHookBacklogReview:
+    """backlog_review_due hintのSessionStart表示テスト"""
+
+    def _seed_untriaged_backlog_logs(self, count: int) -> int:
+        from src.services.discussion_log_service import add_logs
+        from src.services.topic_service import add_topic
+
+        topic = add_topic(
+            title="要望会テスト用topic", description="d", tags=["domain:cc-memory"],
+        )
+        items = [
+            {
+                "topic_id": topic["topic_id"],
+                "title": f"要望{i}",
+                "content": "c",
+                "tags": ["improvement-backlog"],
+            }
+            for i in range(count)
+        ]
+        result = add_logs(items)
+        assert not result["errors"], result["errors"]
+        return topic["topic_id"]
+
+    def test_hidden_below_threshold(self, temp_db):
+        from src.config import BACKLOG_REVIEW_THRESHOLD
+
+        self._seed_untriaged_backlog_logs(BACKLOG_REVIEW_THRESHOLD - 1)
+
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "要望会タイミングです" not in context
+
+    def test_shown_at_threshold(self, temp_db):
+        from src.config import BACKLOG_REVIEW_THRESHOLD
+
+        self._seed_untriaged_backlog_logs(BACKLOG_REVIEW_THRESHOLD)
+
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "要望会タイミングです" in context
+        assert str(BACKLOG_REVIEW_THRESHOLD) in context
+
+    def test_hidden_when_suppressed_by_marker(self, temp_db):
+        from src.config import BACKLOG_REVIEW_THRESHOLD
+        from src.services.tag_service import update_tag
+
+        self._seed_untriaged_backlog_logs(BACKLOG_REVIEW_THRESHOLD)
+        update_tag("domain:cc-memory", notes="#backlog-review-ack")
+
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "要望会タイミングです" not in context

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -562,8 +562,10 @@ class TestBacklogReviewDue:
                 topic["topic_id"], title=f"要望{i}", content="c",
                 tags=["improvement-backlog"],
             )
+        # materialはtopic継承を持たないため、domainタグを直付けする
         add_material(
-            title="要望material", content="c", tags=["improvement-backlog"],
+            title="要望material", content="c",
+            tags=["improvement-backlog", CC_MEMORY_DOMAIN_TAG],
             source="test",
         )
 
@@ -591,4 +593,27 @@ class TestBacklogReviewDue:
             )
 
         hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []
+
+    def test_other_domain_items_not_counted_toward_cc_memory(self, temp_db):
+        """他domainのimprovement-backlog項目がcc-memory向けの集計に混入しないこと。
+
+        cc-memory側はしきい値未満だが、他domain側の件数を合算すればしきい値に
+        届く状況を作り、それでもcc-memory向けhintが発火しないことを確認する。
+        """
+        cc_topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        other_topic = add_topic(title="t2", description="d2", tags=[DOMAIN_TAG])
+
+        for i in range(BACKLOG_REVIEW_THRESHOLD - 1):
+            add_log(
+                cc_topic["topic_id"], title=f"cc要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+        for i in range(5):
+            add_log(
+                other_topic["topic_id"], title=f"他要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
         assert [h for h in hints if h["type"] == "backlog_review_due"] == []

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -595,6 +595,29 @@ class TestBacklogReviewDue:
         hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
         assert [h for h in hints if h["type"] == "backlog_review_due"] == []
 
+    def test_other_domain_material_not_counted_toward_cc_memory(self, temp_db):
+        """他domainのimprovement-backlog付きmaterialがcc-memory向けの集計に混入しないこと。
+
+        materialはtopic継承を持たず直付けタグのみでスコープ判定するためlogとは別クエリを
+        通る。cc-memory側はしきい値未満のlogのみとし、他domainを直付けしたmaterialを
+        追加してもcc-memory向けhintが発火しないことを確認する。
+        """
+        cc_topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+
+        for i in range(BACKLOG_REVIEW_THRESHOLD - 1):
+            add_log(
+                cc_topic["topic_id"], title=f"cc要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+        add_material(
+            title="他domain要望material", content="c",
+            tags=["improvement-backlog", DOMAIN_TAG],
+            source="test",
+        )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []
+
     def test_other_domain_items_not_counted_toward_cc_memory(self, temp_db):
         """他domainのimprovement-backlog項目がcc-memory向けの集計に混入しないこと。
 

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -9,9 +9,11 @@ from src.services.activity_service import add_activity
 from src.services.decision_service import add_decisions
 from src.services.direction_service import DIRECTION_NAME, DIRECTION_NAMESPACE
 from src.services.hint_service import (
+    BACKLOG_REVIEW_THRESHOLD,
     DIRECTION_OVERFLOW_THRESHOLD,
     HINT_LOGS_SPARSE_MESSAGE,
     LOGS_SPARSE_LOG_THRESHOLD,
+    MARKER_BACKLOG_REVIEW,
     MARKER_DIRECTION_OVERFLOW,
     MARKER_LOGS_SPARSE,
     MARKER_RECOMPOSE_BOOTSTRAP,
@@ -29,7 +31,7 @@ from src.services.material_service import add_material
 from src.services.pin_service import add_pin
 from src.services.topic_service import add_topic
 from src.services.tag_service import _injected_tags, update_tag
-from tests.helpers import add_decision
+from tests.helpers import add_decision, add_log
 
 DOMAIN_TAG_NAME = "hint-domain"
 DOMAIN_TAG = f"domain:{DOMAIN_TAG_NAME}"
@@ -510,3 +512,83 @@ class TestEdgeCases:
 
         intent_tag_id = _tag_id("design", namespace="intent")
         assert get_hints("tag", intent_tag_id) == []
+
+
+CC_MEMORY_DOMAIN_TAG = "domain:cc-memory"
+
+
+class TestBacklogReviewDue:
+    def test_fires_at_threshold(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        backlog_hints = [h for h in hints if h["type"] == "backlog_review_due"]
+        assert len(backlog_hints) == 1
+        assert backlog_hints[0]["delivery_hint"] == "immediate"
+        assert backlog_hints[0]["severity"] == "info"
+        assert str(BACKLOG_REVIEW_THRESHOLD) in backlog_hints[0]["message"]
+
+    def test_silent_below_threshold(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD - 1):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []
+
+    def test_triaged_items_excluded_from_count(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog", "improvement-backlog-triaged"],
+            )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []
+
+    def test_material_items_also_counted(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD - 1):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+        add_material(
+            title="要望material", content="c", tags=["improvement-backlog"],
+            source="test",
+        )
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] != []
+
+    def test_suppressed_by_marker(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[CC_MEMORY_DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+        update_tag(CC_MEMORY_DOMAIN_TAG, notes=MARKER_BACKLOG_REVIEW)
+
+        hints = get_hints("tag", _tag_id("cc-memory"))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []
+
+    def test_not_fired_for_other_domain(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(BACKLOG_REVIEW_THRESHOLD):
+            add_log(
+                topic["topic_id"], title=f"要望{i}", content="c",
+                tags=["improvement-backlog"],
+            )
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert [h for h in hints if h["type"] == "backlog_review_due"] == []

--- a/tests/unit/test_tag_notes_marker_sync.py
+++ b/tests/unit/test_tag_notes_marker_sync.py
@@ -42,7 +42,7 @@ def skill_md_content() -> str:
 class TestTagNotesMarkerSyncWithHintService:
     def test_hint_service_has_expected_marker_count(self):
         # 0件だとテスト自体が意味を持たなくなるため、実装側の前提を明示的に固定する
-        assert len(_hint_service_markers()) == 5
+        assert len(_hint_service_markers()) == 6
 
     def test_all_hint_service_markers_documented_in_skill_md(self, skill_md_content):
         missing = _hint_service_markers() - _skill_md_markers(skill_md_content)


### PR DESCRIPTION
## Summary

- improvement-backlogタグ付きlog/materialのうち、improvement-backlog-triagedが付いていない(未処理の)件数が閾値以上になると、SessionStartとcheck-inのhintで「要望会タイミングです（未処理N件）。/backlog-review で着手してください」と案内するようにした
- 新規スキル `backlog-review` を追加した。未処理項目をまとめて取得し、6件以上ならSA(scout)に分類のたたき台を作らせ、5件ずつユーザーの承認を得ながら採用（設計activity化）/却下（decision記録）/保留（タグ付け）に振り分ける
- 振り分けの実行順は「成果物(activity/decision)の作成成功→起点タグの更新」を厳守する。作成に失敗した項目はタグを変えず次回に持ち越す

## 背景・動機

improvement-backlogタグを使った要望の蓄積機構自体は既にあったが、蓄積を検知してレビューを促す仕組みがなく、要望が埋もれたまま増え続けていた。既存のrecompose系hint（decision蓄積の検知）と同じパターンで、log/material側の未処理蓄積を検知できるようにした。

af（activity-finish）時点での検知は今回のスコープに含めていない。update_activityはhint配信の仕組みを持たず、新規に持たせると全activity completion系の挙動変更になり影響範囲が広いため、SessionStartとcheck-inの2経路（セッションが始まれば必ず一度は目に触れる）に絞った。しきい値到達がセッション途中で発生した場合のみ次回SessionStartまで気づかれない、という限定的なギャップが残る。

## Test plan

新規テスト（`tests/unit/test_hint_service.py::TestBacklogReviewDue`）で以下を検証:
- 未処理件数が閾値ちょうどでhintが発火し、メッセージに件数を含むこと
- 閾値未満では発火しないこと
- improvement-backlog-triagedが付いた項目は未処理件数から除外されること
- log/materialの合算で閾値到達を判定すること
- tag notesの抑制マーカーで発火を止められること
- domain:cc-memory以外のdomainタグでは発火しないこと（ハードコード仕様の確認）

新規E2Eテスト（`tests/e2e/test_session_start_hook.py::TestSessionStartHookBacklogReview`）で、SessionStart hookの実出力（additionalContext）に同じ挙動（閾値未満で非表示／閾値到達で表示／マーカーで抑制）が反映されることを確認。

既存テストへの影響: `test_tag_notes_marker_sync.py`が新規抑制マーカーの追加を検知したため、`skills/tag-notes/SKILL.md`のマーカー一覧を追記して同期を取った。関連範囲のテスト（hint_service / session_start_hook / tag_notes_marker_sync / skill_description_triggers / checkin_service）は全てpass、既存テストの破壊なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)