### PR TITLE
feat: 聞き返し検出の候補抽出+照合searchをtool一発化

### DIFF
--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -236,7 +236,7 @@ AIエージェントが人間の判断を待つ問いを1箇所に積み、人�
 | search_limit | int | no | 10 | 候補1件あたりのsearch呼び出しのlimit |
 | score_threshold | float | no | 0.4 | `candidates[].top_hits` に残す最小final_score |
 
-**返り値**: `{candidates: [{kind, turn, text, context_snippet, options?, degraded, top_hits: [{type, id, score, title}]}, ...], total_extracted, excluded_count, searched_count, truncated_count, degraded, score_threshold}`。excluded_reason付き候補・search_top_nを超えた候補は`candidates`に含まれない。transcript_pathが存在しない場合は`{"error": {"code": "TRANSCRIPT_NOT_FOUND", ...}}`。
+**返り値**: `{candidates: [{kind, turn, text, context_snippet, options?, degraded, top_hits: [{type, id, score, title}], search_error?}, ...], total_extracted, excluded_count, searched_count, truncated_count, degraded, score_threshold}`。`search_error`は候補に対するsearch呼び出しがエラーを返した場合のみ付与される（`{"code", "message"}`）。excluded_reason付き候補・search_top_nを超えた候補は`candidates`に含まれない。transcript_pathが存在しない場合は`{"error": {"code": "TRANSCRIPT_NOT_FOUND", ...}}`。
 **用途**: `skills/sync-memory/SKILL.md` ステップ9（聞き返しの後追い検出）の候補抽出＋照合searchを1回の呼び出しに集約する。既存記録があれば聞き返しが不要だったかの主観判定と`report_signal`呼び出しは呼び出し側が行う。
 
 ### 2.7 get_by_ids

--- a/docs/spec/mcp-tools.md
+++ b/docs/spec/mcp-tools.md
@@ -22,7 +22,7 @@ last-synced-migration: 0048
 
 ## 1. ツール一覧
 
-全45ツール。カテゴリ別に一覧する。
+全46ツール。カテゴリ別に一覧する。
 
 ### 1.1 記録系（add系）
 
@@ -70,6 +70,7 @@ last-synced-migration: 0048
 | `search` | 横断検索（FTS5 trigram + ベクトル ハイブリッド） |
 | `search_tags` | タグをキーワード検索する |
 | `analyze_tags` | タグ共起分析（PMI/クラスタ/孤児/重複候補） |
+| `detect_reask_candidates` | transcriptから聞き返し候補を抽出し上位N件のsearchまで一括実行する |
 
 ### 1.5 関係系・pin系
 
@@ -224,6 +225,19 @@ AIエージェントが人間の判断を待つ問いを1箇所に積み、人�
 
 **返り値**: `{results: [SearchHit], archived_tags: [{tag, archived_reason}]}`。scoreは0〜1正規化（1.0=全ソース1位、片方ヒットは最大0.5）。0.4以上=高関連、0.15〜0.4=中、0.15未満=低の目安。snippetでなく全文が必要な場合は結果のtype+idを`get_by_ids`に渡す。各結果アイテムには`archived`（bool）・`archived_tags`（配列）・`score_breakdown.archived_factor`も付く（全タグがarchivedのアイテムのみ`archived: true`になりfinal_scoreが下位表示側に減衰する。除外はしない）。トップレベルの`archived_tags`は応答内の全アイテムのタグのうちarchivedなものの集約で、該当なしでも常に空配列で付く。
 **実装**: FTS5 trigram + ベクトル検索のRRF統合。
