### PR TITLE
feat: MCPサーバー再起動を自動化するスクリプトとrestart skillを追加

### DIFF
--- a/scripts/restart_server.py
+++ b/scripts/restart_server.py
@@ -1,0 +1,17 @@
+"""MCPサーバー強制再起動CLIエントリポイント
+
+実装本体は src/services/restart_service.py に置く。
+本モジュールは `uv run python scripts/restart_server.py` 経由の起動のみを持つ。
+"""
+import sys
+from pathlib import Path
+
+# プロジェクトルートをパスに追加（src.services等の参照用）
+_project_root = Path(__file__).resolve().parents[1]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from src.services.restart_service import main  # noqa: E402
+
+if __name__ == "__main__":
+    main()

--- a/skills/restart/SKILL.md
+++ b/skills/restart/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: restart
+description: 【必須】cc-memoryのローカルMCPサーバー・embeddingサーバーを強制再起動する。プラグインアップデート後にコード変更を反映させたいときに使う。「/restart」「MCPサーバー再起動して」「cc-memoryのサーバー再起動」「サーバー再起動して」などで発動。このスキルを経由せずに再起動用のkill/起動コマンドを直接組み立てて実行してはいけない。DO NOT TRIGGER: 再起動について相談・検討しているだけで実行をまだ求めていない場合、worktree削除やgit pull等PRマージ後の後片付け全体を求められた場合（それはリポジトリのCLAUDE.mdの手順に従う）。
+---
+
+# restart
+
+cc-memoryのローカルMCPサーバー(52837)・embeddingサーバー(52836)を強制的に再起動する。
+
+launcherの通常起動は「生きていれば何もしない」ensure動作のため、プラグインをアップデートした後もコード変更が反映されないことがある。このスキルは既存プロセスを明示的に終了させてから新規プロセスを起動する。
+
+## 実行
+
+ユーザーがこのスキルを明示的に呼び出したこと自体を実行の承認とみなし、追加確認は取らずに以下をBashツールで実行する。
+
+```
+uv run --directory ${CLAUDE_PLUGIN_ROOT} python ${CLAUDE_PLUGIN_ROOT}/scripts/restart_server.py
+```
+
+## 結果の報告
+
+スクリプトはJSON形式で結果を標準出力に返す。
+
+- `mcp_server.ok` が `true`: 再起動成功。`old_pids`（旧プロセス）と`new_pids`（新プロセス）をユーザーに簡潔に伝える
+- `mcp_server.ok` が `false`: 再起動失敗。`detail` の内容をそのままユーザーに伝え、手動確認（`lsof -i tcp:52837 -sTCP:LISTEN`等）を促す
+- `embedding_server.stopped_pids` は空配列でもよい（元々起動していなかっただけ）
+- `caches` は削除したパスの記録。特に問題なければ触れなくてよい
+
+再起動後、他に生存しているClaude Codeセッションがあれば、それぞれで `/mcp` からreconnectが必要な場合があることを伝える。

--- a/src/services/restart_service.py
+++ b/src/services/restart_service.py
@@ -7,32 +7,44 @@ launcher.py の _ensure_server_running() は「生きていれば何もしない
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import NamedTuple
 
-MCP_PORT = 52837
-EMBEDDING_PORT = 52836
+from src.http_config import HTTP_PORT
+from src.services.embedding_service import PORT as EMBEDDING_SERVER_PORT
+
+MCP_PORT = HTTP_PORT
+EMBEDDING_PORT = EMBEDDING_SERVER_PORT
 PLUGIN_CACHE_DIR = Path.home() / ".claude" / "plugins" / "cache" / "claude-code-memory-marketplace"
 
 DEFAULT_START_TIMEOUT_SEC = 30.0
 DEFAULT_POLL_INTERVAL_SEC = 0.5
 DEFAULT_KILL_WAIT_SEC = 10.0
+DEFAULT_KILL_ESCALATE_SEC = 5.0
+SUBPROCESS_TIMEOUT_SEC = 5.0
 
 
 def find_listen_pids(port: int) -> list[int]:
     """指定ポートでLISTEN中のPIDを返す。
 
     -sTCP:LISTEN条件で絞り込むことで、接続中のクライアント(ブリッジ等)を
-    巻き添えにしない。
+    巻き添えにしない。lsofがハングした場合はタイムアウトし、空リストとして扱う
+    (「わからない」を「いない」として安全側に倒す。再起動フロー全体を
+    無期限にブロックしないことを優先する)。
     """
