### PR TITLE
feat: write系MCPツールで生ID→cite自動変換を有効化

### DIFF
--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -223,6 +223,25 @@ def add_activity(
         if related:
             _add_relation_with_conn(conn, "activity", activity_id, related)
 
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す。
+        # publish_entity_event_with_conn / bump_updated_at_and_publish_with_conn は
+        # 呼び出し時点でDBから都度titleをSELECTするため、変換は両者より必ず前に行う。
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="activity",
+            entity_id=activity_id,
+            fields_payload={"title": title, "description": description},
+            tool_name="add_activity",
+            table="activities",
+        )
+        title = converted["title"]
+        description = converted["description"]
+
+        # 本文中の {{cite:X#NNN}} を citations テーブルに保存
+        upsert_citations_for_owner_with_conn(
+            conn, "activity", activity_id, title=title, description=description
+        )
+
         publish_entity_event_with_conn(
             conn, entity_type="activity", entity_id=activity_id, event="created"
         )
@@ -246,23 +265,6 @@ def add_activity(
             bump_updated_at_and_publish_with_conn(conn, "activity", activity_id)
             for target_type, target_id in seen_targets:
                 bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
-
-        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
-        converted = apply_and_writeback_conversions(
-            conn,
-            entity_type="activity",
-            entity_id=activity_id,
-            fields_payload={"title": title, "description": description},
-            tool_name="add_activity",
-            table="activities",
-        )
-        title = converted["title"]
-        description = converted["description"]
-
-        # 本文中の {{cite:X#NNN}} を citations テーブルに保存
-        upsert_citations_for_owner_with_conn(
-            conn, "activity", activity_id, title=title, description=description
-        )
 
         conn.commit()
 

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -7,6 +7,7 @@ from typing import Optional
 from src.db import get_connection, row_to_dict
 from src.services.citations_service import (
     apply_and_writeback_conversions,
+    apply_raw_to_cite_conversion,
     upsert_citations_for_owner_with_conn,
 )
 from src.services.readable_id import strip_entity_id_inplace
@@ -731,6 +732,26 @@ def update_activity(
             or (status is not None and status != old_status)
         )
 
+        # 生 ID リテラルを {{cite:...}} に変換する。update系はUPDATE対象の
+        # activity_idが呼び出し時点で既に存在する行のため（add系と異なりINSERT
+        # による確定を待つ必要がない）、SET句組み立て前に変換を先に行い、
+        # 変換前後の値のどちらを書くかで2段UPDATEになるのを避け1回のUPDATEに統合する。
+        # 変換対象は呼び出し引数として明示された field のみ (title/description が
+        # None の場合は既存値を触らない)。
+        conversion = apply_raw_to_cite_conversion(
+            conn,
+            entity_type="activity",
+            entity_id=activity_id,
+            fields_payload={
+                k: v for k, v in {"title": title, "description": description}.items()
+                if v is not None
+            },
+            tool_name="update_activity",
+        )
+        converted_fields = conversion["fields"]
+        converted_title = converted_fields.get("title")
+        converted_description = converted_fields.get("description")
+
         # 動的SQL構築: 指定されたフィールドのみUPDATEする
         set_parts = []
         values = []
@@ -741,11 +762,11 @@ def update_activity(
 
         if title is not None:
             set_parts.append("title = ?")
-            values.append(title)
+            values.append(converted_title)
 
         if description is not None:
             set_parts.append("description = ?")
-            values.append(description)
+            values.append(converted_description)
 
         if orch_managed is not None:
             set_parts.append("orch_managed = ?")
@@ -767,21 +788,9 @@ def update_activity(
             tuple(values),
         )
 
-        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す。
-        # 変換対象は呼び出し引数として明示された field のみ (title/description が
-        # None の場合は既存値を触らない)。
-        converted = apply_and_writeback_conversions(
-            conn,
-            entity_type="activity",
-            entity_id=activity_id,
-            fields_payload={"title": title, "description": description},
-            tool_name="update_activity",
-            table="activities",
-        )
-
         # citations 全削除→再投入 (本文無変更でも実施)
-        new_title = converted["title"] if title is not None else row["title"]
-        new_description = converted["description"] if description is not None else row["description"]
+        new_title = converted_title if title is not None else row["title"]
+        new_description = converted_description if description is not None else row["description"]
         upsert_citations_for_owner_with_conn(
             conn, "activity", activity_id,
             title=new_title, description=new_description,

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -5,7 +5,10 @@ import sqlite3
 from typing import Optional
 
 from src.db import get_connection, row_to_dict
-from src.services.citations_service import upsert_citations_for_owner_with_conn
+from src.services.citations_service import (
+    apply_and_writeback_conversions,
+    upsert_citations_for_owner_with_conn,
+)
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.pin_service import ENTITY_TABLE_MAP as PIN_ENTITY_TABLE_MAP, _add_pin_with_conn
@@ -243,6 +246,18 @@ def add_activity(
             bump_updated_at_and_publish_with_conn(conn, "activity", activity_id)
             for target_type, target_id in seen_targets:
                 bump_updated_at_and_publish_with_conn(conn, target_type, target_id)
+
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="activity",
+            entity_id=activity_id,
+            fields_payload={"title": title, "description": description},
+            tool_name="add_activity",
+            table="activities",
+        )
+        title = converted["title"]
+        description = converted["description"]
 
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(
@@ -750,9 +765,21 @@ def update_activity(
             tuple(values),
         )
 
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す。
+        # 変換対象は呼び出し引数として明示された field のみ (title/description が
+        # None の場合は既存値を触らない)。
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="activity",
+            entity_id=activity_id,
+            fields_payload={"title": title, "description": description},
+            tool_name="update_activity",
+            table="activities",
+        )
+
         # citations 全削除→再投入 (本文無変更でも実施)
-        new_title = title if title is not None else row["title"]
-        new_description = description if description is not None else row["description"]
+        new_title = converted["title"] if title is not None else row["title"]
+        new_description = converted["description"] if description is not None else row["description"]
         upsert_citations_for_owner_with_conn(
             conn, "activity", activity_id,
             title=new_title, description=new_description,

--- a/src/services/citations_service.py
+++ b/src/services/citations_service.py
@@ -39,6 +39,7 @@ __all__ = [
     "get_in_out",
     "record_citation_event",
     "apply_raw_to_cite_conversion",
+    "apply_and_writeback_conversions",
     "VALID_EVENT_SOURCES",
     "VALID_VERIFICATION_RESULTS",
 ]
@@ -506,3 +507,61 @@ def apply_raw_to_cite_conversion(
         )
         event_ids.append(event_id)
     return {"fields": result_fields, "event_ids": event_ids, "stats": stats}
+
+
+def apply_and_writeback_conversions(
+    conn: sqlite3.Connection,
+    entity_type: str,
+    entity_id: int,
+    fields_payload: dict[str, str | None],
+    tool_name: str | None,
+    table: str,
+) -> dict[str, str | None]:
+    """write 経路の raw ID → cite 変換を適用し、本文が書き換わった field を DB に書き戻す。
+
+    apply_raw_to_cite_conversion のラッパーとして、変換 + 書き戻し + 元 payload との
+    合成のみを担う。変換判断ロジックそのものは apply_raw_to_cite_conversion 側に閉じる。
+
+    Args:
+        conn: 呼び出し元が開いた既存コネクション。INSERT/UPDATE と同一トランザクション
+              内で書き戻す前提。
+        entity_type: OWNER_TEXT_FIELDS のキー ('material' / 'decision' / 'log' /
+                     'activity' / 'topic')
+        entity_id: INSERT / UPDATE 直後の row id
+        fields_payload: 対象 field の現在値 ({field_name: text | None})。None 値は
+                        「呼び出し元が更新対象としていない field」を表し、変換対象からも
+                        書き戻し対象からも除外される。
+        tool_name: 呼び出し元 MCP tool 名 (citation_event_log.tool_name に記録)。
+        table: 書き戻し先の実テーブル名 ('materials' / 'decisions' /
+               'discussion_logs' / 'activities' / 'discussion_topics')。主キー列は
+               全 owner テーブルで 'id' に統一されている前提でハードコードする。
+
+    Returns:
+        変換後の fields dict (呼び出し元が続く upsert_citations_for_owner_with_conn の
+        **kwargs に渡す用)。None だった field もそのまま None で含む。
+    """
+    non_none_fields = {k: v for k, v in fields_payload.items() if v is not None}
+    result = apply_raw_to_cite_conversion(
+        conn,
+        entity_type,
+        entity_id,
+        non_none_fields,
+        tool_name=tool_name,
+    )
+    converted_fields = result["fields"]
+
+    changed = {
+        k: v
+        for k, v in converted_fields.items()
+        if k in non_none_fields and v != non_none_fields[k]
+    }
+    if changed:
+        set_clause = ", ".join(f"{k} = ?" for k in changed)
+        conn.execute(
+            f"UPDATE {table} SET {set_clause} WHERE id = ?",
+            (*changed.values(), entity_id),
+        )
+
+    merged: dict[str, str | None] = dict(fields_payload)
+    merged.update(converted_fields)
+    return merged

--- a/src/services/decision_service.py
+++ b/src/services/decision_service.py
@@ -2,7 +2,10 @@
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
-from src.services.citations_service import upsert_citations_for_owner_with_conn
+from src.services.citations_service import (
+    apply_and_writeback_conversions,
+    upsert_citations_for_owner_with_conn,
+)
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.tag_service import (
@@ -177,6 +180,18 @@ def add_decisions(items: list[dict]) -> dict:
                 if parsed_tags:
                     tag_ids = ensure_tag_ids(conn, parsed_tags)
                     link_tags(conn, "decision_tags", "decision_id", decision_id, tag_ids)
+
+                # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
+                converted = apply_and_writeback_conversions(
+                    conn,
+                    entity_type="decision",
+                    entity_id=decision_id,
+                    fields_payload={"decision": decision, "reason": reason},
+                    tool_name="add_decisions",
+                    table="decisions",
+                )
+                decision = converted["decision"]
+                reason = converted["reason"]
 
                 # 本文中の {{cite:X#NNN}} を citations テーブルに保存
                 upsert_citations_for_owner_with_conn(

--- a/src/services/discussion_log_service.py
+++ b/src/services/discussion_log_service.py
@@ -3,7 +3,10 @@ import re
 import sqlite3
 from typing import Optional
 from src.db import get_connection, row_to_dict
-from src.services.citations_service import upsert_citations_for_owner_with_conn
+from src.services.citations_service import (
+    apply_and_writeback_conversions,
+    upsert_citations_for_owner_with_conn,
+)
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.budget_service import count_entities_for_topics
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
@@ -113,6 +116,18 @@ def add_logs(items: list[dict]) -> dict:
                 if parsed_tags:
                     tag_ids = ensure_tag_ids(conn, parsed_tags)
                     link_tags(conn, "log_tags", "log_id", log_id, tag_ids)
+
+                # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
+                # (title は auto-generated 由来のため対象外、content のみ変換対象)
+                converted = apply_and_writeback_conversions(
+                    conn,
+                    entity_type="log",
+                    entity_id=log_id,
+                    fields_payload={"content": content},
+                    tool_name="add_logs",
+                    table="discussion_logs",
+                )
+                content = converted["content"]
 
                 # 本文中の {{cite:X#NNN}} を citations テーブルに保存
                 upsert_citations_for_owner_with_conn(

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -10,7 +10,10 @@ import yaml
 from src.db import get_connection, row_to_dict
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
-from src.services.citations_service import upsert_citations_for_owner_with_conn
+from src.services.citations_service import (
+    apply_and_writeback_conversions,
+    upsert_citations_for_owner_with_conn,
+)
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
 from src.services.relay.entity_publish import publish_entity_event_with_conn
 from src.services.title_validation import validate_title
@@ -118,6 +121,18 @@ def add_material(title: str, content: str, tags: list[str], source: str, related
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "material", material_id, related)
+
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="material",
+            entity_id=material_id,
+            fields_payload={"title": title, "content": content},
+            tool_name="add_material",
+            table="materials",
+        )
+        title = converted["title"]
+        content = converted["content"]
 
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(
@@ -333,9 +348,24 @@ def update_material(
             tag_ids = ensure_tag_ids(conn, parsed_tags)
             link_tags(conn, "material_tags", "material_id", material_id, tag_ids)
 
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す。
+        # 変換対象は呼び出し引数として明示された field のみ (未指定 field の
+        # 既存値は触らない)。content は mode 結合後の effective_content を対象にする。
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="material",
+            entity_id=material_id,
+            fields_payload={
+                "title": title,
+                "content": effective_content if content is not None else None,
+            },
+            tool_name="update_material",
+            table="materials",
+        )
+
         # citations 全削除→再投入 (本文無変更でも実施)
-        new_title = title if title is not None else row["title"]
-        new_content = effective_content if content is not None else row["content"]
+        new_title = converted["title"] if title is not None else row["title"]
+        new_content = converted["content"] if content is not None else row["content"]
         upsert_citations_for_owner_with_conn(
             conn, "material", material_id, title=new_title, content=new_content
         )

--- a/src/services/material_service.py
+++ b/src/services/material_service.py
@@ -12,6 +12,7 @@ from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import build_embedding_text, generate_and_store_embedding
 from src.services.citations_service import (
     apply_and_writeback_conversions,
+    apply_raw_to_cite_conversion,
     upsert_citations_for_owner_with_conn,
 )
 from src.services.relation_service import _add_relation_with_conn, _validate_targets
@@ -315,17 +316,41 @@ def update_material(
             else:  # append
                 effective_content = existing_content + CONTENT_JOIN_SEPARATOR + content
 
+        # 生 ID リテラルを {{cite:...}} に変換する。update系はUPDATE対象の
+        # material_idが呼び出し時点で既に存在する行のため（add系と異なりINSERT
+        # による確定を待つ必要がない）、SET句組み立て前に変換を先に行い、
+        # 変換前後の値のどちらを書くかで2段UPDATEになるのを避け1回のUPDATEに統合する。
+        # 変換対象は呼び出し引数として明示された field のみ (未指定 field の
+        # 既存値は触らない)。content は mode 結合後の effective_content を対象にする。
+        conversion = apply_raw_to_cite_conversion(
+            conn,
+            entity_type="material",
+            entity_id=material_id,
+            fields_payload={
+                k: v
+                for k, v in {
+                    "title": title,
+                    "content": effective_content if content is not None else None,
+                }.items()
+                if v is not None
+            },
+            tool_name="update_material",
+        )
+        converted_fields = conversion["fields"]
+        converted_title = converted_fields.get("title")
+        converted_content = converted_fields.get("content")
+
         # Build dynamic SQL for title/content
         set_parts = []
         values = []
 
         if title is not None:
             set_parts.append("title = ?")
-            values.append(title)
+            values.append(converted_title)
 
         if content is not None:
             set_parts.append("content = ?")
-            values.append(effective_content)
+            values.append(converted_content)
 
         if source is not None:
             set_parts.append("source = ?")
@@ -348,24 +373,9 @@ def update_material(
             tag_ids = ensure_tag_ids(conn, parsed_tags)
             link_tags(conn, "material_tags", "material_id", material_id, tag_ids)
 
-        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す。
-        # 変換対象は呼び出し引数として明示された field のみ (未指定 field の
-        # 既存値は触らない)。content は mode 結合後の effective_content を対象にする。
-        converted = apply_and_writeback_conversions(
-            conn,
-            entity_type="material",
-            entity_id=material_id,
-            fields_payload={
-                "title": title,
-                "content": effective_content if content is not None else None,
-            },
-            tool_name="update_material",
-            table="materials",
-        )
-
         # citations 全削除→再投入 (本文無変更でも実施)
-        new_title = converted["title"] if title is not None else row["title"]
-        new_content = converted["content"] if content is not None else row["content"]
+        new_title = converted_title if title is not None else row["title"]
+        new_content = converted_content if content is not None else row["content"]
         upsert_citations_for_owner_with_conn(
             conn, "material", material_id, title=new_title, content=new_content
         )

--- a/src/services/topic_service.py
+++ b/src/services/topic_service.py
@@ -2,7 +2,10 @@
 import re
 import sqlite3
 from src.db import get_connection, row_to_dict
-from src.services.citations_service import upsert_citations_for_owner_with_conn
+from src.services.citations_service import (
+    apply_and_writeback_conversions,
+    upsert_citations_for_owner_with_conn,
+)
 from src.services.readable_id import strip_entity_id_inplace
 from src.services.embedding_service import (
     build_embedding_text,
@@ -186,6 +189,18 @@ def add_topic(
         # リレーションを追加
         if related:
             _add_relation_with_conn(conn, "topic", topic_id, related)
+
+        # 生 ID リテラルを {{cite:...}} に変換し、書き換わった本文を DB に書き戻す
+        converted = apply_and_writeback_conversions(
+            conn,
+            entity_type="topic",
+            entity_id=topic_id,
+            fields_payload={"title": title, "description": description},
+            tool_name="add_topic",
+            table="discussion_topics",
+        )
+        title = converted["title"]
+        description = converted["description"]
 
         # 本文中の {{cite:X#NNN}} を citations テーブルに保存
         upsert_citations_for_owner_with_conn(

--- a/tests/integration/test_citation_event_log_helpers.py
+++ b/tests/integration/test_citation_event_log_helpers.py
@@ -19,6 +19,7 @@ from src.db import get_connection, init_database
 from src.services.citations_service import (
     VALID_EVENT_SOURCES,
     VALID_VERIFICATION_RESULTS,
+    apply_and_writeback_conversions,
     apply_raw_to_cite_conversion,
     record_citation_event,
 )
@@ -58,6 +59,18 @@ def _fetch_event(event_id: int) -> dict:
             "verification_result, extra_json "
             "FROM citation_event_log WHERE id = ?",
             (event_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_material(material_id: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, content FROM materials WHERE id = ?",
+            (material_id,),
         ).fetchone()
         return dict(row) if row else None
     finally:
@@ -618,3 +631,100 @@ class TestApplyRawToCiteFieldMapping:
         event = _fetch_event(res["event_ids"][0])
         assert event["verified_at"] is not None
         assert len(event["verified_at"]) >= 19
+
+
+# ============================================================
+# apply_and_writeback_conversions
+# ============================================================
+class TestApplyAndWritebackConversions:
+    def test_none_field_excluded_and_passed_through(self, temp_db):
+        """None値のfieldは変換対象から除外され、DBにも書き戻されず、
+        戻り値の merged dict では None のまま返る"""
+        target_id = _seed_material()
+        material_id = _seed_material(title="orig title", content=f"see M#{target_id}")
+        conn = get_connection()
+        try:
+            with conn:
+                merged = apply_and_writeback_conversions(
+                    conn,
+                    entity_type="material",
+                    entity_id=material_id,
+                    fields_payload={"title": None, "content": f"see M#{target_id}"},
+                    tool_name="update_material",
+                    table="materials",
+                )
+        finally:
+            conn.close()
+        assert merged["title"] is None
+        assert merged["content"] == f"see {{{{cite:M#{target_id}}}}}"
+        row = _fetch_material(material_id)
+        # title は fields_payload で None だったので変換対象外、DB の既存値も不変
+        assert row["title"] == "orig title"
+        assert row["content"] == f"see {{{{cite:M#{target_id}}}}}"
+
+    def test_changed_field_is_written_back_to_db(self, temp_db):
+        """本文が変換で書き換わったfieldはDBへUPDATEで書き戻される"""
+        target_id = _seed_material()
+        material_id = _seed_material(title="t", content=f"see M#{target_id}")
+        conn = get_connection()
+        try:
+            with conn:
+                apply_and_writeback_conversions(
+                    conn,
+                    entity_type="material",
+                    entity_id=material_id,
+                    fields_payload={"title": "t", "content": f"see M#{target_id}"},
+                    tool_name="add_material",
+                    table="materials",
+                )
+        finally:
+            conn.close()
+        row = _fetch_material(material_id)
+        assert row["content"] == f"see {{{{cite:M#{target_id}}}}}"
+
+    def test_unchanged_field_db_value_stays_identical(self, temp_db):
+        """既にcite形式で変換不要なfieldは、書き戻し後もDB値が元のまま"""
+        target_id = _seed_material()
+        original = f"existing {{{{cite:M#{target_id}}}}} only"
+        material_id = _seed_material(title="t", content=original)
+        conn = get_connection()
+        try:
+            with conn:
+                merged = apply_and_writeback_conversions(
+                    conn,
+                    entity_type="material",
+                    entity_id=material_id,
+                    fields_payload={"title": "t", "content": original},
+                    tool_name="add_material",
+                    table="materials",
+                )
+        finally:
+            conn.close()
+        assert merged["content"] == original
+        row = _fetch_material(material_id)
+        assert row["content"] == original
+
+    def test_merged_return_combines_converted_and_untouched_keys(self, temp_db):
+        """戻り値の merged dict は、変換対象keyは変換後の値、対象外keyは元の値をそのまま持つ"""
+        target_id = _seed_material()
+        material_id = _seed_material(title="t", content="body")
+        conn = get_connection()
+        try:
+            with conn:
+                merged = apply_and_writeback_conversions(
+                    conn,
+                    entity_type="material",
+                    entity_id=material_id,
+                    fields_payload={
+                        "title": "t",
+                        "content": f"see M#{target_id}",
+                        "extra_key": "untouched",
+                    },
+                    tool_name="add_material",
+                    table="materials",
+                )
+        finally:
+            conn.close()
+        assert merged["title"] == "t"
+        assert merged["content"] == f"see {{{{cite:M#{target_id}}}}}"
+        assert merged["extra_key"] == "untouched"

--- a/tests/integration/test_write_tools_auto_convert.py
+++ b/tests/integration/test_write_tools_auto_convert.py
@@ -12,6 +12,7 @@ import tempfile
 
 import pytest
 
+import src.services.embedding_service as embedding_service
 from src.db import get_connection, init_database
 from src.services.activity_service import add_activity, update_activity
 from src.services.citations_service import apply_and_writeback_conversions
@@ -19,6 +20,8 @@ from src.services.decision_service import add_decisions
 from src.services.discussion_log_service import add_logs
 from src.services.material_service import add_material, update_material
 from src.services.topic_service import add_topic
+
+EMBEDDING_DIM = 384
 
 DEFAULT_TAGS = ["domain:test"]
 
@@ -46,6 +49,28 @@ def topic_id(temp_db):
         tags=DEFAULT_TAGS,
     )
     return result["topic_id"]
+
+
+@pytest.fixture
+def mock_embedding_http(monkeypatch):
+    """embeddingサーバーへのHTTP呼び出し(_encode_batch)のみをmockする。
+
+    generate_and_store_embedding / encode_document自体は実処理を素通しし、
+    urllib経由のHTTP送信部分(_encode_batch)だけを差し替える
+    (tests/unit/test_embedding_service.py の mock_embedding_server と同型)。
+    _encode_batch に渡された texts を captured["texts"] に記録する。
+    """
+    captured: dict = {}
+
+    def mock_encode_batch(texts, prefix):
+        captured["texts"] = texts
+        captured["prefix"] = prefix
+        return [[0.0] * EMBEDDING_DIM for _ in texts]
+
+    monkeypatch.setattr(embedding_service, "_encode_batch", mock_encode_batch)
+    monkeypatch.setattr(embedding_service, "_server_initialized", True)
+    monkeypatch.setattr(embedding_service, "_backfill_done", True)
+    return captured
 
 
 def _seed_material(title: str = "tgt", content: str = "body") -> int:
@@ -235,18 +260,15 @@ class TestAddMaterialAutoConvert:
         material_id = result["material_id"]
         assert _citations_for("material", material_id) == [("material", target_id)]
 
-    def test_embedding_text_matches_converted_content(self, temp_db, monkeypatch):
-        """embedding生成テキストがDB格納テキスト(変換後)と一致する"""
+    def test_embedding_text_matches_converted_content(
+        self, temp_db, mock_embedding_http
+    ):
+        """embedding生成テキストがDB格納テキスト(変換後)と一致する
+
+        _encode_batch (embeddingサーバーへのHTTP送信直前の境界) のみをmockし、
+        generate_and_store_embedding/encode_documentの実処理(DB書き込み含む)は
+        素通しする。"""
         target_id = _seed_material()
-        captured = {}
-
-        def spy(entity_type, entity_id, text):
-            captured["text"] = text
-            return None
-
-        monkeypatch.setattr(
-            "src.services.material_service.generate_and_store_embedding", spy
-        )
         result = add_material(
             title="t",
             content=f"see M#{target_id}",
@@ -256,9 +278,10 @@ class TestAddMaterialAutoConvert:
         material_id = result["material_id"]
         row = _fetch_material(material_id)
         assert row["content"] == f"see {{{{cite:M#{target_id}}}}}"
-        assert row["content"] in captured["text"]
+        text = mock_embedding_http["texts"][0]
+        assert row["content"] in text
         # 変換前の生ID表記は embedding テキストに残っていない
-        assert f"M#{target_id}" not in captured["text"].replace(row["content"], "")
+        assert f"M#{target_id}" not in text.replace(row["content"], "")
 
     def test_self_reference_treated_as_existing(self, temp_db):
         """INSERT直後の自material IDをcontent内で参照した場合、同一トランザクション内
@@ -340,20 +363,15 @@ class TestUpdateMaterialAutoConvert:
         assert _citations_for("material", material_id) == [("material", target_id)]
 
     def test_embedding_text_matches_converted_content_after_update(
-        self, temp_db, monkeypatch
+        self, temp_db, mock_embedding_http
     ):
-        """update_material後のembedding生成テキストも変換後DB内容と一致する"""
+        """update_material後のembedding生成テキストも変換後DB内容と一致する
+
+        _encode_batch (embeddingサーバーへのHTTP送信直前の境界) のみをmockし、
+        generate_and_store_embedding/encode_documentの実処理(DB書き込み含む)は
+        素通しする。"""
         material_id = _seed_material(title="t", content="old")
         target_id = _seed_material()
-        captured = {}
-
-        def spy(entity_type, entity_id, text):
-            captured["text"] = text
-            return None
-
-        monkeypatch.setattr(
-            "src.services.material_service.generate_and_store_embedding", spy
-        )
         result = update_material(
             material_id=material_id,
             content=f"updated M#{target_id}",
@@ -361,7 +379,7 @@ class TestUpdateMaterialAutoConvert:
         assert "error" not in result
         row = _fetch_material(material_id)
         assert row["content"] == f"updated {{{{cite:M#{target_id}}}}}"
-        assert row["content"] in captured["text"]
+        assert row["content"] in mock_embedding_http["texts"][0]
 
 
 # ============================================================

--- a/tests/integration/test_write_tools_auto_convert.py
+++ b/tests/integration/test_write_tools_auto_convert.py
@@ -1,0 +1,620 @@
+"""write系 MCP tool (経路1) の生ID→cite自動変換の統合テスト。
+
+7 write tool (add_material / update_material / add_logs / add_decisions /
+add_topic / add_activity / update_activity) が service 層内で
+apply_and_writeback_conversions を経由し、保存時に本文中の生 `X#NNN` を
+`{{cite:X#NNN}}` へ自動変換して DB に書き戻し、citation_event_log に
+source="write_auto_convert" のイベントを記録することを検証する。
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from src.db import get_connection, init_database
+from src.services.activity_service import add_activity, update_activity
+from src.services.citations_service import apply_and_writeback_conversions
+from src.services.decision_service import add_decisions
+from src.services.discussion_log_service import add_logs
+from src.services.material_service import add_material, update_material
+from src.services.topic_service import add_topic
+
+DEFAULT_TAGS = ["domain:test"]
+
+# 存在しない (dangling) target として使う ID。実在 seed material の id と衝突しない
+# よう十分大きい値を使う。
+DANGLING_ID = 9999
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+@pytest.fixture
+def topic_id(temp_db):
+    result = add_topic(
+        title="Test Topic",
+        description="Topic for auto-convert tests",
+        tags=DEFAULT_TAGS,
+    )
+    return result["topic_id"]
+
+
+def _seed_material(title: str = "tgt", content: str = "body") -> int:
+    """seed 用に materials へ 1 行 INSERT して id を返す (conversion を経由しない生 INSERT)。"""
+    conn = get_connection()
+    try:
+        with conn:
+            cur = conn.execute(
+                "INSERT INTO materials (title, content, source) VALUES (?, ?, ?)",
+                (title, content, "seed"),
+            )
+        return cur.lastrowid
+    finally:
+        conn.close()
+
+
+def _fetch_material(material_id: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, content FROM materials WHERE id = ?",
+            (material_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_decision(decision_id: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, decision, reason FROM decisions WHERE id = ?",
+            (decision_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_topic(topic_id_: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, description FROM discussion_topics WHERE id = ?",
+            (topic_id_,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_activity(activity_id: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, description FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_log(log_id: int) -> dict:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, content FROM discussion_logs WHERE id = ?",
+            (log_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _all_event_rows() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT id, source, tool_name, target_entity_type, target_entity_id, "
+            "target_field, before_text, after_text, verification_result, extra_json "
+            "FROM citation_event_log ORDER BY id"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def _citations_for(owner_type: str, owner_id: int) -> list[tuple]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT target_type, target_id FROM citations "
+            "WHERE owner_type = ? AND owner_id = ? ORDER BY occurrence",
+            (owner_type, owner_id),
+        ).fetchall()
+        return [(r["target_type"], r["target_id"]) for r in rows]
+    finally:
+        conn.close()
+
+
+# ============================================================
+# add_material
+# ============================================================
+class TestAddMaterialAutoConvert:
+    def test_raw_id_converted_and_event_recorded(self, temp_db):
+        """生IDを含むcontentでadd_materialを呼ぶと、DB格納本文がcite形式に書き換わり、
+        citation_event_logにsource=write_auto_convertのイベントが1件記録される"""
+        target_id = _seed_material()
+        result = add_material(
+            title="t",
+            content=f"see M#{target_id}",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        row = _fetch_material(material_id)
+        assert row["content"] == f"see {{{{cite:M#{target_id}}}}}"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == material_id]
+        assert len(events) == 1
+        assert events[0]["source"] == "write_auto_convert"
+        assert events[0]["tool_name"] == "add_material"
+        assert events[0]["target_field"] == "content"
+        assert events[0]["verification_result"] == "exists"
+
+    def test_idempotent_no_change_no_event(self, temp_db):
+        """既存cite形式のみを含む本文では、本文が不変でイベントも記録されない"""
+        target_id = _seed_material()
+        original = f"existing {{{{cite:M#{target_id}}}}} only"
+        result = add_material(
+            title="t",
+            content=original,
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        row = _fetch_material(material_id)
+        assert row["content"] == original
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == material_id]
+        assert events == []
+
+    def test_dangling_target_rewritten_to_deleted_marker(self, temp_db):
+        """存在しないtarget IDを含む本文では、該当箇所が[deleted ...]マーカーに確定
+        書き換えされ、verification_result=danglingで記録される"""
+        result = add_material(
+            title="t",
+            content=f"lost M#{DANGLING_ID} forever",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        row = _fetch_material(material_id)
+        assert row["content"] == f"lost [deleted M#{DANGLING_ID}] forever"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == material_id]
+        assert len(events) == 1
+        assert events[0]["verification_result"] == "dangling"
+        extra = json.loads(events[0]["extra_json"])
+        assert extra["dangling_targets"] == [{"type": "material", "id": DANGLING_ID}]
+
+    def test_duplicate_raw_id_in_same_field_all_converted(self, temp_db):
+        """同一field内に同じ生IDが複数回出現する場合、全出現が変換される"""
+        target_id = _seed_material()
+        content = f"first M#{target_id}, second M#{target_id}, third M#{target_id}"
+        result = add_material(
+            title="t",
+            content=content,
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        row = _fetch_material(material_id)
+        cite = f"{{{{cite:M#{target_id}}}}}"
+        assert row["content"] == f"first {cite}, second {cite}, third {cite}"
+
+    def test_citations_table_reflects_converted_body(self, temp_db):
+        """変換後の本文でcitationsテーブルが再構築される(cite抽出は変換後本文由来)"""
+        target_id = _seed_material()
+        result = add_material(
+            title="t",
+            content=f"see M#{target_id}",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        assert _citations_for("material", material_id) == [("material", target_id)]
+
+    def test_embedding_text_matches_converted_content(self, temp_db, monkeypatch):
+        """embedding生成テキストがDB格納テキスト(変換後)と一致する"""
+        target_id = _seed_material()
+        captured = {}
+
+        def spy(entity_type, entity_id, text):
+            captured["text"] = text
+            return None
+
+        monkeypatch.setattr(
+            "src.services.material_service.generate_and_store_embedding", spy
+        )
+        result = add_material(
+            title="t",
+            content=f"see M#{target_id}",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        row = _fetch_material(material_id)
+        assert row["content"] == f"see {{{{cite:M#{target_id}}}}}"
+        assert row["content"] in captured["text"]
+        # 変換前の生ID表記は embedding テキストに残っていない
+        assert f"M#{target_id}" not in captured["text"].replace(row["content"], "")
+
+    def test_self_reference_treated_as_existing(self, temp_db):
+        """INSERT直後の自material IDをcontent内で参照した場合、同一トランザクション内
+        SELECTでexists扱いになる(dangling判定にならない)"""
+        conn = get_connection()
+        next_id = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) + 1 AS next_id FROM materials"
+        ).fetchone()["next_id"]
+        conn.close()
+
+        result = add_material(
+            title="self ref",
+            content=f"refers to M#{next_id} (itself)",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = result["material_id"]
+        assert material_id == next_id
+        row = _fetch_material(material_id)
+        assert row["content"] == f"refers to {{{{cite:M#{material_id}}}}} (itself)"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == material_id]
+        assert len(events) == 1
+        assert events[0]["verification_result"] == "exists"
+
+
+# ============================================================
+# update_material
+# ============================================================
+class TestUpdateMaterialAutoConvert:
+    def test_content_converted_title_untouched_when_unspecified(self, temp_db):
+        """update_materialでcontentだけ渡した場合、contentは変換されるが、未指定の
+        titleは既存値に生IDが含まれていても書き換わらない"""
+        conn = get_connection()
+        cur = conn.execute(
+            "INSERT INTO materials (title, content, source) VALUES (?, ?, ?)",
+            (f"legacy M#{DANGLING_ID} title", "old content", "seed"),
+        )
+        material_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+
+        target_id = _seed_material()
+        result = update_material(
+            material_id=material_id,
+            content=f"updated with M#{target_id}",
+        )
+        assert "error" not in result
+        row = _fetch_material(material_id)
+        assert row["content"] == f"updated with {{{{cite:M#{target_id}}}}}"
+        assert row["title"] == f"legacy M#{DANGLING_ID} title"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == material_id]
+        assert len(events) == 1
+        assert events[0]["target_field"] == "content"
+
+    def test_citations_rebuilt_even_when_body_unchanged(self, temp_db):
+        """update_materialの「本文無変更でもcitations全再構築」の既存挙動が維持される"""
+        target_id = _seed_material()
+        create = add_material(
+            title="t",
+            content=f"see {{{{cite:M#{target_id}}}}}",
+            tags=DEFAULT_TAGS,
+            source="s",
+        )
+        material_id = create["material_id"]
+
+        conn = get_connection()
+        conn.execute(
+            "DELETE FROM citations WHERE owner_type = 'material' AND owner_id = ?",
+            (material_id,),
+        )
+        conn.commit()
+        conn.close()
+        assert _citations_for("material", material_id) == []
+
+        result = update_material(material_id=material_id, tags=["domain:test", "design"])
+        assert "error" not in result
+        assert _citations_for("material", material_id) == [("material", target_id)]
+
+    def test_embedding_text_matches_converted_content_after_update(
+        self, temp_db, monkeypatch
+    ):
+        """update_material後のembedding生成テキストも変換後DB内容と一致する"""
+        material_id = _seed_material(title="t", content="old")
+        target_id = _seed_material()
+        captured = {}
+
+        def spy(entity_type, entity_id, text):
+            captured["text"] = text
+            return None
+
+        monkeypatch.setattr(
+            "src.services.material_service.generate_and_store_embedding", spy
+        )
+        result = update_material(
+            material_id=material_id,
+            content=f"updated M#{target_id}",
+        )
+        assert "error" not in result
+        row = _fetch_material(material_id)
+        assert row["content"] == f"updated {{{{cite:M#{target_id}}}}}"
+        assert row["content"] in captured["text"]
+
+
+# ============================================================
+# add_logs
+# ============================================================
+class TestAddLogsAutoConvert:
+    def test_content_converted_title_keeps_raw_id(self, temp_db, topic_id):
+        """add_logsでcontentはcite化され、auto生成titleには生IDが残る
+        (titleは非パース対象、現状維持方針の意図確認テスト)"""
+        target_id = _seed_material()
+        content = f"M#{target_id} についての議論"
+        result = add_logs([{"topic_id": topic_id, "content": content}])
+        assert result["errors"] == []
+        log_id = result["created"][0]["log_id"]
+
+        row = _fetch_log(log_id)
+        assert row["content"] == f"{{{{cite:M#{target_id}}}}} についての議論"
+        # title は content の先頭行から auto-generate されるが、非パース対象なので
+        # 生ID表記のまま残る
+        assert f"M#{target_id}" in row["title"]
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == log_id]
+        assert len(events) == 1
+        assert events[0]["target_field"] == "content"
+
+    def test_batch_partial_failure_savepoint_rollback_others_preserved(
+        self, temp_db, topic_id
+    ):
+        """add_logsバッチで1 itemがIntegrityErrorになった場合、該当itemの変換書き戻し
+        とイベントはSAVEPOINTごと巻き戻り、他itemの変換と記録は残る"""
+        target_id = _seed_material()
+        bad_topic_id = topic_id + DANGLING_ID
+        result = add_logs(
+            [
+                {"topic_id": topic_id, "content": f"first M#{target_id}"},
+                {"topic_id": bad_topic_id, "content": "this item fails"},
+                {"topic_id": topic_id, "content": f"third M#{target_id}"},
+            ]
+        )
+        assert len(result["created"]) == 2
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+
+        events = _all_event_rows()
+        assert len(events) == 2
+        after_texts = {e["after_text"] for e in events}
+        assert f"first {{{{cite:M#{target_id}}}}}" in after_texts
+        assert f"third {{{{cite:M#{target_id}}}}}" in after_texts
+
+
+# ============================================================
+# add_decisions
+# ============================================================
+class TestAddDecisionsAutoConvert:
+    def test_decision_and_reason_independently_converted(self, temp_db, topic_id):
+        """add_decisionsのdecision/reasonは独立に変換される"""
+        target_id = _seed_material()
+        result = add_decisions(
+            [
+                {
+                    "topic_id": topic_id,
+                    "decision": f"adopt M#{target_id}",
+                    "reason": f"because of M#{target_id}",
+                }
+            ]
+        )
+        assert result["errors"] == []
+        decision_id = result["created"][0]["decision_id"]
+
+        row = _fetch_decision(decision_id)
+        cite = f"{{{{cite:M#{target_id}}}}}"
+        assert row["decision"] == f"adopt {cite}"
+        assert row["reason"] == f"because of {cite}"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == decision_id]
+        assert len(events) == 2
+        assert {e["target_field"] for e in events} == {"decision", "reason"}
+
+    def test_only_field_with_raw_id_gets_event(self, temp_db, topic_id):
+        """片方のみ生IDを含む場合は片方のみイベント記録される"""
+        target_id = _seed_material()
+        result = add_decisions(
+            [
+                {
+                    "topic_id": topic_id,
+                    "decision": f"adopt M#{target_id}",
+                    "reason": "plain reason with no reference",
+                }
+            ]
+        )
+        decision_id = result["created"][0]["decision_id"]
+        row = _fetch_decision(decision_id)
+        assert row["decision"] == f"adopt {{{{cite:M#{target_id}}}}}"
+        assert row["reason"] == "plain reason with no reference"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == decision_id]
+        assert len(events) == 1
+        assert events[0]["target_field"] == "decision"
+
+
+# ============================================================
+# add_topic
+# ============================================================
+class TestAddTopicAutoConvert:
+    def test_title_and_description_converted(self, temp_db):
+        """add_topicのtitle/description両フィールドが変換される"""
+        target_id = _seed_material()
+        result = add_topic(
+            title=f"M#{target_id} discussion",
+            description=f"explore M#{target_id}",
+            tags=DEFAULT_TAGS,
+        )
+        new_topic_id = result["topic_id"]
+        row = _fetch_topic(new_topic_id)
+        cite = f"{{{{cite:M#{target_id}}}}}"
+        assert row["title"] == f"{cite} discussion"
+        assert row["description"] == f"explore {cite}"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == new_topic_id]
+        assert len(events) == 2
+        assert {e["target_field"] for e in events} == {"title", "description"}
+
+
+# ============================================================
+# add_activity / update_activity
+# ============================================================
+class TestAddActivityAutoConvert:
+    def test_title_and_description_converted(self, temp_db):
+        """add_activityのtitle/description両フィールドが変換される"""
+        target_id = _seed_material()
+        result = add_activity(
+            title=f"M#{target_id} work",
+            description=f"plan around M#{target_id}",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+        row = _fetch_activity(activity_id)
+        cite = f"{{{{cite:M#{target_id}}}}}"
+        assert row["title"] == f"{cite} work"
+        assert row["description"] == f"plan around {cite}"
+
+        events = [e for e in _all_event_rows() if e["target_entity_id"] == activity_id]
+        assert len(events) == 2
+
+    def test_existing_cite_and_new_raw_mixed_single_event(self, temp_db):
+        """descriptionに既存citeと生ID(存在するtarget)が混在する場合、変換後は両方
+        cite形式で既存分は再変換されず、eventは1件(description field全体で1event)"""
+        existing_target = _seed_material()
+        new_target = _seed_material()
+        description = (
+            f"see {{{{cite:M#{existing_target}}}}} and also M#{new_target}"
+        )
+        result = add_activity(
+            title="act",
+            description=description,
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+        row = _fetch_activity(activity_id)
+        assert row["description"] == (
+            f"see {{{{cite:M#{existing_target}}}}} and also {{{{cite:M#{new_target}}}}}"
+        )
+
+        events = [
+            e
+            for e in _all_event_rows()
+            if e["target_entity_id"] == activity_id and e["target_field"] == "description"
+        ]
+        assert len(events) == 1
+
+    def test_related_target_body_not_touched(self, temp_db):
+        """related経由のcross-referenceが発生しても、変換対象は自entityの本文のみで、
+        related先(material)の本文は書き換わらない(再入なし)"""
+        conn = get_connection()
+        cur = conn.execute(
+            "INSERT INTO materials (title, content, source) VALUES (?, ?, ?)",
+            ("legacy", f"legacy raw M#{DANGLING_ID} untouched", "seed"),
+        )
+        material_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+
+        result = add_activity(
+            title="act",
+            description=f"relates to M#{material_id}",
+            tags=DEFAULT_TAGS,
+            related=[{"type": "material", "ids": [material_id]}],
+            check_in=False,
+        )
+        assert "error" not in result
+        row = _fetch_material(material_id)
+        assert row["content"] == f"legacy raw M#{DANGLING_ID} untouched"
+
+
+class TestUpdateActivityAutoConvert:
+    def test_description_converted_title_untouched_when_unspecified(self, temp_db):
+        """update_activityでdescriptionだけ渡した場合、descriptionは変換されるが未指定の
+        titleは書き換わらない(update_materialと同型のpartial field素通し)"""
+        conn = get_connection()
+        cur = conn.execute(
+            "INSERT INTO activities (title, description, status, orch_managed) "
+            "VALUES (?, ?, ?, ?)",
+            (f"legacy M#{DANGLING_ID} title", "old description", "pending", 0),
+        )
+        activity_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+
+        target_id = _seed_material()
+        result = update_activity(
+            activity_id=activity_id,
+            description=f"updated with M#{target_id}",
+        )
+        assert "error" not in result
+        row = _fetch_activity(activity_id)
+        assert row["description"] == f"updated with {{{{cite:M#{target_id}}}}}"
+        assert row["title"] == f"legacy M#{DANGLING_ID} title"
+
+
+# ============================================================
+# トランザクション境界
+# ============================================================
+class TestTransactionAtomicity:
+    def test_invalid_entity_type_rolls_back_whole_transaction(self, temp_db):
+        """entity_type不正でValueErrorが上がったとき、直前のINSERTを含めてtrans全体が
+        中断される(呼び出し元のtry/except/rollback構造の維持を、共有connトランザクション
+        で検証する)"""
+        conn = get_connection()
+        try:
+            with pytest.raises(ValueError):
+                with conn:
+                    conn.execute(
+                        "INSERT INTO materials (title, content, source) VALUES (?, ?, ?)",
+                        ("t", "c", "s"),
+                    )
+                    apply_and_writeback_conversions(
+                        conn,
+                        entity_type="not_a_real_entity_type",
+                        entity_id=1,
+                        fields_payload={"content": "x"},
+                        tool_name="add_material",
+                        table="materials",
+                    )
+        finally:
+            conn.close()
+
+        conn2 = get_connection()
+        try:
+            count = conn2.execute(
+                "SELECT COUNT(*) AS c FROM materials"
+            ).fetchone()["c"]
+        finally:
+            conn2.close()
+        assert count == 0

--- a/tests/integration/test_write_tools_auto_convert.py
+++ b/tests/integration/test_write_tools_auto_convert.py
@@ -584,6 +584,84 @@ class TestUpdateActivityAutoConvert:
 
 
 # ============================================================
+# add_activity — relay outboxへ流出するtitleがconversion後の値であること
+# ============================================================
+class TestAddActivityRelayOutboxTitleConversion:
+    """add_activityがrelay outboxへpublishするtitleが、生ID表記ではなく変換後の
+    {{cite:X#NNN}}形式になっていることを検証する。
+
+    publish_entity_event_with_conn は呼び出し時点でDBからtitleを都度SELECTする
+    ため、conversion(apply_and_writeback_conversions)がpublishより前に完了して
+    いなければ、outboxのtitleに生ID表記が漏れる(add_activityで過去に発生していた
+    順序バグの回帰テスト)。"""
+
+    @pytest.fixture(autouse=True)
+    def relay_connected(self, tmp_path, monkeypatch):
+        """relay接続済み(RELAY_BEARER_TOKEN設定済み)環境にする。
+
+        tests/unit/test_relay_entity_publish.py の relay_connected と同型。
+        RELAY_STATE_DIR を隔離し、実マシンのcredential.jsonへフォールバック
+        しないようにする。"""
+        monkeypatch.setenv("RELAY_STATE_DIR", str(tmp_path / "relay-state"))
+        monkeypatch.setenv("RELAY_BEARER_TOKEN", "test-token")
+        monkeypatch.delenv("RELAY_BASE_URL", raising=False)
+
+    def _outbox_rows_for_activity(self, activity_id: int) -> list[dict]:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM relay_outbox WHERE ref_type = 'activity' AND ref_id = ? "
+                "ORDER BY id",
+                (str(activity_id),),
+            ).fetchall()
+            result = []
+            for row in rows:
+                item = dict(row)
+                item["labels"] = json.loads(item["labels"])
+                result.append(item)
+            return result
+        finally:
+            conn.close()
+
+    def test_created_event_title_is_converted_not_raw(self, temp_db, disable_embedding):
+        """titleに生IDを含めてadd_activityしても、outboxのevent:created行のtitleは
+        変換後の{{cite:X#NNN}}形式になり、生ID表記(X#NNN)は残らない"""
+        target_id = _seed_material()
+        result = add_activity(
+            title=f"M#{target_id} work",
+            description="d",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+        )
+        activity_id = result["activity_id"]
+        rows = self._outbox_rows_for_activity(activity_id)
+        created_rows = [r for r in rows if "event:created" in r["labels"]]
+        assert len(created_rows) == 1
+        expected_title = f"{{{{cite:M#{target_id}}}}} work"
+        assert created_rows[0]["title"] == expected_title
+        assert f"M#{target_id}" not in created_rows[0]["title"].replace(expected_title, "")
+
+    def test_pins_bump_updated_event_title_is_also_converted(self, temp_db, disable_embedding):
+        """pins指定時にpinsループ後まとめてbumpされるactivity自身のevent:updated行の
+        titleも、conversion後の値になっている(pinsブロックがconversionより後に実行
+        されても、DBには既にconversion済みの値が入っている必要がある)"""
+        target_id = _seed_material()
+        pin_target = _seed_material(title="pin target")
+        result = add_activity(
+            title=f"M#{target_id} work",
+            description="d",
+            tags=DEFAULT_TAGS,
+            check_in=False,
+            pins=[{"type": "material", "ref": pin_target}],
+        )
+        activity_id = result["activity_id"]
+        rows = self._outbox_rows_for_activity(activity_id)
+        updated_rows = [r for r in rows if "event:updated" in r["labels"]]
+        assert len(updated_rows) == 1
+        assert updated_rows[0]["title"] == f"{{{{cite:M#{target_id}}}}} work"
+
+
+# ============================================================
 # トランザクション境界
 # ============================================================
 class TestTransactionAtomicity:


### PR DESCRIPTION
## 概要

cc-memoryのwrite系MCPツール7本(add_material / update_material / add_logs / add_decisions / add_topic / add_activity / update_activity)で、本文中の生ID表記を保存時に `{{cite:...}}` 構造化citation形式へ自動変換する。

変換関数は実装済みだったが本番のwrite toolからは呼ばれておらず、生ID表記で書かれた本文がそのままDBに格納されて参照グラフに乗らない状態が続いていた。本PRでservice層に変換+書き戻しを配線し、新規保存分の生ID混入を保存時点で止める。

## 挙動の変化

- write系ツールに生ID表記を含む本文を渡すと、cite形式(参照先が存在しない場合はdeletedマーカー)に書き換わって格納され、citationsテーブルに参照が乗り、citation_event_logに変換記録が残るようになる
- update系ツールは呼び出しで明示したfieldだけが変換対象。未指定のfieldは既存値に生ID表記が残っていても書き換えない
- embedding生成テキストは変換後の格納値と一致するよう統一する
- 既にcite形式で書かれた本文は再変換されない(冪等)。add_logsの自動生成titleは従来どおり非パース対象

変換はすべて既存の1トランザクション内(commit前)で行われ、失敗時は本文保存ごと巻き戻る。

## テスト計画

新規統合テスト20件+helper単体テスト4件で以下を保証:

- 生ID→cite変換とイベント記録(7ツール各個)
- 冪等性(既存citeの非再変換)、dangling参照のdeletedマーカー確定書き換え
- update系のpartial field素通し(update_material / update_activity 個別に検証)
- add_logsバッチの部分失敗時、該当itemのみSAVEPOINTで巻き戻り他itemの変換・記録は保全
- decision/reasonの独立変換、同一ID複数出現の全変換、related先本文の非改変、自己参照の存在扱い
- embedding生成テキストとDB格納値の一致、不正entity_typeでのトランザクション原子性

既存テストへの影響なし(citation系+変更6サービス対応の341件pass維持。フルスイートはCIで確認)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)