### PR TITLE
feat: ピアセッション間の鮮度差分をツールレスポンスに注入するデルタ通知v1

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -91,18 +91,26 @@ def verify_sqlite_vec() -> None:
     logger.info("sqlite-vec startup check passed")
 
 
-def get_connection() -> sqlite3.Connection:
-    """データベース接続を取得する"""
+def get_connection(load_vec: bool = True) -> sqlite3.Connection:
+    """データベース接続を取得する
+
+    Args:
+        load_vec: sqlite-vecネイティブ拡張をロードするか。デフォルトTrue。
+            ベクトル検索を使わない呼び出し元（例: delta_middlewareの純relational
+            クエリ）はFalseを指定することで、拡張ロード（enable_load_extension +
+            sqlite_vec.load）のコストを毎回の接続オープンから省ける。
+    """
     db_path = get_db_path()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row  # 辞書ライクなアクセスを可能にする
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA foreign_keys = ON")  # 外部キー制約を有効化
-    try:
-        _load_sqlite_vec(conn)
-    except Exception:
-        logger.warning("sqlite-vec could not be loaded. Vector search will be unavailable.")
+    if load_vec:
+        try:
+            _load_sqlite_vec(conn)
+        except Exception:
+            logger.warning("sqlite-vec could not be loaded. Vector search will be unavailable.")
     return conn
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -265,6 +265,10 @@ mcp = FastMCP("cc-memory", instructions=build_instructions())
 from src.services.signal_middleware import SignalCaptureMiddleware
 mcp.add_middleware(SignalCaptureMiddleware())
 
+# check_in以降の関連topicスコープの鮮度差分をツールレスポンスに注入する middleware を登録する
+from src.middleware.delta_middleware import DeltaNotificationMiddleware
+mcp.add_middleware(DeltaNotificationMiddleware())
+
 # サーバー起動時刻（/health で uptime 算出に使用）
 _SERVER_STARTED_AT = datetime.now(timezone.utc)
 

