### PR TITLE
habitsのintelligently層マニフェストにimportance_scoreを反映

### DIFF
--- a/docs/spec/db-schema.md
+++ b/docs/spec/db-schema.md
@@ -762,7 +762,7 @@ tags テーブル用の独立 vec0 仮想テーブル。新規タグ作成時の
 | 0047_drop_decisions_logs_topic_id | decisions.topic_id / discussion_logs.topic_id カラムを物理削除（0046で確保した前提条件を受けての Contract） |
 | 0048_session_identity | session_identity テーブル新設 + decisions/discussion_logs/discussion_topics/activities/materials に caller_session_id 追加（0057で全て削除） |
 | 0057_drop_capability_gating | session_identity テーブル削除 + decisions/discussion_logs/discussion_topics/activities/materials の caller_session_id カラム削除（role-based capability gating機構の呼び出し元解体に伴う撤去） |
-| 0058_add_habit_trigger_mode | habits に description / trigger_mode / importance_score / last_recalled_at を追加、既存habits一部をtrigger_mode='intelligently'に更新 |
+| 0058_add_habit_trigger_mode | habits に description / trigger_mode / importance_score / last_recalled_at を追加（既存habitsへの一括UPDATEは後続コミットで撤去、intelligently化はupdate_habit経由の個別設定に変更） |
 | 0059_add_habit_status | habits に status（'active'/'archived'、既定'active'）を追加 |
 | 0060_add_habit_importance_score_check | trigger_mode='intelligently'かつimportance_score=1.0(未設定)のhabitを3に補正したうえで、importance_scoreにCHECK(IN (1, 2, 3))を追加（テーブル再構築） |
 

--- a/docs/spec/db-schema.md
+++ b/docs/spec/db-schema.md
@@ -3,7 +3,7 @@ watch-tags: domain:cc-memory
 watch-direction: true
 watch-migrations: true
 last-synced: 2026-07-09
-last-synced-migration: 0059
+last-synced-migration: 0060
 -->
 
 # cc-memory DBスキーマ v0
@@ -258,7 +258,7 @@ erDiagram
 | created_at | TEXT | YES | `datetime('now')` | — | 作成時刻 |
 | description | TEXT | NO | `''` | — | 要旨（intelligently層のマニフェスト表示に使う） |
 | trigger_mode | TEXT | NO | `'always'` | CHECK IN ('always', 'intelligently') | SessionStartでの注入方式。alwaysは全文、intelligentlyはタイトルのみのマニフェストにとどめ詳細はon-demand取得 |
-| importance_score | REAL | NO | `1.0` | — | 優先度（1=critical/2=important/3=default）。intelligently層マニフェストのソートに使う |
+| importance_score | REAL | NO | `1.0` | CHECK IN (1, 2, 3) | 優先度（1=critical/2=important/3=default）。intelligently層マニフェストのソートに使う |
 | last_recalled_at | TIMESTAMP | YES | — | — | `get_habits(habit_id=...)` でon-demand取得された直近時刻 |
 | status | TEXT | NO | `'active'` | CHECK IN ('active', 'archived') | 棚卸し状態。active とは独立した軸で、マニフェスト取得は両方をANDで絞り込む |
 
@@ -267,10 +267,13 @@ erDiagram
 - タグ・リレーション・検索インデックス・embedding のいずれにも接続しない。事実上「設定/ポリシー」として独立
 - 0058 で description / trigger_mode / importance_score / last_recalled_at を追加し、SessionStart全件全文注入からalways/intelligently分割注入に変更
 - 0059 で status を追加し、intelligently層マニフェストのソートに importance_score（昇順、1が最優先）を使うよう変更
+- 0060 で、0058時点の既定値1.0が新しい意味づけ（1=critical）と衝突しないよう
+  trigger_mode='intelligently'かつimportance_score=1.0（未設定）のhabitを3（default）に
+  補正したうえで、importance_scoreにCHECK(IN (1, 2, 3))を追加（テーブル再構築）
 
 インデックス: なし
 
-関連 migration: 0019 / 0022（初期データ追加）/ 0025 / 0058（description / trigger_mode / importance_score / last_recalled_at 追加）/ 0059（status 追加）
+関連 migration: 0019 / 0022（初期データ追加）/ 0025 / 0058（description / trigger_mode / importance_score / last_recalled_at 追加）/ 0059（status 追加）/ 0060（importance_score データ補正 + CHECK制約追加）
 
 ### 3.7 tags
 
@@ -761,6 +764,7 @@ tags テーブル用の独立 vec0 仮想テーブル。新規タグ作成時の
 | 0057_drop_capability_gating | session_identity テーブル削除 + decisions/discussion_logs/discussion_topics/activities/materials の caller_session_id カラム削除（role-based capability gating機構の呼び出し元解体に伴う撤去） |
 | 0058_add_habit_trigger_mode | habits に description / trigger_mode / importance_score / last_recalled_at を追加、既存habits一部をtrigger_mode='intelligently'に更新 |
 | 0059_add_habit_status | habits に status（'active'/'archived'、既定'active'）を追加 |
+| 0060_add_habit_importance_score_check | trigger_mode='intelligently'かつimportance_score=1.0(未設定)のhabitを3に補正したうえで、importance_scoreにCHECK(IN (1, 2, 3))を追加（テーブル再構築） |
 
 重複番号: **0005** （add_vec_index / decisions_topic_id_not_null）、**0015** （intent_tag_notes / tag_canonical）、**0039** （extend_tag_namespace / intent_thinking）、**0046** （relations_belongs_to_unify / sanitize_log_to_citation_event_log）。yoyo は depends 宣言で順序を解決するため運用上は機能するが、ファイル名上の連番ユニーク性が崩れている。
 

--- a/docs/spec/db-schema.md
+++ b/docs/spec/db-schema.md
@@ -2,8 +2,8 @@
 watch-tags: domain:cc-memory
 watch-direction: true
 watch-migrations: true
-last-synced: 2026-07-08
-last-synced-migration: 0058
+last-synced: 2026-07-09
+last-synced-migration: 0059
 -->
 
 # cc-memory DBスキーマ v0
