### PR TITLE
relay Monitor監視nudgeをopt-in化し毎ターン判定に切替

### DIFF
--- a/docs/injection-experience-map.md
+++ b/docs/injection-experience-map.md
@@ -20,7 +20,7 @@
 | activities（一覧+固定ナビ） | ≤1,410（階層1 400 + 階層2 800 + 決定論レンダリング注記 70 + 固定ナビ 140） | selected+remainder | 階層1（別セッション作業中）は全件表示。階層2（優先）は in_progress かつ7日以内、または pinned（60日decay）の中から上位5件を表示。末尾の固定ナビに未表示件数（母集団=active全件−表示済み件数）とpinned内訳を機械算出して明示する。階層1・2とも0件のときはヘッダ・注記を出さず固定ナビのみ返す |
 | habits（投影ファイルの鮮度検証+縮退フォールバック） | 0（fresh時）/ 約80字（stale時、通知1行）/ always全文+件数1行（absent時） | fresh・stale時: complete（注入なし、または1行通知のみ）/ absent時: always=complete, intelligently=truncated+count | 通常配信は`~/.claude/rules/cc-memory-habits.md`への自動生成ファイル（launch時読み込み、本hookとは別の注入面）が担う。本セクションはverify_and_healで当該セッションが投影ファイルを読み込めているかを検証するだけで、fresh時は注入ゼロ、stale時は1行通知のみ。投影ファイルが読めない・未生成・kill switch（`CCM_HABITS_RULES_EXPORT=0`）中に限り、always層全文+intelligently層は件数1行の縮退注入を行う |
 | signals | ≤120 | complete | 未トリアージ(status='new')件数をkind内訳付きで1行表示。0件時は非表示 |
-| relay inbox | 0〜150 | complete | identity未解決またはtoken未設定のときのみ非表示（0）。identity解決できればMonitor監視指示1行を常時表示し、未読>0のときのみ「未読N件 → relay_receiveで消化」行を追加（最大2行） |
+| relay inbox | 0〜150 | complete | `CCM_RELAY_SESSION_AWARE`未設定（デフォルトOFF）時は非表示（0、identity解決すら試みない）。ON時、identity未解決またはtoken未設定のときのみ非表示。identity解決できればMonitor監視指示1行を常時表示し、未読>0のときのみ「未読N件 → relay_receiveで消化」行を追加（最大2行）。同env varがONのときのみUserPromptSubmit hookでも毎ターン同種のnudgeを判定する（`hooks/user_prompt_submit_hook.py`参照） |
 | sync_policy | ≤250 | complete | 環境変数 `CCM_SYNC_POLICY` の設定値をそのまま全文配信。未設定時は非表示 |
 
 ## 2. check_in応答

--- a/hooks/hook_state.py
+++ b/hooks/hook_state.py
@@ -139,6 +139,17 @@ class HookState:
         """checked_in_activity_{session_id} に書く"""
         self._write(self._path("checked_in_activity"), str(activity_id))
 