--- a/src/middleware/__init__.py
+++ b/src/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""FastMCP middleware パッケージ"""

--- a/src/middleware/delta_middleware.py
+++ b/src/middleware/delta_middleware.py
@@ -1,0 +1,265 @@
+"""デルタ通知 middleware
+
+check_inでスナップショットしたtopicスコープに対し、以降のツール呼び出しで
+関連topicへ新規追加されたdecision/log/materialがあれば、レスポンスに
+ベルとして注入する。watermarkはMCPサーバープロセス内のin-memory dictで
+保持し、DB・migrationは持たない。サーバー再起動でwipeされ、次のcheck_inで
+再ベースラインされる（意図した挙動）。
+"""
+from __future__ import annotations
+
+import sys
+import threading
+from typing import Any
+
+import mcp.types as mt
+from mcp.types import TextContent
+
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+from src.db import get_connection
+from src.services import delta_service
+
+# セッション別watermark（ctx.session_idキー）。tag_service._injected_tagsと同じ
+# in-memory dict + ロックのパターン。セッション終了はこのモジュールに通知されない
+# ため、_injected_tagsと同様に上限超過時は挿入順の最古セッションから追い出す
+# （放置するとセッション数ぶん永久に成長するため）。
+_watermarks: dict[str, dict] = {}
+_watermarks_lock = threading.Lock()
+_WATERMARKS_MAX_SESSIONS = 256
+
+_CHECK_IN_TOOL_NAMES = frozenset({"check_in"})
+
+# write系ツール名 → 対応するエンティティ種別
+_WRITE_TOOL_ENTITY_TYPES: dict[str, str] = {
+    "add_decisions": "decision",
+    "add_logs": "log",
+    "add_material": "material",
+}
+
+# エンティティ種別 → created配列内のidキー名（watermark辞書のキー名とも一致する）
+_ID_KEYS: dict[str, str] = {
+    "decision": "decision_id",
+    "log": "log_id",
+    "material": "material_id",
+}
+
+
+class DeltaNotificationMiddleware(Middleware):
+    """check-in以降の関連topicスコープの鮮度差分をツールレスポンスに注入する。
+
+    注意: `_handle_check_in`/`_handle_write`/`_handle_other`は内部に`await`を
+    含めないこと。asyncioは単一スレッドで動くため、await地点が無ければ
+    「読み取り→DB→書き戻し」が他のコルーチンに実行を譲らず事実上atomicになり、
+    同一session_idへの並行呼び出しでもannounce-once保証が崩れない。
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        result = await call_next(context)
+
+        session_key = _session_key(context)
+        tool_name = context.message.name
+
+        # デルタ通知は「あったら便利」な後付け機構であり、本来のツール呼び出しは
+        # 既に成功している。ここでの例外（DB busy、想定外のレスポンス形状変化等）が
+        # 全ツール呼び出しを道連れにしないよう、ベストエフォートで握りつぶす。
+        try:
+            if tool_name in _CHECK_IN_TOOL_NAMES:
+                _handle_check_in(session_key, result)
+            elif tool_name in _WRITE_TOOL_ENTITY_TYPES:
+                _handle_write(session_key, tool_name, result)
+            else:
+                _handle_other(session_key, result)
+        except Exception as e:
+            print(f"delta_middleware.on_call_tool error: {e}", file=sys.stderr)
+
+        return result
+
+
+def _session_key(context: MiddlewareContext) -> str:
+    try:
+        session_id = context.fastmcp_context.session_id if context.fastmcp_context else None
+    except Exception:
+        session_id = None
+    return session_id or "__default__"
+
+
+def _handle_check_in(session_key: str, result: Any) -> None:
+    """check_in結果からscope（topic_ids/activity_id）を読み取り、baselineで初期化する。
+
+    activityのid_rawが取れない場合（error応答等）は何もしない
+    （直前のwatermarkがあればそのまま残す）。
+    """
+    structured = getattr(result, "structured_content", None)
+    if not structured:
+        return
+    activity = structured.get("activity")
+    if not isinstance(activity, dict):
+        return
+    activity_id = activity.get("id_raw")
+    if activity_id is None:
+        return
+
+    topic_ids = [
+        t["id_raw"] for t in structured.get("related_topics", []) or []
+        if isinstance(t, dict) and "id_raw" in t
+    ]
+
+    conn = get_connection()
+    try:
+        baseline = delta_service.get_baseline(conn, topic_ids, activity_id)
+    finally:
+        conn.close()
+
+    with _watermarks_lock:
+        if session_key not in _watermarks:
+            while len(_watermarks) >= _WATERMARKS_MAX_SESSIONS:
+                del _watermarks[next(iter(_watermarks))]
+        _watermarks[session_key] = {
+            "topic_ids": topic_ids,
+            "activity_id": activity_id,
+            "decision_id": baseline["decision_id"],
+            "log_id": baseline["log_id"],
+            "material_id": baseline["material_id"],
+        }
+
+
+def _handle_write(session_key: str, tool_name: str, result: Any) -> None:
+    """write系ツールの自己通知抑制: 自分が作成したid（scope内のみ）でwatermarkを前進する。"""
+    with _watermarks_lock:
+        wm = _watermarks.get(session_key)
+    if wm is None:
+        return
+
+    entity_type = _WRITE_TOOL_ENTITY_TYPES[tool_name]
+    id_key = _ID_KEYS[entity_type]
+
+    structured = getattr(result, "structured_content", None)
+    if not structured:
+        return
+
+    if entity_type == "material":
+        # add_materialはcreated配列を持たず、トップレベルに material_id を直接返す
+        raw_id = structured.get(id_key)
+        created_ids = [raw_id] if isinstance(raw_id, int) else []
+    else:
+        created_ids = [
+            item[id_key] for item in structured.get("created", []) or []
+            if isinstance(item, dict) and id_key in item
+        ]
+    if not created_ids:
+        return
+
+    conn = get_connection()
+    try:
+        scoped_ids = _scoped_ids(conn, entity_type, created_ids, wm["topic_ids"], wm["activity_id"])
+    finally:
+        conn.close()
+    if not scoped_ids:
+        return
+
+    with _watermarks_lock:
+        current = _watermarks.get(session_key)
+        if current is None:
+            return
+        current[id_key] = max(current.get(id_key, 0), max(scoped_ids))
+
+
+def _handle_other(session_key: str, result: Any) -> None:
+    """その他のツール呼び出し: scope内の差分があれば注入し、watermarkを前進する。"""
+    with _watermarks_lock:
+        wm = _watermarks.get(session_key)
+    if wm is None:
+        return
+
+    conn = get_connection()
+    try:
+        delta = delta_service.compute_delta(conn, wm["topic_ids"], wm["activity_id"], wm)
+    finally:
+        conn.close()
+
+    if not (delta["new_decisions"] or delta["new_logs"] or delta["new_materials"]):
+        return
+
+    _inject(result, delta)
+
+    with _watermarks_lock:
+        current = _watermarks.get(session_key)
+        if current is None:
+            return
+        if delta["new_decisions"]:
+            current["decision_id"] = max(
+                current["decision_id"], max(d["id"] for d in delta["new_decisions"])
+            )
+        if delta["new_logs"]:
+            current["log_id"] = max(
+                current["log_id"], max(l["id"] for l in delta["new_logs"])
+            )
+        if delta["new_materials"]:
+            current["material_id"] = max(
+                current["material_id"], max(m["id"] for m in delta["new_materials"])
+            )
+
+
+def _scoped_ids(
+    conn, entity_type: str, ids: list[int], topic_ids: list[int], activity_id: int | None
+) -> set[int]:
+    """created idのうち、指定scope（topic_ids/activity_id）に属するものだけを返す。
+
+    add_decisionsの応答はレスポンス軽量化でtopic_idを含まないため、ここでは
+    リクエスト引数を当てにせず、作成直後のidでrelations/relations_viewへ
+    再問い合わせして判定する。
+    """
+    if not ids:
+        return set()
+    id_placeholders = ",".join("?" * len(ids))
+
+    if entity_type in ("decision", "log"):
+        if not topic_ids:
+            return set()
+        topic_placeholders = ",".join("?" * len(topic_ids))
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT source_id FROM relations
+            WHERE source_type = ? AND source_id IN ({id_placeholders})
+              AND target_type = 'topic' AND relation_type = 'belongs_to'
+              AND target_id IN ({topic_placeholders})
+            """,
+            (entity_type, *ids, *topic_ids),
+        ).fetchall()
+        return {row["source_id"] for row in rows}
+
+    if entity_type == "material":
+        scope_sql, scope_params = delta_service.material_scope_clause(topic_ids, activity_id)
+        if not scope_sql:
+            return set()
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT rv.target_id AS id
+            FROM relations_view rv
+            WHERE ({scope_sql}) AND rv.target_type = 'material'
+              AND rv.target_id IN ({id_placeholders})
+            """,
+            (*scope_params, *ids),
+        ).fetchall()
+        return {row["id"] for row in rows}
+
+    return set()
+
+
+def _inject(result: Any, delta: dict) -> None:
+    lines = ["📨 [デルタ通知] check-in以降、関連トピックに新しい記録が追加されました。"]
+    for d in delta["new_decisions"]:
+        lines.append(f"  - decision: {d['title']}（get_decisionsで取得可）")
+    for l in delta["new_logs"]:
+        lines.append(f"  - log: {l['title']}")
+    for m in delta["new_materials"]:
+        lines.append(f"  - material: {m['title']}（get_materialで取得可）")
+    lines.append("ユーザーへの応答を返す前に、内容を確認してください。")
+    result.content.append(TextContent(type="text", text="\n".join(lines)))
+    if result.structured_content is not None:
+        result.structured_content["delta"] = delta