+
+### 2.6b detect_reask_candidates
+
+| 名前 | 型 | 必須 | デフォルト | 説明 |
+| --- | --- | --- | --- | --- |
+| transcript_path | string | yes | - | transcript JSONLのパス |
+| max_candidates | int | no | 50 | 抽出段階の上限件数 |
+| search_top_n | int | no | 8 | search実行対象とする候補の上限件数（excluded_reason付きを除いた先頭N件） |
+| search_limit | int | no | 10 | 候補1件あたりのsearch呼び出しのlimit |
+| score_threshold | float | no | 0.4 | `candidates[].top_hits` に残す最小final_score |
+
+**返り値**: `{candidates: [{kind, turn, text, context_snippet, options?, degraded, top_hits: [{type, id, score, title}]}, ...], total_extracted, excluded_count, searched_count, truncated_count, degraded, score_threshold}`。excluded_reason付き候補・search_top_nを超えた候補は`candidates`に含まれない。transcript_pathが存在しない場合は`{"error": {"code": "TRANSCRIPT_NOT_FOUND", ...}}`。
+**用途**: `skills/sync-memory/SKILL.md` ステップ9（聞き返しの後追い検出）の候補抽出＋照合searchを1回の呼び出しに集約する。既存記録があれば聞き返しが不要だったかの主観判定と`report_signal`呼び出しは呼び出し側が行う。
 
 ### 2.7 get_by_ids
 

--- a/hooks/session_start_hook.py
+++ b/hooks/session_start_hook.py
@@ -10,6 +10,7 @@
 コンテキスト取得フローガイドはここでは注入しない（check_in初回呼び出し時に
 checkin_service側が埋め込む）。
 """
+import functools
 import json
 import sys
 from datetime import datetime, timezone
@@ -463,6 +464,21 @@ def _build_relay_inbox_section(conn, session_id: str | None = None, source: str 
     return "\n".join(lines) + "\n"
 
 
+def _build_transcript_path_section(
+    conn, session_id: str | None = None, source: str | None = None, transcript_path: str | None = None
+) -> str:  # conn, session_id, source: buildersループの統一シグネチャ
+    """このセッションのtranscript pathを1行注入する。
+
+    MCPサーバーのサブプロセスにはtranscript_pathが渡らないため（session_id同様、
+    Claude Code側にIPC経路が無い）、SessionStart hookのstdinで受け取った値を
+    ここで会話コンテキストに載せ、Claudeが明示引数として`detect_reask_candidates`等の
+    tool呼び出しに転記する方式を取る。用途はsync-memoryステップ9（聞き返しの後追い検出）。
+    """
+    if not transcript_path:
+        return ""
+    return f"このセッションのtranscript path: {transcript_path}\n"
+
+
 def _build_snapshot_section(conn, session_id: str | None = None, source: str | None = None) -> str:  # conn, session_id, source: buildersループの統一シグネチャ
     """スナップショット取得＋ヘルスチェック。異常検知時のみ警告を返す。
 
