### PR TITLE
fix: hookのfail-open検証e2eテストにDB隔離を追加

### DIFF
--- a/tests/e2e/test_relay_monitor_watch_hook.py
+++ b/tests/e2e/test_relay_monitor_watch_hook.py
@@ -400,7 +400,8 @@ class TestIdentityCacheSharing:
 class TestFailOpen:
     """例外系はすべて空JSON出力（フェイルオープン）"""
 
-    def test_invalid_json_input(self, state_dir):
+    def test_invalid_json_input(self, state_dir, tmp_path):
+        db_path = str(tmp_path / "test.db")
         result = subprocess.run(
             [sys.executable, "hooks/relay_monitor_watch_hook.py"],
             input="not valid json",
@@ -411,6 +412,7 @@ class TestFailOpen:
                 **os.environ,
                 "HOOK_STATE_DIR": str(state_dir),
                 "CCM_RELAY_SESSION_AWARE": "1",
+                "DISCUSSION_DB_PATH": db_path,
             },
         )
         assert result.returncode == 0

--- a/tests/e2e/test_stop_hook.py
+++ b/tests/e2e/test_stop_hook.py
@@ -178,6 +178,7 @@ class TestExceptionFailOpen:
         state_as_file.write_text("not a directory")
 
         env_override = {
+            **env_setup["env_override"],
             "HOOK_STATE_DIR": str(state_as_file),
         }
 

--- a/tests/e2e/test_user_prompt_submit_hook.py
+++ b/tests/e2e/test_user_prompt_submit_hook.py
@@ -487,14 +487,14 @@ class TestEmptyStdin:
 class TestFailOpen:
     """例外→空JSON（フェイルオープン）"""
 
-    def test_invalid_json_input(self, state_dir):
+    def test_invalid_json_input(self, state_dir, temp_db):
         proc = subprocess.run(
             [sys.executable, "hooks/user_prompt_submit_hook.py"],
             input="not valid json",
             capture_output=True,
             text=True,
             cwd=str(_PROJECT_ROOT),
-            env={**os.environ, "HOOK_STATE_DIR": str(state_dir)},
+            env={**os.environ, "HOOK_STATE_DIR": str(state_dir), "DISCUSSION_DB_PATH": temp_db},
         )
         assert proc.returncode == 0
         assert json.loads(proc.stdout) == {}


### PR DESCRIPTION
## Summary

- 例外発生時にhookがfail-open（承認しつつmachine_errorシグナルを記録）する挙動を検証するe2eテスト3件が、DISCUSSION_DB_PATH環境変数の隔離なしに実行されていた
- そのためローカルでpytestを実行するたびに、本番のcc-memory DBのsignal_eventsテーブルへ偽のmachine_errorシグナルが書き込まれていた
- 各テストの直後には同じ例外経路をDB隔離込みで検証する姉妹テストが存在しており、そのパターンに合わせて隔離するよう修正した

## Test plan

- [x] `tests/e2e/test_stop_hook.py::TestExceptionFailOpen` 全件pass
- [x] `tests/e2e/test_user_prompt_submit_hook.py::TestFailOpen` 全件pass
- [x] `tests/e2e/test_relay_monitor_watch_hook.py::TestFailOpen` 全件pass
- [x] 3ファイル通しで実行し、修正対象以外の既存テスト（60件）に影響がないことを確認。別クラスで4件failするが、修正前のコードでも同様にfailすることを確認済みで本PRと無関係（別環境要因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)