### PR TITLE
fix: go-gateのpull-json転記とmcp-tools.mdの重複節を修正

### DIFF
--- a/docs/spec/go-gate.md
+++ b/docs/spec/go-gate.md
@@ -263,9 +263,9 @@ uv run python3 scripts/go_package.py new --activity <id> [--base origin/main] [-
     scripts/gate_check.sh(正規呼び出し経路)を実行し、機械判定欄(gate.machine /
     gate.effective / detector_sha256 / verdict_sha256)とブラスト半径・revert容易性の
     2小見出しを実データで充填した雛形を生成する。--pull-json に pull_precedents 応答
-    (JSON、design-pull-core.md 3-3-1 のスキーマ)を渡すと pull.presented / pull.guarantee
-    を機械転記する(手書きしない)。人間記述欄(判例引用・判例が無かった論点・1-b・1-c・
-    shadow)はプレースホルダのまま
+    (JSON、docs/spec/mcp-tools.md 2.32節 pull_precedentsのスキーマ)を渡すと
+    pull.presented / pull.guarantee を機械転記する(手書きしない)。人間記述欄
+    (判例引用・判例が無かった論点・1-b・1-c・shadow)はプレースホルダのまま
 
 uv run python3 scripts/go_package.py lint <file.md> [--mode shadow|live] [--allow-placeholder]
     L1〜L8 を検証する(下記)。--allow-placeholder は L2(セクション非空)・L6(shadowブロック

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -550,16 +550,6 @@ AIエージェントが人間の判断を待つ問いを1箇所に積み、人�
 **動作**: outbox行の配送状況はrelay_outboxテーブルのローカルSELECTのみで判定する（`processed_at`セット済み=delivered、`dead_at`セット済み=dead、いずれも無ければpending）。message本文（`ref_id`）は返さない（同一プロセス内の他sessionが発行した行にも越境してアクセスできてしまうため、意図的に除外）。runtimeセクションは常に返る。`running: false`はこのプロセスでrelay v2常駐処理が起動していないことを示す（エラーではない）。relayサーバー本体へのHTTPアクセスは一切発生しない。
 **エラー処理**: outbox_idが正の整数でない場合は`validation`。指定したIDの行が存在しない場合（存在しないID、またはdead化から一定期間経過後にDLQ物理削除済み。保持日数は`relay_sdk`側の設定値）は`not_found`。
 
-### 2.42 relay_status
-
-| 名前 | 型 | 必須 | デフォルト | 説明 |
-| --- | --- | --- | --- | --- |
-| outbox_id | int | no | null | relay_publishの返り値のoutbox_id。指定するとその行の配送状況を返す。省略時はoutboxセクションを返り値から省く |
-
-**返り値**: `{outbox: {outbox_id, status, labels, title, created_at, processed_at, dead_at, retry_count, last_error} | null, runtime: {configured, running, threads: {<thread名>: {alive, restart_count, last_restart_at, last_error}}}}`。
-**動作**: outbox行の配送状況はrelay_outboxテーブルのローカルSELECTのみで判定する（`processed_at`セット済み=delivered、`dead_at`セット済み=dead、いずれも無ければpending）。message本文（`ref_id`）は返さない（同一プロセス内の他sessionが発行した行にも越境してアクセスできてしまうため、意図的に除外）。runtimeセクションは常に返る。`running: false`はこのプロセスでrelay v2常駐処理が起動していないことを示す（エラーではない）。relayサーバー本体へのHTTPアクセスは一切発生しない。
-**エラー処理**: outbox_idが正の整数でない場合は`validation`。指定したIDの行が存在しない場合（存在しないID、またはdead化から一定期間経過後にDLQ物理削除済み。保持日数は`relay_sdk`側の設定値）は`not_found`。
-
 ### 2.43 add_ask
 
 | 名前 | 型 | 必須 | デフォルト | 説明 |

--- a/scripts/go_package.py
+++ b/scripts/go_package.py
@@ -482,6 +482,9 @@ def load_pull_json(path: Optional[str]) -> tuple[Union[str, list], Optional[str]
 
     decisionのIDはreadable_id変換済みの`id_raw`キーで返る(`id`ではない)ため、
     そちらを読む。未指定時は稼働前扱い(presented="unavailable", guarantee=None)。
+
+    decision要素に`id_raw`が無い場合は転記をスキップするが、沈黙のfailureを避ける
+    ため標準エラー出力に警告を出す(呼び出しは中断しない)。
     """
     if not path:
         return "unavailable", None
@@ -493,6 +496,16 @@ def load_pull_json(path: Optional[str]) -> tuple[Union[str, list], Optional[str]
         for decision in topic.get("decisions") or []:
             did = decision.get("id_raw")
             if did is None:
+                if "id" in decision:
+                    sys.stderr.write(
+                        f"WARNING: pull_precedents応答のdecision要素が旧キー`id`のみを持ち"
+                        f"`id_raw`が無いため転記をスキップした: {decision!r}\n"
+                    )
+                else:
+                    sys.stderr.write(
+                        f"WARNING: pull_precedents応答のdecision要素に`id_raw`が無いため"
+                        f"転記をスキップした: {decision!r}\n"
+                    )
                 continue
             key = ("decision", did)
             if key in seen:

--- a/scripts/go_package.py
+++ b/scripts/go_package.py
@@ -477,10 +477,11 @@ def lint_document(text: str, mode: str = "shadow", allow_placeholder: bool = Fal
 
 
 def load_pull_json(path: Optional[str]) -> tuple[Union[str, list], Optional[str]]:
-    """pull_precedents 応答JSON(design-pull-core.md 3-3-1 スキーマ)から
+    """pull_precedents 応答JSON(docs/spec/mcp-tools.md 2.32節 pull_precedentsのスキーマ)から
     pull.presented / pull.guarantee を機械転記する。
 
-    未指定時は稼働前扱い(presented="unavailable", guarantee=None)。
+    decisionのIDはreadable_id変換済みの`id_raw`キーで返る(`id`ではない)ため、
+    そちらを読む。未指定時は稼働前扱い(presented="unavailable", guarantee=None)。
     """
     if not path:
         return "unavailable", None
@@ -490,7 +491,7 @@ def load_pull_json(path: Optional[str]) -> tuple[Union[str, list], Optional[str]
     seen: set[tuple[str, int]] = set()
     for topic in data.get("topics") or []:
         for decision in topic.get("decisions") or []:
-            did = decision.get("id")
+            did = decision.get("id_raw")
             if did is None:
                 continue
             key = ("decision", did)

--- a/tests/unit/test_go_package.py
+++ b/tests/unit/test_go_package.py
@@ -559,8 +559,9 @@ def test_load_pull_json_dedupes_repeated_decision_ids(tmp_path: Path):
     assert presented == [{"type": "decision", "id": 3101}]
 
 
-def test_load_pull_json_ignores_legacy_id_key(tmp_path: Path):
-    """旧スキーマ(id/topic_id)のdecisionは`id_raw`が無いため無視される(常にNoneになる不具合の再発防止)。"""
+def test_load_pull_json_ignores_legacy_id_key_and_warns(tmp_path: Path, capsys):
+    """旧スキーマ(id/topic_id)のdecisionは`id_raw`が無いため無視される(常にNoneになる不具合の再発防止)が、
+    黙って捨てず標準エラー出力に警告を出す。"""
     payload = {
         "guarantee": "enumerated",
         "topics": [
@@ -572,6 +573,27 @@ def test_load_pull_json_ignores_legacy_id_key(tmp_path: Path):
     presented, guarantee = load_pull_json(str(f))
     assert guarantee == "enumerated"
     assert presented == []
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "id_raw" in err
+
+
+def test_load_pull_json_warns_when_id_raw_and_id_both_missing(tmp_path: Path, capsys):
+    """id_raw/idどちらも無いdecision要素は転記をスキップしつつ、警告を出す。"""
+    payload = {
+        "guarantee": "enumerated",
+        "topics": [
+            {"topic_id_raw": 1, "decisions": [{}]},
+        ],
+    }
+    f = tmp_path / "pull.json"
+    f.write_text(json.dumps(payload), encoding="utf-8")
+    presented, guarantee = load_pull_json(str(f))
+    assert guarantee == "enumerated"
+    assert presented == []
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "id_raw" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_go_package.py
+++ b/tests/unit/test_go_package.py
@@ -531,8 +531,8 @@ def test_load_pull_json_transcribes_decisions_and_guarantee(tmp_path: Path):
     payload = {
         "guarantee": "enumerated",
         "topics": [
-            {"topic_id": 1, "decisions": [{"id": 3101}, {"id": 3102}]},
-            {"topic_id": 2, "decisions": [{"id": 3103}]},
+            {"topic_id_raw": 1, "decisions": [{"id_raw": 3101}, {"id_raw": 3102}]},
+            {"topic_id_raw": 2, "decisions": [{"id_raw": 3103}]},
         ],
     }
     f = tmp_path / "pull.json"
@@ -550,13 +550,28 @@ def test_load_pull_json_dedupes_repeated_decision_ids(tmp_path: Path):
     payload = {
         "guarantee": "enumerated",
         "topics": [
-            {"topic_id": 1, "decisions": [{"id": 3101}, {"id": 3101}]},
+            {"topic_id_raw": 1, "decisions": [{"id_raw": 3101}, {"id_raw": 3101}]},
         ],
     }
     f = tmp_path / "pull.json"
     f.write_text(json.dumps(payload), encoding="utf-8")
     presented, _ = load_pull_json(str(f))
     assert presented == [{"type": "decision", "id": 3101}]
+
+
+def test_load_pull_json_ignores_legacy_id_key(tmp_path: Path):
+    """旧スキーマ(id/topic_id)のdecisionは`id_raw`が無いため無視される(常にNoneになる不具合の再発防止)。"""
+    payload = {
+        "guarantee": "enumerated",
+        "topics": [
+            {"topic_id": 1, "decisions": [{"id": 3101}]},
+        ],
+    }
+    f = tmp_path / "pull.json"
+    f.write_text(json.dumps(payload), encoding="utf-8")
+    presented, guarantee = load_pull_json(str(f))
+    assert guarantee == "enumerated"
+    assert presented == []
 
 
 # ---------------------------------------------------------------------------
@@ -713,7 +728,7 @@ def test_cmd_new_with_pull_json_transcribes_presented(gate_repos: Path, tmp_path
 
     pull_json_path = tmp_path / "pull.json"
     pull_json_path.write_text(
-        json.dumps({"guarantee": "enumerated", "topics": [{"topic_id": 1, "decisions": [{"id": 3101}]}]}),
+        json.dumps({"guarantee": "enumerated", "topics": [{"topic_id_raw": 1, "decisions": [{"id_raw": 3101}]}]}),
         encoding="utf-8",
     )
     out_path = tmp_path / "pkg.md"


### PR DESCRIPTION
## Summary
- go-gateの`load_pull_json`がpull_precedents応答の実際のキー(`id_raw`/`topic_id_raw`、readable_id変換済み)ではなく旧キー(`id`/`topic_id`)を読んでいたため、判例引用の機械転記が常に空になり、go-gateのL8ルール(判例引用網羅保証)が実質無効化されていた
- 参照先の`design-pull-core.md`は実在しないファイルだったため、実在する`docs/spec/mcp-tools.md` 2.32節への参照に差し替えた
- `docs/spec/mcp-tools.md`でrelay_statusの節が2回連続で重複していた。2つ目は実装(`outbox`キーは省略時もnullとして常に存在する)と不一致な古い記述だったため削除した

## Test plan
- `load_pull_json`が実スキーマ(`id_raw`/`topic_id_raw`)を正しく読み取り、旧スキーマ(`id`/`topic_id`)は無視して空を返すことを確認するテストを追加
- `cmd_new --pull-json`経由の統合テストのfixtureも実スキーマに更新
- 変更ファイル対応テスト(test_go_package.py / test_lint_doc_cochange.py / test_quality_skill_updates.py)97件pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)