### PR TITLE
fix: sanitize_tool_result_hookのsys.path追加漏れを修正

### DIFF
--- a/hooks/sanitize_tool_result_hook.py
+++ b/hooks/sanitize_tool_result_hook.py
@@ -20,6 +20,10 @@ import sys
 import tomllib
 from pathlib import Path
 
+_project_root = Path(__file__).resolve().parents[1]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 from hooks.hook_transcript import _is_cc_memory_tool
 from src.services.citations_pure import (
     TYPE_CODE_TO_NAME,

--- a/tests/unit/test_hooks_json_lint.py
+++ b/tests/unit/test_hooks_json_lint.py
@@ -10,6 +10,8 @@ harness が読むランタイム契約そのものであるため、実装 (各�
 import ast
 import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -94,3 +96,38 @@ def test_declared_event_script_is_registered_in_hooks_json(script_path: Path):
     event = _declared_event(script_path)
     registered = _registered_scripts_by_event()
     assert script_path.name in registered.get(event, [])
+
+
+@pytest.mark.parametrize(
+    "script_path", _DECLARING_SCRIPTS, ids=[p.name for p in _DECLARING_SCRIPTS]
+)
+def test_script_module_imports_succeed_under_declared_cwd(script_path: Path):
+    """hooks.json の実行コマンド (`cd ${CLAUDE_PLUGIN_ROOT} && uv run python
+    hooks/<script>.py`) が想定する cwd = プロジェクトルートで、スクリプトの
+    トップレベル import が解決できることを確認する。
+
+    hooks/*.py は `hooks.xxx` / `src.xxx` の絶対 import を使う規約のため、
+    プロジェクトルートを sys.path に追加する処理 (`sys.path.insert(0, ...)`)
+    を各スクリプト自身が持たないと `ModuleNotFoundError` で起動時に落ちる。
+    この種の欠陥は単体テスト (pytest 実行時は既にプロジェクトルートが
+    sys.path 上にある) では検出できず、実際に別プロセスとして起動する形で
+    しか再現しない。
+    """
+    relative_path = script_path.relative_to(_PROJECT_ROOT)
+    # `python -c` は sys.path[0] が '' (cwd) になり、hooks.json が実際に叩く
+    # `python hooks/<script>.py` (sys.path[0] = スクリプトの親ディレクトリ) と
+    # sys.path の状態が異なる。sys.path[0] を明示的にスクリプトの親ディレクトリへ
+    # 上書きしてから run_path することで、本番と同じ import 解決条件を再現する。
+    setup = f"import sys; sys.path[0] = {str(script_path.parent)!r}"
+    run = f"import runpy; runpy.run_path({str(relative_path)!r}, run_name='_hooks_json_lint_import_check')"
+    result = subprocess.run(
+        [sys.executable, "-c", f"{setup}\n{run}"],
+        cwd=_PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"{relative_path} のトップレベル import が cwd={_PROJECT_ROOT} で失敗した:\n"
+        f"{result.stderr}"
+    )


### PR DESCRIPTION
## Summary
- `hooks/sanitize_tool_result_hook.py` はプロジェクトルートを `sys.path` に追加する処理が無いまま `from hooks.hook_transcript import ...` のような絶対importを使っており、PostToolUse実行のたび(全ツール呼び出し後)に `ModuleNotFoundError` で起動時クラッシュしていた
- 他のhookスクリプト (`sanitize_backfill_hook.py` 等) と同じ `sys.path.insert` 処理を追加して解消した
- 単体テスト(pytest実行時は既にプロジェクトルートがsys.path上にある)では検出できず、実プロセスとして起動した場合のみ再現する種類の欠陥だったため、hooks.json配線lintテストに、実際に別プロセスで起動しimportが解決できることを検証するテストを追加した

## Test plan
- 修正前後で `test_script_module_imports_succeed_under_declared_cwd[sanitize_tool_result_hook.py]` がRED→GREENになることを確認(バグ検出力の検証)
- hooks配下の全登録スクリプトについて、`hooks.json` が実行する条件(cwd=プロジェクトルート)と同じsys.path状態で起動してもトップレベルimportが解決できることを確認
- 既存の `tests/unit/test_sanitize_tool_result_hook.py`(15件)・`tests/unit/test_hooks_json_lint.py` が全てpass