### PR TITLE
feat: recomposeナッジにdelta閾値引き上げ+日次クールダウンを追加

### DIFF
--- a/src/services/checkin_service.py
+++ b/src/services/checkin_service.py
@@ -548,7 +548,8 @@ def check_in(activity_id: int, session_id: str | None = None) -> dict:
             else:
                 activity["status"] = "in_progress"
 
-        # 9. recomposeナッジhint生成（既存connを共有して読み取り）
+        # 9. recomposeナッジhint生成（既存connを共有。hint発火時は日次クールダウン
+        #    マーカーのnotes書き込みを伴うが、commitは本関数末尾でまとめて行う）
         recompose_hints = _get_recompose_hints(conn, activity_id)
 
         # 10. summary生成
@@ -593,9 +594,11 @@ def check_in(activity_id: int, session_id: str | None = None) -> dict:
             result["hints"] = recompose_hints
         result["summary"] = summary
 
+        conn.commit()
         return result
 
     except Exception as e:
+        conn.rollback()
         return {
             "error": {
                 "code": "DATABASE_ERROR",

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -5,7 +5,7 @@ hintの種別と発火条件は仕様確定decisionに従う。
 
 種別:
 - recompose_bootstrap (immediate): tag scope, domain: namespaceのみ, decision累計 ≥ 30
-- recompose_delta (immediate): tag scope, domain: namespaceのみ, pinned material以降の増分 ≥ 50
+- recompose_delta (immediate): tag scope, domain: namespaceのみ, pinned material以降の増分 ≥ 100
 - logs_sparse (deferred): topic scope, log < 5 かつ decision > 0
 - follow_up_after_decision (deferred): 直近turnでadd_decisions単独、他記録系なし
 - record_missing (deferred): 一定turn記録系ツール未呼出
@@ -19,6 +19,11 @@ hintの種別と発火条件は仕様確定decisionに従う。
 - 各マーカーは素の形（恒久抑制）に加えて `<marker>-until:YYYY-MM-DD` の形式
   （指定日当日まで有効な期限付き抑制）も受け付ける。不正な日付形式は無視される
   （フェイルオープン、抑制しない側に倒す）。判定は_is_marker_activeに集約する
+- recompose_bootstrap / recompose_deltaはhintが実際に生成される都度、対象tagの
+  notesへ `<marker>-until:{today}` を自動追記する日次クールダウンを持つ（同日内の
+  再発火を防ぐ）。既存の日付付きマーカーが未来日の場合は上書きしない（手動設定の
+  長期抑制を優先する）。書き込みは_apply_cooldown_markerに集約する
+- direction_overflowはこの日次クールダウンの対象外（手動マーカーのみで抑制する）
 - orch-managed activityでの全suppressは呼出側責務 (本moduleは判定しない)
 
 severity値域: info | warn のみ (block不採用)
@@ -40,6 +45,7 @@ from typing import Any, Literal, TypedDict
 from src.config import DIRECTION_OVERFLOW_THRESHOLD
 from src.db import get_connection
 from src.services.direction_service import count_direction_decisions
+from src.services.tag_service import _set_tag_notes_by_id_with_conn
 
 # --- 型定義 ---
 
@@ -75,7 +81,7 @@ class Hint(TypedDict):
 # --- 閾値 ---
 
 RECOMPOSE_BOOTSTRAP_THRESHOLD = 30
-RECOMPOSE_DELTA_THRESHOLD = 50
+RECOMPOSE_DELTA_THRESHOLD = 100
 LOGS_SPARSE_LOG_THRESHOLD = 5
 
 
@@ -118,6 +124,45 @@ def _is_marker_active(notes: str, marker: str) -> bool:
             return True
     remainder = pattern.sub("", notes)
     return marker in remainder
+
+
+def _merge_cooldown_marker(notes: str, marker: str, today: date) -> str:
+    """notesに対してmarkerの日次クールダウンマーカーを解析し、更新後のnotesを返す。
+
+    既存の日付付きマーカー（`<marker>-until:YYYY-MM-DD`）がtodayより後（未来）で
+    あれば、ユーザーが意図的に設定した長期抑制とみなしnotesをそのまま返す（no-op）。
+    存在しない、不正な日付形式、またはtoday以前の日付であれば、既存の日付付き
+    マーカーを除去したうえでtoday基準のマーカーを追記する（更新は「除去→末尾追記」
+    で実現し、出現位置は保持しない）。素の恒久マーカーの扱いは呼び出し元の責務
+    （hintが生成された時点で恒久抑制は既に効いていないことが前提）。
+    """
+    pattern = _dated_marker_pattern(marker)
+    for date_str in pattern.findall(notes):
+        try:
+            until = date.fromisoformat(date_str)
+        except ValueError:
+            continue
+        if until > today:
+            return notes
+    remainder = pattern.sub("", notes).strip()
+    new_marker = f"{marker}{_DATED_MARKER_SUFFIX}{today.isoformat()}"
+    return f"{remainder}\n\n{new_marker}" if remainder else new_marker
+
+
+def _apply_cooldown_marker(
+    conn: sqlite3.Connection, tag_id: int, notes: str, marker: str
+) -> str:
+    """hint発火に伴い、対象tagのnotesへ日次クールダウンマーカーを書き込む。
+
+    _merge_cooldown_markerがno-opと判定した場合はDB書き込みを行わない。
+    書き込みが発生した場合のみcommitする。呼び出し元（_get_hints_for_tag）は
+    後続の判定で更新後のnotesを参照する必要があるため、返り値を使い回すこと。
+    """
+    new_notes = _merge_cooldown_marker(notes, marker, date.today())
+    if new_notes != notes:
+        _set_tag_notes_by_id_with_conn(conn, tag_id, new_notes)
+        conn.commit()
+    return new_notes
 
 
 # --- 文言 ---
@@ -266,6 +311,7 @@ def _get_hints_for_tag(conn: sqlite3.Connection, tag_id: int) -> list[Hint]:
                     "source": f"recompose_delta:tag:{tag_id}",
                     "delivery_hint": "immediate",
                 })
