### PR TITLE
fix: hookの未発火・DB汚染バグを3件修正

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/session_start_hook.py"
+          },
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/sanitize_backfill_hook.py"
           }
         ]
       }
@@ -44,6 +48,17 @@
           {
             "type": "command",
             "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/preblock_hook.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python hooks/sanitize_tool_result_hook.py"
           }
         ]
       }

--- a/hooks/user_prompt_submit_hook.py
+++ b/hooks/user_prompt_submit_hook.py
@@ -117,6 +117,9 @@ def main() -> None:
 
         # 1. stdin読み込み
         raw = sys.stdin.read()
+        if not raw.strip():
+            print("{}")
+            return
         data = json.loads(raw)
         session_id = data.get("session_id", "")
 

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -276,6 +276,58 @@ class TestIdLeakNudge:
         assert HookState(_SESSION_ID).get_id_leak_count() == 0
 
 
+class TestEmptyStdin:
+    """stdin空/空白のみ → 空JSON、machine_errorシグナルは記録しない"""
+
+    def test_empty_stdin_returns_empty_json(self, state_dir):
+        proc = subprocess.run(
+            [sys.executable, "hooks/user_prompt_submit_hook.py"],
+            input="",
+            capture_output=True,
+            text=True,
+            cwd=str(_PROJECT_ROOT),
+            env={**os.environ, "HOOK_STATE_DIR": str(state_dir)},
+        )
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout) == {}
+
+    def test_whitespace_only_stdin_returns_empty_json(self, state_dir):
+        proc = subprocess.run(
+            [sys.executable, "hooks/user_prompt_submit_hook.py"],
+            input="   \n\t",
+            capture_output=True,
+            text=True,
+            cwd=str(_PROJECT_ROOT),
+            env={**os.environ, "HOOK_STATE_DIR": str(state_dir)},
+        )
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout) == {}
+
+    def test_empty_stdin_does_not_record_signal(self, state_dir, temp_db):
+        """空stdinはjson.loadsの例外経路に入らず、signal_eventsへ記録されない"""
+        from src.db import get_connection
+
+        proc = subprocess.run(
+            [sys.executable, "hooks/user_prompt_submit_hook.py"],
+            input="",
+            capture_output=True,
+            text=True,
+            cwd=str(_PROJECT_ROOT),
+            env={**os.environ, "HOOK_STATE_DIR": str(state_dir), "DISCUSSION_DB_PATH": temp_db},
+        )
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout) == {}
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT * FROM signal_events WHERE source = 'hook:user_prompt_submit'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is None
+
+
 class TestFailOpen:
     """例外→空JSON（フェイルオープン）"""
 

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -279,18 +279,6 @@ class TestIdLeakNudge:
 class TestEmptyStdin:
     """stdin空/空白のみ → 空JSON、machine_errorシグナルは記録しない"""
 