+    # --- monitor_started (relay inbox監視) ---
+
+    def get_monitor_started(self) -> bool:
+        """このセッションでrelay inbox監視用のMonitorが起動済みかを取得。
+        未設定（ファイルなし） -> False。"""
+        return self._path("monitor_started").exists()
+
+    def set_monitor_started(self) -> None:
+        """monitor_started_{session_id} マーカーファイルを作成する（冪等）。"""
+        self._write(self._path("monitor_started"), "1")
+
     # --- events.jsonl ---
 
     @property

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -48,6 +48,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Monitor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/relay_monitor_watch_hook.py"
+          }
+        ]
+      }
+    ],
     "MessageDisplay": [
       {
         "matcher": "*",

--- a/hooks/relay_monitor_watch_hook.py
+++ b/hooks/relay_monitor_watch_hook.py
@@ -1,0 +1,103 @@
+"""PostToolUse hook (matcher: Monitor): relay inbox監視の起動判定。
+
+CCM_RELAY_SESSION_AWARE（デフォルトOFF）が有効なとき、Monitorツール呼び出しの
+tool_inputがそのセッションのrelay inbox pathを監視するコマンドだったことを
+検知し、セッションIDキーのマーカーファイル（HookState.set_monitor_started）を
+書く。user_prompt_submit_hookはこのマーカーの有無で「そのセッション中に
+Monitor監視が起動済みか」を判定し、未起動なら毎ターンリマインダーを注入する。
+
+本hookはPostToolUse（ツール呼び出し完了後）で発火する独立プロセスであり、
+SessionStart hook同様Claude Code CLIが起動する独立プロセスでMCPリクエスト
+コンテキストを持たないため、identity解決はresolve_identity_by_ancestry()
+（祖先pidチェーン一致、ps最大5回spawn）に依存する。
+
+tool_response の内部構造はMonitorツール（ハーネス実装）依存で公開仕様が
+無いため、判定は保守的に倒す: dict形式で明確に `is_error` が真のときのみ
+「呼び出し失敗」とみなしスキップし、それ以外（構造不明を含む）はマーカーを
+書く側に倒す（fail-open。マーカーを書き損ねてリマインダーが出続ける方が、
+誤ってマーカーを書いて本来必要なリマインダーを消してしまうより実害が
+小さいため）。
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# プロジェクトルートをパスに追加（src.config等の参照用）
+_project_root = Path(__file__).resolve().parents[1]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from hooks.hook_state import HookState
+from hooks.signal_capture import try_capture_signal
+from src import config
+
+
+def _looks_like_failure(tool_response) -> bool:
+    """tool_responseが明確な失敗を示しているときのみTrueを返す。
+
+    判定不能（tool_responseがdict以外、is_errorキーが無い等）はFalse
+    （fail-open。マーカーを書く側に倒す）。
+    """
+    if isinstance(tool_response, dict):
+        return bool(tool_response.get("is_error"))
+    return False
+
+
+def main() -> None:
+    try:
+        if not config.RELAY_SESSION_AWARE_ENABLED:
+            print("{}")
+            return
+
+        # 環境変数によるテスト用オーバーライド
+        if os.environ.get("HOOK_STATE_DIR"):
+            HookState.BASE_DIR = Path(os.environ["HOOK_STATE_DIR"])
+
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+
+        session_id = data.get("session_id", "")
+        tool_name = data.get("tool_name", "")
+        if not session_id or tool_name != "Monitor":
+            print("{}")
+            return
+
+        tool_input = data.get("tool_input") or {}
+        command = tool_input.get("command", "")
+        if not isinstance(command, str) or not command:
+            print("{}")
+            return
+
+        from src.services.relay.identity import get_relay_identity, resolve_identity_by_ancestry
+
+        identity = get_relay_identity() or resolve_identity_by_ancestry()
+        if not identity:
+            # identity解決に失敗するセッションはrelay非参加とみなし何もしない（fail-open）
+            print("{}")
+            return
+
+        from src.services.relay.inbox import inbox_path
+
+        path = str(inbox_path(identity))
+        if path not in command:
+            # 別目的のMonitor呼び出し（このセッションのinbox監視ではない）
+            print("{}")
+            return
+
+        if _looks_like_failure(data.get("tool_response")):
+            print("{}")
+            return
+
+        HookState(session_id).set_monitor_started()
+        print("{}")
+
+    except Exception as e:
+        # フェイルオープン: 例外時は状態記録をスキップするのみでtool実行自体は妨げない
+        print(f"relay_monitor_watch_hook.py error: {e}", file=sys.stderr)
+        try_capture_signal(kind="machine_error", source="hook:relay_monitor_watch", summary=str(e)[:200])
+        print("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -4,7 +4,8 @@
 - アクティビティ一覧（作業中・優先のみ個別表示。末尾に固定ナビ+未表示件数句）
 - 振る舞い（正は~/.claude/rules配下の自動生成ファイル。本hookは投影ファイルの
   鮮度検証と、読み込めていないセッションへの縮退フォールバックのみを担う）
-- relay Monitor監視指示（identity解決に成功した場合は常時。未読N件の報告行のみ未読が実在するときに追加）
+- relay Monitor監視指示（CCM_RELAY_SESSION_AWARE=1のときのみ。identity解決に
+  成功した場合は常時、未読N件の報告行のみ未読が実在するときに追加）
 
 コンテキスト取得フローガイドはここでは注入しない（check_in初回呼び出し時に
 checkin_service側が埋め込む）。
@@ -411,7 +412,11 @@ def _build_signals_section(conn, session_id: str | None = None, source: str | No
 def _build_relay_inbox_section(conn, session_id: str | None = None, source: str | None = None) -> str:  # conn, session_id, source: buildersループの統一シグネチャ
     """identityが解決できる限りMonitor監視指示を常時出す。未読件数の表示のみ0件時は省く。
 
-    relay未構成（token未設定）ならidentity解決を試みる前に打ち切る。
+    CCM_RELAY_SESSION_AWARE（デフォルトOFF）のkill switch。OFF時はtokenチェック・
+    identity解決を一切試みず空文字を返す。relayを使わないユーザー・セッションに
+    関連コンテキストを注入しないための入口ゲート。
+
+    ON時、relay未構成（token未設定）ならidentity解決を試みる前に打ち切る。
     本hookはSessionStart（Claude Code起動をブロックする経路）で毎回実行される
     ため、identity解決の前にコストの小さいtokenチェックを行い、無駄な
     プロセスspawnを避ける。
@@ -427,7 +432,15 @@ def _build_relay_inbox_section(conn, session_id: str | None = None, source: str 
     ものなので、既存の未読・inbox file有無に関わらずidentity解決できた
     時点で常に出す（inbox_path/count_unreadはファイル不在でも安全に動作する）。
     未読N件の報告行のみ、未読が実在するときに追加する。
+
+    identity解決に成功した時点でensure_inbox_fileを呼び、inbox fileを
+    先行生成する。Monitorツールでの `tail -f` はファイル不在だと即座に
+    失敗するため、未読0件（inbox未配達）のセッションでも監視を開始できる
+    状態を作っておく。
     """
+    if not config.RELAY_SESSION_AWARE_ENABLED:
+        return ""
+
     from src.services.relay import config as relay_config
 
     if not relay_config.get_token():
@@ -439,9 +452,9 @@ def _build_relay_inbox_section(conn, session_id: str | None = None, source: str 
     if not identity:
         return ""
 
-    from src.services.relay.inbox import count_unread, inbox_path
+    from src.services.relay.inbox import count_unread, ensure_inbox_file
 
-    path = inbox_path(identity)
+    path = ensure_inbox_file(identity)
     count = count_unread(identity)
 
     lines = []

--- a/hooks/user_prompt_submit_hook.py
+++ b/hooks/user_prompt_submit_hook.py
@@ -6,11 +6,17 @@
 3. events.jsonl全読み
 4. 未消費のnudgeイベント判定 → system-reminder注入
 5. id_leak_count > 0 → 内部 ID 漏出 system-reminder 注入 + count reset
-6. 何もなし → 空JSON出力
+6. relay session-aware nudge（CCM_RELAY_SESSION_AWARE=1のときのみ） →
+   system-reminder注入
+7. 何もなし → 空JSON出力
 
 Stop hookでnudge判定とevents.jsonl追記を行い、本hookで消費して注入する。
 MessageDisplay hookが内部IDリテラル件数をid_leak_countに蓄積し、本hookで参照する。
 注入タイミングが「ユーザーの次の発言時」になるため、文面もその文脈に合わせている。
+relay session-aware nudge（手順6）はSessionStartの一回きりの起動指示が読み流されて
+機能しない問題への対応で、events.jsonl/id_leakとは独立にHookState.monitor_started
+マーカー（hooks/relay_monitor_watch_hook.pyがPostToolUseで書く）とrelay inboxの
+未読件数を毎ターン判定する。
 """
 import json
 import os
@@ -25,6 +31,7 @@ if str(_project_root) not in sys.path:
 
 from hooks.hook_state import HookState
 from hooks.signal_capture import try_capture_signal
+from src import config
 
 
 def _make_hook_output(message: str) -> dict:
@@ -109,6 +116,55 @@ def _format_nudge_message(event: dict, ntype: str | None) -> str | None:
     return None
 
 
+def _build_relay_turn_nudge(state: HookState) -> str | None:
+    """relay session-aware毎ターンnudge（CCM_RELAY_SESSION_AWARE=1のときのみ動作）。
+
+    SessionStart一回きりの起動指示はエージェントに読み流されて機能しないことが
+    確認されたため、毎ターン判定してリマインダーを注入する。
+
+    relay未構成（token未設定）・identity解決失敗（祖先pidチェーンで同一launcher
+    プロセスを特定できない）のセッションはrelay非参加とみなし、Noneを返す
+    （fail-open。エラーにしない）。
+
+    Monitor監視が未起動（HookState.get_monitor_startedがFalse）なら起動指示、
+    未読が1件以上あれば消化指示を、該当する行だけ束ねて返す。どちらも
+    非該当（起動済みかつ未読0件）ならNoneを返す。
+    """
+    if not config.RELAY_SESSION_AWARE_ENABLED:
+        return None
+
+    from src.services.relay import config as relay_config
+
+    if not relay_config.get_token():
+        return None
+
+    from src.services.relay.identity import get_relay_identity, resolve_identity_by_ancestry
+
+    identity = get_relay_identity() or resolve_identity_by_ancestry()
+    if not identity:
+        return None
+
+    from src.services.relay.inbox import count_unread, inbox_path
+
+    monitor_started = state.get_monitor_started()
+    unread = count_unread(identity)
+
+    if monitor_started and unread <= 0:
+        return None
+
+    lines = []
+    if not monitor_started:
+        path = inbox_path(identity)
+        lines.append(
+            f"relay inboxの監視がまだ起動されていません。"
+            f"Monitorツールで {path} を監視してください。"
+        )
+    if unread > 0:
+        lines.append(f"relay inbox 未読: {unread}件 → relay_receiveで消化してください。")
+
+    return _wrap_system_reminder("\n".join(lines))
+
+
 def main() -> None:
     try:
         # 環境変数によるテスト用オーバーライド
@@ -160,7 +216,14 @@ def main() -> None:
             print(json.dumps(_make_hook_output(_ID_LEAK_NUDGE_MESSAGE), ensure_ascii=False))
             return
 
-        # 6. 何もなし
+        # 6. relay session-aware nudge（CCM_RELAY_SESSION_AWARE=1のときのみ、
+        # 既存nudge・id_leakのどちらも非該当だった場合のみ判定）
+        relay_message = _build_relay_turn_nudge(state)
+        if relay_message:
+            print(json.dumps(_make_hook_output(relay_message), ensure_ascii=False))
+            return
+
+        # 7. 何もなし
         print("{}")
 
     except Exception as e:

--- a/src/config.py
+++ b/src/config.py
@@ -68,6 +68,12 @@ CCM_MIGRATION_DRYRUN: bool = os.environ.get("CCM_MIGRATION_DRYRUN", "1") != "0"
 # migration_ledger内容ハッシュ不一致時の既定動作。"error"（既定、起動中断）| "warn"（警告のみで続行）
 CCM_MIGRATION_HASH_ENFORCE: str = os.environ.get("CCM_MIGRATION_HASH_ENFORCE", "error").lower()
 
+# --- Relay session awareness ---
+# relay Monitor監視指示・毎ターンnudgeのopt-in kill switch。デフォルトOFF（"1"でON）。
+# OFF時はSessionStart/UserPromptSubmitのどちらからもrelay関連の文言を一切出さず、
+# relayを使わないユーザー・セッションにコンテキストを注入しない。
+RELAY_SESSION_AWARE_ENABLED: bool = os.environ.get("CCM_RELAY_SESSION_AWARE", "0") == "1"
+
 # --- Archived tags ---
 # 全タグがarchivedのアイテムに適用する final_score の降格係数
 ARCHIVED_DEMOTION_FACTOR: float = float(os.environ.get("CCM_ARCHIVED_DEMOTION_FACTOR", "0.3"))

--- a/src/services/relay/inbox.py
+++ b/src/services/relay/inbox.py
@@ -52,6 +52,20 @@ def _write_cursor(session_id: str, offset: int) -> None:
     os.replace(tmp, path)
 
 
+def ensure_inbox_file(session_id: str) -> Path:
+    """inbox fileが存在しなければ空ファイルとして先行生成する（touch、冪等）。
+
+    Monitorツールで `tail -f` する監視対象は事前に存在している必要がある。
+    ファイル不在のまま `tail -f` すると即座に失敗して監視が成立しないため、
+    identity解決に成功した時点（SessionStart hook等）でこれを呼び、
+    未配達（unread=0）セッションでも監視を開始できる状態を作る。
+    """
+    path = inbox_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    return path
+
+
 def append(session_id: str, record: dict) -> None:
     """inbox に 1 レコードを追記する（flock 排他 + fsync）。"""
     path = inbox_path(session_id)

--- a/tests/e2e/test_relay_monitor_watch_hook.py
+++ b/tests/e2e/test_relay_monitor_watch_hook.py
@@ -1,0 +1,302 @@
+"""hooks/relay_monitor_watch_hook.py (PostToolUse, matcher: Monitor) のE2Eテスト。
+
+subprocess経由でhookを起動し、stdin（tool_name/tool_input/tool_response）を
+渡してHookState.monitor_startedマーカーファイルの有無を検証する。
+identity解決はresolve_identity_by_ancestryに依存するため、テストプロセス
+自身のpidを共通祖先に見立てたlauncher登録ファイルを使う。
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hooks.hook_state import HookState
+from src.db import get_connection, init_database
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SESSION_ID = "e2e-relay-monitor-watch-session"
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    """テスト用のHookState.BASE_DIRを返す"""
+    monkeypatch.setattr(HookState, "BASE_DIR", tmp_path)
+    return tmp_path
+
+
+def _register_launcher(relay_state_dir: Path) -> str:
+    """このテストプロセス自身のpidを共通祖先に見立てたlauncher登録ファイルを作る。
+
+    _run_hookはsubprocess.runでhookを直接の子プロセスとして起動するため、hook
+    subprocessのppidは必ずこのテストプロセスのpid（os.getpid()）になる。
+    """
+    session_id = "relay-monitor-watch-resolved-by-ancestry"
+    sessions_dir = relay_state_dir / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    registration = {
+        "session_id": session_id,
+        "pid": os.getpid(),
+        "ancestor_pids": [os.getpid()],
+        "created_at": "2026-07-08T00:00:00Z",
+    }
+    (sessions_dir / f"launcher-{os.getpid()}.json").write_text(
+        json.dumps(registration), encoding="utf-8"
+    )
+    return session_id
+
+
+def _run_hook(
+    input_data: dict, hook_state_dir: Path, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    """relay_monitor_watch_hook.pyをサブプロセスで実行する"""
+    env = {**os.environ, "HOOK_STATE_DIR": str(hook_state_dir)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "hooks/relay_monitor_watch_hook.py"],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+        cwd=str(_PROJECT_ROOT),
+        env=env,
+    )
+
+
+class TestEnvVarGate:
+    def test_no_marker_when_env_var_off(self, state_dir, tmp_path):
+        """env var OFF（デフォルト）なら、tool_name/commandが完全一致していても
+        マーカーを書かない（identity解決自体を試みない）"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = _register_launcher(relay_state_dir)
+            path = relay_inbox.inbox_path(identity)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Monitor",
+                "tool_input": {"command": f"tail -f {path}"},
+                "tool_response": {"content": "Monitor started (task xyz)."},
+            },
+            state_dir,
+            extra_env={"RELAY_STATE_DIR": str(relay_state_dir)},
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert HookState(_SESSION_ID).get_monitor_started() is False
+
+
+class TestMonitorStartedMarker:
+    def test_marker_written_when_command_matches_inbox_path(self, state_dir, tmp_path):
+        """env var ON・tool_name=Monitor・commandが該当セッションのinbox pathを
+        含む・tool_responseにエラー兆候なしならマーカーを書く"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = _register_launcher(relay_state_dir)
+            path = relay_inbox.inbox_path(identity)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Monitor",
+                "tool_input": {"command": f"tail -f {path}"},
+                "tool_response": {"content": "Monitor started (task xyz)."},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert HookState(_SESSION_ID).get_monitor_started() is True
+
+    def test_no_marker_when_tool_name_is_not_monitor(self, state_dir, tmp_path):
+        """matcher対象外のtool（想定外呼び出し・防御的テスト）はマーカーを書かない"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = _register_launcher(relay_state_dir)
+            path = relay_inbox.inbox_path(identity)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Bash",
+                "tool_input": {"command": f"tail -f {path}"},
+                "tool_response": {},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert HookState(_SESSION_ID).get_monitor_started() is False
+
+    def test_no_marker_when_command_targets_unrelated_path(self, state_dir, tmp_path):
+        """コマンドが別ファイルを監視するMonitor呼び出し（このセッションのinbox
+        監視ではない）ならマーカーを書かない"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            _register_launcher(relay_state_dir)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Monitor",
+                "tool_input": {"command": "tail -f /var/log/something-unrelated.log"},
+                "tool_response": {},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert HookState(_SESSION_ID).get_monitor_started() is False
+
+    def test_no_marker_when_identity_unresolved(self, state_dir, tmp_path):
+        """launcher登録ファイルが無くidentity解決に失敗する場合はマーカーを
+        書かない（fail-open、relay非参加とみなす）"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Monitor",
+                "tool_input": {"command": "tail -f /whatever/path"},
+                "tool_response": {},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert HookState(_SESSION_ID).get_monitor_started() is False
+
+    def test_no_marker_when_tool_response_reports_error(self, state_dir, tmp_path):
+        """tool_responseが明確にis_error=Trueを示すときはマーカーを書かない"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = _register_launcher(relay_state_dir)
+            path = relay_inbox.inbox_path(identity)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {
+                "session_id": _SESSION_ID,
+                "tool_name": "Monitor",
+                "tool_input": {"command": f"tail -f {path}"},
+                "tool_response": {"is_error": True, "content": "command not found"},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert HookState(_SESSION_ID).get_monitor_started() is False
+
+    def test_no_marker_when_session_id_empty(self, state_dir, tmp_path):
+        relay_state_dir = tmp_path / "relay-state"
+
+        result = _run_hook(
+            {
+                "session_id": "",
+                "tool_name": "Monitor",
+                "tool_input": {"command": "tail -f /whatever/path"},
+                "tool_response": {},
+            },
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+
+
+class TestFailOpen:
+    """例外系はすべて空JSON出力（フェイルオープン）"""
+
+    def test_invalid_json_input(self, state_dir):
+        result = subprocess.run(
+            [sys.executable, "hooks/relay_monitor_watch_hook.py"],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+            cwd=str(_PROJECT_ROOT),
+            env={
+                **os.environ,
+                "HOOK_STATE_DIR": str(state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert "error" in result.stderr.lower()
+
+    def test_invalid_json_input_records_machine_error_signal(self, state_dir, tmp_path):
+        """top-level except到達時にsignal_eventsへmachine_errorが記録される"""
+        db_path = str(tmp_path / "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        try:
+            init_database()
+
+            result = subprocess.run(
+                [sys.executable, "hooks/relay_monitor_watch_hook.py"],
+                input="not valid json",
+                capture_output=True,
+                text=True,
+                cwd=str(_PROJECT_ROOT),
+                env={
+                    **os.environ,
+                    "HOOK_STATE_DIR": str(state_dir),
+                    "CCM_RELAY_SESSION_AWARE": "1",
+                    "DISCUSSION_DB_PATH": db_path,
+                },
+            )
+            assert result.returncode == 0
+            assert json.loads(result.stdout) == {}
+
+            conn = get_connection()
+            try:
+                row = conn.execute(
+                    "SELECT * FROM signal_events WHERE source = 'hook:relay_monitor_watch'"
+                ).fetchone()
+            finally:
+                conn.close()
+            assert row is not None
+            assert row["kind"] == "machine_error"
+        finally:
+            if "DISCUSSION_DB_PATH" in os.environ:
+                del os.environ["DISCUSSION_DB_PATH"]

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -1252,6 +1252,10 @@ class TestSessionStartHookSignals:
 class TestSessionStartHookRelayInbox:
     """relay inbox未読件数 + Monitor監視指示の表示テスト
 
+    CCM_RELAY_SESSION_AWARE=1（本クラスの既定extra_env）を渡した場合のON時の
+    振る舞いを検証する。OFF時（未設定）の振る舞いはTestSessionStartHookRelay
+    SessionAwareGateで検証する。
+
     hookは実プロセスとしてsubprocess経由で起動され、MCPリクエストコンテキストを
     一切持たない。そのためget_relay_identity()（ヘッダ/ctx.session_id経路）は
     常にNoneへ解決する。祖先pidチェーンによるフォールバック
@@ -1274,7 +1278,10 @@ class TestSessionStartHookRelayInbox:
         state_dir = tmp_path / "relay-state"
         result = _run_session_start_hook(
             temp_db,
-            extra_env={"RELAY_STATE_DIR": str(state_dir)},
+            extra_env={
+                "RELAY_STATE_DIR": str(state_dir),
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
             env_remove=["RELAY_BEARER_TOKEN"],
         )
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -1301,6 +1308,7 @@ class TestSessionStartHookRelayInbox:
             extra_env={
                 "RELAY_STATE_DIR": str(state_dir),
                 "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
             },
         )
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -1352,6 +1360,7 @@ class TestSessionStartHookRelayInbox:
             extra_env={
                 "RELAY_STATE_DIR": str(state_dir),
                 "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
             },
         )
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -1374,7 +1383,7 @@ class TestSessionStartHookRelayInbox:
 
         result = _run_session_start_hook(
             temp_db,
-            extra_env={"RELAY_STATE_DIR": str(state_dir)},
+            extra_env={"RELAY_STATE_DIR": str(state_dir), "CCM_RELAY_SESSION_AWARE": "1"},
             env_remove=["RELAY_BEARER_TOKEN"],
         )
         context = result["hookSpecificOutput"]["additionalContext"]
@@ -1384,12 +1393,14 @@ class TestSessionStartHookRelayInbox:
     def test_monitor_instruction_shown_when_inbox_never_created(self, temp_db, tmp_path):
         """identity解決・relay構成済みなら、このidentity宛のinbox fileが
         一度も作られていなくてもMonitor監視指示は出る（未読N件の報告行のみ省く。
-        セッション作業中に届く新着を取りこぼさないための常時発火）"""
+        セッション作業中に届く新着を取りこぼさないための常時発火）。
+        呼び出し後、inbox fileがtail -fの即時失敗を防ぐため先行生成されている"""
         state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
 
         os.environ["RELAY_STATE_DIR"] = str(state_dir)
         try:
-            self._register_launcher_matching_this_test_process(state_dir)
+            session_id = self._register_launcher_matching_this_test_process(state_dir)
         finally:
             del os.environ["RELAY_STATE_DIR"]
 
@@ -1398,12 +1409,18 @@ class TestSessionStartHookRelayInbox:
             extra_env={
                 "RELAY_STATE_DIR": str(state_dir),
                 "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
             },
         )
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "Monitorツール" in context
         assert "relay inbox 未読" not in context
+        os.environ["RELAY_STATE_DIR"] = str(state_dir)
+        try:
+            assert relay_inbox.inbox_path(session_id).exists()
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
 
     def test_monitor_instruction_shown_when_unread_is_zero(self, temp_db, tmp_path):
         """identity解決・relay構成済みでinbox fileが存在し、既読化済みで
@@ -1425,12 +1442,59 @@ class TestSessionStartHookRelayInbox:
             extra_env={
                 "RELAY_STATE_DIR": str(state_dir),
                 "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
             },
         )
         context = result["hookSpecificOutput"]["additionalContext"]
 
         assert "Monitorツール" in context
         assert "relay inbox 未読" not in context