+                notes = _apply_cooldown_marker(conn, tag_id, notes, MARKER_RECOMPOSE_DELTA)
     else:
         if not (_is_marker_active(notes, MARKER_RECOMPOSE_GENERIC)
                 or _is_marker_active(notes, MARKER_RECOMPOSE_BOOTSTRAP)):
@@ -285,6 +331,7 @@ def _get_hints_for_tag(conn: sqlite3.Connection, tag_id: int) -> list[Hint]:
                     "source": f"recompose_bootstrap:tag:{tag_id}",
                     "delivery_hint": "immediate",
                 })
+                notes = _apply_cooldown_marker(conn, tag_id, notes, MARKER_RECOMPOSE_BOOTSTRAP)
 
     if not _is_marker_active(notes, MARKER_DIRECTION_OVERFLOW):
         direction_count = count_direction_decisions(conn, domain_tag_ids=[tag_id])

--- a/src/services/hint_service.py
+++ b/src/services/hint_service.py
@@ -154,14 +154,14 @@ def _apply_cooldown_marker(
 ) -> str:
     """hint発火に伴い、対象tagのnotesへ日次クールダウンマーカーを書き込む。
 
+    conn共有版の規約に従い、commitは呼び出し元に委ねる（本関数はcommitしない）。
     _merge_cooldown_markerがno-opと判定した場合はDB書き込みを行わない。
-    書き込みが発生した場合のみcommitする。呼び出し元（_get_hints_for_tag）は
-    後続の判定で更新後のnotesを参照する必要があるため、返り値を使い回すこと。
+    呼び出し元（_get_hints_for_tag）は後続の判定で更新後のnotesを参照する必要が
+    あるため、返り値を使い回すこと。
     """
     new_notes = _merge_cooldown_marker(notes, marker, date.today())
     if new_notes != notes:
         _set_tag_notes_by_id_with_conn(conn, tag_id, new_notes)
-        conn.commit()
     return new_notes
 
 
@@ -245,11 +245,15 @@ def get_hints(scope: Scope, target_id: int) -> list[Hint]:
     """指定scope/target_idに該当するhintを返す。
 
     呼出側はorch-managed等のsuppress判定を別途行うこと。本moduleはDB状態のみで判定する。
+    本関数は自前のconnを所有するため、クールダウンマーカー書き込みのcommitは
+    ここで行う（conn共有版のget_hints_with_connはcommitしない）。
     """
     try:
         conn = get_connection()
         try:
-            return get_hints_with_conn(conn, scope, target_id)
+            hints = get_hints_with_conn(conn, scope, target_id)
+            conn.commit()
+            return hints
         finally:
             conn.close()
     except Exception as e:

