### PR TITLE
feat: add_activityに作成と同時にpinを張るpins引数を追加

### DIFF
--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -266,9 +266,11 @@ Claude Codeセッション間の通信・文脈配信レイヤ。relay v2 サー
 | description | string | yes | - | 詳細説明 |
 | tags | list[string] | yes | - | 1個以上。`domain:` と `intent:` 必須 |
 | related | list[RelatedRef] | no | null | 関連エンティティ |
+| pins | list[PinRef] | no | null | `[{"type": "tag"\|"activity"\|"topic"\|"decision"\|"log"\|"material", "ref": int\|string}]`。作成されたactivity自身をsourceにpinを張る。refはadd_pinのtarget_refと同じ形式（tagのみnamespace:name文字列可） |
 | check_in | bool | no | true | 作成後にcheck_inを実行するか |
 
 **返り値**: 作成されたアクティビティ情報。check_in=Trueの場合は `check_in_result` を含む。
+**pinsのエラー**: いずれか1件でも解決に失敗すると、activity作成自体（activity_tags・relationsを含む）を巻き戻す。部分成功はしない。
 
 ### 2.12 get_activities
 

--- a/src/main.py
+++ b/src/main.py
@@ -895,6 +895,7 @@ def add_activity(
     description: str,
     tags: list[str],
     related: list[dict] | None = None,
+    pins: list[dict] | None = None,
     check_in: bool = True,
     orch_managed: bool = False,
 ) -> dict:
@@ -906,6 +907,7 @@ def add_activity(
     - トピック紐付け: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], related=[{"type": "topic", "ids": [123]}])
     - 複数関連: add_activity("...", "...", [...], related=[{"type": "topic", "ids": [1, 2]}, {"type": "activity", "ids": [3]}])
     - intent:implementは合意済みdecisionをrelateする: add_activity("...", "...", ["domain:cc-memory", "intent:implement"], related=[{"type": "decision", "ids": [10, 11]}])
+    - 作成と同時にpinも張る: add_activity("...", "...", [...], pins=[{"type": "material", "ref": 42}, {"type": "tag", "ref": "domain:cc-memory"}])
     - check_inなしで作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], check_in=False)
     - orchが管理するアクティビティとして作成: add_activity("...", "...", [...], orch_managed=True)
 
@@ -914,6 +916,7 @@ def add_activity(
         description: アクティビティの詳細説明（必須）。スコアリングに活用されるため、以下の情報があれば記載を推奨: 締め切り、ブロッカー（自分が/外部）、影響度・緊急度
         tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
         related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1]}, {"type": "decision", "ids": [10, 11]}]。作成と同時にリレーションを張る。intent:implementタグを含む場合、relatedにtype='decision'のエントリを最低1件含めないとIMPLEMENT_WORKFLOW_GUARDエラーで弾かれる（議論・設計フェーズで合意したdecisionか、いきなりimplementする理由を記録したdecisionをrelateする）
+        pins: 作成したactivity自身から張るpin（optional）。[{"type": "tag"|"activity"|"topic"|"decision"|"log"|"material", "ref": int|str}, ...] 形式。sourceは作成されたactivity自身になる。refはadd_pinのtarget_refと同じ形式（tagのみnamespace:name文字列を許容、それ以外は整数ID）。例: [{"type": "material", "ref": 42}, {"type": "tag", "ref": "domain:cc-memory"}]。いずれかのpinが解決できない・存在しない場合、activity自体の作成も含めて全体が失敗する（部分成功はしない）
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）。Trueの場合、返り値にcheck_in_resultが含まれる
         orch_managed: orchが管理するアクティビティか（デフォルト: False）。Trueを指定すると個人フローのSessionStart一覧から除外され、Stop hookのcheck-inブロック・nudgeも抑制される。orchワークフローで作成するアクティビティに付与する
 