+
+
+class TestSessionStartHookRelaySessionAwareGate:
+    """CCM_RELAY_SESSION_AWARE（kill switch）未設定時（デフォルトOFF）の振る舞い。
+
+    token設定済み・launcher登録済みでidentity解決可能・未読ありという
+    「本来なら表示される」全条件を満たしていても、env var未設定なら
+    relay関連の文言が一切出ないことを検証する。
+    """
+
+    def test_no_relay_text_when_env_var_unset_even_if_fully_configured(
+        self, temp_db, tmp_path
+    ):
+        state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(state_dir)
+        try:
+            sessions_dir = state_dir / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            session_id = "resolved-by-ancestry-gate-test"
+            registration = {
+                "session_id": session_id,
+                "pid": os.getpid(),
+                "ancestor_pids": [os.getpid()],
+                "created_at": "2026-07-08T00:00:00Z",
+            }
+            (sessions_dir / f"launcher-{os.getpid()}.json").write_text(
+                json.dumps(registration), encoding="utf-8"
+            )
+            relay_inbox.append(session_id, {"body": "hello"})
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_session_start_hook(
+            temp_db,
+            extra_env={
+                "RELAY_STATE_DIR": str(state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+            },
+            env_remove=["CCM_RELAY_SESSION_AWARE"],
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "relay inbox" not in context
+        assert "Monitorツール" not in context
 
 
 class TestSessionStartHookContextBudget:

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -24,15 +24,20 @@ def state_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _run_hook(input_data: dict, state_dir: Path) -> subprocess.CompletedProcess:
+def _run_hook(
+    input_data: dict, state_dir: Path, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
     """user_prompt_submit_hook.pyをサブプロセスで実行する"""
+    env = {**os.environ, "HOOK_STATE_DIR": str(state_dir)}
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [sys.executable, "hooks/user_prompt_submit_hook.py"],
         input=json.dumps(input_data),
         capture_output=True,
         text=True,
         cwd=str(_PROJECT_ROOT),
-        env={**os.environ, "HOOK_STATE_DIR": str(state_dir)},
+        env=env,
     )
 
 
@@ -274,6 +279,173 @@ class TestIdLeakNudge:
         ctx2 = json.loads(result2.stdout)["hookSpecificOutput"]["additionalContext"]
         assert "internal IDs" in ctx2
         assert HookState(_SESSION_ID).get_id_leak_count() == 0
+
+
+class TestRelaySessionAwareNudge:
+    """relay session-aware毎ターんnudge（CCM_RELAY_SESSION_AWARE=1のときのみ）
+
+    identity解決はresolve_identity_by_ancestry（祖先pidチェーン一致）に依存する。
+    _run_hookはsubprocess.runでhookを直接の子プロセスとして起動するため、hook
+    subprocessのppidは必ずこのテストプロセスのpid（os.getpid()）になる。
+    """
+
+    def _register_launcher(self, state_dir: Path) -> str:
+        session_id = "relay-nudge-resolved-by-ancestry"
+        sessions_dir = state_dir / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        registration = {
+            "session_id": session_id,
+            "pid": os.getpid(),
+            "ancestor_pids": [os.getpid()],
+            "created_at": "2026-07-08T00:00:00Z",
+        }
+        (sessions_dir / f"launcher-{os.getpid()}.json").write_text(
+            json.dumps(registration), encoding="utf-8"
+        )
+        return session_id
+
+    def test_no_injection_when_env_var_off(self, state_dir, tmp_path):
+        """env var OFF（デフォルト）なら、identity解決可能・未読ありでも何も注入しない"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = self._register_launcher(relay_state_dir)
+            relay_inbox.append(identity, {"body": "hello"})
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {"session_id": _SESSION_ID},
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+            },
+        )
+        assert json.loads(result.stdout) == {}
+
+    def test_injection_when_monitor_not_started(self, state_dir, tmp_path):
+        """env var ON・identity解決成功・Monitor未起動なら起動指示を注入する"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            self._register_launcher(relay_state_dir)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        result = _run_hook(
+            {"session_id": _SESSION_ID},
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "Monitorツール" in ctx
+        assert "未読" not in ctx
+
+    def test_injection_when_unread_present_and_monitor_started(self, state_dir, tmp_path):
+        """env var ON・Monitor起動済み・未読ありなら消化指示のみを注入する（起動指示は出ない）"""
+        relay_state_dir = tmp_path / "relay-state"
+        from src.services.relay import inbox as relay_inbox
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            identity = self._register_launcher(relay_state_dir)
+            relay_inbox.append(identity, {"body": "hello"})
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        HookState(_SESSION_ID).set_monitor_started()
+
+        result = _run_hook(
+            {"session_id": _SESSION_ID},
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "relay inbox 未読: 1件" in ctx
+        assert "relay_receive" in ctx
+        assert "Monitorツール" not in ctx
+
+    def test_no_injection_when_monitor_started_and_no_unread(self, state_dir, tmp_path):
+        """env var ON・Monitor起動済み・未読0件なら何も注入しない"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            self._register_launcher(relay_state_dir)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        HookState(_SESSION_ID).set_monitor_started()
+
+        result = _run_hook(
+            {"session_id": _SESSION_ID},
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert json.loads(result.stdout) == {}
+
+    def test_no_injection_when_identity_unresolved(self, state_dir, tmp_path):
+        """env var ON・relay構成済みでもidentity解決に失敗するセッションは
+        何も注入しない（fail-open、relay非参加とみなす。launcher登録ファイルを
+        一切置かないため、祖先pidチェーンが誰とも一致しない）"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        result = _run_hook(
+            {"session_id": _SESSION_ID},
+            state_dir,
+            extra_env={
+                "RELAY_STATE_DIR": str(relay_state_dir),
+                "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+                "CCM_RELAY_SESSION_AWARE": "1",
+            },
+        )
+        assert json.loads(result.stdout) == {}
+
+    def test_existing_record_nudge_takes_priority(self, state_dir, tmp_path):
+        """既存nudge（record等）があればrelay系より優先され、relay系は次ターンに繰り越す"""
+        relay_state_dir = tmp_path / "relay-state"
+
+        os.environ["RELAY_STATE_DIR"] = str(relay_state_dir)
+        try:
+            self._register_launcher(relay_state_dir)
+        finally:
+            del os.environ["RELAY_STATE_DIR"]
+
+        _write_events([{"e": "nudge", "type": "record", "turn": 2}], state_dir)
+
+        extra_env = {
+            "RELAY_STATE_DIR": str(relay_state_dir),
+            "RELAY_BEARER_TOKEN": "dummy-token-for-e2e",
+            "CCM_RELAY_SESSION_AWARE": "1",
+        }
+
+        # 1回目: record nudgeが優先される
+        result = _run_hook({"session_id": _SESSION_ID}, state_dir, extra_env=extra_env)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "直近の応答で記録ツール" in ctx
+
+        # 2回目: record nudgeは消費済みなのでrelay系が注入される
+        result2 = _run_hook({"session_id": _SESSION_ID}, state_dir, extra_env=extra_env)
+        ctx2 = json.loads(result2.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Monitorツール" in ctx2
 
 
 class TestFailOpen:

--- a/tests/unit/test_hook_state.py
+++ b/tests/unit/test_hook_state.py
@@ -64,6 +64,20 @@ class TestIdLeakCount:
         assert hook_state.get_id_leak_count() == 0
 
 
+class TestMonitorStarted:
+    def test_get_returns_false_when_no_file(self, hook_state):
+        assert hook_state.get_monitor_started() is False
+
+    def test_set_then_get(self, hook_state):
+        hook_state.set_monitor_started()
+        assert hook_state.get_monitor_started() is True
+
+    def test_cleared_by_clear_session(self, hook_state):
+        hook_state.set_monitor_started()
+        HookState.clear_session("test-session-123")
+        assert hook_state.get_monitor_started() is False
+
+
 class TestTranscriptOffset:
     def test_get_returns_zero_when_no_file(self, hook_state):
         assert hook_state.get_transcript_offset() == 0

--- a/tests/unit/test_relay_inbox.py
+++ b/tests/unit/test_relay_inbox.py
@@ -144,6 +144,30 @@ class TestDrainHasMore:
         assert result["has_more"] is True
 
 
+class TestEnsureInboxFile:
+    """ensure_inbox_file: Monitorの `tail -f` がファイル不在で即座に失敗しない
+    よう、inbox fileを先行生成（touch）する。"""
+
+    def test_creates_empty_file_when_absent(self):
+        path = inbox.ensure_inbox_file("never-messaged")
+        assert path == inbox.inbox_path("never-messaged")
+        assert path.exists()
+        assert path.read_bytes() == b""
+
+    def test_is_idempotent_and_does_not_truncate_existing_content(self):
+        inbox.append("s1", {"n": 1})
+        path = inbox.ensure_inbox_file("s1")
+        assert path.exists()
+        # 既存レコードが消えていない（truncateしない）ことを確認
+        assert inbox.count_unread("s1") == 1
+
+    def test_creates_parent_directory(self, tmp_path, monkeypatch):
+        fresh_state_dir = tmp_path / "not-yet-created"
+        monkeypatch.setenv("RELAY_STATE_DIR", str(fresh_state_dir))
+        path = inbox.ensure_inbox_file("s2")
+        assert path.exists()
+
+
 class TestCountUnread:
     def test_missing_inbox_returns_zero(self):
         assert inbox.count_unread("never-subscribed") == 0

--- a/tests/unit/test_session_start_relay_inbox_section.py
+++ b/tests/unit/test_session_start_relay_inbox_section.py
@@ -11,11 +11,20 @@ import tempfile
 
 import pytest
 
+import src.config as ccm_config
 import src.services.relay.config as relay_config
 import src.services.relay.identity as relay_identity
 import src.services.relay.inbox as relay_inbox
 from src.db import init_database
 from hooks.session_start_hook import _build_relay_inbox_section, _build_session_context
+
+
+@pytest.fixture(autouse=True)
+def relay_session_aware_on(monkeypatch):
+    """本ファイルの大半のテストはCCM_RELAY_SESSION_AWARE=1（ON）時の表示ロジックを
+    検証するため、autouseでデフォルトONにする。OFF時（kill switch）の振る舞いは
+    TestEnvVarGateで個別にFalseへ上書きして検証する。"""
+    monkeypatch.setattr(ccm_config, "RELAY_SESSION_AWARE_ENABLED", True)
 
 
 @pytest.fixture
@@ -111,17 +120,18 @@ class TestGateConditions:
         )
         assert _build_relay_inbox_section(None) == ""
 
-    def test_shows_monitor_instruction_when_inbox_file_not_created(
+    def test_shows_monitor_instruction_and_touches_inbox_when_never_created(
         self, monkeypatch, relay_configured
     ):
         """identity解決・relay構成済みなら、このidentity宛のinbox fileが
         一度も作られていなくてもMonitor監視指示を返す（新着を取りこぼさないため
-        既存メッセージの有無を問わず常時発火する。ファイル自体はtouchしない）"""
+        既存メッセージの有無を問わず常時発火する）。Monitorの `tail -f` が
+        ファイル不在で即座に失敗しないよう、この時点でinbox fileを先行生成する"""
         monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: "never-messaged")
         result = _build_relay_inbox_section(None)
         assert "Monitorツール" in result
         assert "未読" not in result
-        assert not relay_inbox.inbox_path("never-messaged").exists()
+        assert relay_inbox.inbox_path("never-messaged").exists()
 
 
 class TestIdentityResolved:
@@ -168,6 +178,35 @@ class TestIdentityResolved:
         monkeypatch.setattr(relay_inbox, "count_unread", lambda session_id: 1)
         result = _build_relay_inbox_section(None)
         assert str(path) in result
+
+
+class TestEnvVarGate:
+    """CCM_RELAY_SESSION_AWARE（kill switch）の振る舞い。
+
+    autouse fixtureがデフォルトONにしているため、ここでは個別にFalseへ
+    上書きしてOFF時の振る舞いを検証する。
+    """
+
+    def test_returns_empty_when_disabled_even_if_fully_configured(
+        self, monkeypatch, relay_configured
+    ):
+        """OFF時は、token設定済み・identity解決可能・未読ありでも空文字を返す
+        （relayを使わないセッションへの注入を止める入口ゲート）"""
+        monkeypatch.setattr(ccm_config, "RELAY_SESSION_AWARE_ENABLED", False)
+        monkeypatch.setattr(relay_identity, "get_relay_identity", lambda: "stable-id-1")
+        _make_inbox_file(relay_configured, "stable-id-1")
+        monkeypatch.setattr(relay_inbox, "count_unread", lambda session_id: 3)
+        assert _build_relay_inbox_section(None) == ""
+
+    def test_does_not_check_token_when_disabled(self, monkeypatch, tmp_path):
+        """OFF時はget_token()すら呼ばない（tokenチェックより手前のゼロコスト経路）"""
+        monkeypatch.setattr(ccm_config, "RELAY_SESSION_AWARE_ENABLED", False)
+
+        def boom_get_token():
+            raise AssertionError("get_token should not be called when disabled")
+
+        monkeypatch.setattr(relay_config, "get_token", boom_get_token)
+        assert _build_relay_inbox_section(None) == ""
 
 
 class TestSessionContextProtection:


### PR DESCRIPTION
## Summary

- SessionStart hookのrelay Monitor監視指示・未読件数表示は、セッション開始時の一回きりの注入だった。エージェントが読み流すと機能せず、かつrelayを使わないユーザー・セッションにも常に関連コンテキストが注入される問題があった
- `CCM_RELAY_SESSION_AWARE`環境変数（デフォルトOFF）を新設し、SessionStartの当該セクションとUserPromptSubmitの新規nudgeの両方をこの1つのスイッチでゲートする。OFF時はidentity解決すら試みず、relayを一切知らされない
- ON時、UserPromptSubmit hookが毎ターン「Monitor監視が起動済みか」「relay inbox未読が何件か」を判定し、未対応ならリマインダーを注入するようにした。Monitor起動判定は新設のPostToolUse hook（matcher: Monitor）が担い、tool_inputのコマンド文字列に対象セッションのinbox pathが含まれ、かつtool_responseに明確な失敗の兆候が無い場合にのみ、セッションIDキーのマーカーファイルを書く
- 既知バグとして、未読0件のセッションではrelay inboxのjsonlファイル自体が未生成で、素直に`tail -f`すると即座に失敗する問題があった。identity解決成功時点でinboxファイルを先行生成（touch）することで解消した

## 設計上の注記

Monitor起動判定の「呼び出しが成功したか」の扱いについて: MonitorツールのPostToolUse `tool_response`の内部構造は公開仕様が無いため、判定は保守的に倒した。`tool_response`がdict形式で`is_error`が明確に真のときのみ失敗とみなし、それ以外（構造不明を含む）はマーカーを書く側に倒している（fail-open）。実機でMonitorツール呼び出し自体は起動時点で即座に完了することを確認済みで、PostToolUseがバックグラウンド監視の終了を待つ設計ではないことは検証できている。

## Test plan

- env var OFF時、SessionStart・UserPromptSubmitのどちらの出力にもrelay関連の文言が一切含まれないこと（token設定済み・identity解決可能・未読ありという「本来なら表示される」条件を全部満たした状態でも出ないことを含む）
- env var ON時:
  - Monitor未起動なら起動指示、未読1件以上なら消化指示が、該当する行だけ束ねて注入されること
  - 両方非該当（起動済みかつ未読0件）なら何も注入しないこと
  - 既存の記録漏れnudge・id_leak nudgeがある場合はそちらが優先され、relay系は次ターンに繰り越されること
  - identity解決に失敗するセッションでは何も注入しないこと（fail-open）
- PostToolUse hookの新規テスト: commandがセッションのinbox pathと一致するときのみマーカーを書き、tool_name不一致・path不一致・identity未解決・tool_response明示エラーの各ケースではマーカーを書かないこと
- `ensure_inbox_file`: ファイル不在時の生成、既存内容を保持したままの冪等な再呼び出し、親ディレクトリ未作成時の生成
- 既存テスト（SessionStart hookのcontext budget等）への影響なし

対象範囲のunit/e2eテスト（`tests/unit/test_hook_state.py` `tests/unit/test_relay_inbox.py` `tests/unit/test_session_start_relay_inbox_section.py` `tests/e2e/test_session_start_hook.py` `tests/e2e/test_user_prompt_submit_hook.py` `tests/e2e/test_relay_monitor_watch_hook.py`）はローカルで全件pass確認済み。フルスイートはCIに委譲する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)