--- a/src/services/tag_service.py
+++ b/src/services/tag_service.py
@@ -1141,6 +1141,11 @@ def collect_tag_notes_for_injection(
     return results if results else None
 
 
+def _set_tag_notes_by_id_with_conn(conn: sqlite3.Connection, tag_id: int, notes: str) -> None:
+    """tag_id指定でnotesを全文置換する。commitは呼び出し元が行う。"""
+    conn.execute("UPDATE tags SET notes = ? WHERE id = ?", (notes, tag_id))
+
+
 def _append_tag_notes_with_conn(conn, tag_str: str, content: str) -> int:
     """タグのnotesにcontentを追記しtag_idを返す。タグ不在時はValueError。"""
     if not content or not content.strip():

--- a/tests/integration/test_checkin_service.py
+++ b/tests/integration/test_checkin_service.py
@@ -2,6 +2,7 @@
 import os
 import tempfile
 import pytest
+import src.services.checkin_service as checkin_service
 from src.db import init_database, get_connection
 from src.services.activity_service import add_activity, update_activity
 from tests.helpers import add_decision, add_log, retract_decision
@@ -14,6 +15,7 @@ from src.services.checkin_service import (
     DECISIONS_FULL_LIMIT,
 )
 from src.services.hint_service import (
+    MARKER_RECOMPOSE_BOOTSTRAP,
     RECOMPOSE_BOOTSTRAP_THRESHOLD as _RECOMPOSE_HINT_BOOTSTRAP_THRESHOLD,
     RECOMPOSE_DELTA_THRESHOLD as _RECOMPOSE_HINT_DELTA_THRESHOLD,
 )
@@ -1054,6 +1056,19 @@ def _set_decision_created_at(decision_id: int, ts: str) -> None:
         conn.close()
 
 
+def _get_tag_notes(name: str, namespace: str = "domain") -> str:
+    """指定タグのnotesを別connで読み出す（commit有無の検証用）。"""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT notes FROM tags WHERE namespace = ? AND name = ?",
+            (namespace, name),
+        ).fetchone()
+        return row["notes"] or "" if row else ""
+    finally:
+        conn.close()
+
+
 def _make_activity_with_domain_tag() -> int:
     """domain:タグ DOMAIN_TAG を持つアクティビティを作成しIDを返す。
 
@@ -1289,3 +1304,36 @@ class TestRecomposeHints:
 
         assert "error" not in result
         assert "hints" not in result
+
+
+class TestRecomposeCooldownTransaction:
+    """hint取得後にcheck_in本体が失敗した場合のトランザクション境界のテスト"""
+
+    def test_cooldown_marker_not_committed_when_check_in_fails_after_hint(
+        self, temp_db, monkeypatch
+    ):
+        """_get_recompose_hints呼び出し後、check_in本体が例外で失敗した場合、
+        hintは応答されずDATABASE_ERRORになる一方、クールダウンマーカーの書き込みも
+        ロールバックされ、notesには残らないこと（hint未達のまま消費されない）"""
+        activity_id = _make_activity_with_domain_tag()
+        topic_id = _make_topic_with_domain_tag()
+        for i in range(_RECOMPOSE_HINT_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"決定{i}", reason="理由", topic_id=topic_id)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("boom after hint generation")
+
+        monkeypatch.setattr(checkin_service, "_build_summary", _boom)
+
+        result = check_in(activity_id)
+
+        assert result.get("error", {}).get("code") == "DATABASE_ERROR"
+        assert MARKER_RECOMPOSE_BOOTSTRAP not in _get_tag_notes(DOMAIN_TAG_NAME)
+
+        # マーカーがロールバックされているため、パッチを戻して再度check_inすれば
+        # hintが再発火する
+        monkeypatch.undo()
+        result_retry = check_in(activity_id)
+        assert "error" not in result_retry
+        assert "hints" in result_retry
+        assert any("蓄積しています" in h for h in result_retry["hints"])

--- a/tests/unit/test_hint_service.py
+++ b/tests/unit/test_hint_service.py
@@ -1,9 +1,11 @@
 """hint_service: 統一hint APIのユニットテスト"""
 import os
 import tempfile
+from datetime import date
 
 import pytest
 
+import src.services.hint_service as hint_service
 from src.db import get_connection, init_database
 from src.services.activity_service import add_activity
 from src.services.decision_service import add_decisions
@@ -21,6 +23,7 @@ from src.services.hint_service import (
     RECOMPOSE_BOOTSTRAP_THRESHOLD,
     RECOMPOSE_DELTA_THRESHOLD,
     _is_marker_active,
+    _merge_cooldown_marker,
     get_hints,
     get_hints_with_conn,
     is_orch_managed_activity,
@@ -67,6 +70,30 @@ def _tag_id(name: str, namespace: str = "domain") -> int:
         return row["id"]
     finally:
         conn.close()
+
+
+def _get_tag_notes(name: str, namespace: str = "domain") -> str:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT notes FROM tags WHERE namespace = ? AND name = ?",
+            (namespace, name),
+        ).fetchone()
+        return row["notes"] or ""
+    finally:
+        conn.close()
+
+
+def _fixed_date(y: int, m: int, d: int) -> type:
+    """date.today()が固定値を返すdateサブクラスを生成する(monkeypatch用)。"""
+    fixed = date(y, m, d)
+
+    class _FixedDate(date):
+        @classmethod
+        def today(cls):
+            return fixed
+
+    return _FixedDate
 
 
 def _set_material_updated_at(material_id: int, ts: str) -> None:
@@ -488,6 +515,131 @@ class TestDatedMarkerSnooze:
     def test_logs_sparse_message_includes_snooze_instructions(self):
         assert "-until:" in HINT_LOGS_SPARSE_MESSAGE
         assert MARKER_LOGS_SPARSE in HINT_LOGS_SPARSE_MESSAGE
+
+
+class TestMergeCooldownMarkerHelper:
+    """_merge_cooldown_marker: 日次クールダウンマーカー更新の純粋関数テスト（DB不要）"""
+
+    def test_no_existing_marker_appends_today(self):
+        today = date(2026, 1, 15)
+        result = _merge_cooldown_marker("既存メモ", MARKER_RECOMPOSE_BOOTSTRAP, today)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-15" in result
+        assert "既存メモ" in result
+
+    def test_past_dated_marker_updated_to_today(self):
+        today = date(2026, 1, 15)
+        notes = f"メモ {MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-01"
+        result = _merge_cooldown_marker(notes, MARKER_RECOMPOSE_BOOTSTRAP, today)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-15" in result
+        assert "2026-01-01" not in result
+
+    def test_today_dated_marker_updated(self):
+        """境界値: 既存マーカーの日付がtodayと同一の場合も"今日以前"として更新処理を通す"""
+        today = date(2026, 1, 15)
+        notes = f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-15"
+        result = _merge_cooldown_marker(notes, MARKER_RECOMPOSE_BOOTSTRAP, today)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-15" in result
+
+    def test_future_dated_marker_not_overwritten(self):
+        """ユーザーが意図的に設定した未来日の長期抑制は上書きしない"""
+        today = date(2026, 1, 15)
+        notes = f"メモ {MARKER_RECOMPOSE_BOOTSTRAP}-until:2099-01-01"
+        result = _merge_cooldown_marker(notes, MARKER_RECOMPOSE_BOOTSTRAP, today)
+        assert result == notes
+
+    def test_invalid_date_format_replaced(self):
+        today = date(2026, 1, 15)
+        notes = f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-13-99"
+        result = _merge_cooldown_marker(notes, MARKER_RECOMPOSE_BOOTSTRAP, today)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-15" in result
+        assert "2026-13-99" not in result
+
+    def test_empty_notes_produces_marker_only(self):
+        today = date(2026, 1, 15)
+        result = _merge_cooldown_marker("", MARKER_RECOMPOSE_DELTA, today)
+        assert result == f"{MARKER_RECOMPOSE_DELTA}-until:2026-01-15"
+
+
+class TestRecomposeCooldownMarker:
+    """hint発火に伴う日次クールダウンマーカーの自動追記・DB結線テスト"""
+
+    def test_bootstrap_fire_appends_cooldown_marker(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "recompose_bootstrap" for h in hints)
+
+        today = date.today().isoformat()
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:{today}" in _get_tag_notes(DOMAIN_TAG_NAME)
+
+    def test_delta_fire_appends_cooldown_marker(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        mat = add_material(title="m", content="c", tags=[DOMAIN_TAG], source="s")
+        add_pin("tag", DOMAIN_TAG, "material", mat["material_id"])
+        _set_material_updated_at(mat["material_id"], "2024-06-01 00:00:00")
+
+        for i in range(RECOMPOSE_DELTA_THRESHOLD):
+            d = add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+            _set_decision_created_at(d["decision_id"], "2024-07-01 00:00:00")
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "recompose_delta" for h in hints)
+
+        today = date.today().isoformat()
+        assert f"{MARKER_RECOMPOSE_DELTA}-until:{today}" in _get_tag_notes(DOMAIN_TAG_NAME)
+
+    def test_same_day_refire_is_suppressed_by_auto_marker(self, temp_db):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+
+        hints_first = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "recompose_bootstrap" for h in hints_first)
+
+        # decision数(発火条件)は満たしたままだが、直前の発火で付いた当日付き
+        # クールダウンマーカーにより2回目は抑制される
+        hints_second = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert not any(h["type"] == "recompose_bootstrap" for h in hints_second)
+
+    def test_next_day_refires_after_cooldown(self, temp_db, monkeypatch):
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+
+        monkeypatch.setattr(hint_service, "date", _fixed_date(2026, 1, 1))
+        hints_day1 = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "recompose_bootstrap" for h in hints_day1)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-01" in _get_tag_notes(DOMAIN_TAG_NAME)
+
+        monkeypatch.setattr(hint_service, "date", _fixed_date(2026, 1, 2))
+        hints_day2 = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "recompose_bootstrap" for h in hints_day2)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2026-01-02" in _get_tag_notes(DOMAIN_TAG_NAME)
+
+    def test_manual_future_marker_is_not_overwritten_by_auto_cooldown(self, temp_db):
+        """手動で未来日のuntilマーカーを設定済みの場合、hint自体が抑制され続け、
+        そのマーカーの日付もget_hints呼び出しによって書き換えられない"""
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(RECOMPOSE_BOOTSTRAP_THRESHOLD):
+            add_decision(decision=f"d{i}", reason="r", topic_id=topic["topic_id"])
+        update_tag(DOMAIN_TAG, notes=f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2099-01-01")
+
+        hints = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert not any(h["type"] == "recompose_bootstrap" for h in hints)
+        assert f"{MARKER_RECOMPOSE_BOOTSTRAP}-until:2099-01-01" in _get_tag_notes(DOMAIN_TAG_NAME)
+
+    def test_direction_overflow_not_subject_to_cooldown(self, temp_db):
+        """direction_overflowは日次クールダウンの対象外。連続発火してもマーカーは付かない"""
+        topic = add_topic(title="t", description="d", tags=[DOMAIN_TAG])
+        for i in range(DIRECTION_OVERFLOW_THRESHOLD):
+            _add_direction_decision(topic["topic_id"], i)
+
+        get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        hints_second = get_hints("tag", _tag_id(DOMAIN_TAG_NAME))
+        assert any(h["type"] == "direction_overflow" for h in hints_second)
+        assert MARKER_DIRECTION_OVERFLOW not in _get_tag_notes(DOMAIN_TAG_NAME)
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## 概要

recompose-context ナッジhintの発動しやすさを調整する。

- `recompose_delta` の発火閾値を50→100に引き上げ、pinned material更新以降の増分に対する発火頻度を抑えた（`recompose_bootstrap` の閾値30は変更なし）
- `recompose_bootstrap` / `recompose_delta` のhintが実際に生成されたタイミングで、対象tagのnotesへ `<marker>-until:今日` の抑制マーカーを自動追記する日次クールダウンを新設した

## 背景

閾値到達後、同じセッション内やcheck-inの度に同じrecompose提案が繰り返し表示されており、ユーザーが同じ内容を何度も目にする状態だった。日次クールダウンにより「1日1回まで」に抑える。

## 挙動

- クールダウンマーカーは日付付き（`-until:YYYY-MM-DD`）のみを自動更新の対象とする。ユーザーが手動で未来日のuntilマーカーを設定している場合はその意図を尊重し、上書きしない
- 素の（`-until:`なしの）恒久抑制マーカーが付いている場合はそもそもhint自体が生成されないため、クールダウン処理には到達しない
- `direction_overflow` hintは今回の日次クールダウンの対象外（既存の手動マーカーによる抑制のみ）

## テスト計画

新規テスト（`tests/unit/test_hint_service.py`）:
- `_merge_cooldown_marker`（マーカー文字列の解析・更新ロジック）の純粋関数テスト: マーカー未存在時の新規追記、過去日/当日マーカーの更新、不正な日付形式の置き換え、未来日マーカーの保持
- hint発火に伴うクールダウンマーカーのDB結線テスト: bootstrap/delta双方の初回発火時のマーカー付与、同日内の再発火抑制、日付をまたいだ場合の再発火、手動未来日マーカーがhint自体を抑制し続け上書きされないこと、`direction_overflow`がクールダウン対象外であること

変更範囲のテスト（`test_hint_service.py` / `test_checkin_service.py` / `test_tag_service.py` / `test_tag_notes.py` / `test_tag_notes_marker_sync.py`）228件pass。閾値変更に伴う既存テストの期待値は定数参照のため自動追従し、破壊なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)