--- a/src/middleware/delta_middleware.py
+++ b/src/middleware/delta_middleware.py
@@ -30,6 +30,12 @@ _WATERMARKS_MAX_SESSIONS = 256
 
 _CHECK_IN_TOOL_NAMES = frozenset({"check_in"})
 
+# check_inの結果を直接ではなくネストしたキーで返すツール名 → キー名。
+# add_activity(check_in=True、デフォルト)はcheck_inの結果をトップレベルではなく
+# result["check_in_result"]に入れて返す（activity_service.add_activity参照）ため、
+# _CHECK_IN_TOOL_NAMESとは別扱いにしないとbaselineが一切セットされない。
+_CHECK_IN_NESTED_KEY_TOOL_NAMES: dict[str, str] = {"add_activity": "check_in_result"}
+
 # write系ツール名 → 対応するエンティティ種別
 _WRITE_TOOL_ENTITY_TYPES: dict[str, str] = {
     "add_decisions": "decision",
@@ -70,6 +76,8 @@ class DeltaNotificationMiddleware(Middleware):
         try:
             if tool_name in _CHECK_IN_TOOL_NAMES:
                 _handle_check_in(session_key, result)
+            elif tool_name in _CHECK_IN_NESTED_KEY_TOOL_NAMES:
+                _handle_check_in(session_key, result, nested_key=_CHECK_IN_NESTED_KEY_TOOL_NAMES[tool_name])
             elif tool_name in _WRITE_TOOL_ENTITY_TYPES:
                 _handle_write(session_key, tool_name, result)
             else:
@@ -88,15 +96,24 @@ def _session_key(context: MiddlewareContext) -> str:
     return session_id or "__default__"
 
 
-def _handle_check_in(session_key: str, result: Any) -> None:
+def _handle_check_in(session_key: str, result: Any, nested_key: str | None = None) -> None:
     """check_in結果からscope（topic_ids/activity_id）を読み取り、baselineで初期化する。
 
-    activityのid_rawが取れない場合（error応答等）は何もしない
-    （直前のwatermarkがあればそのまま残す）。
+    nested_keyが指定された場合、structured_content自体ではなく
+    structured_content[nested_key]をcheck_in結果として扱う（add_activity(check_in=True)
+    がcheck_in結果をresult["check_in_result"]にネストして返すため）。
+
+    activityのid_rawが取れない場合（error応答・nested_keyの値が辞書でない＝
+    add_activity(check_in=False)相当等）は何もしない（直前のwatermarkがあれば
+    そのまま残す）。
     """
     structured = getattr(result, "structured_content", None)
     if not structured:
         return
+    if nested_key is not None:
+        structured = structured.get(nested_key)
+        if not isinstance(structured, dict):
+            return
     activity = structured.get("activity")
     if not isinstance(activity, dict):
         return

--- a/src/middleware/delta_middleware.py
+++ b/src/middleware/delta_middleware.py
@@ -126,7 +126,9 @@ def _handle_check_in(session_key: str, result: Any, nested_key: str | None = Non
         if isinstance(t, dict) and "id_raw" in t
     ]
 
-    conn = get_connection()
+    # delta_service.get_baselineは純relationalクエリでベクトル検索を使わないため、
+    # sqlite-vecネイティブ拡張のロードをスキップしてオープンコストを削減する。
+    conn = get_connection(load_vec=False)
     try:
         baseline = delta_service.get_baseline(conn, topic_ids, activity_id)
     finally:
@@ -171,7 +173,8 @@ def _handle_write(session_key: str, tool_name: str, result: Any) -> None:
     if not created_ids:
         return
 
-    conn = get_connection()
+    # _scoped_idsも純relationalクエリのみ（vec不要）。理由は_handle_check_in参照。
+    conn = get_connection(load_vec=False)
     try:
         scoped_ids = _scoped_ids(conn, entity_type, created_ids, wm["topic_ids"], wm["activity_id"])
     finally:
@@ -193,7 +196,12 @@ def _handle_other(session_key: str, result: Any) -> None:
     if wm is None:
         return
 
-    conn = get_connection()
+    # delta_service.compute_deltaも純relationalクエリのみ（vec不要）。
+    # PR #550レビュー指摘: check-in済みセッションの以降の全ツール呼び出しで無条件に
+    # 発生するmiddleware専用接続のコストのうち、拡張ロード分だけでも削減する
+    # （接続オープン自体・クエリ3本のコストは残る。deltaの有無を事前に知る手段が
+    # ないため、これ以上の早期リターンは設計を変えないと難しいと判断し見送った）。
+    conn = get_connection(load_vec=False)
     try:
         delta = delta_service.compute_delta(conn, wm["topic_ids"], wm["activity_id"], wm)
     finally:

--- a/src/services/delta_service.py
+++ b/src/services/delta_service.py
@@ -1,0 +1,185 @@
+"""デルタ通知サービス
+
+check-in時にスナップショットしたtopicスコープに対し、以降追加された
+decision/log/materialを差分として取得するための純粋クエリ関数群。
+呼び出し元（delta_middleware）がconnとwatermarkを管理し、本モジュールは
+DB問い合わせのみを担う。
+"""
+import sqlite3
+
+LOG_TITLE_SNIPPET_LEN = 50
+
+
+def material_scope_clause(
+    topic_ids: list[int], activity_id: int | None
+) -> tuple[str, list[int]]:
+    """materialのスコープ条件（topic群 OR activity_id）をSQL断片とパラメータ列で返す。
+
+    topicとactivityは別々のオートインクリメント空間のため、値がたまたま一致しても
+    type違いで誤爆しないよう、type毎にid集合をペアで絞り込む（IN列挙をtype横断で
+    共有しない）。get_baseline/compute_delta/delta_middleware._scoped_idsの3箇所で
+    同一ロジックを使うための共通ヘルパー。
+
+    Returns:
+        (sql_fragment, params)。両方とも空になるのはtopic_ids/activity_idが
+        いずれも指定されない場合のみで、その場合sql_fragmentは空文字列になる
+        （呼び出し側でtruthy判定して使うこと）。
+    """
+    clauses = []
+    params: list[int] = []
+    if topic_ids:
+        placeholders = ",".join("?" * len(topic_ids))
+        clauses.append(f"(rv.source_type = 'topic' AND rv.source_id IN ({placeholders}))")
+        params.extend(topic_ids)
+    if activity_id is not None:
+        clauses.append("(rv.source_type = 'activity' AND rv.source_id = ?)")
+        params.append(activity_id)
+    return " OR ".join(clauses), params
+
+
+def get_baseline(
+    conn: sqlite3.Connection, topic_ids: list[int], activity_id: int | None = None
+) -> dict:
+    """指定topic群（decision/log）・topic群+activity_id（material）の現在のmax idを返す。
+
+    materialのスコープをcompute_deltaと揃えてtopic群 **または** activity_idにしている
+    （揃えないと、activityにのみ紐づき check-in以前から存在していたmaterialが、
+    check-in直後の最初のdelta計算で新規と誤検知される）。
+    topic_ids・activity_idがいずれも無ければ全て0を返す（該当なし）。
+    retracted_atは考慮しない（baselineは差分の起点となるidカットオフに過ぎず、
+    retracted済みかどうかに関係なくidの大小のみが意味を持つため）。
+
+    Returns:
+        {"decision_id": int, "log_id": int, "material_id": int}
+    """
+    decision_id = 0
+    log_id = 0
+
+    if topic_ids:
+        placeholders = ",".join("?" * len(topic_ids))
+
+        decision_row = conn.execute(
+            f"""
+            SELECT MAX(d.id) AS max_id
+            FROM decisions d
+            JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                            AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                            AND r.target_id IN ({placeholders})
+            """,
+            tuple(topic_ids),
+        ).fetchone()
+        decision_id = (decision_row["max_id"] if decision_row else None) or 0
+
+        log_row = conn.execute(
+            f"""
+            SELECT MAX(l.id) AS max_id
+            FROM discussion_logs l
+            JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                            AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                            AND r.target_id IN ({placeholders})
+            """,
+            tuple(topic_ids),
+        ).fetchone()
+        log_id = (log_row["max_id"] if log_row else None) or 0
+
+    material_id = 0
+    scope_sql, scope_params = material_scope_clause(topic_ids, activity_id)
+    if scope_sql:
+        material_row = conn.execute(
+            f"""
+            SELECT MAX(m.id) AS max_id
+            FROM materials m
+            JOIN relations_view rv ON ({scope_sql})
+                                   AND rv.target_type = 'material' AND rv.target_id = m.id
+            """,
+            tuple(scope_params),
+        ).fetchone()
+        material_id = (material_row["max_id"] if material_row else None) or 0
+
+    return {"decision_id": decision_id, "log_id": log_id, "material_id": material_id}
+
+
+def compute_delta(
+    conn: sqlite3.Connection,
+    topic_ids: list[int],
+    activity_id: int | None,
+    wm: dict,
+) -> dict:
+    """`id > wm[...]` の新規decision/log/materialをtitle付きで返す。
+
+    decision/logはtopic群へのbelongs_toリレーション経由（activity_idは対象外）。
+    materialはtopic群 **または** activity_idに関連するものが対象
+    （relations_view経由、belongs_to/related問わず）。
+    いずれもretracted_at IS NULLが必須（materialも対象。旧設計の
+    「materialには付けない」は誤りだったため注意）。
+
+    Args:
+        conn: DB接続
+        topic_ids: スコープとなるtopic群のID
+        activity_id: スコープとなるactivityのID（materialのスコープにのみ使う）
+        wm: watermark辞書。少なくとも decision_id/log_id/material_id を持つ
+
+    Returns:
+        {"new_decisions": [{"id": int, "title": str}, ...],
+         "new_logs": [...], "new_materials": [...]}（空配列可）
+    """
+    new_decisions: list[dict] = []
+    new_logs: list[dict] = []
+    new_materials: list[dict] = []
+
+    if topic_ids:
+        placeholders = ",".join("?" * len(topic_ids))
+
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT d.id, d.title, d.decision
+            FROM decisions d
+            JOIN relations r ON r.source_type = 'decision' AND r.source_id = d.id
+                            AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                            AND r.target_id IN ({placeholders})
+            WHERE d.retracted_at IS NULL AND d.id > ?
+            ORDER BY d.id
+            """,
+            (*topic_ids, wm.get("decision_id", 0)),
+        ).fetchall()
+        new_decisions = [
+            {"id": row["id"], "title": row["title"] or row["decision"]} for row in rows
+        ]
+
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT l.id, l.title, l.content
+            FROM discussion_logs l
+            JOIN relations r ON r.source_type = 'log' AND r.source_id = l.id
+                            AND r.target_type = 'topic' AND r.relation_type = 'belongs_to'
+                            AND r.target_id IN ({placeholders})
+            WHERE l.retracted_at IS NULL AND l.id > ?
+            ORDER BY l.id
+            """,
+            (*topic_ids, wm.get("log_id", 0)),
+        ).fetchall()
+        new_logs = [
+            {"id": row["id"], "title": row["title"] or (row["content"] or "")[:LOG_TITLE_SNIPPET_LEN]}
+            for row in rows
+        ]
+
+    scope_sql, scope_params = material_scope_clause(topic_ids, activity_id)
+    if scope_sql:
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT m.id, m.title
+            FROM materials m
+            JOIN relations_view rv ON ({scope_sql})
+                                   AND rv.target_type = 'material' AND rv.target_id = m.id
+            WHERE m.retracted_at IS NULL AND m.id > ?
+            ORDER BY m.id
+            """,
+            (*scope_params, wm.get("material_id", 0)),
+        ).fetchall()
+        new_materials = [{"id": row["id"], "title": row["title"]} for row in rows]
+
+    return {
+        "new_decisions": new_decisions,
+        "new_logs": new_logs,
+        "new_materials": new_materials,
+    }

--- a/tests/unit/test_delta_middleware.py
+++ b/tests/unit/test_delta_middleware.py
@@ -86,6 +86,55 @@ async def test_check_in_records_baseline_and_scope(scope):
 
 
 @pytest.mark.asyncio
+async def test_add_activity_default_checkin_records_baseline(temp_db):
+    """add_activity(check_in=True、デフォルト)経由でもbaselineが記録されること。
+
+    check_in結果はresult["check_in_result"]にネストして返るため、ツール名
+    "check_in"の場合と同じ処理では拾えない。add_activityは"典型的な使い方"の
+    主要経路（新規アクティビティ作成時にそのまま着手する）のため、これが
+    未対応だとbaselineが一切セットされずデルタ通知が発動しない（PR #550レビュー指摘）。
+    """
+    topic = add_topic(title="Scope Topic via add_activity", description="d", tags=["domain:test"])
+    tid = topic["topic_id"]
+    middleware = DeltaNotificationMiddleware()
+
+    add_activity_result = add_activity(
+        title="Activity via default check_in", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid]}],
+    )
+    aid = add_activity_result["activity_id"]
+
+    await middleware.on_call_tool(
+        _make_context("add_activity", "session-A"),
+        _call_next_returning(ToolResult(structured_content=add_activity_result)),
+    )
+
+    wm = _watermarks["session-A"]
+    assert wm["activity_id"] == aid
+    assert wm["topic_ids"] == [tid]
+
+
+@pytest.mark.asyncio
+async def test_add_activity_explicit_no_checkin_does_not_record_baseline(temp_db):
+    """add_activity(check_in=False)はcheck_in_resultを含まないため、baselineは記録されない。"""
+    topic = add_topic(title="Scope Topic no checkin", description="d", tags=["domain:test"])
+    tid = topic["topic_id"]
+    middleware = DeltaNotificationMiddleware()
+
+    add_activity_result = add_activity(
+        title="Activity without check_in", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid]}], check_in=False,
+    )
+
+    await middleware.on_call_tool(
+        _make_context("add_activity", "session-B"),
+        _call_next_returning(ToolResult(structured_content=add_activity_result)),
+    )
+
+    assert "session-B" not in _watermarks
+
+
+@pytest.mark.asyncio
 async def test_cross_session_delta_injected_then_announce_once(scope):
     tid, aid = scope
     middleware = DeltaNotificationMiddleware()

--- a/tests/unit/test_delta_middleware.py
+++ b/tests/unit/test_delta_middleware.py
@@ -1,0 +1,319 @@
+"""DeltaNotificationMiddleware のintegrationテスト
+
+複数session_idを模擬し、check_in→baseline記録、別セッションの書き込みに
+よるベル注入、announce-once（同じ差分は一度しか通知しない）、
+自己通知抑制、再check_inでのscopeリセットを検証する。
+
+temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp.tools.tool import ToolResult
+
+from src.services.activity_service import add_activity
+from src.services.checkin_service import check_in
+from src.services.decision_service import add_decisions
+from src.services.discussion_log_service import add_logs
+from src.services.material_service import add_material
+from src.services.topic_service import add_topic
+from src.middleware.delta_middleware import DeltaNotificationMiddleware, _watermarks
+from tests.helpers import add_decision
+
+
+@pytest.fixture(autouse=True)
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストでembedding呼び出しを無効化する"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_watermarks():
+    """モジュールレベルのwatermark状態をテスト間で共有しないようにする"""
+    _watermarks.clear()
+    yield
+    _watermarks.clear()
+
+
+def _make_context(tool_name: str, session_id):
+    message = MagicMock()
+    message.name = tool_name
+    fastmcp_ctx = MagicMock()
+    fastmcp_ctx.session_id = session_id
+    context = MagicMock()
+    context.message = message
+    context.fastmcp_context = fastmcp_ctx
+    return context
+
+
+def _call_next_returning(tool_result: ToolResult):
+    async def _inner(_ctx):
+        return tool_result
+    return _inner
+
+
+def _noop_tool_result() -> ToolResult:
+    return ToolResult(structured_content={"noop": True})
+
+
+@pytest.fixture
+def scope(temp_db):
+    """スコープ用のtopicとそれに紐づくactivityを1組作成する"""
+    topic = add_topic(title="Scope Topic", description="d", tags=["domain:test"])
+    tid = topic["topic_id"]
+    activity = add_activity(
+        title="Scope Activity", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid]}], check_in=False,
+    )
+    aid = activity["activity_id"]
+    return tid, aid
+
+
+@pytest.mark.asyncio
+async def test_check_in_records_baseline_and_scope(scope):
+    tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    checkin_result = check_in(aid)
+    ctx = _make_context("check_in", "session-A")
+    await middleware.on_call_tool(ctx, _call_next_returning(ToolResult(structured_content=checkin_result)))
+
+    wm = _watermarks["session-A"]
+    assert wm["activity_id"] == aid
+    assert wm["topic_ids"] == [tid]
+    assert wm["decision_id"] == 0
+    assert wm["log_id"] == 0
+    assert wm["material_id"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cross_session_delta_injected_then_announce_once(scope):
+    tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    # (a) Aがcheck_in
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+
+    # (b) 別セッションBがscope topicにdecisionを追加（Bはmiddlewareを経由しない
+    # 素の書き込みとして表現。ピアセッションからの書き込みを模している）
+    b_decision = add_decision("Bの決定", "reason", topic_id=tid)
+
+    # (c) Aの次のツール呼び出しでdeltaがcontentに出る
+    result1 = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    injected_text = result1.content[-1].text
+    assert "デルタ通知" in injected_text
+    assert "Bの決定" in injected_text
+    assert result1.structured_content["delta"]["new_decisions"] == [
+        {"id": b_decision["decision_id"], "title": "Bの決定"}
+    ]
+
+    # (d) 同じ呼び出しを再度実行 → announce-onceで出ない
+    result2 = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert len(result2.content) == 1
+    assert "delta" not in (result2.structured_content or {})
+
+
+@pytest.mark.asyncio
+async def test_self_write_not_notified(scope):
+    tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+
+    # (e) A自身がscope topicにdecisionを追加。add_decisionsのツール呼び出しを
+    # middleware経由で処理させ、自己通知抑制のwatermark前進を確認する
+    own_write_result = add_decisions([{"topic_id": tid, "decision": "自分の決定", "reason": "r"}])
+    await middleware.on_call_tool(
+        _make_context("add_decisions", "session-A"),
+        _call_next_returning(ToolResult(structured_content=own_write_result)),
+    )
+
+    result = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert len(result.content) == 1
+    assert "delta" not in (result.structured_content or {})
+
+
+@pytest.mark.asyncio
+async def test_self_write_not_notified_for_logs(scope):
+    """add_decisionsだけでなくadd_logs経由の自己通知抑制も別コードパスとして確認する。"""
+    tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+
+    own_write_result = add_logs([{"topic_id": tid, "content": "自分のログ"}])
+    await middleware.on_call_tool(
+        _make_context("add_logs", "session-A"),
+        _call_next_returning(ToolResult(structured_content=own_write_result)),
+    )
+
+    result = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert len(result.content) == 1
+    assert "delta" not in (result.structured_content or {})
+
+
+@pytest.mark.asyncio
+async def test_self_write_not_notified_for_materials(scope):
+    """add_materialはcreated配列を持たずtop-levelにmaterial_idを返す特殊系のため、
+    add_decisions/add_logsとは別コードパス（_handle_writeのmaterial分岐）を確認する。
+    """
+    tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+
+    own_write_result = add_material(
+        title="自分のmaterial", content="x", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [tid]}],
+    )
+    await middleware.on_call_tool(
+        _make_context("add_material", "session-A"),
+        _call_next_returning(ToolResult(structured_content=own_write_result)),
+    )
+
+    result = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert len(result.content) == 1
+    assert "delta" not in (result.structured_content or {})
+
+
+@pytest.mark.asyncio
+async def test_recheckin_resets_scope(temp_db):
+    topic1 = add_topic(title="Topic1", description="d", tags=["domain:test"])
+    tid1 = topic1["topic_id"]
+    activity1 = add_activity(
+        title="Activity1", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid1]}], check_in=False,
+    )
+    aid1 = activity1["activity_id"]
+
+    topic2 = add_topic(title="Topic2", description="d", tags=["domain:test"])
+    tid2 = topic2["topic_id"]
+    activity2 = add_activity(
+        title="Activity2", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid2]}], check_in=False,
+    )
+    aid2 = activity2["activity_id"]
+
+    middleware = DeltaNotificationMiddleware()
+
+    checkin1 = check_in(aid1)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin1)),
+    )
+    assert _watermarks["session-A"]["topic_ids"] == [tid1]
+    assert _watermarks["session-A"]["activity_id"] == aid1
+
+    # (f) 再check_in（別activity）でscopeが上書きされる
+    checkin2 = check_in(aid2)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin2)),
+    )
+    assert _watermarks["session-A"]["topic_ids"] == [tid2]
+    assert _watermarks["session-A"]["activity_id"] == aid2
+
+
+@pytest.mark.asyncio
+async def test_session_without_checkin_gets_no_notification(scope):
+    tid, _aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    add_decision("誰かの決定", "reason", topic_id=tid)
+
+    result = await middleware.on_call_tool(
+        _make_context("get_topics", "session-without-checkin"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert len(result.content) == 1
+    assert "delta" not in (result.structured_content or {})
+    assert "session-without-checkin" not in _watermarks
+
+
+@pytest.mark.asyncio
+async def test_session_id_none_falls_back_to_default(scope):
+    _tid, aid = scope
+    middleware = DeltaNotificationMiddleware()
+
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", None),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+    assert "__default__" in _watermarks
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_write_does_not_suppress_future_in_scope_deltas(temp_db):
+    """scope外topicへの自己書き込みはwatermarkを進めず、後続の別セッションの
+    scope内書き込みも正しく検出され続けることを確認する。
+    """
+    scope_topic = add_topic(title="Scope Topic", description="d", tags=["domain:test"])
+    tid = scope_topic["topic_id"]
+    other_topic = add_topic(title="Other Topic", description="d", tags=["domain:test"])
+    other_tid = other_topic["topic_id"]
+    activity = add_activity(
+        title="Activity", description="d", tags=["domain:test"],
+        related=[{"type": "topic", "ids": [tid]}], check_in=False,
+    )
+    aid = activity["activity_id"]
+
+    middleware = DeltaNotificationMiddleware()
+    checkin_result = check_in(aid)
+    await middleware.on_call_tool(
+        _make_context("check_in", "session-A"),
+        _call_next_returning(ToolResult(structured_content=checkin_result)),
+    )
+    assert _watermarks["session-A"]["decision_id"] == 0
+
+    # Aがscope外topicにdecisionを書く
+    out_of_scope_write = add_decisions([
+        {"topic_id": other_tid, "decision": "scope外の決定", "reason": "r"}
+    ])
+    await middleware.on_call_tool(
+        _make_context("add_decisions", "session-A"),
+        _call_next_returning(ToolResult(structured_content=out_of_scope_write)),
+    )
+    # scope外への書き込みはwatermarkを進めない
+    assert _watermarks["session-A"]["decision_id"] == 0
+
+    # 別セッションBがscope内topicにdecisionを追加
+    b_decision = add_decision("scope内の決定", "reason", topic_id=tid)
+
+    result = await middleware.on_call_tool(
+        _make_context("get_topics", "session-A"),
+        _call_next_returning(_noop_tool_result()),
+    )
+    assert result.structured_content["delta"]["new_decisions"] == [
+        {"id": b_decision["decision_id"], "title": "scope内の決定"}
+    ]

--- a/tests/unit/test_delta_service.py
+++ b/tests/unit/test_delta_service.py
@@ -1,0 +1,240 @@
+"""delta_service: get_baseline / compute_delta のユニットテスト
+
+temp_db / disable_embedding フィクスチャは tests/conftest.py で共有。
+"""
+import pytest
+
+from src.db import get_connection
+from src.services.activity_service import add_activity
+from src.services.material_service import add_material
+from src.services.retract_service import retract
+from src.services.topic_service import add_topic
+from src.services.delta_service import compute_delta, get_baseline
+from tests.helpers import add_decision, add_log
+
+
+@pytest.fixture(autouse=True)
+def _auto_disable_embedding(disable_embedding):
+    """このファイル内の全テストでembedding呼び出しを無効化する"""
+
+
+@pytest.fixture
+def scope_topic(temp_db):
+    """スコープ内のtopicを1件作成する"""
+    result = add_topic(title="Scope Topic", description="in scope", tags=["domain:test"])
+    return result["topic_id"]
+
+
+@pytest.fixture
+def other_topic(temp_db):
+    """スコープ外のtopicを1件作成する"""
+    result = add_topic(title="Other Topic", description="out of scope", tags=["domain:test"])
+    return result["topic_id"]
+
+
+def test_get_baseline_returns_zero_for_empty_topic_ids(temp_db):
+    conn = get_connection()
+    try:
+        baseline = get_baseline(conn, [])
+    finally:
+        conn.close()
+    assert baseline == {"decision_id": 0, "log_id": 0, "material_id": 0}
+
+
+def test_get_baseline_returns_max_ids_within_scope(temp_db, scope_topic, other_topic):
+    d1 = add_decision("decision A", "reason A", topic_id=scope_topic)
+    add_decision("decision B (other topic)", "reason B", topic_id=other_topic)
+    l1 = add_log(topic_id=scope_topic, content="log A")
+    m1 = add_material(
+        title="Material A", content="content A", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [scope_topic]}],
+    )
+
+    conn = get_connection()
+    try:
+        baseline = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    assert baseline["decision_id"] == d1["decision_id"]
+    assert baseline["log_id"] == l1["log_id"]
+    assert baseline["material_id"] == m1["material_id"]
+
+
+def test_compute_delta_returns_new_entities_after_watermark(temp_db, scope_topic):
+    d_old = add_decision("old decision", "reason", topic_id=scope_topic)
+    l_old = add_log(topic_id=scope_topic, content="old log")
+    m_old = add_material(
+        title="Old Material", content="old", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [scope_topic]}],
+    )
+
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    d_new = add_decision("new decision", "reason", topic_id=scope_topic, tags=None)
+    l_new = add_log(topic_id=scope_topic, content="new log", title="New Log Title")
+    m_new = add_material(
+        title="New Material", content="new", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [scope_topic]}],
+    )
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta["new_decisions"] == [{"id": d_new["decision_id"], "title": "new decision"}]
+    assert delta["new_logs"] == [{"id": l_new["log_id"], "title": "New Log Title"}]
+    assert delta["new_materials"] == [{"id": m_new["material_id"], "title": "New Material"}]
+
+    # 古いエンティティは拾わない
+    old_decision_ids = {d["id"] for d in delta["new_decisions"]}
+    assert d_old["decision_id"] not in old_decision_ids
+
+
+def test_compute_delta_excludes_scope_external_topics(temp_db, scope_topic, other_topic):
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    add_decision("decision in other topic", "reason", topic_id=other_topic)
+    add_log(topic_id=other_topic, content="log in other topic")
+    add_material(
+        title="Material in other topic", content="x", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [other_topic]}],
+    )
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta == {"new_decisions": [], "new_logs": [], "new_materials": []}
+
+
+def test_compute_delta_excludes_retracted_decision(temp_db, scope_topic):
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    d_new = add_decision("will be retracted", "reason", topic_id=scope_topic)
+    retract("decision", [d_new["decision_id"]])
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta["new_decisions"] == []
+
+
+def test_compute_delta_excludes_retracted_log(temp_db, scope_topic):
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    l_new = add_log(topic_id=scope_topic, content="will be retracted")
+    retract("log", [l_new["log_id"]])
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta["new_logs"] == []
+
+
+def test_compute_delta_excludes_retracted_material(temp_db, scope_topic):
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    m_new = add_material(
+        title="Will be retracted", content="x", tags=["domain:test"], source="test",
+        related=[{"type": "topic", "ids": [scope_topic]}],
+    )
+    retract("material", [m_new["material_id"]])
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta["new_materials"] == []
+
+
+def test_get_baseline_includes_material_via_activity_scope(temp_db, scope_topic):
+    """activity_idを渡した場合、activity経由のみのmaterialもbaselineに含まれ、
+    check-in直後の最初のcompute_deltaで誤って新規と報告されない（false positive防止）ことを確認する。
+    """
+    activity_result = add_activity(
+        title="Baseline Test Activity", description="d", tags=["domain:test"], check_in=False,
+    )
+    activity_id = activity_result["activity_id"]
+
+    m_existing = add_material(
+        title="Pre-existing via activity", content="x", tags=["domain:test"], source="test",
+        related=[{"type": "activity", "ids": [activity_id]}],
+    )
+
+    conn = get_connection()
+    try:
+        baseline = get_baseline(conn, [scope_topic], activity_id=activity_id)
+    finally:
+        conn.close()
+    assert baseline["material_id"] == m_existing["material_id"]
+
+    conn = get_connection()
+    try:
+        delta = compute_delta(conn, [scope_topic], activity_id=activity_id, wm=baseline)
+    finally:
+        conn.close()
+    assert delta["new_materials"] == []
+
+
+def test_compute_delta_includes_material_via_activity_scope(temp_db, scope_topic):
+    """topicに一切紐付かず、activity経由のみで関連するmaterialも拾えること"""
+    activity_result = add_activity(
+        title="Delta Test Activity", description="d", tags=["domain:test"], check_in=False,
+    )
+    activity_id = activity_result["activity_id"]
+
+    conn = get_connection()
+    try:
+        wm = get_baseline(conn, [scope_topic])
+    finally:
+        conn.close()
+
+    m_new = add_material(
+        title="Material via activity", content="x", tags=["domain:test"], source="test",
+        related=[{"type": "activity", "ids": [activity_id]}],
+    )
+
+    conn = get_connection()
+    try:
+        delta_without_activity = compute_delta(conn, [scope_topic], activity_id=None, wm=wm)
+        delta_with_activity = compute_delta(conn, [scope_topic], activity_id=activity_id, wm=wm)
+    finally:
+        conn.close()
+
+    assert delta_without_activity["new_materials"] == []
+    assert delta_with_activity["new_materials"] == [
+        {"id": m_new["material_id"], "title": "Material via activity"}
+    ]