-    result = subprocess.run(
-        ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True, text=True, check=False, timeout=SUBPROCESS_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return []
     return sorted({int(p) for p in result.stdout.split() if p.strip()})
 
 
@@ -42,17 +54,56 @@ def process_start_signature(pid: int) -> str | None:
     LISTEN確認だけでは、PID再利用や検出タイミングのズレで
     古いプロセスを新規と誤認しうる。起動時刻の比較でこれを防ぐ。
     """
-    result = subprocess.run(
-        ["ps", "-o", "lstart=", "-p", str(pid)],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True, text=True, check=False, timeout=SUBPROCESS_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     output = result.stdout.strip()
     return output or None
 
 
-def kill_pids(pids: list[int]) -> None:
+def _process_alive(pid: int) -> bool:
+    """シグナル0の送信でプロセスの生死を確認する(実際にはシグナルを送らない)。"""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def kill_pids(
+    pids: list[int],
+    *,
+    escalate_after_sec: float = DEFAULT_KILL_ESCALATE_SEC,
+    poll_interval_sec: float = DEFAULT_POLL_INTERVAL_SEC,
+) -> None:
+    """各PIDにSIGTERMを送り、escalate_after_sec待っても生存していればSIGKILLで強制終了する。
+
+    SIGTERMのみで終了しないプロセスを生かしたまま次の処理に進むと、
+    新規サーバーがポートのbindに失敗して見えない失敗を招く。
+    """
     for pid in pids:
-        subprocess.run(["kill", str(pid)], check=False)
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.monotonic() + escalate_after_sec
+    remaining = {pid for pid in pids if _process_alive(pid)}
+    while remaining and time.monotonic() < deadline:
+        time.sleep(poll_interval_sec)
+        remaining = {pid for pid in remaining if _process_alive(pid)}
+
+    for pid in remaining:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
 
 
 class RestartResult(NamedTuple):

--- a/src/services/restart_service.py
+++ b/src/services/restart_service.py
@@ -1,0 +1,169 @@
+"""cc-memory MCPサーバー・embeddingサーバーの強制再起動ロジック
+
+launcher.py の _ensure_server_running() は「生きていれば何もしない」ensure動作であり、
+プラグインアップデート後にコード変更が反映されない。本モジュールは既存プロセスを
+明示的に終了させてから新規プロセスを起動する「強制入れ替え」を提供する。
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+MCP_PORT = 52837
+EMBEDDING_PORT = 52836
+PLUGIN_CACHE_DIR = Path.home() / ".claude" / "plugins" / "cache" / "claude-code-memory-marketplace"
+
+DEFAULT_START_TIMEOUT_SEC = 30.0
+DEFAULT_POLL_INTERVAL_SEC = 0.5
+DEFAULT_KILL_WAIT_SEC = 10.0
+
+
+def find_listen_pids(port: int) -> list[int]:
+    """指定ポートでLISTEN中のPIDを返す。
+
+    -sTCP:LISTEN条件で絞り込むことで、接続中のクライアント(ブリッジ等)を
+    巻き添えにしない。
+    """
+    result = subprocess.run(
+        ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+        capture_output=True, text=True, check=False,
+    )
+    return sorted({int(p) for p in result.stdout.split() if p.strip()})
+
+
+def process_start_signature(pid: int) -> str | None:
+    """プロセスの起動時刻を返す。プロセスが存在しなければNone。
+
+    LISTEN確認だけでは、PID再利用や検出タイミングのズレで
+    古いプロセスを新規と誤認しうる。起動時刻の比較でこれを防ぐ。
+    """
+    result = subprocess.run(
+        ["ps", "-o", "lstart=", "-p", str(pid)],
+        capture_output=True, text=True, check=False,
+    )
+    output = result.stdout.strip()
+    return output or None
+
+
+def kill_pids(pids: list[int]) -> None:
+    for pid in pids:
+        subprocess.run(["kill", str(pid)], check=False)
+
+
+class RestartResult(NamedTuple):
+    ok: bool
+    old_pids: list[int]
+    new_pids: list[int]
+    detail: str
+
+
+def _is_replaced(old_signatures: dict[int, str | None], new_pids: list[int]) -> bool:
+    """new_pidsの中に、旧プロセスの記録と一致しないもの(=新規)が1つでもあればTrue"""
+    for pid in new_pids:
+        if pid not in old_signatures:
+            return True
+        if old_signatures[pid] != process_start_signature(pid):
+            return True
+    return False
+
+
+def restart_mcp_server(
+    project_root: Path,
+    *,
+    start_timeout_sec: float = DEFAULT_START_TIMEOUT_SEC,
+    poll_interval_sec: float = DEFAULT_POLL_INTERVAL_SEC,
+    kill_wait_sec: float = DEFAULT_KILL_WAIT_SEC,
+) -> RestartResult:
+    """MCPサーバー本体を強制的に再起動する。
+
+    既存プロセスをkillしてから新規launcherプロセスを起動し、
+    新PIDの起動時刻が旧PIDの記録と一致しないことをもって
+    「新規プロセスへの入れ替わり」を確認してから成功とみなす。
+    """
+    old_pids = find_listen_pids(MCP_PORT)
+    old_signatures = {pid: process_start_signature(pid) for pid in old_pids}
+
+    if old_pids:
+        kill_pids(old_pids)
+        deadline = time.monotonic() + kill_wait_sec
+        while time.monotonic() < deadline and find_listen_pids(MCP_PORT):
+            time.sleep(poll_interval_sec)
+
+    subprocess.Popen(
+        ["uv", "run", "--directory", str(project_root), "python", "-m", "src.launcher"],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=str(project_root),
+    )
+
+    deadline = time.monotonic() + start_timeout_sec
+    while time.monotonic() < deadline:
+        new_pids = find_listen_pids(MCP_PORT)
+        if new_pids and _is_replaced(old_signatures, new_pids):
+            return RestartResult(True, old_pids, new_pids, "restarted")
+        time.sleep(poll_interval_sec)
+
+    return RestartResult(
+        False, old_pids, find_listen_pids(MCP_PORT),
+        f"server did not come up on port {MCP_PORT} within {start_timeout_sec}s",
+    )
+
+
+def stop_embedding_server() -> list[int]:
+    """embeddingサーバーを停止する。再起動はしない(次回encode呼び出し時にlazy spawnされる)。"""
+    pids = find_listen_pids(EMBEDDING_PORT)
+    kill_pids(pids)
+    return pids
+
+
+def clean_caches(project_root: Path) -> dict:
+    """プラグインキャッシュと__pycache__を削除する。"""
+    removed_plugin_cache = False
+    if PLUGIN_CACHE_DIR.exists():
+        shutil.rmtree(PLUGIN_CACHE_DIR)
+        removed_plugin_cache = True
+
+    removed_pycache_dirs = []
+    for pycache in project_root.rglob("__pycache__"):
+        if pycache.is_dir():
+            shutil.rmtree(pycache)
+            removed_pycache_dirs.append(str(pycache))
+
+    return {
+        "removed_plugin_cache": removed_plugin_cache,
+        "removed_pycache_dirs": removed_pycache_dirs,
+    }
+
+
+def restart_all(project_root: Path) -> dict:
+    mcp_result = restart_mcp_server(project_root)
+    embedding_stopped = stop_embedding_server()
+    cache_result = clean_caches(project_root)
+    return {
+        "mcp_server": {
+            "ok": mcp_result.ok,
+            "old_pids": mcp_result.old_pids,
+            "new_pids": mcp_result.new_pids,
+            "detail": mcp_result.detail,
+        },
+        "embedding_server": {"stopped_pids": embedding_stopped},
+        "caches": cache_result,
+    }
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parent.parent.parent
+    result = restart_all(project_root)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result["mcp_server"]["ok"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_restart_service.py
+++ b/tests/unit/test_restart_service.py
@@ -5,8 +5,6 @@ subprocess呼び出し(lsof/ps/kill/Popen)を外部境界としてmonkeypatchし
 """
 import subprocess
 
-import pytest
-
 from src.services import restart_service
 
 
@@ -28,6 +26,16 @@ def test_find_listen_pids_parses_lsof_output(monkeypatch):
 def test_find_listen_pids_empty_when_nothing_listens(monkeypatch):
     def fake_run(cmd, **kwargs):
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    assert restart_service.find_listen_pids(52837) == []
+
+
+def test_find_listen_pids_empty_on_timeout(monkeypatch):
+    """lsofがハングした場合でも再起動フロー全体を無期限にブロックしない"""
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
 
     monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
 
@@ -67,18 +75,64 @@ def test_process_start_signature_none_for_dead_process(monkeypatch):
     assert restart_service.process_start_signature(1234) is None
 
 
-def test_kill_pids_invokes_kill_for_each_pid(monkeypatch):
-    captured_cmds = []
-
+def test_process_start_signature_none_on_timeout(monkeypatch):
     def fake_run(cmd, **kwargs):
-        captured_cmds.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
 
     monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
 
-    restart_service.kill_pids([1234, 5678])
+    assert restart_service.process_start_signature(1234) is None
 
-    assert captured_cmds == [["kill", "1234"], ["kill", "5678"]]
+
+def test_process_alive_false_when_process_lookup_error(monkeypatch):
+    def fake_kill(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(restart_service.os, "kill", fake_kill)
+
+    assert restart_service._process_alive(1234) is False
+
+
+def test_process_alive_true_when_permission_denied(monkeypatch):
+    """権限エラーは「シグナルは送れないが存在はする」ことを意味するため生存扱いにする"""
+    def fake_kill(pid, sig):
+        raise PermissionError
+
+    monkeypatch.setattr(restart_service.os, "kill", fake_kill)
+
+    assert restart_service._process_alive(1234) is True
+
+
+def test_kill_pids_sends_sigterm_only_when_process_dies_promptly(monkeypatch):
+    """SIGTERMだけで終了する場合はSIGKILLへエスカレーションしない"""
+    signals_sent = []
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            raise ProcessLookupError  # 生存確認: SIGTERM後すぐ死んだ想定
+        signals_sent.append((pid, sig))
+
+    monkeypatch.setattr(restart_service.os, "kill", fake_kill)
+
+    restart_service.kill_pids([1234])
+
+    assert signals_sent == [(1234, restart_service.signal.SIGTERM)]
+
+
+def test_kill_pids_escalates_to_sigkill_when_process_survives_sigterm(monkeypatch):
+    """SIGTERMを送っても生存し続けるプロセスにはSIGKILLを送る"""
+    signals_sent = []
+
+    def fake_kill(pid, sig):
+        signals_sent.append((pid, sig))  # sig=0(生存確認)も例外を投げず「生存」を返す
+
+    monkeypatch.setattr(restart_service.os, "kill", fake_kill)
+    monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
+
+    restart_service.kill_pids([1234], escalate_after_sec=0, poll_interval_sec=0)
+
+    assert (1234, restart_service.signal.SIGTERM) in signals_sent
+    assert (1234, restart_service.signal.SIGKILL) in signals_sent
 
 
 def test_is_replaced_true_when_new_pid_unseen_before(monkeypatch):
@@ -102,26 +156,39 @@ def test_is_replaced_false_when_signature_unchanged(monkeypatch):
 
 
 def test_restart_mcp_server_success_flow(monkeypatch, tmp_path):
-    """旧PID記録 → kill → 新プロセス起動 → 起動時刻検証、の一連の流れを検証する"""
-    listen_pids_responses = iter([
-        [1111],  # old_pids取得
-        [],      # kill後の生存確認(1回目でLISTEN消失)
-        [2222],  # Popen後のポーリング(新PID検出)
-    ])
-    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: next(listen_pids_responses))
+    """旧PID記録 → kill → 新プロセス起動 → 起動時刻検証、の一連の流れを検証する。
+
+    find_listen_pidsの呼び出し回数・順序ではなく、kill完了/新規プロセス起動という
+    「状態」に対して一貫した値を返すfakeにする。これにより、実装が途中で
+    追加のLISTEN確認を挟むように変わっても、observable contract（最終的な
+    RestartResult）が同じである限りテストは壊れない。
+    """
+    state = {"killed": False, "new_server_started": False}
+
+    def fake_find_listen_pids(port):
+        if state["new_server_started"]:
+            return [2222]
+        if state["killed"]:
+            return []
+        return [1111]
+
+    def fake_kill_pids(pids):
+        assert pids == [1111]
+        state["killed"] = True
+
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        state["new_server_started"] = True
+
+    monkeypatch.setattr(restart_service, "find_listen_pids", fake_find_listen_pids)
     monkeypatch.setattr(
         restart_service, "process_start_signature",
         lambda pid: {1111: "old-sig", 2222: "new-sig"}.get(pid),
     )
-
-    killed = []
-    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
-
-    popen_calls = []
-    monkeypatch.setattr(
-        restart_service.subprocess, "Popen",
-        lambda cmd, **kwargs: popen_calls.append((cmd, kwargs)),
-    )
+    monkeypatch.setattr(restart_service, "kill_pids", fake_kill_pids)
+    monkeypatch.setattr(restart_service.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
 
     result = restart_service.restart_mcp_server(tmp_path, poll_interval_sec=0)
@@ -129,7 +196,7 @@ def test_restart_mcp_server_success_flow(monkeypatch, tmp_path):
     assert result.ok is True
     assert result.old_pids == [1111]
     assert result.new_pids == [2222]
-    assert killed == [1111]
+    assert state["killed"] is True
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd == ["uv", "run", "--directory", str(tmp_path), "python", "-m", "src.launcher"]
@@ -139,16 +206,21 @@ def test_restart_mcp_server_success_flow(monkeypatch, tmp_path):
 
 def test_restart_mcp_server_skips_kill_when_nothing_was_listening(monkeypatch, tmp_path):
     """サーバーが元から起動していない場合はkillを呼ばずそのまま起動する"""
-    listen_pids_responses = iter([
-        [],      # old_pids取得(何も無い)
-        [2222],  # Popen後のポーリング(新PID検出)
-    ])
-    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: next(listen_pids_responses))
+    state = {"new_server_started": False}
+
+    def fake_find_listen_pids(port):
+        return [2222] if state["new_server_started"] else []
+
+    monkeypatch.setattr(restart_service, "find_listen_pids", fake_find_listen_pids)
     monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "sig")
 
     killed = []
     monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
-    monkeypatch.setattr(restart_service.subprocess, "Popen", lambda cmd, **kwargs: None)
+
+    def fake_popen(cmd, **kwargs):
+        state["new_server_started"] = True
+
+    monkeypatch.setattr(restart_service.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
 
     result = restart_service.restart_mcp_server(tmp_path, poll_interval_sec=0)

--- a/tests/unit/test_restart_service.py
+++ b/tests/unit/test_restart_service.py
@@ -1,0 +1,230 @@
+"""src/services/restart_service.py のユニットテスト
+
+subprocess呼び出し(lsof/ps/kill/Popen)を外部境界としてmonkeypatchし、
+プロセス入れ替え判定ロジック・キャッシュ削除の契約を検証する。
+"""
+import subprocess
+
+import pytest
+
+from src.services import restart_service
+
+
+def test_find_listen_pids_parses_lsof_output(monkeypatch):
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="1234\n5678\n", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    pids = restart_service.find_listen_pids(52837)
+
+    assert pids == [1234, 5678]
+    assert captured_cmd == [["lsof", "-ti", "tcp:52837", "-sTCP:LISTEN"]]
+
+
+def test_find_listen_pids_empty_when_nothing_listens(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    assert restart_service.find_listen_pids(52837) == []
+
+
+def test_find_listen_pids_dedupes_and_sorts(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="5678\n1234\n1234\n", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    assert restart_service.find_listen_pids(52837) == [1234, 5678]
+
+
+def test_process_start_signature_returns_stripped_lstart_output(monkeypatch):
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="  Thu Jul 24 09:32:04 2026  \n", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    signature = restart_service.process_start_signature(1234)
+
+    assert signature == "Thu Jul 24 09:32:04 2026"
+    assert captured_cmd == [["ps", "-o", "lstart=", "-p", "1234"]]
+
+
+def test_process_start_signature_none_for_dead_process(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="ps: 1234: No such process")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    assert restart_service.process_start_signature(1234) is None
+
+
+def test_kill_pids_invokes_kill_for_each_pid(monkeypatch):
+    captured_cmds = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(restart_service.subprocess, "run", fake_run)
+
+    restart_service.kill_pids([1234, 5678])
+
+    assert captured_cmds == [["kill", "1234"], ["kill", "5678"]]
+
+
+def test_is_replaced_true_when_new_pid_unseen_before(monkeypatch):
+    monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "sig")
+
+    assert restart_service._is_replaced({}, [9999]) is True
+
+
+def test_is_replaced_true_when_signature_changed_for_same_pid(monkeypatch):
+    """PID再利用のケース: 同じPID番号でも起動時刻が変わっていれば別プロセスとみなす"""
+    monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "new-sig")
+
+    assert restart_service._is_replaced({1234: "old-sig"}, [1234]) is True
+
+
+def test_is_replaced_false_when_signature_unchanged(monkeypatch):
+    """旧プロセスがkillされず生き残っているケース: 入れ替わっていないと判定する"""
+    monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "same-sig")
+
+    assert restart_service._is_replaced({1234: "same-sig"}, [1234]) is False
+
+
+def test_restart_mcp_server_success_flow(monkeypatch, tmp_path):
+    """旧PID記録 → kill → 新プロセス起動 → 起動時刻検証、の一連の流れを検証する"""
+    listen_pids_responses = iter([
+        [1111],  # old_pids取得
+        [],      # kill後の生存確認(1回目でLISTEN消失)
+        [2222],  # Popen後のポーリング(新PID検出)
+    ])
+    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: next(listen_pids_responses))
+    monkeypatch.setattr(
+        restart_service, "process_start_signature",
+        lambda pid: {1111: "old-sig", 2222: "new-sig"}.get(pid),
+    )
+
+    killed = []
+    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
+
+    popen_calls = []
+    monkeypatch.setattr(
+        restart_service.subprocess, "Popen",
+        lambda cmd, **kwargs: popen_calls.append((cmd, kwargs)),
+    )
+    monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
+
+    result = restart_service.restart_mcp_server(tmp_path, poll_interval_sec=0)
+
+    assert result.ok is True
+    assert result.old_pids == [1111]
+    assert result.new_pids == [2222]
+    assert killed == [1111]
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd == ["uv", "run", "--directory", str(tmp_path), "python", "-m", "src.launcher"]
+    assert kwargs["start_new_session"] is True
+    assert kwargs["cwd"] == str(tmp_path)
+
+
+def test_restart_mcp_server_skips_kill_when_nothing_was_listening(monkeypatch, tmp_path):
+    """サーバーが元から起動していない場合はkillを呼ばずそのまま起動する"""
+    listen_pids_responses = iter([
+        [],      # old_pids取得(何も無い)
+        [2222],  # Popen後のポーリング(新PID検出)
+    ])
+    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: next(listen_pids_responses))
+    monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "sig")
+
+    killed = []
+    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
+    monkeypatch.setattr(restart_service.subprocess, "Popen", lambda cmd, **kwargs: None)
+    monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
+
+    result = restart_service.restart_mcp_server(tmp_path, poll_interval_sec=0)
+
+    assert result.ok is True
+    assert result.old_pids == []
+    assert killed == []
+
+
+def test_restart_mcp_server_times_out_when_server_never_comes_up(monkeypatch, tmp_path):
+    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: [])
+    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: None)
+    monkeypatch.setattr(restart_service.subprocess, "Popen", lambda cmd, **kwargs: None)
+    monkeypatch.setattr(restart_service.time, "sleep", lambda _: None)
+
+    result = restart_service.restart_mcp_server(
+        tmp_path, start_timeout_sec=0, poll_interval_sec=0, kill_wait_sec=0,
+    )
+
+    assert result.ok is False
+    assert result.new_pids == []
+    assert "did not come up on port 52837" in result.detail
+
+
+def test_stop_embedding_server_kills_found_pids(monkeypatch):
+    monkeypatch.setattr(
+        restart_service, "find_listen_pids",
+        lambda port: [3333] if port == restart_service.EMBEDDING_PORT else [],
+    )
+    killed = []
+    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
+
+    result = restart_service.stop_embedding_server()
+
+    assert result == [3333]
+    assert killed == [3333]
+
+
+def test_stop_embedding_server_noop_when_not_running(monkeypatch):
+    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: [])
+    killed = []
+    monkeypatch.setattr(restart_service, "kill_pids", lambda pids: killed.extend(pids))
+
+    result = restart_service.stop_embedding_server()
+
+    assert result == []
+    assert killed == []
+
+
+def test_clean_caches_removes_plugin_cache_and_pycache(monkeypatch, tmp_path):
+    plugin_cache = tmp_path / "plugin_cache"
+    plugin_cache.mkdir()
+    (plugin_cache / "dummy.txt").write_text("x")
+    monkeypatch.setattr(restart_service, "PLUGIN_CACHE_DIR", plugin_cache)
+
+    project_root = tmp_path / "project"
+    pycache = project_root / "src" / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "foo.pyc").write_text("x")
+
+    result = restart_service.clean_caches(project_root)
+
+    assert result["removed_plugin_cache"] is True
+    assert not plugin_cache.exists()
+    assert result["removed_pycache_dirs"] == [str(pycache)]
+    assert not pycache.exists()
+
+
+def test_clean_caches_handles_missing_plugin_cache_dir(monkeypatch, tmp_path):
+    plugin_cache = tmp_path / "nonexistent"
+    monkeypatch.setattr(restart_service, "PLUGIN_CACHE_DIR", plugin_cache)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    result = restart_service.clean_caches(project_root)
+
+    assert result["removed_plugin_cache"] is False
+    assert result["removed_pycache_dirs"] == []

--- a/tests/unit/test_restart_service.py
+++ b/tests/unit/test_restart_service.py
@@ -230,6 +230,90 @@ def test_restart_mcp_server_skips_kill_when_nothing_was_listening(monkeypatch, t
     assert killed == []
 
 
+def test_restart_mcp_server_replaces_old_process_that_ignores_sigterm(monkeypatch, tmp_path):
+    """旧プロセスがSIGTERMを無視してもkill_pidsのSIGKILLエスカレーションで
+    kill_wait_sec以内に確実に片付き、新規プロセスへ入れ替わることを検証する。
+
+    kill_pidsはmockせず実装をそのまま呼び出す。エスカレーション自体が
+    無かった旧実装では、このシナリオはold_pidsがkill_wait_sec(既定10秒)
+    経過後も消えずに残り、新規プロセスがポートbindに失敗して
+    start_timeout_secでの汎用タイムアウトに陥っていた。
+    """
+    clock = {"now": 0.0}
+    monkeypatch.setattr(restart_service.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(restart_service.time, "sleep", lambda sec: clock.__setitem__("now", clock["now"] + sec))
+
+    process_alive = {1111: True}
+
+    def fake_os_kill(pid, sig):
+        if sig == 0:
+            if not process_alive.get(pid, False):
+                raise ProcessLookupError
+            return  # 生存確認: SIGTERMを送っても死なない想定
+        if sig == restart_service.signal.SIGKILL:
+            process_alive[pid] = False
+        # SIGTERMは無視され続ける(何もしない)
+
+    monkeypatch.setattr(restart_service.os, "kill", fake_os_kill)
+
+    new_server_started = {"flag": False}
+
+    def fake_find_listen_pids(port):
+        # 旧プロセスが生きている限りポートは旧PIDが握り続ける
+        # (新規プロセスはbindに失敗して観測されない)。escalationが効かず
+        # 旧プロセスが生存し続けた場合、この分岐によりis_replaced判定は
+        # 常にFalseのまま推移し、start_timeout_secでのタイムアウトを再現する。
+        if process_alive[1111]:
+            return [1111]
+        return [2222] if new_server_started["flag"] else []
+
+    monkeypatch.setattr(restart_service, "find_listen_pids", fake_find_listen_pids)
+    monkeypatch.setattr(
+        restart_service, "process_start_signature",
+        lambda pid: {1111: "old-sig", 2222: "new-sig"}.get(pid),
+    )
+
+    def fake_popen(cmd, **kwargs):
+        new_server_started["flag"] = True
+
+    monkeypatch.setattr(restart_service.subprocess, "Popen", fake_popen)
+
+    result = restart_service.restart_mcp_server(tmp_path)
+
+    assert result.ok is True
+    assert result.old_pids == [1111]
+    assert result.new_pids == [2222]
+    assert process_alive[1111] is False
+
+
+def test_restart_mcp_server_proceeds_to_start_new_process_even_if_old_process_never_dies(monkeypatch, tmp_path):
+    """SIGKILLを送っても消えない旧プロセス(D state等で応答しないケース)が
+    kill_wait_sec以内に片付かない場合、現状の実装はエスカレーションや
+    早期失敗を挟まずそのまま新規プロセス起動に進む。この既知の振る舞いを
+    固定する(ソフトウェア側の再試行では解決できないOS側の異常なので、
+    software側にできるのは早期に失敗を返すことだけだが、現状はそれもしない)。
+    """
+    clock = {"now": 0.0}
+    monkeypatch.setattr(restart_service.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(restart_service.time, "sleep", lambda sec: clock.__setitem__("now", clock["now"] + sec))
+
+    monkeypatch.setattr(restart_service.os, "kill", lambda pid, sig: None)  # 常に成功=常に生存
+    monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: [1111])
+    monkeypatch.setattr(restart_service, "process_start_signature", lambda pid: "old-sig")
+
+    popen_calls = []
+    monkeypatch.setattr(restart_service.subprocess, "Popen", lambda cmd, **kwargs: popen_calls.append(cmd))
+
+    result = restart_service.restart_mcp_server(
+        tmp_path, start_timeout_sec=1, poll_interval_sec=0.5, kill_wait_sec=1,
+    )
+
+    assert len(popen_calls) == 1  # kill_wait_sec超過後も新規プロセス起動には進んでしまう
+    assert result.ok is False
+    assert result.old_pids == [1111]
+    assert "did not come up on port 52837" in result.detail
+
+
 def test_restart_mcp_server_times_out_when_server_never_comes_up(monkeypatch, tmp_path):
     monkeypatch.setattr(restart_service, "find_listen_pids", lambda port: [])
     monkeypatch.setattr(restart_service, "kill_pids", lambda pids: None)


### PR DESCRIPTION
## Summary

- PRマージ・プラグインアップデート後にローカルMCPサーバー(52837)のコード変更を確実に反映させるため、既存プロセスを明示的に終了させてから再起動する`src/services/restart_service.py`を追加した。launcherの通常起動は「生きていれば何もしない」ensure動作のため、アップデート後もサーバーコードが古いまま残ることがあった
- 上記スクリプトを呼ぶ`restart` skillを追加した。ユーザーが明示的にskillを呼び出すことを実行の承認とみなし、追加確認なしで再起動する
- 対象はローカルMCPサーバー・embeddingサーバーの停止・プラグインキャッシュ削除のみ。launchdに依存するリモートサーバー再起動や、worktree/ブランチの後片付けは対象外（launchd plistは配布物にできないため）

## 設計判断

- サーバー入れ替わりの検証は、ポートのLISTEN確認だけでなくプロセスの起動時刻比較で行う。LISTEN確認だけでは、killが失敗して旧プロセスが生き残っているケースを「再起動成功」と誤判定しうるため
- kill対象はポートに対し`-sTCP:LISTEN`条件で絞り込む。条件を外すと接続中のブリッジプロセスまで巻き添えでkillされ、再接続の輻輳を招く

## Test plan

- [x] `tests/unit/test_restart_service.py`: プロセス入れ替え判定（新規PID/PID再利用いずれも入れ替わりとして検出）、旧プロセス不在時はkillをスキップ、起動タイムアウト時の失敗検出、embeddingサーバー停止、プラグインキャッシュ/`__pycache__`削除、の各契約を検証
- [x] `tests/unit/test_skill_md_structure.py`: 既存の全SKILL.md横断smokeテストが新規`restart` skillのfrontmatlerも含めてpass