### PR TITLE
fix: embeddingサーバーのモデルロードでdeviceをCPUに固定する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,4 +35,5 @@ cc-memoryはローカルディレクトリをmarketplaceとして登録してお
 5. プラグインキャッシュを削除: `rm -rf ~/.claude/plugins/cache/claude-code-memory-marketplace/`
 6. `__pycache__` を削除: `find . -type d -name __pycache__ -exec rm -rf {} +`
 7. 既存のhttpサーバーを停止・再起動: `lsof -ti tcp:52837 -sTCP:LISTEN | xargs kill; uv run python -m src.launcher &`（`-sTCP:LISTEN` を付けないと :52837 に接続中のブリッジプロセスまで巻き添えで kill され、生存セッションの再接続競争を誘発する。多数のセッションが同時接続している状態でkillすると、再接続待ちのブリッジ全部が同時に起動リトライを行い、起動が失敗することがある）
-8. 生存している全Claude Codeセッションで `/mcp` からreconnectを実行する（個別でOK、全セッション同時に落とす必要なし）。reconnectで復旧しない場合はそのセッションを再起動する
+8. embeddingサーバーを停止: `lsof -ti tcp:52836 -sTCP:LISTEN | xargs kill`（再起動は不要。次回encode時に`embedding_service`がlazy spawnする。`-sTCP:LISTEN`を付けないと接続中クライアントを巻き添えにする）
+9. 生存している全Claude Codeセッションで `/mcp` からreconnectを実行する（個別でOK、全セッション同時に落とす必要なし）。reconnectで復旧しない場合はそのセッションを再起動する

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -132,7 +132,7 @@ graph TB
 ### 3.4 埋め込み
 
 - `src/services/embedding_service.py`: アプリ側からembedding取得を呼ぶクライアント
-- `src/infra/embedding_server.py`: モデル保持・encodeを1プロセスに集約するHTTPサーバー（localhost:52836、idle timeout 5分、モデル `cl-nagoya/ruri-v3-70m`）。横断インフラ寄りだが本体はストア層が読むため §3 にも記載
+- `src/infra/embedding_server.py`: モデル保持・encodeを1プロセスに集約するHTTPサーバー（localhost:52836、リクエストTTL 3600秒/drain idle 30秒/drain deadline 1800秒でgraceful shutdown、いずれもenv varで調整可、モデル `cl-nagoya/ruri-v3-70m`）。横断インフラ寄りだが本体はストア層が読むため §3 にも記載
 
 ### 3.5 公開IF
 

--- a/src/infra/embedding_server.py
+++ b/src/infra/embedding_server.py
@@ -80,7 +80,9 @@ def _load_model():
     try:
         from sentence_transformers import SentenceTransformer
 
-        _model = SentenceTransformer(MODEL_NAME)
+        # Apple SiliconではMPSが自動選択され、過去にMetal GPUの数十GB級メモリ暴走を
+        # 起こしたため、小型モデルはCPU固定とする。
+        _model = SentenceTransformer(MODEL_NAME, device="cpu")
         logger.info(f"Model loaded successfully: {MODEL_NAME}")
     except Exception as e:
         logger.error(f"Model loading failed: {e}")

--- a/tests/services/test_embedding_server_startup.py
+++ b/tests/services/test_embedding_server_startup.py
@@ -8,6 +8,7 @@ import socket
 
 import pytest
 
+import sentence_transformers
 from src.infra import embedding_server
 from src.infra.lock_file import is_port_listening
 
@@ -47,3 +48,24 @@ def test_main_binds_port_before_model_load(monkeypatch):
             created["server"].server_close()
 
     assert load_observed["port_bound"] is True
+
+
+def test_load_model_passes_cpu_device(monkeypatch):
+    """_load_model(): SentenceTransformer に device="cpu" を明示で渡す。
+
+    Apple SiliconではMPSが自動選択されるため、明示なしだと device 引数不足の
+    まま MPS にフォールバックしてしまう。
+    """
+    recorded_kwargs = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, **kwargs):
+            recorded_kwargs["model_name"] = model_name
+            recorded_kwargs.update(kwargs)
+
+    monkeypatch.setattr(sentence_transformers, "SentenceTransformer", FakeSentenceTransformer)
+
+    embedding_server._load_model()
+
+    assert recorded_kwargs["model_name"] == embedding_server.MODEL_NAME
+    assert recorded_kwargs["device"] == "cpu"


### PR DESCRIPTION
## 概要

Apple SiliconではSentenceTransformerのモデルロード時にMPS（Metal Performance Shaders）が自動選択されうる。過去にこの自動選択が原因でMetal GPU側のメモリ使用量が数十GB級まで暴走した事例があり、小型モデルを扱うこのサーバーではその挙動を避ける必要がある。

## Before/After

- Before: モデルロード時にdeviceを指定せず、環境によってはMPSが選択されメモリ暴走のリスクがあった
- After: モデルロード時にCPUを明示指定し、MPS自動選択を回避する

あわせて以下のドキュメント記述を実装の現状に合わせて修正した。

- embeddingサーバーのシャットダウン仕様（idle timeoutベースの説明→リクエストTTL/drain idle/drain deadlineベースの説明）
- サーバー保守手順（52837の再起動手順に続けて、embeddingサーバー(52836)側の停止手順を追記。停止のみで次回encode時にlazy spawnするため再起動は不要）

## テスト計画

新規テスト（`test_load_model_passes_cpu_device`）の検証項目:

- `_load_model()`がSentenceTransformerのコンストラクタにモデル名とともに`device="cpu"`を渡すこと

既存テスト（起動・シャットダウン・embeddingサービス関連）への影響なし、全件pass維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)