@@ -501,7 +517,9 @@ def _build_snapshot_section(conn, session_id: str | None = None, source: str | N
     return ""
 
 
-def _build_session_context(session_id: str | None = None, source: str | None = None) -> str:
+def _build_session_context(
+    session_id: str | None = None, source: str | None = None, transcript_path: str | None = None
+) -> str:
     """サービス層経由でセッション開始時のコンテキストを組み立てる。
 
     session_id は session_start_hook の stdin payload に含まれる Claude Code 提供の
@@ -509,6 +527,8 @@ def _build_session_context(session_id: str | None = None, source: str | None = N
     source は同 payload の "source"（startup|resume|clear|compact）。現状
     _build_habits_section のみが参照し、compact後にrulesファイル内容が
     コンテキストに保持されるかの実機未検証を安全側に倒すため使う。
+    transcript_path は同payloadの"transcript_path"。_build_transcript_path_section
+    のみが参照する。
 
     各セクションは独立してtry/exceptで保護し、
     一部のセクションが失敗しても残りは返す。
@@ -523,6 +543,7 @@ def _build_session_context(session_id: str | None = None, source: str | None = N
             _build_sync_policy_section,
             _build_signals_section,
             _build_relay_inbox_section,
+            functools.partial(_build_transcript_path_section, transcript_path=transcript_path),
         ]
         for builder in builders:
             try:
@@ -545,6 +566,7 @@ def main() -> None:
         raw = sys.stdin.read()
         session_id: str | None = None
         source: str | None = None
+        transcript_path: str | None = None
         if raw:
             try:
                 payload = json.loads(raw)
@@ -555,12 +577,16 @@ def main() -> None:
                     src = payload.get("source")
                     if isinstance(src, str) and src:
                         source = src
+                    tp = payload.get("transcript_path")
+                    if isinstance(tp, str) and tp:
+                        transcript_path = tp
             except json.JSONDecodeError:
-                # session_id/source 取得失敗時は従来挙動（self 照合なし・compact判定
-                # なし）にフォールバック。初期値 None のまま継続するため再代入不要
+                # session_id/source/transcript_path 取得失敗時は従来挙動（self 照合なし・
+                # compact判定なし・transcript path注入なし）にフォールバック。初期値 None
+                # のまま継続するため再代入不要
                 pass
 
-        context = _build_session_context(session_id, source)
+        context = _build_session_context(session_id, source, transcript_path)
 
         output = {
             "hookSpecificOutput": {

--- a/skills/sync-memory/SKILL.md
+++ b/skills/sync-memory/SKILL.md
@@ -237,11 +237,11 @@ description: "「sync-memory改善」トピックで議論中。ステップ4の
 
 **手順:**
 
-1. Claudeが現在のセッションのtranscript pathを解決し、`scripts/detect_reask_candidates.py --transcript <path> --out <tmp.jsonl>` を実行する。出力は候補jsonl（各行に `kind` / `turn` / `text` / `context_snippet` / `excluded_reason?` を持つ）。解決できない場合はこのステップをスキップし、完了報告に一行残す
-2. `excluded_reason` が付いた候補は対象外として除外する
-3. 残候補のうち先頭N件（上限あり。Nを超える候補は判定対象外とし、超過した旨を完了報告に一行残す）について、`text` をクエリに `search(keyword=..., limit=10)` を呼び、既存記録top-3を得る（閾値は本ステップ末尾の実装ノート参照）
-4. `search` レスポンスの `degraded=true` のときは判定を保守側に倒す（該当候補についてはprecedent_miss記録を行わない。skipした事実はStep 11の完了報告に一行残す）
-5. `search` 上位のうち `score` が閾値以上のものを「高類似ヒット」と扱う。高類似ヒットが1件もない候補は判定・記録の対象外とする。高類似ヒットがある候補についてのみ、Claudeが「この既存記録があれば、この聞き返しはそもそも不要だったか」を判定する。この判定はClaudeの主観判断であり、同じ候補・同じ既存記録でも判定がぶれうる
+1. SessionStart時にコンテキストへ注入された「このセッションのtranscript path: ...」の行からtranscript pathを取り出す。無ければこのステップをスキップし、完了報告に一行残す
+2. 取り出したtranscript pathを渡して `detect_reask_candidates(transcript_path=<path>)` を1回呼ぶ。旧来の抽出スクリプト（`scripts/detect_reask_candidates.py`相当）・`excluded_reason` が付いた候補の除外・残候補のうち先頭N件（上限あり。Nを超える候補は判定対象外とし、超過した旨を完了報告に一行残す）への `search` バッチ実行までを内部で行い、各候補に既存記録top-3（`top_hits`。閾値は本ステップ末尾の実装ノート参照）が付いた `candidates` を返す
+3. 個別の `search` 呼び出しは発生しない（手順2に集約済み）
+4. 候補ごとの `candidate.degraded`（内部で行われた `search` バッチ呼び出しの `degraded` を候補単位に反映したもの）で `degraded=true` のときは判定を保守側に倒す（該当候補についてはprecedent_miss記録を行わない。skipした事実はStep 11の完了報告に一行残す）
+5. 候補ごとの `top_hits`（閾値は本ステップ末尾の実装ノート参照。`detect_reask_candidates`が内部で閾値判定済み）を「高類似ヒット」として扱う。高類似ヒットが1件もない候補は判定・記録の対象外とする。高類似ヒットがある候補についてのみ、Claudeが「この既存記録があれば、この聞き返しはそもそも不要だったか」を判定する。この判定はClaudeの主観判断であり、同じ候補・同じ既存記録でも判定がぶれうる
 6. yes判定のみ `report_signal(kind="precedent_miss", summary=..., detail=..., refs=[高類似ヒットの各id], context={"missed_ids": [...]})` を呼ぶ。summaryのフォーマットは下記参照（dedup fingerprintの安定性のため決定論的な文字列に固定する）
 7. 判定ログ（候補text・ヒットid・判定結果）は本ステップ内では保存しない（signal_events側のcontextに集約される）
 
@@ -257,9 +257,9 @@ summaryは決定論的な文字列 `missed: <最上位ヒットの既存記録ty
 
 **実装ノート（初期値、観察後に確定値へ差し替え）:**
 
-- 判定に回す候補上限N: 5〜10件
-- 「高類似ヒット」の閾値: search score 0.4以上
-- 除外辞書: `scripts/detect_reask_candidates.py` の組み込み既定を使う（`--dict` で差し替え可能）
+- 判定に回す候補上限N: 5〜10件（`detect_reask_candidates`の`search_top_n`引数、既定8件）
+- 「高類似ヒット」の閾値: search score 0.4以上（`detect_reask_candidates`の`score_threshold`引数、既定0.4）
+- 除外辞書: `scripts/detect_reask_candidates.py` の組み込み既定を使う（`detect_reask_candidates`ツールは辞書差し替え引数を持たない。差し替えが要る場合は従来通りスクリプトを直接呼ぶ）
 
 ### 10. 棚卸し・remember（自動実行）
 

--- a/src/main.py
+++ b/src/main.py
@@ -734,7 +734,8 @@ def detect_reask_candidates(
 
     Returns:
         candidates: [{"kind", "turn", "text", "context_snippet", "options"?, "excluded_reason"?
-            （search対象に残ったものには付かない）, "degraded", "top_hits": [{"type","id","score","title"}]}, ...]
+            （search対象に残ったものには付かない）, "degraded", "top_hits": [{"type","id","score","title"}],
+            "search_error"?（search呼び出しがエラーを返した場合のみ付与。{"code","message"}）}, ...]
             excluded_reason付き候補、search_top_nを超えた候補は含まない
         total_extracted: 抽出段階の全候補数（除外分含む）
         excluded_count: excluded_reason付きで除外した件数

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from src.services import (
     signal_service,
     budget_service,
     ask_service,
+    reask_detection_service,
 )
 from src.services.checkin_service import check_in as _check_in
 from src.services.relay import service as relay_session_service
@@ -705,6 +706,53 @@ def search(
         all_tags = _collect_result_tags(result.get("results", []))
         _attach_archived_tags_summary(result, all_tags)
     return result
+
+
+@mcp.tool()
+def detect_reask_candidates(
+    transcript_path: str,
+    max_candidates: int = 50,
+    search_top_n: int = 8,
+    search_limit: int = 10,
+    score_threshold: float = 0.4,
+) -> dict:
+    """
+    Choose: sync-memoryの聞き返し後追い検出ステップで使う。transcriptから聞き返し候補
+    （AskUserQuestion呼び出し・ユーザー訂正発話）を抽出し、除外辞書適用後の上位N件について
+    既存記録の類似searchまで一括で行う。transcript_pathはSessionStart時にコンテキストへ
+    注入されたものをそのまま渡す。
+
+    「この既存記録があれば聞き返しは不要だったか」の主観判定とreport_signalの呼び出しは
+    このtoolの範囲外（呼び出し側であるskills/sync-memory/SKILL.mdのステップ9が担う）。
+
+    Args:
+        transcript_path: transcript JSONLのパス
+        max_candidates: 抽出段階の上限件数（デフォルト50）
+        search_top_n: search実行対象とする候補の上限件数（excluded_reason付きを除いた先頭N件、デフォルト8）
+        search_limit: 候補1件あたりのsearch呼び出しのlimit（デフォルト10）
+        score_threshold: candidates[].top_hitsに残す最小final_score（デフォルト0.4）
+
+    Returns:
+        candidates: [{"kind", "turn", "text", "context_snippet", "options"?, "excluded_reason"?
+            （search対象に残ったものには付かない）, "degraded", "top_hits": [{"type","id","score","title"}]}, ...]
+            excluded_reason付き候補、search_top_nを超えた候補は含まない
+        total_extracted: 抽出段階の全候補数（除外分含む）
+        excluded_count: excluded_reason付きで除外した件数
+        searched_count: 実際にsearchした件数
+        truncated_count: search_top_nを超えてsearch対象外になった件数
+        degraded: いずれかのsearch呼び出しでdegraded=Trueだったか（Trueの候補は判定を保守側に倒す）
+        score_threshold: 実際に使われた閾値
+
+        transcript_pathが存在しない場合は {"error": {"code": "TRANSCRIPT_NOT_FOUND", ...}}
+    """
+    return reask_detection_service.detect_reask_candidates(
+        transcript_path,
+        max_candidates=max_candidates,
+        search_top_n=search_top_n,
+        search_limit=search_limit,
+        score_threshold=score_threshold,
+        caller_session_id=_current_session_id(),
+    )
 
 
 @mcp.tool()

--- a/src/services/reask_detection_service.py
+++ b/src/services/reask_detection_service.py
@@ -78,7 +78,9 @@ def detect_reask_candidates(
         entry = dict(candidate)
         if "error" in search_result:
             entry["search_error"] = search_result["error"]
-            entry["degraded"] = False
+            is_degraded = bool(search_result.get("degraded"))
+            degraded_any = degraded_any or is_degraded
+            entry["degraded"] = is_degraded
             entry["top_hits"] = []
             results.append(entry)
             continue

--- a/src/services/reask_detection_service.py
+++ b/src/services/reask_detection_service.py
@@ -1,0 +1,112 @@
+"""聞き返し検出の機械部分を1回のサービス呼び出しに集約する。
+
+transcript path解決済みの前提で、候補抽出（scripts/detect_reask_candidates.py）→
+excluded_reason付き候補の除外→残候補上位N件のsearchバッチ実行、までを行う。
+既存記録との類似度に基づく「聞き返しが不要だったか」の主観判定と
+report_signal(kind="precedent_miss")の呼び出しは、本サービスの範囲外のまま
+呼び出し側（skills/sync-memory/SKILL.md ステップ9）に残す。
+"""
+from pathlib import Path
+from typing import Optional
+
+from scripts.detect_reask_candidates import extract_candidates
+from src.services import search_service
+
+DEFAULT_MAX_CANDIDATES = 50
+DEFAULT_SEARCH_TOP_N = 8
+DEFAULT_SEARCH_LIMIT = 10
+DEFAULT_SCORE_THRESHOLD = 0.4
+
+
+def detect_reask_candidates(
+    transcript_path: str,
+    max_candidates: int = DEFAULT_MAX_CANDIDATES,
+    search_top_n: int = DEFAULT_SEARCH_TOP_N,
+    search_limit: int = DEFAULT_SEARCH_LIMIT,
+    score_threshold: float = DEFAULT_SCORE_THRESHOLD,
+    caller_session_id: Optional[str] = None,
+) -> dict:
+    """transcriptから聞き返し候補を抽出し、上位N件について既存記録の類似検索まで行う。
+
+    Args:
+        transcript_path: transcript JSONLのパス（`~`展開に対応）
+        max_candidates: 抽出段階の上限件数
+        search_top_n: search実行対象とする候補の上限件数（excluded_reason付きを除いた後の先頭N件）
+        search_limit: 候補1件あたりのsearch呼び出しのlimit
+        score_threshold: `candidates[].top_hits` に残す最小final_score
+        caller_session_id: search呼び出しのtelemetry相関キー
+
+    Returns:
+        成功時: {
+            "candidates": [
+                {..extract_candidatesの各キー.., "top_hits": [{"type","id","score","title"}, ...],
+                 "degraded": bool}, ...
+            ],  # search対象外（excluded_reason付き、またはsearch_top_n超過）は含まない
+            "total_extracted": int,  # 抽出段階の全候補数（除外分含む）
+            "excluded_count": int,   # excluded_reason付きで除外した件数
+            "searched_count": int,   # 実際にsearchした件数
+            "truncated_count": int,  # search_top_nを超えてsearch対象外になった件数
+            "degraded": bool,        # いずれかのsearch呼び出しでdegraded=Trueだったか
+            "score_threshold": float,
+        }
+        失敗時: {"error": {"code": "TRANSCRIPT_NOT_FOUND", "message": str}}
+    """
+    path = Path(transcript_path).expanduser()
+    if not path.is_file():
+        return {
+            "error": {
+                "code": "TRANSCRIPT_NOT_FOUND",
+                "message": f"transcript_pathが見つからない: {transcript_path}",
+            }
+        }
+
+    all_candidates = extract_candidates(str(path), max_candidates=max_candidates)
+    total_extracted = len(all_candidates)
+
+    eligible = [c for c in all_candidates if "excluded_reason" not in c]
+    excluded_count = total_extracted - len(eligible)
+
+    to_search = eligible[:search_top_n]
+    truncated_count = len(eligible) - len(to_search)
+
+    degraded_any = False
+    results: list[dict] = []
+    for candidate in to_search:
+        search_result = search_service.search(
+            candidate["text"], limit=search_limit, caller_session_id=caller_session_id,
+        )
+        entry = dict(candidate)
+        if "error" in search_result:
+            entry["search_error"] = search_result["error"]
+            entry["degraded"] = False
+            entry["top_hits"] = []
+            results.append(entry)
+            continue
+
+        is_degraded = bool(search_result.get("degraded"))
+        degraded_any = degraded_any or is_degraded
+        entry["degraded"] = is_degraded
+        entry["top_hits"] = [
+            {
+                "type": hit.get("type"),
+                # search_serviceを直接呼ぶため、MCPツール層のcitation変換（id_raw -> id）を
+                # 経由しない。生のidはid_rawキーに入る（main.pyのsearchツール経由の
+                # レスポンスとはこの1点だけ形が異なる）。
+                "id": hit.get("id_raw", hit.get("id")),
+                "score": hit.get("final_score", hit.get("score")),
+                "title": hit.get("title") or hit.get("snippet"),
+            }
+            for hit in search_result.get("results", [])
+            if (hit.get("final_score", hit.get("score", 0)) or 0) >= score_threshold
+        ]
+        results.append(entry)
+
+    return {
+        "candidates": results,
+        "total_extracted": total_extracted,
+        "excluded_count": excluded_count,
+        "searched_count": len(to_search),
+        "truncated_count": truncated_count,
+        "degraded": degraded_any,
+        "score_threshold": score_threshold,
+    }

--- a/tests/e2e/test_session_start_hook.py
+++ b/tests/e2e/test_session_start_hook.py
@@ -1249,6 +1249,33 @@ class TestSessionStartHookSignals:
         assert "未トリアージのシグナル" not in context
 
 
+class TestSessionStartHookTranscriptPath:
+    """transcript_path 1行注入テスト（聞き返し検出tool一発化のための下地）"""
+
+    def test_transcript_path_present_in_payload_is_injected(self, temp_db):
+        """stdin payloadにtranscript_pathがあれば1行注入される"""
+        result = _run_session_start_hook(
+            temp_db, stdin_payload={"transcript_path": "/tmp/example-transcript.jsonl"}
+        )
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "このセッションのtranscript path: /tmp/example-transcript.jsonl" in context
+
+    def test_transcript_path_absent_from_payload_no_injection(self, temp_db):
+        """stdin payloadにtranscript_pathが無ければセクション自体が出ない"""
+        result = _run_session_start_hook(temp_db, stdin_payload={"session_id": "sid-1"})
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "transcript path" not in context
+
+    def test_transcript_path_non_string_ignored(self, temp_db):
+        """transcript_pathが文字列でない場合は無視され注入されない"""
+        result = _run_session_start_hook(temp_db, stdin_payload={"transcript_path": 12345})
+        context = result["hookSpecificOutput"]["additionalContext"]
+
+        assert "transcript path" not in context
+
+
 class TestSessionStartHookRelayInbox:
     """relay inbox未読件数 + Monitor監視指示の表示テスト
 

--- a/tests/unit/test_reask_detection_service.py
+++ b/tests/unit/test_reask_detection_service.py
@@ -1,0 +1,137 @@
+"""reask_detection_service.detect_reask_candidates のテスト。
+
+transcript pathの解決失敗、excluded_reason付き候補の除外、search_top_nによる
+候補打ち切り、既存記録との類似search結果の反映を検証する。
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+import src.services.embedding_service as emb
+from src.db import init_database
+from src.services import reask_detection_service
+from src.services.topic_service import add_topic
+
+
+@pytest.fixture(autouse=True)
+def disable_embedding(monkeypatch):
+    monkeypatch.setattr(emb, "_server_initialized", False)
+    monkeypatch.setattr(emb, "_backfill_done", True)
+    monkeypatch.setattr(emb, "_ensure_server_running", lambda: False)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        os.environ["DISCUSSION_DB_PATH"] = db_path
+        init_database()
+        yield db_path
+        if "DISCUSSION_DB_PATH" in os.environ:
+            del os.environ["DISCUSSION_DB_PATH"]
+
+
+def _write_transcript(tmpdir: str, entries: list[dict]) -> str:
+    path = os.path.join(tmpdir, "transcript.jsonl")
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return path
+
+
+def _ask_entry(question: str) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "AskUserQuestion",
+                    "input": {"questions": [{"question": question}]},
+                }
+            ]
+        },
+    }
+
+
+def test_transcript_not_found_returns_error(temp_db):
+    result = reask_detection_service.detect_reask_candidates("/no/such/transcript.jsonl")
+
+    assert result["error"]["code"] == "TRANSCRIPT_NOT_FOUND"
+
+
+def test_excluded_candidate_is_filtered_and_not_searched(temp_db, monkeypatch):
+    """opinion_request等のexcluded_reason付き候補はcandidatesに出ず、searchも呼ばれない。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = _write_transcript(tmpdir, [_ask_entry("案Aと案Bどっちがいいと思う?")])
+
+        search_calls = []
+        from src.services import search_service
+
+        real_search = search_service.search
+
+        def tracking_search(*args, **kwargs):
+            search_calls.append((args, kwargs))
+            return real_search(*args, **kwargs)
+
+        monkeypatch.setattr(reask_detection_service.search_service, "search", tracking_search)
+
+        result = reask_detection_service.detect_reask_candidates(path)
+
+    assert result["total_extracted"] == 1
+    assert result["excluded_count"] == 1
+    assert result["candidates"] == []
+    assert result["searched_count"] == 0
+    assert search_calls == []
+
+
+def test_high_similarity_hit_is_attached_to_candidate(temp_db):
+    """既存recordとテキストが一致する候補はtop_hitsにそのrecordを含む。
+
+    embeddingサーバーを無効化しているためFTS5(trigram)のみが働く。trigramは
+    実質的な部分文字列一致のため、候補textを既存recordの本文に含まれる
+    部分文字列と完全一致させてヒットを作る。
+    """
+    add_topic(
+        title="uplinkのretry上限",
+        description="uplinkのretry上限は何回に固定するかで議論した結果、3回に決まった",
+        tags=["domain:cc-memory-test-reask", "intent:discuss"],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = _write_transcript(
+            tmpdir, [_ask_entry("uplinkのretry上限は何回に固定するか")]
+        )
+        result = reask_detection_service.detect_reask_candidates(path, score_threshold=0.0)
+
+    assert result["searched_count"] == 1
+    candidate = result["candidates"][0]
+    assert candidate["kind"] == "ask"
+    hit_titles = [h["title"] for h in candidate["top_hits"]]
+    assert any("uplink" in (t or "") for t in hit_titles)
+
+
+def test_search_top_n_truncates_candidates(temp_db):
+    """excluded_reasonの無い候補がsearch_top_nを超える場合、超過分はsearch対象外になる。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        entries = [_ask_entry(f"これは候補{i}についての確認事項です") for i in range(5)]
+        path = _write_transcript(tmpdir, entries)
+        result = reask_detection_service.detect_reask_candidates(path, search_top_n=2)
+
+    assert result["total_extracted"] == 5
+    assert result["excluded_count"] == 0
+    assert result["searched_count"] == 2
+    assert result["truncated_count"] == 3
+    assert len(result["candidates"]) == 2
+
+
+def test_max_candidates_limits_extraction(temp_db):
+    """max_candidatesで抽出段階そのものが打ち切られる。"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        entries = [_ask_entry(f"これは候補{i}についての確認事項です") for i in range(5)]
+        path = _write_transcript(tmpdir, entries)
+        result = reask_detection_service.detect_reask_candidates(path, max_candidates=2, search_top_n=10)
+
+    assert result["total_extracted"] == 2

--- a/tests/unit/test_reask_detection_service.py
+++ b/tests/unit/test_reask_detection_service.py
@@ -127,6 +127,32 @@ def test_search_top_n_truncates_candidates(temp_db):
     assert len(result["candidates"]) == 2
 
 
+def test_search_error_with_degraded_true_is_not_forced_to_false(temp_db, monkeypatch):
+    """search()がerrorとdegraded=Trueを同時に返す場合（例: KEYWORD_TOO_SHORT かつ
+    embedding search も不可）、candidateのdegradedはsearch_resultの実値(True)を
+    引き継ぎ、search_errorも付与される。degraded=Falseに握り潰してはならない。
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = _write_transcript(tmpdir, [_ask_entry("これは確認事項です")])
+
+        def stub_search(*args, **kwargs):
+            return {
+                "error": {"code": "KEYWORD_TOO_SHORT", "message": "キーワードが短すぎる"},
+                "degraded": True,
+            }
+
+        monkeypatch.setattr(reask_detection_service.search_service, "search", stub_search)
+
+        result = reask_detection_service.detect_reask_candidates(path)
+
+    assert result["searched_count"] == 1
+    candidate = result["candidates"][0]
+    assert candidate["degraded"] is True
+    assert candidate["search_error"] == {"code": "KEYWORD_TOO_SHORT", "message": "キーワードが短すぎる"}
+    assert candidate["top_hits"] == []
+    assert result["degraded"] is True
+
+
 def test_max_candidates_limits_extraction(temp_db):
     """max_candidatesで抽出段階そのものが打ち切られる。"""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- sync-memoryの聞き返し後追い検出ステップで、transcript path解決→抽出スクリプト実行→候補ごとのsearch呼び出しという手作業チェーンを`detect_reask_candidates`ツール1回に集約した
- transcript pathはMCPサーバーのサブプロセスに自動で渡らないため、SessionStart hookがstdinで受け取った値をコンテキストに1行注入し、Claudeが明示引数として転記する経路にした
- 聞き返しが不要だったかの主観判定と`report_signal`の呼び出しは引き続きSKILL.md側（Claudeの判断）に残る

## Test plan
- `detect_reask_candidates`サービスの新規テスト: transcript未検出時のエラー応答、`excluded_reason`付き候補の除外とsearch非実行、既存記録と一致する候補への高類似ヒット付与、`search_top_n`超過時の打ち切り件数、`max_candidates`による抽出打ち切り
- SessionStart hookの新規テスト: `transcript_path`のコンテキスト注入・非注入・非文字列値の無視
- `skills/sync-memory/SKILL.md`のstep9記述更新に伴い、既存の文面契約テスト（ステップ番号・除外カテゴリ・degraded保守側フォールバック等）を新フローの文言に合わせて更新、全件pass
- ツールdocstring文字数上限テスト・spec docツール総数整合テスト、既存の関連スイート（session start hook e2e、detect_reask_candidates script単体）に影響なし