@@ -921,7 +924,7 @@ def add_activity(
         作成されたアクティビティ情報（check_in=Trueの場合はcheck_in_resultにtag_notes等を含む）
     """
     result = activity_service.add_activity(
-        title, description, tags, related=related, check_in=check_in,
+        title, description, tags, related=related, pins=pins, check_in=check_in,
         orch_managed=orch_managed,
     )
     if "error" not in result:

--- a/src/main.py
+++ b/src/main.py
@@ -903,22 +903,22 @@ def add_activity(
     新しいアクティビティを追加する。デフォルトで作成後にcheck_inも実行する。
 
     典型的な使い方:
-    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search", "ranking"])
-    - トピック紐付け: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], related=[{"type": "topic", "ids": [123]}])
-    - 複数関連: add_activity("...", "...", [...], related=[{"type": "topic", "ids": [1, 2]}, {"type": "activity", "ids": [3]}])
-    - intent:implementは合意済みdecisionをrelateする: add_activity("...", "...", ["domain:cc-memory", "intent:implement"], related=[{"type": "decision", "ids": [10, 11]}])
-    - 作成と同時にpinも張る: add_activity("...", "...", [...], pins=[{"type": "material", "ref": 42}, {"type": "tag", "ref": "domain:cc-memory"}])
-    - check_inなしで作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement"], check_in=False)
-    - orchが管理するアクティビティとして作成: add_activity("...", "...", [...], orch_managed=True)
+    - 作業アクティビティを作成: add_activity("○○機能を実装", "詳細説明...", ["domain:cc-memory", "intent:implement", "search"])
+    - トピック紐付け: add_activity(..., related=[{"type": "topic", "ids": [123]}])
+    - 複数関連: add_activity(..., related=[{"type": "topic", "ids": [1, 2]}, {"type": "activity", "ids": [3]}])
+    - intent:implementはdecisionをrelateする: add_activity(..., ["domain:cc-memory", "intent:implement"], related=[{"type": "decision", "ids": [10, 11]}])
+    - 作成と同時にpinも張る: add_activity(..., pins=[{"type": "material", "ref": 42}, {"type": "tag", "ref": "domain:cc-memory"}])
+    - check_inなしで作成: add_activity(..., check_in=False)
+    - orch管理として作成: add_activity(..., orch_managed=True)
 
     Args:
         title: アクティビティのタイトル（35字以内）
-        description: アクティビティの詳細説明（必須）。スコアリングに活用されるため、以下の情報があれば記載を推奨: 締め切り、ブロッカー（自分が/外部）、影響度・緊急度
-        tags: タグ配列（必須、1個以上）。domain:タグとintent:タグは必須。素タグも積極的に付けること。namespace: domain:(プロジェクト)/intent:(意図)/素タグ(キーワード)。例: ["domain:cc-memory", "intent:implement", "search", "ranking"]
-        related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式。複数エンティティを配列で同時紐付け可能。例: [{"type": "topic", "ids": [1]}, {"type": "decision", "ids": [10, 11]}]。作成と同時にリレーションを張る。intent:implementタグを含む場合、relatedにtype='decision'のエントリを最低1件含めないとIMPLEMENT_WORKFLOW_GUARDエラーで弾かれる（議論・設計フェーズで合意したdecisionか、いきなりimplementする理由を記録したdecisionをrelateする）
-        pins: 作成したactivity自身から張るpin（optional）。[{"type": "tag"|"activity"|"topic"|"decision"|"log"|"material", "ref": int|str}, ...] 形式。sourceは作成されたactivity自身になる。refはadd_pinのtarget_refと同じ形式（tagのみnamespace:name文字列を許容、それ以外は整数ID）。例: [{"type": "material", "ref": 42}, {"type": "tag", "ref": "domain:cc-memory"}]。いずれかのpinが解決できない・存在しない場合、activity自体の作成も含めて全体が失敗する（部分成功はしない）
-        check_in: 作成後にcheck_inを実行するか（デフォルト: True）。Trueの場合、返り値にcheck_in_resultが含まれる
-        orch_managed: orchが管理するアクティビティか（デフォルト: False）。Trueを指定すると個人フローのSessionStart一覧から除外され、Stop hookのcheck-inブロック・nudgeも抑制される。orchワークフローで作成するアクティビティに付与する
+        description: アクティビティの詳細説明（必須）。スコアリングに活用されるため、締め切り・ブロッカー・影響度/緊急度があれば記載を推奨
+        tags: タグ配列（必須、1個以上）。domain:とintent:は必須、素タグも積極的に付ける。例: ["domain:cc-memory", "intent:implement", "search"]
+        related: 関連エンティティ（optional）。[{"type": "topic"|"activity"|"material"|"decision"|"log", "ids": [int, ...]}, ...] 形式、複数同時紐付け可。作成と同時にリレーションを張る。intent:implementタグ時はtype="decision"を1件以上含めないとIMPLEMENT_WORKFLOW_GUARDエラーになる
+        pins: 作成したactivity自身から張るpin（optional）。[{"type": "tag"|"activity"|"topic"|"decision"|"log"|"material", "ref": int|str}, ...] 形式（refはadd_pinのtarget_refと同じ、tagのみnamespace:name文字列可）。いずれか1件でも解決失敗すると、activity作成自体を含め全体がロールバックされる（部分成功なし）
+        check_in: 作成後にcheck_inを実行するか（デフォルト: True）。Trueなら返り値にcheck_in_resultを含む
+        orch_managed: orch管理アクティビティか（デフォルト: False）。TrueならSessionStart一覧・Stop hookのcheck-in催促から除外される
 
     Returns:
         作成されたアクティビティ情報（check_in=Trueの場合はcheck_in_resultにtag_notes等を含む）

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -8,6 +8,7 @@ from src.db import get_connection, row_to_dict
 from src.services.citations_service import upsert_citations_for_owner_with_conn
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
+from src.services.pin_service import ENTITY_TABLE_MAP as PIN_ENTITY_TABLE_MAP, _add_pin_with_conn
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.title_validation import validate_title
@@ -112,11 +113,39 @@ def _check_implement_workflow_guard(
     }
 
 
+def _validate_pins(pins: list[dict]) -> dict | None:
+    """add_activityのpins引数をバリデーションする。不正な場合はエラーdictを返す。"""
+    if not pins:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "pins must not be empty",
+            }
+        }
+    for pin in pins:
+        if "type" not in pin or "ref" not in pin:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": "Each pin must have 'type' and 'ref' fields",
+                }
+            }
+        if pin["type"] not in PIN_ENTITY_TABLE_MAP:
+            return {
+                "error": {
+                    "code": "VALIDATION_ERROR",
+                    "message": f"Invalid pin type: {pin['type']}. Must be one of: {', '.join(sorted(PIN_ENTITY_TABLE_MAP.keys()))}",
+                }
+            }
+    return None
+
+
 def add_activity(
     title: str,
     description: str,
     tags: list[str],
     related: list[dict] | None = None,
+    pins: list[dict] | None = None,
     check_in: bool = True,
     orch_managed: bool = False,
 ) -> dict:
@@ -133,6 +162,12 @@ def add_activity(
             例: [{"type": "topic", "ids": [1, 2]}, {"type": "decision", "ids": [10]}]
             intent:implement タグを含む場合、related に type='decision' のエントリを
             最低1件含めないと IMPLEMENT_WORKFLOW_GUARD エラーで弾かれる。
+        pins: 作成したactivity自身から張るpin（optional）。
+            [{"type": "tag" | "activity" | "topic" | "decision" | "log" | "material", "ref": int | str}, ...] 形式。
+            source は作成された activity 自身になる。ref は add_pin の target_ref と同じ形式
+            （tag のみ namespace:name 文字列を許容、それ以外は整数ID）。
+            いずれかの pin が解決できない・存在しない場合、activity 自体の作成も含めて
+            全体が失敗する（部分成功はしない）。
         check_in: 作成後にcheck_inを実行するか（デフォルト: True）
         orch_managed: orch が管理する activity か（デフォルト: False）。
             True を指定すると activities.orch_managed = 1 で作成される。
@@ -154,6 +189,12 @@ def add_activity(
     # relatedのバリデーション
     if related:
         err = _validate_targets("activity", related)
+        if err:
+            return err
+
+    # pinsのバリデーション
+    if pins:
+        err = _validate_pins(pins)
         if err:
             return err
 
@@ -179,6 +220,17 @@ def add_activity(
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "activity", activity_id, related)
+
+        # pinを追加（source は作成した activity 自身）。
+        # いずれかが失敗したらトランザクション全体を破棄し、activity作成自体も失敗させる。
+        if pins:
+            for pin in pins:
+                pin_result = _add_pin_with_conn(
+                    conn, "activity", activity_id, pin["type"], pin["ref"]
+                )
+                if "error" in pin_result:
+                    conn.rollback()
+                    return pin_result
 
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -114,14 +114,10 @@ def _check_implement_workflow_guard(
 
 
 def _validate_pins(pins: list[dict]) -> dict | None:
-    """add_activityのpins引数をバリデーションする。不正な場合はエラーdictを返す。"""
-    if not pins:
-        return {
-            "error": {
-                "code": "VALIDATION_ERROR",
-                "message": "pins must not be empty",
-            }
-        }
+    """add_activityのpins引数をバリデーションする。不正な場合はエラーdictを返す。
+
+    呼び出し元は空リスト・Noneをno-opとして扱い、非空の場合のみ本関数を呼ぶ。
+    """
     for pin in pins:
         if "type" not in pin or "ref" not in pin:
             return {
@@ -221,6 +217,10 @@ def add_activity(
         if related:
             _add_relation_with_conn(conn, "activity", activity_id, related)
 
+        publish_entity_event_with_conn(
+            conn, entity_type="activity", entity_id=activity_id, event="created"
+        )
+
         # pinを追加（source は作成した activity 自身）。
         # いずれかが失敗したらトランザクション全体を破棄し、activity作成自体も失敗させる。
         if pins:
@@ -235,10 +235,6 @@ def add_activity(
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(
             conn, "activity", activity_id, title=title, description=description
-        )
-
-        publish_entity_event_with_conn(
-            conn, entity_type="activity", entity_id=activity_id, event="created"
         )
 
         conn.commit()

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -10,7 +10,10 @@ from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.pin_service import ENTITY_TABLE_MAP as PIN_ENTITY_TABLE_MAP, _add_pin_with_conn
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
-from src.services.relay.entity_publish import publish_entity_event_with_conn
+from src.services.relay.entity_publish import (
+    bump_updated_at_and_publish_with_conn,
+    publish_entity_event_with_conn,
+)
 from src.services.title_validation import validate_title
 from src.services.tag_service import (
     validate_and_parse_tags,
@@ -223,14 +226,23 @@ def add_activity(
 
         # pinを追加（source は作成した activity 自身）。
         # いずれかが失敗したらトランザクション全体を破棄し、activity作成自体も失敗させる。
+        # bump+publishはpinごとに個別発火させず、relation_serviceの
+        # _bump_and_publish_endpoints_with_connと同様にsourceを1回・targetを
+        # 重複排除してループ後にまとめて行う（outbox行の重複増殖を防ぐ）。
         if pins:
+            seen_targets: set[tuple[str, int]] = set()
             for pin in pins:
                 pin_result = _add_pin_with_conn(
-                    conn, "activity", activity_id, pin["type"], pin["ref"]
+                    conn, "activity", activity_id, pin["type"], pin["ref"], bump=False
                 )
                 if "error" in pin_result:
                     conn.rollback()
                     return pin_result
+                seen_targets.add((pin_result["target_type"], pin_result["target_id"]))
+
+            bump_updated_at_and_publish_with_conn(conn, "activity", activity_id)
+            for target_type, target_id in seen_targets:
+                bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
 
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -119,15 +119,21 @@ def _resolve_ref(
         })
 
 
-def add_pin(
+def _add_pin_with_conn(
+    conn: sqlite3.Connection,
     source_type: str,
     source_ref: Union[int, str],
     target_type: str,
     target_ref: Union[int, str],
 ) -> dict:
-    """pinを追加する（source → target）。
+    """conn共有版: pinを追加する（source → target）。
+
+    add_pin本体、およびエンティティ作成と同時にpinを張る経路
+    （activity_service.add_activity等）の両方から呼ばれる中核処理。
+    commit/rollback/closeは呼び出し元の責務。
 
     Args:
+        conn: DB接続（呼び出し元のトランザクションに参加）
         source_type: 起点エンティティ種別
         source_ref: 起点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
         target_type: 終点エンティティ種別
@@ -153,107 +159,130 @@ def add_pin(
             }
         }
 
-    conn = get_connection()
-    try:
-        # ref解決
-        source_id, err = _resolve_ref(conn, source_type, source_ref)
-        if err:
-            return err
-        if source_id is None:
-            return {
-                "error": {
-                    "code": "NOT_FOUND",
-                    "message": f"tag '{source_ref}' not found",
-                }
+    # ref解決
+    source_id, err = _resolve_ref(conn, source_type, source_ref)
+    if err:
+        return err
+    if source_id is None:
+        return {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"tag '{source_ref}' not found",
             }
-
-        target_id, err = _resolve_ref(conn, target_type, target_ref)
-        if err:
-            return err
-        if target_id is None:
-            return {
-                "error": {
-                    "code": "NOT_FOUND",
-                    "message": f"tag '{target_ref}' not found",
-                }
-            }
-
-        # 自己参照拒否
-        if source_type == target_type and source_id == target_id:
-            return {
-                "error": {
-                    "code": "VALIDATION_ERROR",
-                    "message": f"Self-reference is not allowed: {source_type}#{source_id} → {target_type}#{target_id}",
-                }
-            }
-
-        # 存在性チェック
-        source_table = ENTITY_TABLE_MAP[source_type]
-        row = conn.execute(
-            f"SELECT id FROM {source_table} WHERE id = ?", (source_id,)
-        ).fetchone()
-        if not row:
-            return {
-                "error": {
-                    "code": "NOT_FOUND",
-                    "message": f"{source_type} with id {source_id} not found",
-                }
-            }
-
-        target_table = ENTITY_TABLE_MAP[target_type]
-        row = conn.execute(
-            f"SELECT id FROM {target_table} WHERE id = ?", (target_id,)
-        ).fetchone()
-        if not row:
-            return {
-                "error": {
-                    "code": "NOT_FOUND",
-                    "message": f"{target_type} with id {target_id} not found",
-                }
-            }
-
-        # INSERT OR IGNORE（冪等）
-        conn.execute(
-            "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
-            (source_type, source_id, target_type, target_id),
-        )
-        # 実際に新規追加された（冪等な再呼び出しでない）ときのみ、pin自体は独立
-        # publishせずsource/target両entityをevent:updatedでpublishする
-        if conn.execute("SELECT changes()").fetchone()[0] > 0:
-            bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
-            bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
-        conn.commit()
-
-        result = {
-            "source_type": source_type,
-            "source_id": source_id,
-            "target_type": target_type,
-            "target_id": target_id,
         }
 
-        # supersededへのpinはhintを付与する（自動解決はしない）。
-        # hintクエリはcommit済みpinへの補足情報。失敗してもpin挿入は維持しhintなしで返す。
-        try:
-            hints = []
-            if source_type == "decision":
-                superseder_id = _is_decision_superseded(conn, source_id)
-                if superseder_id is not None:
-                    hints.append(
-                        f"decision#{source_id} は decision#{superseder_id} に superseded されています。"
-                        f"古い decision を意図的に pin する場合はそのままで問題ありません。"
-                    )
-            if target_type == "decision":
-                superseder_id = _is_decision_superseded(conn, target_id)
-                if superseder_id is not None:
-                    hints.append(
-                        f"decision#{target_id} は decision#{superseder_id} に superseded されています。"
-                        f"古い decision を意図的に pin する場合はそのままで問題ありません。"
-                    )
-            if hints:
-                result["hint"] = "\n".join(hints)
-        except Exception:
-            pass
+    target_id, err = _resolve_ref(conn, target_type, target_ref)
+    if err:
+        return err
+    if target_id is None:
+        return {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"tag '{target_ref}' not found",
+            }
+        }
 
+    # 自己参照拒否
+    if source_type == target_type and source_id == target_id:
+        return {
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": f"Self-reference is not allowed: {source_type}#{source_id} → {target_type}#{target_id}",
+            }
+        }
+
+    # 存在性チェック
+    source_table = ENTITY_TABLE_MAP[source_type]
+    row = conn.execute(
+        f"SELECT id FROM {source_table} WHERE id = ?", (source_id,)
+    ).fetchone()
+    if not row:
+        return {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"{source_type} with id {source_id} not found",
+            }
+        }
+
+    target_table = ENTITY_TABLE_MAP[target_type]
+    row = conn.execute(
+        f"SELECT id FROM {target_table} WHERE id = ?", (target_id,)
+    ).fetchone()
+    if not row:
+        return {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"{target_type} with id {target_id} not found",
+            }
+        }
+
+    # INSERT OR IGNORE（冪等）
+    conn.execute(
+        "INSERT OR IGNORE INTO pins (source_type, source_id, target_type, target_id) VALUES (?, ?, ?, ?)",
+        (source_type, source_id, target_type, target_id),
+    )
+    # 実際に新規追加された（冪等な再呼び出しでない）ときのみ、pin自体は独立
+    # publishせずsource/target両entityをevent:updatedでpublishする
+    if conn.execute("SELECT changes()").fetchone()[0] > 0:
+        bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
+        bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
+
+    result = {
+        "source_type": source_type,
+        "source_id": source_id,
+        "target_type": target_type,
+        "target_id": target_id,
+    }
+
+    # supersededへのpinはhintを付与する（自動解決はしない）。
+    # hintクエリはpin挿入への補足情報。失敗してもpin挿入は維持しhintなしで返す。
+    try:
+        hints = []
+        if source_type == "decision":
+            superseder_id = _is_decision_superseded(conn, source_id)
+            if superseder_id is not None:
+                hints.append(
+                    f"decision#{source_id} は decision#{superseder_id} に superseded されています。"
+                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                )
+        if target_type == "decision":
+            superseder_id = _is_decision_superseded(conn, target_id)
+            if superseder_id is not None:
+                hints.append(
+                    f"decision#{target_id} は decision#{superseder_id} に superseded されています。"
+                    f"古い decision を意図的に pin する場合はそのままで問題ありません。"
+                )
+        if hints:
+            result["hint"] = "\n".join(hints)
+    except Exception:
+        pass
+
+    return result
+
+
+def add_pin(
+    source_type: str,
+    source_ref: Union[int, str],
+    target_type: str,
+    target_ref: Union[int, str],
+) -> dict:
+    """pinを追加する（source → target）。
+
+    Args:
+        source_type: 起点エンティティ種別
+        source_ref: 起点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+        target_type: 終点エンティティ種別
+        target_ref: 終点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+
+    Returns:
+        成功時: {"source_type": str, "source_id": int, "target_type": str, "target_id": int}
+        失敗時: {"error": {"code": str, "message": str}}
+    """
+    conn = get_connection()
+    try:
+        result = _add_pin_with_conn(conn, source_type, source_ref, target_type, target_ref)
+        if "error" not in result:
+            conn.commit()
         return result
 
     except Exception as e:

--- a/src/services/pin_service.py
+++ b/src/services/pin_service.py
@@ -125,6 +125,7 @@ def _add_pin_with_conn(
     source_ref: Union[int, str],
     target_type: str,
     target_ref: Union[int, str],
+    bump: bool = True,
 ) -> dict:
     """conn共有版: pinを追加する（source → target）。
 
@@ -138,6 +139,9 @@ def _add_pin_with_conn(
         source_ref: 起点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
         target_type: 終点エンティティ種別
         target_ref: 終点エンティティのID（intまたはstr）。tagのみnamespace:name形式を許容
+        bump: 実際にpinが新規追加されたとき、source/targetをこの関数内でbump+publishするか。
+            複数pinを1呼び出し元でループ処理する場合（activity_service.add_activity等）は
+            False を渡し、呼び出し元でsourceを1回・targetを重複排除してbumpする。
 
     Returns:
         成功時: {"source_type": str, "source_id": int, "target_type": str, "target_id": int}
@@ -223,7 +227,7 @@ def _add_pin_with_conn(
     )
     # 実際に新規追加された（冪等な再呼び出しでない）ときのみ、pin自体は独立
     # publishせずsource/target両entityをevent:updatedでpublishする
-    if conn.execute("SELECT changes()").fetchone()[0] > 0:
+    if bump and conn.execute("SELECT changes()").fetchone()[0] > 0:
         bump_updated_at_and_publish_with_conn(conn, source_type, source_id)
         bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
 

--- a/tests/unit/test_activity_service.py
+++ b/tests/unit/test_activity_service.py
@@ -177,6 +177,38 @@ class TestAddActivityPinsFailure:
         assert "error" in result
         assert result["error"]["code"] == "VALIDATION_ERROR"
 
+    def test_pin_failure_rolls_back_related_and_tags(self, topic):
+        """related・pinsを両方指定してpinが失敗した場合、activity_tags・relationsも残らない"""
+        topic_id = topic["topic_id"]
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            related=[{"type": "topic", "ids": [topic_id]}],
+            pins=[{"type": "material", "ref": 99999}],
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+        conn = get_connection()
+        try:
+            activity_row = conn.execute(
+                "SELECT id FROM activities WHERE title = ?", ("テストactivity",)
+            ).fetchone()
+            assert activity_row is None
+
+            tag_count = conn.execute(
+                "SELECT COUNT(*) FROM activity_tags"
+            ).fetchone()[0]
+            assert tag_count == 0
+
+            relation_count = conn.execute(
+                "SELECT COUNT(*) FROM relations WHERE source_type = 'activity'"
+            ).fetchone()[0]
+            assert relation_count == 0
+        finally:
+            conn.close()
+
 
 class TestAddActivityPinsIdempotent:
     """pins引数: 冪等性"""

--- a/tests/unit/test_activity_service.py
+++ b/tests/unit/test_activity_service.py
@@ -1,0 +1,231 @@
+"""activity_service の単体テスト
+
+add_activityのpins引数（作成と同時にpinを張る機能）の挙動を検証する。
+"""
+import os
+import tempfile
+import pytest
+
+from src.db import init_database, get_connection
+from src.services.activity_service import add_activity
+from src.services.material_service import add_material
+from src.services.topic_service import add_topic
+from src.services.tag_service import _injected_tags, ensure_tag_ids
+
+
+DEFAULT_TAGS = ["domain:test"]
+
+
+@pytest.fixture
+def temp_db():
+    """テスト用の一時的なデータベースを作成する"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        _injected_tags.clear()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def material(temp_db):
+    """テスト用資材を作成する"""
+    return add_material(
+        title="テスト資材",
+        content="テスト資材の内容",
+        tags=DEFAULT_TAGS,
+        source="テスト用データ",
+    )
+
+
+@pytest.fixture
+def topic(temp_db):
+    """テスト用トピックを作成する"""
+    return add_topic(title="テストトピック", description="テスト用", tags=DEFAULT_TAGS)
+
+
+def _pin_exists(activity_id: int, target_type: str, target_id: int) -> bool:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM pins WHERE source_type='activity' AND source_id=? "
+            "AND target_type=? AND target_id=?",
+            (activity_id, target_type, target_id),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+class TestAddActivityPinsBasic:
+    """pins引数: 作成と同時にpinを張る"""
+
+    def test_pin_to_material_on_create(self, material):
+        """materialへのpinを作成と同時に張れる"""
+        material_id = material["material_id"]
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "material", "ref": material_id}],
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+        assert _pin_exists(activity_id, "material", material_id)
+
+    def test_pin_to_topic_on_create(self, topic):
+        """topicへのpinを作成と同時に張れる"""
+        topic_id = topic["topic_id"]
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "topic", "ref": topic_id}],
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+        assert _pin_exists(activity_id, "topic", topic_id)
+
+    def test_pin_to_tag_ref_string_on_create(self, temp_db):
+        """tagのrefをnamespace:name形式の文字列で指定できる"""
+        conn = get_connection()
+        try:
+            tag_ids = ensure_tag_ids(conn, [("domain", "cc-memory")])
+            conn.commit()
+            tag_id = tag_ids[0]
+        finally:
+            conn.close()
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "tag", "ref": "domain:cc-memory"}],
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+        assert _pin_exists(activity_id, "tag", tag_id)
+
+    def test_multiple_pins_on_create(self, material, topic):
+        """複数のpinを同時に張れる"""
+        material_id = material["material_id"]
+        topic_id = topic["topic_id"]
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[
+                {"type": "material", "ref": material_id},
+                {"type": "topic", "ref": topic_id},
+            ],
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+        assert _pin_exists(activity_id, "material", material_id)
+        assert _pin_exists(activity_id, "topic", topic_id)
+
+
+class TestAddActivityPinsFailure:
+    """pins引数: 失敗時は全体を失敗させる（部分成功しない）"""
+
+    def test_nonexistent_pin_target_fails_entire_creation(self, temp_db):
+        """存在しないpin targetを指定するとactivity自体の作成も失敗する"""
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "material", "ref": 99999}],
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == "NOT_FOUND"
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id FROM activities WHERE title = ?", ("テストactivity",)
+            ).fetchone()
+            assert row is None
+        finally:
+            conn.close()
+
+    def test_invalid_pin_type_fails_before_activity_created(self, temp_db):
+        """pinsのtypeが不正な場合、activity作成前にVALIDATION_ERRORで弾かれる"""
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "invalid_type", "ref": 1}],
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT id FROM activities WHERE title = ?", ("テストactivity",)
+            ).fetchone()
+            assert row is None
+        finally:
+            conn.close()
+
+    def test_pin_missing_required_field_returns_validation_error(self, temp_db):
+        """pinsの要素にrefが欠けている場合VALIDATION_ERRORを返す"""
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[{"type": "material"}],
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestAddActivityPinsIdempotent:
+    """pins引数: 冪等性"""
+
+    def test_duplicate_pin_targets_in_same_call_is_idempotent(self, material):
+        """同一pinsに同じtargetを重複指定してもエラーにならず1件のみ作成される"""
+        material_id = material["material_id"]
+
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+            pins=[
+                {"type": "material", "ref": material_id},
+                {"type": "material", "ref": material_id},
+            ],
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pins WHERE source_type='activity' AND source_id=? "
+                "AND target_type='material' AND target_id=?",
+                (activity_id, material_id),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 1
+
+
+class TestAddActivityWithoutPins:
+    """pins引数を省略した場合の後方互換性"""
+
+    def test_no_pins_argument_creates_activity_without_pins(self, temp_db):
+        """pinsを指定しない場合、activityは作成されpinsテーブルには何も追加されない"""
+        result = add_activity(
+            title="テストactivity", description="説明", tags=DEFAULT_TAGS,
+        )
+
+        assert "error" not in result
+        activity_id = result["activity_id"]
+
+        conn = get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pins WHERE source_type='activity' AND source_id=?",
+                (activity_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0

--- a/tests/unit/test_pin_service.py
+++ b/tests/unit/test_pin_service.py
@@ -527,6 +527,109 @@ class TestTransferPinsWithConn:
         assert old_count == 0
 
 
+class TestAddPinWithConnExtraction:
+    """_add_pin_with_conn: add_pinから抽出したconn共有版が呼び出し元のトランザクションに参加すること"""
+
+    def test_participates_in_caller_transaction_uncommitted_invisible(self, activity, material):
+        """呼び出し元がcommitするまで、他connからpinは見えない"""
+        from src.services.pin_service import _add_pin_with_conn
+
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        conn = get_connection()
+        try:
+            result = _add_pin_with_conn(conn, "activity", activity_id, "material", material_id)
+            assert "error" not in result
+            assert result["target_type"] == "material"
+            assert result["target_id"] == material_id
+
+            other_conn = get_connection()
+            try:
+                row = other_conn.execute(
+                    "SELECT * FROM pins WHERE source_type='activity' AND source_id=? "
+                    "AND target_type='material' AND target_id=?",
+                    (activity_id, material_id),
+                ).fetchone()
+                assert row is None
+            finally:
+                other_conn.close()
+
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT * FROM pins WHERE source_type='activity' AND source_id=? "
+                "AND target_type='material' AND target_id=?",
+                (activity_id, material_id),
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+    def test_error_result_lets_caller_rollback_without_partial_write(self, activity, material):
+        """存在しないtargetの場合はエラーdictを返し、呼び出し元のrollbackで何も残らない"""
+        from src.services.pin_service import _add_pin_with_conn
+
+        activity_id = activity["activity_id"]
+        material_id = material["material_id"]
+
+        conn = get_connection()
+        try:
+            # 先に無関係のpinをINSERT（同一トランザクション内、まだcommitしていない）
+            conn.execute(
+                "INSERT INTO pins (source_type, source_id, target_type, target_id) "
+                "VALUES ('activity', ?, 'material', ?)",
+                (activity_id, material_id),
+            )
+            result = _add_pin_with_conn(conn, "activity", activity_id, "material", 99999)
+            assert "error" in result
+            assert result["error"]["code"] == "NOT_FOUND"
+            conn.rollback()
+        finally:
+            conn.close()
+
+        # rollbackにより、事前INSERT分もまとめて消えている
+        verify_conn = get_connection()
+        try:
+            row = verify_conn.execute(
+                "SELECT * FROM pins WHERE source_type='activity' AND source_id=? "
+                "AND target_type='material' AND target_id=?",
+                (activity_id, material_id),
+            ).fetchone()
+            assert row is None
+        finally:
+            verify_conn.close()
+
+    def test_still_computes_superseded_hint_when_shared_conn(self, topic, activity):
+        """conn共有呼び出しでもsupersededなdecisionへのhint付与は動く"""
+        from src.services.pin_service import _add_pin_with_conn
+        from src.services.relation_service import add_relation
+
+        topic_id = topic["topic_id"]
+        activity_id = activity["activity_id"]
+
+        d_old_res = add_decisions([{"topic_id": topic_id, "decision": "古い決定", "reason": "旧"}])
+        d_new_res = add_decisions([{"topic_id": topic_id, "decision": "新しい決定", "reason": "新"}])
+        d_old = d_old_res["created"][0]["decision_id"]
+        d_new = d_new_res["created"][0]["decision_id"]
+        add_relation(
+            "decision", d_new, [{"type": "decision", "ids": [d_old]}],
+            relation_type="supersedes",
+        )
+
+        conn = get_connection()
+        try:
+            result = _add_pin_with_conn(conn, "activity", activity_id, "decision", d_old)
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert "error" not in result
+        assert "hint" in result
+        assert f"decision#{d_old}" in result["hint"]
+        assert f"decision#{d_new}" in result["hint"]
+
+
 class TestPinsCascadeDelete:
     """migration 0038: 各entityのDELETE時にpinsがCASCADE削除されること"""
 

--- a/tests/unit/test_relay_entity_publish.py
+++ b/tests/unit/test_relay_entity_publish.py
@@ -438,3 +438,47 @@ class TestPinPublish:
         assert result["removed"] == 0
         after = len(_rows_for("material", material["material_id"]))
         assert after == before
+
+
+class TestAddActivityPinsPublishOrder:
+    """add_activityのpins引数はevent:createdをpin由来のevent:updatedより必ず先にoutboxへ
+    積み、activity自身のbump+publishをpin件数分重複させない（複数targetの一括追加は
+    relation_serviceの_bump_and_publish_endpoints_with_connと同じくsource1回+target重複排除）。"""
+
+    def test_created_precedes_updated_and_activity_bump_is_not_duplicated(self, temp_db, disable_embedding):
+        material = add_material(title="m", content="c", tags=DEFAULT_TAGS, source="test")
+        topic = add_topic(title="t", description="d", tags=DEFAULT_TAGS)
+
+        before_material = len(_rows_for("material", material["material_id"]))
+        before_topic = len(_rows_for("topic", topic["topic_id"]))
+
+        result = add_activity(
+            title="a", description="d", tags=DEFAULT_TAGS, check_in=False,
+            pins=[
+                {"type": "material", "ref": material["material_id"]},
+                {"type": "topic", "ref": topic["topic_id"]},
+            ],
+        )
+        assert "error" not in result
+        activity_id = result["activity_id"]
+
+        activity_rows = _rows_for("activity", activity_id)
+        # event:created 1件 + pinsループ後にまとめてbumpされたevent:updated 1件のみ。
+        # pin 2件を渡してもactivity側の行が2件（1件/pin）に重複増殖しないことを検証する。
+        assert len(activity_rows) == 2
+        assert "event:created" in activity_rows[0]["labels"]
+        assert "event:updated" in activity_rows[1]["labels"]
+
+        material_rows = _rows_for("material", material["material_id"])
+        assert len(material_rows) == before_material + 1
+        assert "event:updated" in material_rows[-1]["labels"]
+
+        topic_rows = _rows_for("topic", topic["topic_id"])
+        assert len(topic_rows) == before_topic + 1
+        assert "event:updated" in topic_rows[-1]["labels"]
+
+        # activityのevent:createdは、pins由来のevent:updated（activity自身のbump分・
+        # material・topic）のいずれよりも先にoutboxへ積まれる（idが小さい）
+        created_id = activity_rows[0]["id"]
+        updated_ids = [activity_rows[1]["id"], material_rows[-1]["id"], topic_rows[-1]["id"]]
+        assert all(created_id < updated_id for updated_id in updated_ids)


### PR DESCRIPTION
## なぜ要るか

activity作成直後に別エンティティへpinを張る操作は、これまでadd_activityとadd_pinの2回のツール呼び出しが必要だった。作成直後にpinを張る定型パターンがactivity作成時に集中しているため、1回の呼び出しで完結できるようにする。

## 振る舞い（before/after）

- before: `add_activity`でactivityを作成した後、返ってきたIDを使って`add_pin`を別途呼ぶ必要があった。途中でエラーが起きても、activity自体は作成済みのまま残った。
- after: `add_activity`に`pins`引数（作成したactivity自身をsourceとするpin先のリスト）を渡せる。pin解決に失敗した場合はactivity作成自体を含めてロールバックし、部分成功を残さない（activity_tags・relationsも含めて何も残らない）。
- pinの内部実装（`_add_pin_with_conn`）は既存の`add_pin`からも共有され、既存`add_pin`単体の外部挙動は変わらない。
- activity作成イベント（`event:created`）は、pin付与に伴う`event:updated`より必ず先にoutboxへ積まれる。以前は逆順になりうる実装だったため、購読側の状態遷移前提を崩さないよう発火順序を保証した。

## テスト計画

新規テスト（`test_activity_service.py` / `test_pin_service.py`）の検証項目:

- 作成と同時にmaterial・topic・tag（namespace:name文字列指定）へpinを張れる
- 複数pinを同時に張れる
- pin対象が存在しない場合、activity作成自体が失敗し何も残らない（activityレコードに加え、activity_tags・relationsも0件であることを確認）
- pinのtypeが不正な場合、activity作成前にバリデーションエラーで弾かれる
- pinの必須フィールド欠落時にバリデーションエラーを返す
- 同一呼び出し内で同じpin対象を重複指定しても冪等に1件のみ作成される
- pins省略時は既存挙動（pin追加なし）を維持する
- `_add_pin_with_conn`抽出後も既存`add_pin`単体の挙動（自己参照拒否・supersededへのhint付与等含む）が変わらない

既存テストへの影響: 破壊なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)