### PR TITLE
fix: sanitize_tool_result_hookのcontent二重ラップを解消

### DIFF
--- a/hooks/sanitize_tool_result_hook.py
+++ b/hooks/sanitize_tool_result_hook.py
@@ -2,7 +2,9 @@
 
 stdin から JSON (tool_name / tool_response / cwd / session_id / transcript_path) を読み、
 cc-memory tool の場合に tool_response.content をサニタイズして
-hookSpecificOutput.updatedToolOutput で stdout へ返す。
+hookSpecificOutput.updatedToolOutput で stdout へ返す。updatedToolOutput の型
+(dict か content block 配列そのものか) は tool_response の元の型に合わせて出し分ける
+(理由は main() 内の分岐直上コメントを参照)。
 
 opt-out:
 - 環境変数 `CC_MEMORY_SANITIZE_DISABLE=1` set: 即 exit 0
@@ -251,6 +253,15 @@ def main() -> int:
             return 0
         sanitized_text, counters = _sanitize_content(content, db_path)
         content_block = [{"type": "text", "text": sanitized_text}]
+        # updatedToolOutput は tool_response の元の型構造をそのまま保って返す必要がある。
+        # tool_response が dict の場合、CLI 側は content 以外のフィールドも維持された
+        # dict を前提にしている (test_case_10_official_hook_output_schema)。tool_response
+        # が非 dict (生文字列等) の場合は、updatedToolOutput 自体が content block 配列と
+        # してそのまま扱われる (test_case_14_non_dict_tool_response_yields_unwrapped_content_block)。
+        # ここで型を dict/配列のどちらかに統一すると、統一しなかった側の経路で content が
+        # 二重にラップされ、CLI 側のサイズ計算処理がクラッシュする。tool_response の内部
+        # 構造自体はハーネス依存で公開仕様が無い (hooks/relay_monitor_watch_hook.py:23-24
+        # 参照) ため、この非対称性は暗黙の契約として扱い、統一しないこと。
         if isinstance(tool_response, dict):
             updated_output = {**tool_response, "content": content_block}
         else:

--- a/hooks/sanitize_tool_result_hook.py
+++ b/hooks/sanitize_tool_result_hook.py
@@ -254,7 +254,7 @@ def main() -> int:
         if isinstance(tool_response, dict):
             updated_output = {**tool_response, "content": content_block}
         else:
-            updated_output = {"content": content_block}
+            updated_output = content_block
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PostToolUse",

--- a/tests/unit/test_sanitize_tool_result_hook.py
+++ b/tests/unit/test_sanitize_tool_result_hook.py
@@ -375,16 +375,19 @@ def test_case_12_other_tool_response_fields_preserved(fixture_db):
 
 
 # ---------------------------------------------------------------------------
-# Case #14: updatedToolOutput.content は常に list 型であり、str 型には絶対にならない
-# (content が文字列だとクライアント側で content 配列を前提とした処理がクラッシュする)
+# Case #14: tool_response が非 dict (生文字列) のとき、updatedToolOutput は
+# content block 配列そのものになる (二重ラップされない)
 # ---------------------------------------------------------------------------
 
 
-def test_case_14_content_is_always_list_never_string(fixture_db):
-    """tool_response が dict でなく生の JSON 文字列そのものの場合でも、
+def test_case_14_non_dict_tool_response_yields_unwrapped_content_block(fixture_db):
+    """tool_response が dict でなく生の JSON 文字列そのものの場合、
 
-    updatedToolOutput.content は常に content block 配列 ([{"type": "text", "text": ...}])
-    になり、str 型には絶対にならないことを保証する回帰テスト。
+    updatedToolOutput は content block 配列 ([{"type": "text", "text": ...}]) そのもの
+    になり、`{"content": [...]}` のように dict でさらに包まれてはならないことを保証する
+    回帰テスト。updatedToolOutput は Claude Code CLI 側でツール結果の content に
+    そのままセットされるため、二重にラップすると content が dict になり
+    クライアント側の処理がクラッシュする。
     """
     raw_tool_response = json.dumps({"activities": [], "total_count": 0, "archived_tags": []})
     payload = {
@@ -397,10 +400,11 @@ def test_case_14_content_is_always_list_never_string(fixture_db):
     stdout, code = _run_hook(payload)
     assert code == 0
     out = json.loads(stdout)
-    content = out["hookSpecificOutput"]["updatedToolOutput"]["content"]
-    assert isinstance(content, list)
-    assert not isinstance(content, str)
-    assert content == [{"type": "text", "text": raw_tool_response}]
+    updated_output = out["hookSpecificOutput"]["updatedToolOutput"]
+    assert isinstance(updated_output, list)
+    assert not isinstance(updated_output, dict)
+    assert not isinstance(updated_output, str)
+    assert updated_output == [{"type": "text", "text": raw_tool_response}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

tool_responseが文字列などdict以外の場合、PostToolUseフックが返す`updatedToolOutput`が`{"content": [...]}`というdictでさらに包まれてしまい、Claude Code CLI側のツール結果サイズ計算処理がクラッシュしていた。CLI側は`updatedToolOutput`をcontent block配列そのものとして扱う前提のため、dictで二重に包むと配列を対象にした処理が型不一致で失敗する。

この状態ではcc-memoryのMCPツール呼び出しが、tool_responseの型によっては全滅する。`updatedToolOutput`を二重に包まずcontent block配列そのものとして返すよう修正した。

## Test plan

- 更新した回帰テストで、tool_responseが非dict(生文字列)のとき`updatedToolOutput`がdictでもstrでもなくcontent block配列そのものであることを検証
- 既存15件のテストに影響なし、全16件pass
- 実機でサーバーを再起動し、`get_activities`等のMCPツール呼び出しがエラーなく成功することを確認