-    def test_empty_stdin_returns_empty_json(self, state_dir):
-        proc = subprocess.run(
-            [sys.executable, "hooks/user_prompt_submit_hook.py"],
-            input="",
-            capture_output=True,
-            text=True,
-            cwd=str(_PROJECT_ROOT),
-            env={**os.environ, "HOOK_STATE_DIR": str(state_dir)},
-        )
-        assert proc.returncode == 0
-        assert json.loads(proc.stdout) == {}
-
     def test_whitespace_only_stdin_returns_empty_json(self, state_dir):
         proc = subprocess.run(
             [sys.executable, "hooks/user_prompt_submit_hook.py"],

--- a/tests/unit/test_hooks_json_lint.py
+++ b/tests/unit/test_hooks_json_lint.py
@@ -1,0 +1,96 @@
+"""hooks/hooks.json の配線を実装から導出した期待値と突き合わせる lint テスト。
+
+「ロジックは正しいが hooks.json に未登録で発火しない」という配線バグ
+(sanitize_tool_result_hook.py / sanitize_backfill_hook.py が該当) は、フック
+関数自体の単体テストでは検出できない。hooks.json は文書ではなく Claude Code
+harness が読むランタイム契約そのものであるため、実装 (各フックスクリプトの
+モジュール docstring 冒頭 `"<Event> hook: ..."`) から期待される登録イベントを
+機械的に導出し、hooks.json の実際の登録内容と突き合わせる。
+"""
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_HOOKS_DIR = _PROJECT_ROOT / "hooks"
+_HOOKS_JSON_PATH = _HOOKS_DIR / "hooks.json"
+
+# hooks/ 配下のスクリプトが自身の担当イベントを宣言する規約:
+# モジュール docstring 冒頭が `"<Event> hook: ..."` の形。
+_DECLARED_EVENT_PATTERN = re.compile(r"^(\w+) hook:")
+_COMMAND_SCRIPT_PATTERN = re.compile(r"hooks/(\S+\.py)")
+
+
+def _load_hooks_json() -> dict:
+    return json.loads(_HOOKS_JSON_PATH.read_text(encoding="utf-8"))
+
+
+def _registered_scripts_by_event() -> dict[str, list[str]]:
+    """hooks.json の各イベントに登録されているスクリプトのファイル名一覧を返す。"""
+    data = _load_hooks_json()
+    result: dict[str, list[str]] = {}
+    for event_name, matcher_blocks in data.get("hooks", {}).items():
+        scripts: list[str] = []
+        for block in matcher_blocks:
+            for entry in block.get("hooks", []):
+                command = entry.get("command", "")
+                scripts.extend(_COMMAND_SCRIPT_PATTERN.findall(command))
+        result[event_name] = scripts
+    return result
+
+
+def _declared_event(script_path: Path) -> str | None:
+    """script_path の docstring 冒頭が宣言する担当イベント名を返す。
+
+    規約に従わないヘルパーモジュール (hooks.json に直接登録される想定でない
+    もの) は None を返す。
+    """
+    doc = ast.get_docstring(ast.parse(script_path.read_text(encoding="utf-8")))
+    if not doc:
+        return None
+    m = _DECLARED_EVENT_PATTERN.match(doc)
+    return m.group(1) if m else None
+
+
+def _declaring_hook_scripts() -> list[Path]:
+    scripts = []
+    for path in sorted(_HOOKS_DIR.glob("*.py")):
+        if _declared_event(path) is not None:
+            scripts.append(path)
+    return scripts
+
+
+_DECLARING_SCRIPTS = _declaring_hook_scripts()
+
+
+class TestHooksJsonScriptExistence:
+    """hooks.json が参照するコマンドが実在スクリプトを指すことの構造smoke。"""
+
+    def test_all_referenced_scripts_exist_on_disk(self):
+        registered = _registered_scripts_by_event()
+        missing = [
+            script
+            for scripts in registered.values()
+            for script in scripts
+            if not (_HOOKS_DIR / script).exists()
+        ]
+        assert missing == []
+
+
+@pytest.mark.parametrize(
+    "script_path", _DECLARING_SCRIPTS, ids=[p.name for p in _DECLARING_SCRIPTS]
+)
+def test_declared_event_script_is_registered_in_hooks_json(script_path: Path):
+    """script_path が docstring で宣言する hook イベントに、hooks.json 上で
+    実際に登録されていることを確認する。
+
+    ロジックは正しいのに hooks.json に未登録、という配線バグ (今回の
+    sanitize_tool_result_hook.py / sanitize_backfill_hook.py のケース) を、
+    今後別のフックが同種の欠陥を持った場合も含めて検知する。
+    """
+    event = _declared_event(script_path)
+    registered = _registered_scripts_by_event()
+    assert script_path.name in registered.get(event, [])

--- a/tests/unit/test_literal_type_validation.py
+++ b/tests/unit/test_literal_type_validation.py
@@ -155,7 +155,7 @@ INVALID_CASES = [
 
 
 @pytest.mark.parametrize("tool_name,args,target_key", INVALID_CASES)
-def test_invalid_literal_value_raises_validation_error(tool_name, args, target_key):
+def test_invalid_literal_value_raises_validation_error(tool_name, args, target_key, temp_db):
     """許容値以外の文字列を渡すと ValidationError で弾かれる。"""
 
     async def _call():


### PR DESCRIPTION
## Summary

- `sanitize_tool_result_hook.py`（PostToolUse）と`sanitize_backfill_hook.py`（SessionStart）がhooks.jsonに未登録だった。cc-memoryの内部IDをtranscriptへ書き込む前に構造化形式へ変換する処理が実質発火していなかったため、既存のPreToolUse/SessionStartエントリと同じ`matcher: "*"`形式で登録し、実際に動作するようにした
- literal型バリデーションの異常系パラメータ化テストがDB隔離を行わず、ValidationError発生時のmachine_errorシグナルを本番DBへ書き込んでいた。既存の他パラメータ化テストと同じ`temp_db`フィクスチャを適用し、テスト実行が本番DBに影響しないようにした
- `user_prompt_submit_hook.py`はstdinが空/空白のみの呼び出しでJSONDecodeErrorが発生し、フェイルオープン経路経由でmachine_errorシグナルが本番DBに累積していた。json.loadsに渡す前に空/空白stdinを検出して空JSONを返すガードを追加し、シグナル記録自体が発生しないようにした

## 設計上のトレードオフ

`PostToolUse`に`matcher: "*"`で`sanitize_tool_result_hook.py`を登録したことで、cc-memoryのツール呼び出しに限らず全ツール呼び出しのたびに同スクリプトのサブプロセス起動が発生する（ツール1回あたりのプロセス起動が`PreToolUse`分と合わせて2回に増える）。この方式は`PreToolUse`（`preblock_hook.py`）が既に採っている「`matcher: "*"`で登録し、対象ツールかどうかの絞り込みはスクリプト内部のtool_name判定に委ねる」パターンと一貫させることを優先した結果であり、意図的なトレードオフである。

## Test plan

- 空/空白stdin入力時: hookが空JSONを返し、`signal_events`テーブルへの記録が発生しないことを検証
- 不正JSON入力時（既存の例外経路）: 空JSONを返しつつ`signal_events`へmachine_errorが記録される、という従来の挙動が維持されていることを検証
- literal型バリデーションの異常系テストがDB隔離下で実行され、本番DBを汚染しないことを確認
- hooks.json の配線を実装（各フックスクリプトのdocstring宣言）から導出して突き合わせる回帰テストを追加。これにより「ロジックは正しいがhooks.jsonに未登録」という今回と同種の欠陥を機械的に検知できることを確認（登録前の状態を再現させてテストが実際に落ちることも確認済み）
- 変更対象ファイルに対応するテスト（e2e/unit）はpass、既存テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