@@ -73,6 +73,7 @@ erDiagram
     text trigger_mode
     real importance_score
     timestamp last_recalled_at
+    text status
   }
 ```
 
@@ -257,17 +258,19 @@ erDiagram
 | created_at | TEXT | YES | `datetime('now')` | — | 作成時刻 |
 | description | TEXT | NO | `''` | — | 要旨（intelligently層のマニフェスト表示に使う） |
 | trigger_mode | TEXT | NO | `'always'` | CHECK IN ('always', 'intelligently') | SessionStartでの注入方式。alwaysは全文、intelligentlyはタイトルのみのマニフェストにとどめ詳細はon-demand取得 |
-| importance_score | REAL | NO | `1.0` | — | 優先度スコア |
+| importance_score | REAL | NO | `1.0` | — | 優先度（1=critical/2=important/3=default）。intelligently層マニフェストのソートに使う |
 | last_recalled_at | TIMESTAMP | YES | — | — | `get_habits(habit_id=...)` でon-demand取得された直近時刻 |
+| status | TEXT | NO | `'active'` | CHECK IN ('active', 'archived') | 棚卸し状態。active とは独立した軸で、マニフェスト取得は両方をANDで絞り込む |
 
 補足:
 - 0019 で reminders として新設、0025 で habits にリネーム
 - タグ・リレーション・検索インデックス・embedding のいずれにも接続しない。事実上「設定/ポリシー」として独立
 - 0058 で description / trigger_mode / importance_score / last_recalled_at を追加し、SessionStart全件全文注入からalways/intelligently分割注入に変更
+- 0059 で status を追加し、intelligently層マニフェストのソートに importance_score（昇順、1が最優先）を使うよう変更
 
 インデックス: なし
 
-関連 migration: 0019 / 0022（初期データ追加）/ 0025 / 0058（description / trigger_mode / importance_score / last_recalled_at 追加）
+関連 migration: 0019 / 0022（初期データ追加）/ 0025 / 0058（description / trigger_mode / importance_score / last_recalled_at 追加）/ 0059（status 追加）
 
 ### 3.7 tags
 
@@ -757,6 +760,7 @@ tags テーブル用の独立 vec0 仮想テーブル。新規タグ作成時の
 | 0048_session_identity | session_identity テーブル新設 + decisions/discussion_logs/discussion_topics/activities/materials に caller_session_id 追加（0057で全て削除） |
 | 0057_drop_capability_gating | session_identity テーブル削除 + decisions/discussion_logs/discussion_topics/activities/materials の caller_session_id カラム削除（role-based capability gating機構の呼び出し元解体に伴う撤去） |
 | 0058_add_habit_trigger_mode | habits に description / trigger_mode / importance_score / last_recalled_at を追加、既存habits一部をtrigger_mode='intelligently'に更新 |
+| 0059_add_habit_status | habits に status（'active'/'archived'、既定'active'）を追加 |
 
 重複番号: **0005** （add_vec_index / decisions_topic_id_not_null）、**0015** （intent_tag_notes / tag_canonical）、**0039** （extend_tag_namespace / intent_thinking）、**0046** （relations_belongs_to_unify / sanitize_log_to_citation_event_log）。yoyo は depends 宣言で順序を解決するため運用上は機能するが、ファイル名上の連番ユニーク性が崩れている。
 

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -369,9 +369,9 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 
 ### 2.21 add_habit / get_habits / update_habit
 
-- `add_habit(content: string) -> dict`: habitを登録。SessionStart時に全件注入される（セッション途中の登録は次セッション以降に有効）。
+- `add_habit(content: string, importance_score: int = 3, status: string = "active") -> dict`: habitを登録。SessionStart時に全件注入される（セッション途中の登録は次セッション以降に有効）。importance_scoreは1(critical)/2(important)/3(default)のいずれかで、intelligently層マニフェストのソートに使う。statusは`'active'`/`'archived'`のいずれか。
 - `get_habits(active: bool = true, habit_id?: int) -> dict`: 登録済みhabit一覧。既定でactive=1のみ返す。無効化済みも含む全件が欲しいときは`active=false`を渡す。SessionStartで全文注入されるのは`trigger_mode='always'`のみで、`'intelligently'`はタイトルのみのマニフェスト表示になる。`habit_id`を渡すとその1件だけを本文付きで取得でき、intelligentlyな振る舞いの詳細を引くときに使う（取得と同時に`last_recalled_at`が更新される）。
-- `update_habit(habit_id: int, content?: string, active?: bool, trigger_mode?: string, description?: string) -> dict`: active=Falseで無効化。trigger_modeは`'always'`（全文常時注入）/`'intelligently'`（マニフェストのみ表示、詳細は`get_habits(habit_id=...)`でon-demand取得）のいずれか。descriptionはintelligently層のマニフェスト表示に使う要旨。
+- `update_habit(habit_id: int, content?: string, active?: bool, trigger_mode?: string, description?: string, importance_score?: int, status?: string) -> dict`: active=Falseで無効化。trigger_modeは`'always'`（全文常時注入）/`'intelligently'`（マニフェストのみ表示、詳細は`get_habits(habit_id=...)`でon-demand取得）のいずれか。descriptionはintelligently層のマニフェスト表示に使う要旨（100文字以内）。importance_scoreは1(critical)/2(important)/3(default)のいずれかでマニフェストのソートに使う。statusは`'active'`/`'archived'`のいずれかで、`'archived'`はマニフェストから除外される。
 
 ### 2.22 add_pin / remove_pin
 

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -285,7 +285,8 @@ def _build_habits_section(conn, session_id: str | None = None) -> str:  # conn, 
 
     trigger_mode='always'は全文を表示し、'intelligently'はタイトルのみの
     マニフェスト（案内1行＋タイトル列挙）にとどめ、詳細はget_habits(habit_id=...)
-    でon-demand取得する前提にする。
+    でon-demand取得する前提にする。マニフェストの各行には[critical]/[important]/
+    [default]のimportance_score由来ラベルを前置し、優先度の高いものを先頭に出す。
     """
     always_contents = get_active_habit_contents_with_conn(conn)
     manifest = list_intelligently_habit_manifest_with_conn(conn)
@@ -300,10 +301,12 @@ def _build_habits_section(conn, session_id: str | None = None) -> str:  # conn, 
     if manifest:
         lines.append("")
         lines.append(
-            "他の振る舞い（タイトルのみ、詳細は get_habits(habit_id=...) で取得）:"
+            "他の振る舞い（詳細は get_habits(habit_id=...) で取得）:"
         )
+        label_width = max(len(f"[{item['importance_label']}]") for item in manifest)
         for item in manifest:
-            lines.append(f"- {item['title']} (habit_id={item['habit_id']})")
+            label = f"[{item['importance_label']}]".ljust(label_width)
+            lines.append(f"- {label} #{item['habit_id']}  {item['title']}")
 
     return "\n".join(lines) + "\n"
 

--- a/migrations/0059_add_habit_status.sql
+++ b/migrations/0059_add_habit_status.sql
@@ -1,0 +1,17 @@
+-- Migration 0059: habitsにstatusを追加
+--
+-- depends: 0058_add_habit_trigger_mode
+--
+-- 背景:
+--   habits には有効/無効を表す active カラムが既にあるが、intelligently層の
+--   マニフェストが対象を絞り込む軸としては別の意味の状態（棚卸し済みで
+--   もう表示しないと判断したアーカイブ状態）が必要になった。active を
+--   アーカイブに転用すると「一時的な無効化」と「恒久的な棚卸し済み」が
+--   区別できなくなるため、独立したカラムとして追加する。
+--
+-- 変更内容:
+--   - habits に status（'active'/'archived'、既定'active'）を追加
+--   - active とは独立した軸であり、両方の条件はAND併用される
+--     （マニフェスト取得は active = 1 AND status = 'active' で絞り込む）
+
+ALTER TABLE habits ADD COLUMN status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'archived'));

--- a/migrations/0060_add_habit_importance_score_check.sql
+++ b/migrations/0060_add_habit_importance_score_check.sql
@@ -1,0 +1,65 @@
+-- Migration 0060: 既存importance_scoreデータの補正とCHECK制約追加
+--
+-- depends: 0059_add_habit_status
+--
+-- 背景:
+--   0058でimportance_scoreを追加した時点では「値が大きいほど優先度が高い」
+--   前提のスコアだったが、その後アプリケーション層で1=critical/2=important/
+--   3=defaultという順位型の意味づけに変更された。0058のカラム既定値は1.0の
+--   ままのため、trigger_mode='intelligently'に切り替え済みだがimportance_score
+--   を一度も明示指定していないhabitは、既定値1.0がそのまま新しい意味での
+--   1(critical)と解釈され、実際には未トリアージなだけの振る舞いがcriticalラベルで
+--   表示されてしまう。
+--
+--   この意味づけ変更（1=critical/2=important/3=default）を導入するアプリケーション
+--   コードと同一のリリースで本migrationを適用するため、適用時点でimportance_score=1.0
+--   のまま残っているintelligently habitは「新しい意味でのcriticalとして明示指定された」
+--   のではなく「旧既定値が未上書きのまま残っている」ケースであると判別できる
+--   （importance_scoreを指定する引数は本migrationとセットのアプリケーション変更で
+--   初めて追加されるため、それ以前に1を明示指定する手段自体が存在しない）。
+--
+-- 変更内容:
+--   1. trigger_mode='intelligently'かつimportance_score=1.0（0058の既定値のまま
+--      未設定）のhabitをimportance_score=3（default）に補正する
+--   2. SQLiteはCHECK制約の後付けができないためテーブルを再構築し、
+--      importance_scoreにCHECK(importance_score IN (1, 2, 3))を追加する
+--
+--   habitsは他エンティティのようにタグ・リレーション・検索インデックスに
+--   接続しておらず、参照するトリガー・インデックスも存在しないため、
+--   再構築時にそれらの再作成は不要（0026等の再構築migrationと異なる点）。
+
+-- ================================================
+-- Step 1: 既存データの補正
+-- ================================================
+
+UPDATE habits
+SET importance_score = 3
+WHERE trigger_mode = 'intelligently' AND importance_score = 1.0;
+
+-- ================================================
+-- Step 2: テーブル再構築（importance_scoreにCHECK制約を追加）
+-- ================================================
+
+CREATE TABLE habits_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT DEFAULT (datetime('now')),
+    description TEXT NOT NULL DEFAULT '',
+    trigger_mode TEXT NOT NULL DEFAULT 'always' CHECK(trigger_mode IN ('always', 'intelligently')),
+    importance_score REAL NOT NULL DEFAULT 1.0 CHECK(importance_score IN (1, 2, 3)),
+    last_recalled_at TIMESTAMP NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'archived'))
+);
+
+INSERT INTO habits_new (
+    id, content, active, created_at, description, trigger_mode,
+    importance_score, last_recalled_at, status
+)
+SELECT
+    id, content, active, created_at, description, trigger_mode,
+    importance_score, last_recalled_at, status
+FROM habits;
+
+DROP TABLE habits;
+ALTER TABLE habits_new RENAME TO habits;

--- a/src/main.py
+++ b/src/main.py
@@ -1324,9 +1324,12 @@ def get_map(
 
 
 @mcp.tool()
-def add_habit(content: str) -> dict:
-    """エージェントの振る舞いを登録する。SessionStart時に全件注入される（セッション途中の登録は次セッション以降に有効）。"覚えといて"と言われた行動ルールはここに登録する"""
-    return habit_service.add_habit(content)
+def add_habit(content: str, importance_score: int = 3, status: str = "active") -> dict:
+    """エージェントの振る舞いを登録する。SessionStart時に全件注入される（セッション途中の登録は次セッション以降に有効）。"覚えといて"と言われた行動ルールはここに登録する。
+    importance_scoreは1(critical)/2(important)/3(default、既定)のいずれかで、
+    trigger_mode='intelligently'なhabitのマニフェスト表示順に使われる。
+    statusは'active'/'archived'（既定'active'）"""
+    return habit_service.add_habit(content, importance_score=importance_score, status=status)
 
 
 @mcp.tool()
@@ -1346,17 +1349,23 @@ def update_habit(
     active: Optional[bool] = None,
     trigger_mode: Optional[str] = None,
     description: Optional[str] = None,
+    importance_score: Optional[int] = None,
+    status: Optional[str] = None,
 ) -> dict:
     """振る舞いを更新する。active=Falseで無効化、active=Trueで再有効化。
     trigger_modeは'always'（全文常時注入）/'intelligently'（マニフェストのみ、
     詳細はget_habits(habit_id=...)でon-demand取得）のいずれか。descriptionは
-    intelligentlyのマニフェスト表示に使う要旨"""
+    intelligentlyのマニフェスト表示に使う要旨（100文字以内）。importance_scoreは
+    1(critical)/2(important)/3(default)のいずれかでマニフェスト表示順に使われる。
+    statusは'active'/'archived'のいずれかで、'archived'はマニフェストから除外される"""
     return habit_service.update_habit(
         habit_id,
         content=content,
         active=active,
         trigger_mode=trigger_mode,
         description=description,
+        importance_score=importance_score,
+        status=status,
     )
 
 

--- a/src/services/habit_service.py
+++ b/src/services/habit_service.py
@@ -19,21 +19,34 @@ def get_active_habit_contents_with_conn(conn) -> list[str]:
     return [r["content"] for r in rows]
 
 
+def _importance_label(importance_score) -> str:
+    """importance_scoreからマニフェスト表示用ラベルを導出する。
+
+    1: critical, 2: important, それ以外（3等）: default。
+    """
+    if importance_score == 1:
+        return "critical"
+    if importance_score == 2:
+        return "important"
+    return "default"
+
+
 def list_intelligently_habit_manifest_with_conn(conn) -> list[dict]:
     """trigger_mode='intelligently'な振る舞いのマニフェストを取得する（conn共有版）。
 
     タグに相当する仕組みが habits に存在しないため tags は含めない。
     title は description を優先し、未設定（棚卸し前等）なら content の
     先頭50文字にフォールバックする。
-    importance_score降順（同値はid昇順）で並べ、優先度の高いものを先頭に出す。
+    importance_score昇順（同値はid昇順）で並べ、1(critical)を先頭に出す。
+    status='archived'の振る舞いは除外する（activeとは独立した無効化軸）。
 
     Returns:
-        [{habit_id, title, trigger_mode}, ...]
+        [{habit_id, title, trigger_mode, importance_score, importance_label}, ...]
     """
     rows = conn.execute(
-        "SELECT id, content, description FROM habits "
-        "WHERE active = 1 AND trigger_mode = 'intelligently' "
-        "ORDER BY importance_score DESC, id ASC"
+        "SELECT id, content, description, importance_score FROM habits "
+        "WHERE trigger_mode = 'intelligently' AND active = 1 AND status = 'active' "
+        "ORDER BY importance_score ASC, id ASC"
     ).fetchall()
     manifest = []
     for row in rows:
@@ -42,28 +55,45 @@ def list_intelligently_habit_manifest_with_conn(conn) -> list[dict]:
             "habit_id": row["id"],
             "title": title,
             "trigger_mode": "intelligently",
+            "importance_score": row["importance_score"],
+            "importance_label": _importance_label(row["importance_score"]),
         })
     return manifest
 
 
-def _add_habit_with_conn(conn, content: str) -> int:
+_VALID_IMPORTANCE_SCORES = (1, 2, 3)
+_VALID_STATUSES = ("active", "archived")
+_MAX_DESCRIPTION_LENGTH = 100
+
+
+def _add_habit_with_conn(
+    conn, content: str, importance_score: int = 3, status: str = "active"
+) -> int:
     """振る舞いをINSERTしてhabit_idを返す（conn共有版）。バリデーションエラー時はValueError。"""
     if not content or not content.strip():
         raise ValueError("content must not be empty")
+    if importance_score not in _VALID_IMPORTANCE_SCORES:
+        raise ValueError(
+            f"importance_score must be one of: {', '.join(map(str, _VALID_IMPORTANCE_SCORES))}"
+        )
+    if status not in _VALID_STATUSES:
+        raise ValueError(f"status must be one of: {', '.join(_VALID_STATUSES)}")
     cursor = conn.execute(
-        "INSERT INTO habits (content) VALUES (?)",
-        (content,),
+        "INSERT INTO habits (content, importance_score, status) VALUES (?, ?, ?)",
+        (content, importance_score, status),
     )
     habit_id = cursor.lastrowid
     publish_entity_event_with_conn(conn, entity_type="habit", entity_id=habit_id, event="created")
     return habit_id
 
 
-def add_habit(content: str) -> dict:
+def add_habit(content: str, importance_score: int = 3, status: str = "active") -> dict:
     """振る舞いを追加する。
 
     Args:
         content: 振る舞いの内容（空文字不可）
+        importance_score: 優先度（1/2/3のいずれか、既定3）
+        status: 'active'/'archived'のいずれか（既定'active'）
 
     Returns:
         作成された振る舞い情報
@@ -76,9 +106,30 @@ def add_habit(content: str) -> dict:
             }
         }
 
+    if importance_score not in _VALID_IMPORTANCE_SCORES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": (
+                    f"importance_score must be one of: "
+                    f"{', '.join(map(str, _VALID_IMPORTANCE_SCORES))}"
+                ),
+            }
+        }
+
+    if status not in _VALID_STATUSES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"status must be one of: {', '.join(_VALID_STATUSES)}",
+            }
+        }
+
     conn = get_connection()
     try:
-        habit_id = _add_habit_with_conn(conn, content)
+        habit_id = _add_habit_with_conn(
+            conn, content, importance_score=importance_score, status=status
+        )
         conn.commit()
 
         return {"habit_id": habit_id}
@@ -139,6 +190,7 @@ def get_habits(active: bool = True, habit_id: int | None = None) -> dict:
                 "description": habit["description"],
                 "importance_score": habit["importance_score"],
                 "last_recalled_at": habit["last_recalled_at"],
+                "status": habit["status"],
             })
 
         return {
@@ -166,6 +218,8 @@ def update_habit(
     active: bool | None = None,
     trigger_mode: str | None = None,
     description: str | None = None,
+    importance_score: int | None = None,
+    status: str | None = None,
 ) -> dict:
     """振る舞いを更新する。
 
@@ -176,16 +230,28 @@ def update_habit(
         trigger_mode: 'always'（全文をSessionStartで常時注入）または
             'intelligently'（マニフェストのみ表示、詳細はget_habits(habit_id=...)で
             on-demand取得）のいずれか（optional）
-        description: intelligently層のマニフェスト表示に使う要旨（optional）
+        description: intelligently層のマニフェスト表示に使う要旨（100文字以内、optional）
+        importance_score: 優先度（1/2/3のいずれか、optional）
+        status: 'active'/'archived'のいずれか（optional）
 
     Returns:
         更新された振る舞い情報
     """
-    if content is None and active is None and trigger_mode is None and description is None:
+    if (
+        content is None
+        and active is None
+        and trigger_mode is None
+        and description is None
+        and importance_score is None
+        and status is None
+    ):
         return {
             "error": {
                 "code": "VALIDATION_ERROR",
-                "message": "At least one of content, active, trigger_mode or description must be provided",
+                "message": (
+                    "At least one of content, active, trigger_mode, description, "
+                    "importance_score or status must be provided"
+                ),
             }
         }
 
@@ -210,6 +276,33 @@ def update_habit(
             "error": {
                 "code": "VALIDATION_ERROR",
                 "message": f"trigger_mode must be one of: {', '.join(_VALID_TRIGGER_MODES)}",
+            }
+        }
+
+    if description is not None and len(description) > _MAX_DESCRIPTION_LENGTH:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"description must be at most {_MAX_DESCRIPTION_LENGTH} characters",
+            }
+        }
+
+    if importance_score is not None and importance_score not in _VALID_IMPORTANCE_SCORES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": (
+                    f"importance_score must be one of: "
+                    f"{', '.join(map(str, _VALID_IMPORTANCE_SCORES))}"
+                ),
+            }
+        }
+
+    if status is not None and status not in _VALID_STATUSES:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"status must be one of: {', '.join(_VALID_STATUSES)}",
             }
         }
 
@@ -248,6 +341,14 @@ def update_habit(
             set_parts.append("description = ?")
             values.append(description)
 
+        if importance_score is not None:
+            set_parts.append("importance_score = ?")
+            values.append(importance_score)
+
+        if status is not None:
+            set_parts.append("status = ?")
+            values.append(status)
+
         set_clause = ", ".join(set_parts)
         values.append(habit_id)
 
@@ -274,6 +375,8 @@ def update_habit(
             "created_at": habit["created_at"],
             "trigger_mode": habit["trigger_mode"],
             "description": habit["description"],
+            "importance_score": habit["importance_score"],
+            "status": habit["status"],
         }
 
     except Exception as e:

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -179,13 +179,15 @@ def _seed_habit(content: str, active: int = 1) -> int:
         conn.close()
 
 
-def _set_habit_trigger_mode(habit_id: int, trigger_mode: str, description: str = "") -> None:
-    """テスト用振る舞いのtrigger_mode/descriptionを更新する"""
+def _set_habit_trigger_mode(
+    habit_id: int, trigger_mode: str, description: str = "", importance_score: int = 3
+) -> None:
+    """テスト用振る舞いのtrigger_mode/description/importance_scoreを更新する"""
     conn = get_connection()
     try:
         conn.execute(
-            "UPDATE habits SET trigger_mode = ?, description = ? WHERE id = ?",
-            (trigger_mode, description, habit_id),
+            "UPDATE habits SET trigger_mode = ?, description = ?, importance_score = ? WHERE id = ?",
+            (trigger_mode, description, importance_score, habit_id),
         )
         conn.commit()
     finally:
@@ -382,7 +384,35 @@ class TestSessionStartHookHabits:
 
         assert "短い要旨" in context
         assert "intelligently層の本文全部が長い振る舞い内容" not in context
-        assert f"habit_id={habit_id}" in context
+        assert f"#{habit_id}" in context
+
+    def test_intelligently_manifest_prefixes_importance_label(self, temp_db):
+        """intelligently層のマニフェスト各行にimportance_score由来のラベルが前置される"""
+        critical_id = _seed_habit("critical振る舞い")
+        _set_habit_trigger_mode(
+            critical_id, "intelligently", description="critical要旨", importance_score=1
+        )
+        important_id = _seed_habit("important振る舞い")
+        _set_habit_trigger_mode(
+            important_id, "intelligently", description="important要旨", importance_score=2
+        )
+        default_id = _seed_habit("default振る舞い")
+        _set_habit_trigger_mode(
+            default_id, "intelligently", description="default要旨", importance_score=3
+        )
+
+        result = _run_session_start_hook(temp_db)
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "[critical]" in context
+        assert "[important]" in context
+        assert "[default]" in context
+
+        # criticalがimportantより前、importantがdefaultより前に出る（優先度順）
+        critical_pos = context.index("critical要旨")
+        important_pos = context.index("important要旨")
+        default_pos = context.index("default要旨")
+        assert critical_pos < important_pos < default_pos
 
     def test_always_habit_shown_in_full(self, temp_db):
         """trigger_mode='always'（既定）の振る舞いは全文が出る"""

--- a/tests/test_migrations/test_0059_add_habit_status.py
+++ b/tests/test_migrations/test_0059_add_habit_status.py
@@ -1,0 +1,89 @@
+"""migration 0059_add_habit_status のテスト
+
+0059適用後に habits テーブルへ status 列が追加され、既定値 'active' と
+CHECK制約（'active'/'archived'のみ許可）が仕様通りであることを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0059含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    """指定テーブルのカラム名セットを返す。"""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+class TestStatusColumnAdded:
+    """0059適用後にstatus列が追加されていることの確認"""
+
+    def test_habits_has_status_column(self, migrated_db):
+        """migration 0059 適用後、habits テーブルに status 列が存在する"""
+        conn = get_connection()
+        try:
+            column_names = _get_column_names(conn, "habits")
+            assert "status" in column_names
+        finally:
+            conn.close()
+
+    def test_default_status_is_active(self, migrated_db):
+        """status を指定せず INSERT した行は既定値 'active' になる"""
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO habits (content) VALUES (?)", ("テスト振る舞い",)
+            )
+            habit_id = cursor.lastrowid
+            conn.commit()
+            row = conn.execute(
+                "SELECT status FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["status"] == "active"
+        finally:
+            conn.close()
+
+    def test_status_check_constraint_rejects_invalid_value(self, migrated_db):
+        """statusのCHECK制約が'active'/'archived'以外を拒否する"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO habits (content, status) VALUES (?, ?)",
+                    ("不正な値", "deleted"),
+                )
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_status_check_constraint_accepts_archived(self, migrated_db):
+        """statusに'archived'を指定してINSERTできる"""
+        conn = get_connection()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO habits (content, status) VALUES (?, ?)",
+                ("アーカイブ済み振る舞い", "archived"),
+            )
+            habit_id = cursor.lastrowid
+            conn.commit()
+            row = conn.execute(
+                "SELECT status FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["status"] == "archived"
+        finally:
+            conn.close()

--- a/tests/test_migrations/test_0060_add_habit_importance_score_check.py
+++ b/tests/test_migrations/test_0060_add_habit_importance_score_check.py
@@ -1,0 +1,252 @@
+"""migration 0060_add_habit_importance_score_check のテスト
+
+0058でimportance_scoreを追加した時点の既定値は1.0（旧「値が大きいほど優先度が
+高い」前提の名残）だが、0059/0060と同時に導入されるアプリケーション側の意味づけは
+1=critical/2=important/3=defaultという順位型になった。0060適用前に
+trigger_mode='intelligently'へ切り替え済みでimportance_scoreを未設定（既定値1.0の
+まま）だったhabitは、意味づけ変更後は「まだトリアージされていないだけ」なのに
+critical扱いされてしまう。本テストは、0060がこのケースをimportance_score=3
+（default）へ補正すること、既に別の値が入っている行やalwaysモードの行は
+補正対象にしないこと、そしてimportance_scoreへのCHECK制約（1/2/3のみ許可）が
+テーブル再構築後に機能することを確認する。
+"""
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from yoyo import default_migration_table, read_migrations
+from yoyo.connections import parse_uri
+from yoyo.migrations import MigrationList
+
+from src.db import MIGRATIONS_DIR, _VecSQLiteBackend, get_connection, init_database
+
+
+@pytest.fixture
+def migrated_db():
+    """全migration（0060含む）を適用済みのテスト用DBを提供する。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def db_before_0060():
+    """0059までのmigrationを適用したDBを提供する。0060の挙動を分離検証するために使う。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+
+        parsed = parse_uri(f"sqlite:///{db_path}")
+        backend = _VecSQLiteBackend(parsed, default_migration_table)
+        backend.init_database()
+        all_migs = read_migrations(str(MIGRATIONS_DIR))
+        pre_0060 = MigrationList([m for m in all_migs if m.id < "0060"])
+        with backend.lock():
+            backend.apply_migrations(pre_0060)
+
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _apply_migration_0060(db_path: str) -> None:
+    """db_pathに対してmigration 0060のみを適用する。"""
+    parsed = parse_uri(f"sqlite:///{db_path}")
+    backend = _VecSQLiteBackend(parsed, default_migration_table)
+    all_migs = read_migrations(str(MIGRATIONS_DIR))
+    only_0060 = MigrationList([m for m in all_migs if m.id.startswith("0060")])
+    with backend.lock():
+        backend.apply_migrations(only_0060)
+
+
+class TestExistingDataMigration:
+    """0060適用時の既存importance_score補正の確認"""
+
+    def test_untriaged_intelligently_habit_becomes_default(self, db_before_0060):
+        """trigger_mode='intelligently'かつimportance_score=1.0(未設定)のhabitは3に補正される"""
+        conn = get_connection()
+        try:
+            habit_id = conn.execute(
+                "INSERT INTO habits (content, trigger_mode) VALUES (?, ?)",
+                ("untriaged intelligently habit", "intelligently"),
+            ).lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0060(db_before_0060)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT importance_score FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["importance_score"] == 3
+        finally:
+            conn.close()
+
+    def test_explicitly_scored_intelligently_habit_unaffected(self, db_before_0060):
+        """importance_scoreが既に1.0以外に設定済みのintelligently habitは補正されない"""
+        conn = get_connection()
+        try:
+            habit_id = conn.execute(
+                "INSERT INTO habits (content, trigger_mode, importance_score) VALUES (?, ?, ?)",
+                ("already scored habit", "intelligently", 2),
+            ).lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0060(db_before_0060)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT importance_score FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["importance_score"] == 2
+        finally:
+            conn.close()
+
+    def test_always_mode_habit_with_default_score_unaffected(self, db_before_0060):
+        """trigger_mode='always'のhabitはimportance_score=1.0のままでも補正対象にならない"""
+        conn = get_connection()
+        try:
+            habit_id = conn.execute(
+                "INSERT INTO habits (content) VALUES (?)",
+                ("always mode habit",),
+            ).lastrowid
+            conn.commit()
+        finally:
+            conn.close()
+
+        _apply_migration_0060(db_before_0060)
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT trigger_mode, importance_score FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["trigger_mode"] == "always"
+            assert row["importance_score"] == 1.0
+        finally:
+            conn.close()
+
+
+class TestImportanceScoreCheckConstraint:
+    """0060適用後のimportance_score CHECK制約の確認"""
+
+    def test_check_constraint_rejects_invalid_value(self, migrated_db):
+        """importance_scoreのCHECK制約が1/2/3以外を拒否する"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO habits (content, importance_score) VALUES (?, ?)",
+                    ("不正なスコア", 5),
+                )
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_check_constraint_rejects_non_integer_value(self, migrated_db):
+        """importance_scoreのCHECK制約が1.5等の非整数値も拒否する"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO habits (content, importance_score) VALUES (?, ?)",
+                    ("中途半端なスコア", 1.5),
+                )
+        finally:
+            conn.rollback()
+            conn.close()
+
+    @pytest.mark.parametrize("score", [1, 2, 3])
+    def test_check_constraint_accepts_valid_values(self, migrated_db, score):
+        """importance_scoreに1/2/3を指定してINSERTできる"""
+        conn = get_connection()
+        try:
+            habit_id = conn.execute(
+                "INSERT INTO habits (content, importance_score) VALUES (?, ?)",
+                ("有効なスコア", score),
+            ).lastrowid
+            conn.commit()
+            row = conn.execute(
+                "SELECT importance_score FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["importance_score"] == score
+        finally:
+            conn.close()
+
+    def test_default_value_still_satisfies_check(self, migrated_db):
+        """importance_scoreを指定せずINSERTしても既定値1.0がCHECK制約を満たす"""
+        conn = get_connection()
+        try:
+            habit_id = conn.execute(
+                "INSERT INTO habits (content) VALUES (?)", ("既定値のまま",)
+            ).lastrowid
+            conn.commit()
+            row = conn.execute(
+                "SELECT importance_score FROM habits WHERE id = ?", (habit_id,)
+            ).fetchone()
+            assert row["importance_score"] == 1.0
+        finally:
+            conn.close()
+
+
+class TestSchemaPreservedAfterRebuild:
+    """テーブル再構築後も既存カラム・制約が保持されていることの確認"""
+
+    def test_status_check_constraint_still_enforced(self, migrated_db):
+        """0059で追加されたstatusのCHECK制約が再構築後も機能する"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO habits (content, status) VALUES (?, ?)",
+                    ("不正なstatus", "deleted"),
+                )
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_trigger_mode_check_constraint_still_enforced(self, migrated_db):
+        """0058で追加されたtrigger_modeのCHECK制約が再構築後も機能する"""
+        conn = get_connection()
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO habits (content, trigger_mode) VALUES (?, ?)",
+                    ("不正なtrigger_mode", "sometimes"),
+                )
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_all_columns_preserved(self, migrated_db):
+        """再構築後もhabitsの全カラムが揃っている"""
+        conn = get_connection()
+        try:
+            columns = {
+                row["name"]
+                for row in conn.execute("PRAGMA table_info(habits)").fetchall()
+            }
+            assert columns == {
+                "id",
+                "content",
+                "active",
+                "created_at",
+                "description",
+                "trigger_mode",
+                "importance_score",
+                "last_recalled_at",
+                "status",
+            }
+        finally:
+            conn.close()

--- a/tests/unit/test_habit_service.py
+++ b/tests/unit/test_habit_service.py
@@ -58,6 +58,36 @@ class TestAddHabit:
         assert "error" not in result2
         assert result1["habit_id"] != result2["habit_id"]
 
+    @pytest.mark.parametrize("importance_score", [0, 4, -1, 1.5])
+    def test_add_habit_invalid_importance_score(self, temp_db, importance_score):
+        """importance_scoreが1/2/3以外だとバリデーションエラーになる"""
+        result = add_habit("不正なスコアの振る舞い", importance_score=importance_score)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "importance_score" in result["error"]["message"]
+
+    @pytest.mark.parametrize("importance_score", [1, 2, 3])
+    def test_add_habit_valid_importance_score(self, temp_db, importance_score):
+        """importance_scoreが1/2/3ならエラーにならない"""
+        result = add_habit("有効なスコアの振る舞い", importance_score=importance_score)
+
+        assert "error" not in result
+
+    def test_add_habit_invalid_status(self, temp_db):
+        """statusがactive/archived以外だとバリデーションエラーになる"""
+        result = add_habit("不正なstatusの振る舞い", status="deleted")
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "status" in result["error"]["message"]
+
+    def test_add_habit_status_archived(self, temp_db):
+        """status='archived'を指定して追加できる"""
+        result = add_habit("最初からアーカイブする振る舞い", status="archived")
+
+        assert "error" not in result
+
 
 class TestGetHabits:
     """get_habitsのテスト"""
@@ -264,6 +294,70 @@ class TestUpdateHabit:
         assert result["trigger_mode"] == "intelligently"
         assert result["description"] == "要旨テキスト"
 
+    def test_update_description_too_long(self, temp_db):
+        """descriptionが100字を超えるとバリデーションエラーになる"""
+        created = add_habit("要旨が長すぎる振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, description="あ" * 101)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "description" in result["error"]["message"]
+
+    def test_update_description_exactly_max_length(self, temp_db):
+        """descriptionがちょうど100字ならエラーにならない"""
+        created = add_habit("要旨がちょうど上限の振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, description="あ" * 100)
+
+        assert "error" not in result
+        assert result["description"] == "あ" * 100
+
+    @pytest.mark.parametrize("importance_score", [0, 4, -1])
+    def test_update_invalid_importance_score(self, temp_db, importance_score):
+        """importance_scoreが1/2/3以外だとバリデーションエラーになる"""
+        created = add_habit("スコア更新対象の振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, importance_score=importance_score)
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "importance_score" in result["error"]["message"]
+
+    def test_update_importance_score_valid(self, temp_db):
+        """importance_scoreを1/2/3に更新できる"""
+        created = add_habit("スコア更新対象の振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, importance_score=1)
+
+        assert "error" not in result
+        assert result["importance_score"] == 1
+
+    def test_update_invalid_status(self, temp_db):
+        """statusがactive/archived以外だとバリデーションエラーになる"""
+        created = add_habit("status更新対象の振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, status="deleted")
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert "status" in result["error"]["message"]
+
+    def test_update_status_to_archived(self, temp_db):
+        """status='archived'に更新できる"""
+        created = add_habit("アーカイブする振る舞い")
+        habit_id = created["habit_id"]
+
+        result = update_habit(habit_id, status="archived")
+
+        assert "error" not in result
+        assert result["status"] == "archived"
+
 
 class TestTriggerModeSplit:
     """trigger_mode（always/intelligently）分割のテスト"""
@@ -354,8 +448,8 @@ class TestTriggerModeSplit:
         finally:
             conn.close()
 
-    def test_manifest_orders_by_importance_score_desc(self, temp_db):
-        """importance_score降順（同値はid昇順）で並ぶ"""
+    def test_manifest_orders_by_importance_score_asc(self, temp_db):
+        """importance_score昇順（同値はid昇順）で並び、1(critical)が先頭に出る"""
         conn = get_connection()
         try:
             low_id = add_habit("低優先度")["habit_id"]
@@ -363,7 +457,7 @@ class TestTriggerModeSplit:
             mid_id = add_habit("中優先度")["habit_id"]
             conn.executemany(
                 "UPDATE habits SET trigger_mode = 'intelligently', importance_score = ? WHERE id = ?",
-                [(0.5, low_id), (2.0, high_id), (1.0, mid_id)],
+                [(3, low_id), (1, high_id), (2, mid_id)],
             )
             conn.commit()
 
@@ -371,6 +465,71 @@ class TestTriggerModeSplit:
             manifest_ids = [m["habit_id"] for m in manifest]
 
             assert manifest_ids == [high_id, mid_id, low_id]
+        finally:
+            conn.close()
+
+    def test_manifest_orders_by_id_when_importance_score_tied(self, temp_db):
+        """importance_scoreが同値のときはid昇順で並ぶ"""
+        conn = get_connection()
+        try:
+            first_id = add_habit("先に追加")["habit_id"]
+            second_id = add_habit("後に追加")["habit_id"]
+            conn.executemany(
+                "UPDATE habits SET trigger_mode = 'intelligently', importance_score = ? WHERE id = ?",
+                [(2, first_id), (2, second_id)],
+            )
+            conn.commit()
+
+            manifest = list_intelligently_habit_manifest_with_conn(conn)
+            manifest_ids = [m["habit_id"] for m in manifest]
+
+            assert manifest_ids == [first_id, second_id]
+        finally:
+            conn.close()
+
+    def test_manifest_includes_importance_label(self, temp_db):
+        """importance_scoreからcritical/important/defaultラベルが導出される"""
+        conn = get_connection()
+        try:
+            critical_id = add_habit("critical振る舞い")["habit_id"]
+            important_id = add_habit("important振る舞い")["habit_id"]
+            default_id = add_habit("default振る舞い")["habit_id"]
+            conn.executemany(
+                "UPDATE habits SET trigger_mode = 'intelligently', importance_score = ? WHERE id = ?",
+                [(1, critical_id), (2, important_id), (3, default_id)],
+            )
+            conn.commit()
+
+            manifest = list_intelligently_habit_manifest_with_conn(conn)
+            labels = {m["habit_id"]: m["importance_label"] for m in manifest}
+
+            assert labels[critical_id] == "critical"
+            assert labels[important_id] == "important"
+            assert labels[default_id] == "default"
+        finally:
+            conn.close()
+
+    def test_manifest_excludes_archived_status(self, temp_db):
+        """status='archived'の振る舞いはマニフェストから除外される"""
+        conn = get_connection()
+        try:
+            archived_id = add_habit("アーカイブ済み")["habit_id"]
+            active_id = add_habit("現役")["habit_id"]
+            conn.execute(
+                "UPDATE habits SET trigger_mode = 'intelligently', status = 'archived' WHERE id = ?",
+                (archived_id,),
+            )
+            conn.execute(
+                "UPDATE habits SET trigger_mode = 'intelligently' WHERE id = ?",
+                (active_id,),
+            )
+            conn.commit()
+
+            manifest = list_intelligently_habit_manifest_with_conn(conn)
+            manifest_ids = [m["habit_id"] for m in manifest]
+
+            assert archived_id not in manifest_ids
+            assert active_id in manifest_ids
         finally:
             conn.close()
 


### PR DESCRIPTION
## 背景

habitsテーブルに追加されたimportance_scoreが、intelligently層マニフェストのソート・フィルタに一切使われていなかった。優先度を上げても表示順・表示要否に反映されない状態だった。

このPRは #542 の変更を前提にしたstacked PRで、base branchを `feature/session-start-budget-m2` にしている。

## 変更内容

- `list_intelligently_habit_manifest_with_conn` のソートを `importance_score ASC, id ASC` に変更（1=critical/2=important/3=defaultで、criticalが先頭に出る）
- SessionStart出力のintelligently層マニフェスト各行に `[critical]`/`[important]`/`[default]` ラベルを前置
- habitsに `status`（'active'/'archived'）カラムを新設。`active`（有効/無効の論理削除）とは独立した棚卸し軸で、マニフェストは両方をAND条件で絞り込む。`status='archived'`はマニフェストから除外される
- `add_habit`/`update_habit` に `importance_score`（1/2/3のみ許可）と `status`（active/archived）引数を追加
- `description` に100文字以内のバリデーションを追加

`last_recalled_at` によるrecency自体をマニフェストのソートに使うことは今回のスコープ外（カラムと更新処理は既存のまま維持）。

## テスト計画

- `list_intelligently_habit_manifest_with_conn` がimportance_score昇順（同値はid昇順）でソートされること、importance_scoreからのラベル導出（1→critical/2→important/3→default）が正しいこと
- `status='archived'` のhabitがマニフェストから除外され、`active=0`のhabitは既存どおり除外されること
- `add_habit`/`update_habit` で importance_score に1/2/3以外を渡すとバリデーションエラーになること
- `add_habit`/`update_habit` で status に active/archived以外を渡すとバリデーションエラーになること
- description が100文字を超えるとバリデーションエラーになり、ちょうど100文字は許可されること
- SessionStart hookのmanifest出力にimportance labelが前置され、critical/important/defaultの順で並ぶこと
- migration 0059 適用後、status列がデフォルト'active'で追加され、CHECK制約が'active'/'archived'以外を拒否すること

既存テストへの影響: CIと同条件（`-n auto`、unit+test_migrations / integration+e2e の2ジョブ相当）で実行し、新規failはなし。8件のfail（relay_config/relay_status系5件、migration 0034/0052系3件）はこのブランチの変更前から存在する既存failであることをベースブランチとの比較で確認済み。