### PR DESCRIPTION
## Summary
- check-in時にスナップショットした関連topicスコープに対し、以降decision/log/materialが追加されたら、次のツール呼び出しレスポンスに差分をFastMCP Middleware経由で注入する
- 別セッションが同じトピックに決定・検証済みmaterialを追加しても、こちら側は気づけないという鮮度問題への対策
- watermarkはMCPサーバープロセス内のin-memory dict（セッション数上限256・FIFO追い出し）で保持し、DB・migrationは持たない。サーバー再起動で消え、次のcheck-inで再ベースラインされる
- Middleware内部で例外が起きても、本来のツール呼び出しレスポンスには影響しない（ベストエフォート）

## Test plan
- delta_serviceの検証項目: watermark以降の新規decision/log/materialのみを抽出、scope外topicの除外、retracted除外（decision/log/material全て）、activity経由のみに紐づくmaterialが正しくスコープ・baseline双方に含まれること（check-in直後の誤通知防止）
- Middlewareの検証項目: announce-once（同一差分の再通知なし）、自己通知抑制（add_decisions/add_logs/add_materialの3種を個別に検証）、scope外への自己書き込みが後続の正当な通知を妨げないこと、check-in未実施セッションへの非通知、再check-inでのscopeリセット、session_id無しのフォールバック
- 全体回帰テスト: 既存の失敗8件（relay設定・migrationフィクスチャ関連、本PRと無関係）以外は健全