### PR TITLE
feat: テストピラミッド形状をCIで機械検証するtest-pyramid job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,20 +98,17 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: uv sync --frozen
-
       - name: Check every tests/ subdirectory is referenced by a CI job
-        run: uv run python scripts/check_test_dir_coverage.py
+        run: python3 scripts/check_test_dir_coverage.py
 
       - name: Check tests/unit does not contain real subprocess launches
-        run: uv run python scripts/check_unit_subprocess_placement.py
+        run: python3 scripts/check_unit_subprocess_placement.py
 
       - name: Check no test function silently disappeared
         env:
           CCM_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          uv run python scripts/check_test_removal.py \
+          python3 scripts/check_test_removal.py \
             --base ${{ github.event.pull_request.base.sha }} \
             --head ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - name: unit
-            path: tests/unit tests/test_migrations
+            path: tests/unit tests/test_migrations tests/services
           - name: integration-e2e
             path: tests/integration tests/e2e
 
@@ -83,6 +83,37 @@ jobs:
 
       - name: Check docs/spec/db-schema-tables.md is generated from migrations
         run: uv run python scripts/dump_db_schema.py --check
+
+  test-pyramid:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Check every tests/ subdirectory is referenced by a CI job
+        run: uv run python scripts/check_test_dir_coverage.py
+
+      - name: Check tests/unit does not contain real subprocess launches
+        run: uv run python scripts/check_unit_subprocess_placement.py
+
+      - name: Check no test function silently disappeared
+        env:
+          CCM_PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          uv run python scripts/check_test_removal.py \
+            --base ${{ github.event.pull_request.base.sha }} \
+            --head ${{ github.event.pull_request.head.sha }}
 
   migration-lint:
     runs-on: ubuntu-latest

--- a/docs/spec/test-convention.md
+++ b/docs/spec/test-convention.md
@@ -77,7 +77,7 @@ SKILL.md は AI が読んで実行する自然言語プロンプトであり、�
 - `tests/integration/`: 複数サービスの連携・MCPツール層の配線を検証するテスト
 - `tests/e2e/`: subprocess 起動（hooks・CLIスクリプト・実サーバー）を伴うテスト
 - `tests/test_migrations/`: migration の部分適用テスト（§1 の定型）
-- `tests/services/`: 歴史的経緯で残っている。新規テストはここに置かず、上記4分類のいずれかに置く
+- `tests/services/`: 歴史的経緯で残っている。新規テストはここに置かず、上記4分類のいずれかに置く（CIでは`unit`ジョブの一部として実行される）
 - 命名は対象モジュールに対応させる: `src/services/foo.py` → `tests/unit/test_foo.py`。対応が機械的に辿れることが、実装時の「対応テストだけ回す」運用（§6）の前提になる
 - 同名テストファイルを複数ディレクトリに置かない（対応の一意性を壊す）
 
@@ -93,7 +93,15 @@ SKILL.md は AI が読んで実行する自然言語プロンプトであり、�
 
 実装フェーズでのテスト実行は「変更ファイルに対応するテスト + 関連する integration テスト」までに絞る。フルスイートの実行は push 後の CI に委譲し、done 条件は「対応テスト + lint 通過」とする。CI の失敗は別ターンで吸収する。
 
-## 7. 本規約の配達経路
+## 7. CIによる形状チェック（`test-pyramid` job）
+
+`.github/workflows/test.yml` の `test-pyramid` job が、本規約の一部を機械的に強制する。
+
+1. `scripts/check_test_dir_coverage.py`: `tests/` 直下の全サブディレクトリが `.github/workflows/*.yml` のいずれかのjobから参照されていることを検証する。参照の無いディレクトリはCIで一切実行されていない可能性が高い
+2. `scripts/check_unit_subprocess_placement.py`: `tests/unit/` 配下に実プロセスのsubprocess起動を含むファイルが紛れ込んでいないかを検証する（§4のtests/unit/tests/e2e分類を強制）。既存の許容ファイルは `scripts/test_pyramid_allowlist.txt` に列挙する
+3. `scripts/check_test_removal.py`: base commitからhead commitにかけて、気づかれずに消えたテスト関数が無いかを検証する。意図的な削除であれば、PR本文に `[test-removal: <理由>]` 形式のマーカー行を含めることで通過できる（`[no-schema-shape-change]` 等の既存の例外マーカーと同じ運用）
+
+## 8. 本規約の配達経路
 
 - 正本: 本ファイル（`docs/spec/test-convention.md`）
 - 書き手向け: `tests/CLAUDE.md` が最重要原則と正本へのポインタを持つ（tests/ 配下のファイル編集時に自動でコンテキストに載る）

--- a/scripts/check_test_dir_coverage.py
+++ b/scripts/check_test_dir_coverage.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""テストピラミッド網羅チェック: `tests/` 直下の全サブディレクトリが
+`.github/workflows/*.yml` のいずれかのjobから参照されているかを検証する。
+
+参照判定は「workflow YAMLの生テキストに `tests/<サブディレクトリ名>` という
+文字列が含まれるか」の単純な文字列マッチで行う。pytestの実行パス引数・
+`--collect-only` の対象パスいずれの書き方でも検出できる一方、ディレクトリ名が
+たまたま別の文字列（コメント等）に含まれるだけでも誤って「参照あり」判定になる
+点はこの実装のトレードオフ。
+
+`tests/` 直下のサブディレクトリは動的に列挙するため、新しいテストディレクトリ
+（`tests/foo/` 等）を追加してもこのスクリプト自体の変更は不要で、workflow側に
+参照を追加し忘れるとCIがこのチェックで落ちる。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+
+
+def discover_test_dirs(tests_root: Path) -> list[str]:
+    """`tests/` 直下のサブディレクトリ名一覧を返す(隠しディレクトリ・__pycache__は除外)。"""
+    if not tests_root.is_dir():
+        return []
+    names = [
+        p.name
+        for p in tests_root.iterdir()
+        if p.is_dir() and not p.name.startswith(".") and not p.name.startswith("_")
+    ]
+    return sorted(names)
+
+
+def workflow_text(workflows_dir: Path) -> str:
+    """`.github/workflows/*.yml` (`*.yaml` も含む) の全内容を連結して返す。"""
+    chunks: list[str] = []
+    if not workflows_dir.is_dir():
+        return ""
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        chunks.append(path.read_text())
+    return "\n".join(chunks)
+
+
+def find_unreferenced_dirs(test_dirs: list[str], combined_workflow_text: str) -> list[str]:
+    """workflowテキストに `tests/<name>` を含まないディレクトリ名一覧を返す。"""
+    return [name for name in test_dirs if f"tests/{name}" not in combined_workflow_text]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=Path, default=_PROJECT_ROOT)
+    args = parser.parse_args(argv)
+
+    repo_root: Path = args.repo_root
+    tests_root = repo_root / "tests"
+    workflows_dir = repo_root / ".github" / "workflows"
+
+    test_dirs = discover_test_dirs(tests_root)
+    if not test_dirs:
+        print(f"WARNING: {tests_root} 配下にサブディレクトリが見つからなかった", file=sys.stderr)
+        return 0
+
+    combined = workflow_text(workflows_dir)
+    unreferenced = find_unreferenced_dirs(test_dirs, combined)
+
+    if unreferenced:
+        print(
+            "FAIL: 以下のtests/サブディレクトリが .github/workflows/*.yml のどのjobからも "
+            "参照されていない(CIで実行されていない可能性):",
+            file=sys.stderr,
+        )
+        for name in unreferenced:
+            print(f"  - tests/{name}", file=sys.stderr)
+        return 1
+
+    print(f"check_test_dir_coverage: OK ({len(test_dirs)}ディレクトリ全て参照済み: {', '.join(test_dirs)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_removal.py
+++ b/scripts/check_test_removal.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""テスト消失検知: base commitからhead commitにかけて、気づかれずに消えた
+テスト関数が無いかを検証する。
+
+base/head それぞれのcommitを一時worktreeにcheckoutし、`pytest --collect-only`
+で収集したnode ID集合を関数レベル(parametrize展開前の
+`モジュールパス::クラス名::関数名`。`[...]` のparametrize suffixは比較対象から
+除く)に正規化して比較する。base側のnode IDはgitのrename検出結果でファイル
+パス部分を付け替えてから比較するため、単純なファイルrename(関数自体は無傷)
+は「消えた」扱いにならない。baseに存在しheadで消えた関数があれば、PR本文に
+`[test-removal: ...]` で始まるマーカー行が含まれているかを確認し、無ければ
+消えた関数一覧を表示してエラー終了する。
+
+使い方:
+    uv run python scripts/check_test_removal.py --base <ref> --head <ref>
+
+PR本文をチェック対象に含めるには環境変数 CCM_PR_BODY にPR本文を渡す
+(GitHub Actions では `${{ github.event.pull_request.body }}` を渡す想定。
+`scripts/lint_doc_cochange.py` の前例に倣う)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+
+TEST_REMOVAL_MARKER_PREFIX = "[test-removal: "
+
+# pytestのnode ID行の先頭判定に使う。node IDはファイルパスから始まり、
+# parametrize idに空白や記号が混じっても先頭の `<path>.py::` 部分に空白は
+# 出現しないため、行頭一致で十分に判別できる。
+_NODEID_LINE_RE = re.compile(r"^\S+\.py::")
+
+
+def to_function_id(node_id: str) -> str:
+    """pytest node ID からparametrize suffix(`[...]`)を取り除いた関数レベルIDを返す。
+
+    `path::Class::method[params]` -> `path::Class::method`
+    `path::function[params]` -> `path::function`
+    """
+    parts = node_id.split("::")
+    last = parts[-1]
+    if "[" in last:
+        last = last.split("[", 1)[0]
+    parts[-1] = last
+    return "::".join(parts)
+
+
+def parse_collect_output(stdout: str) -> set[str]:
+    """`pytest --collect-only -q` の標準出力から関数レベルのnode ID集合を抽出する。"""
+    ids: set[str] = set()
+    for line in stdout.splitlines():
+        line = line.rstrip("\n")
+        if _NODEID_LINE_RE.match(line):
+            ids.add(to_function_id(line))
+    return ids
+
+
+def collect_test_ids(repo_root: Path, ref: str, *, uv_sync: bool = True) -> set[str]:
+    """指定refを一時worktreeにcheckoutし、pytest --collect-onlyで関数レベルの
+    node ID集合を取得する。
+
+    実行環境(依存パッケージ)もref時点のpyproject.toml/uv.lockに合わせて
+    `uv sync --frozen` で再構築するため、ref間でテスト対象コードやテスト自体の
+    import 可否が変わっていても正しく収集できる。
+    """
+    with tempfile.TemporaryDirectory(prefix="test-pyramid-collect-") as tmp:
+        worktree_dir = Path(tmp) / "wt"
+        add = subprocess.run(
+            ["git", "worktree", "add", "--detach", "-f", str(worktree_dir), ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if add.returncode != 0:
+            raise RuntimeError(
+                f"'git worktree add' に失敗した(ref={ref}):\n{add.stdout}\n{add.stderr}"
+            )
+        try:
+            if uv_sync:
+                sync = subprocess.run(
+                    ["uv", "sync", "--frozen"],
+                    cwd=worktree_dir,
+                    capture_output=True,
+                    text=True,
+                )
+                if sync.returncode != 0:
+                    raise RuntimeError(
+                        f"'uv sync --frozen' に失敗した(ref={ref}):\n{sync.stdout}\n{sync.stderr}"
+                    )
+
+            tests_dir = worktree_dir / "tests"
+            if not tests_dir.is_dir():
+                return set()
+
+            collect = subprocess.run(
+                ["uv", "run", "pytest", "--collect-only", "-q", "tests"],
+                cwd=worktree_dir,
+                capture_output=True,
+                text=True,
+            )
+            # pytestの終了コード: 0=正常, 2=一部収集エラーを含む(部分結果は使える),
+            # 5=収集0件。それ以外は環境自体が壊れている可能性が高く、
+            # 「テストが消えた」との誤判定を避けるためハードエラーにする。
+            if collect.returncode not in (0, 2, 5):
+                raise RuntimeError(
+                    f"'pytest --collect-only' が異常終了した(ref={ref}, "
+                    f"returncode={collect.returncode}):\n{collect.stdout}\n{collect.stderr}"
+                )
+            if collect.returncode == 2:
+                print(
+                    f"WARNING: ref={ref} のテスト収集で一部エラーが発生した"
+                    "(収集できたテストのみで比較する):",
+                    file=sys.stderr,
+                )
+                print(collect.stderr, file=sys.stderr)
+
+            return parse_collect_output(collect.stdout)
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree_dir)],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+            )
+
+
+def has_removal_marker(pr_body: str) -> bool:
+    return any(line.strip().startswith(TEST_REMOVAL_MARKER_PREFIX) for line in pr_body.splitlines())
+
+
+def detect_file_renames(repo_root: Path, base: str, head: str) -> dict[str, str]:
+    """base..headのマージベース基準diffから、tests/配下のファイルrenameを
+    `{旧パス: 新パス}` の辞書として返す。
+
+    ファイルrenameだけでnode IDのファイルパス部分が変わり、関数自体は
+    無傷でも「消えた」と誤検知されるのを防ぐための正規化に使う。
+    """
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-M", f"{base}...{head}", "--", "tests/"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {}
+
+    renames: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) == 3 and fields[0].startswith("R"):
+            _status, old_path, new_path = fields
+            renames[old_path] = new_path
+    return renames
+
+
+def apply_renames(ids: set[str], renames: dict[str, str]) -> set[str]:
+    """node ID集合のファイルパス部分をrenameマップで新パスへ付け替える。"""
+    if not renames:
+        return ids
+    remapped: set[str] = set()
+    for node_id in ids:
+        path, sep, rest = node_id.partition("::")
+        new_path = renames.get(path, path)
+        remapped.add(f"{new_path}{sep}{rest}" if sep else new_path)
+    return remapped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", required=True, help="比較元ref(例: PRのbase commit sha)")
+    parser.add_argument("--head", required=True, help="比較先ref(例: PRのhead commit sha)")
+    parser.add_argument("--repo-root", type=Path, default=_PROJECT_ROOT)
+    parser.add_argument(
+        "--no-uv-sync",
+        action="store_true",
+        help="worktree内でuv syncを実行しない(呼び出し元が既に依存関係を揃えている場合の高速化用)",
+    )
+    args = parser.parse_args(argv)
+
+    pr_body = os.environ.get("CCM_PR_BODY", "")
+
+    base_ids = collect_test_ids(args.repo_root, args.base, uv_sync=not args.no_uv_sync)
+    head_ids = collect_test_ids(args.repo_root, args.head, uv_sync=not args.no_uv_sync)
+
+    renames = detect_file_renames(args.repo_root, args.base, args.head)
+    base_ids = apply_renames(base_ids, renames)
+
+    removed = sorted(base_ids - head_ids)
+
+    if not removed:
+        print("check_test_removal: OK (消えたテスト関数なし)")
+        return 0
+
+    if has_removal_marker(pr_body):
+        print(
+            f"check_test_removal: {len(removed)}件のテスト関数が削除されているが、"
+            f"PR本文の '{TEST_REMOVAL_MARKER_PREFIX}...' マーカーを確認したため許可する:"
+        )
+        for name in removed:
+            print(f"  - {name}")
+        return 0
+
+    print(
+        f"FAIL: base({args.base})に存在していた以下の{len(removed)}件のテスト関数が"
+        f"head({args.head})で検出されなくなった:",
+        file=sys.stderr,
+    )
+    for name in removed:
+        print(f"  - {name}", file=sys.stderr)
+    print(
+        f"意図的な削除であれば、PR本文に '{TEST_REMOVAL_MARKER_PREFIX}<理由>]' 形式の"
+        "マーカー行を含めること。",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_removal.py
+++ b/scripts/check_test_removal.py
@@ -137,15 +137,33 @@ def has_removal_marker(pr_body: str) -> bool:
     return any(line.strip().startswith(TEST_REMOVAL_MARKER_PREFIX) for line in pr_body.splitlines())
 
 
+def decide(base_ids: set[str], head_ids: set[str], pr_body: str) -> tuple[list[str], bool]:
+    """base_ids/head_idsから消えた関数一覧と、それを許可してよいかを判定する。
+
+    Returns:
+        (removed, allowed): removedはbaseに存在しheadで消えた関数IDのsorted list。
+        allowedはremovedが空、またはpr_bodyにtest-removalマーカーがあるときTrue。
+    """
+    removed = sorted(base_ids - head_ids)
+    if not removed:
+        return removed, True
+    return removed, has_removal_marker(pr_body)
+
+
 def detect_file_renames(repo_root: Path, base: str, head: str) -> dict[str, str]:
-    """base..headのマージベース基準diffから、tests/配下のファイルrenameを
-    `{旧パス: 新パス}` の辞書として返す。
+    """base..head(2ドット、baseとheadの直接比較)から、tests/配下のファイル
+    renameを`{旧パス: 新パス}` の辞書として返す。
+
+    `collect_test_ids` はbase/headを文字通りのrefとしてworktree checkoutする
+    ため、rename検出もそれに合わせて2ドット(直接比較)にする。3ドット
+    (マージベース基準)にすると、baseブランチがPR分岐後に進んでいる場合に
+    比較範囲がずれ、baseブランチ側で起きたrenameを見落として誤検知しうる。
 
     ファイルrenameだけでnode IDのファイルパス部分が変わり、関数自体は
     無傷でも「消えた」と誤検知されるのを防ぐための正規化に使う。
     """
     result = subprocess.run(
-        ["git", "diff", "--name-status", "-M", f"{base}...{head}", "--", "tests/"],
+        ["git", "diff", "--name-status", "-M", f"{base}..{head}", "--", "tests/"],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -194,13 +212,13 @@ def main(argv: list[str] | None = None) -> int:
     renames = detect_file_renames(args.repo_root, args.base, args.head)
     base_ids = apply_renames(base_ids, renames)
 
-    removed = sorted(base_ids - head_ids)
+    removed, allowed = decide(base_ids, head_ids, pr_body)
 
     if not removed:
         print("check_test_removal: OK (消えたテスト関数なし)")
         return 0
 
-    if has_removal_marker(pr_body):
+    if allowed:
         print(
             f"check_test_removal: {len(removed)}件のテスト関数が削除されているが、"
             f"PR本文の '{TEST_REMOVAL_MARKER_PREFIX}...' マーカーを確認したため許可する:"

--- a/scripts/check_unit_subprocess_placement.py
+++ b/scripts/check_unit_subprocess_placement.py
@@ -5,9 +5,11 @@
 伴うテストは `tests/e2e/` に置く規約になっている(docs/spec/test-convention.md §4)。
 この規約から外れた新規ファイルの紛れ込みを機械的に検知する。
 
-検出パターンは `subprocess.run(` / `subprocess.Popen(` / `Popen(` の呼び出し
-構文(開き括弧まで)。docstringやコメント中の「subprocess.Popenが呼ばれる」の
-ような散文的な言及は開き括弧を伴わないため誤検知しない。
+検出パターンは `subprocess.run(` / `subprocess.Popen(` / `Popen(` /
+`subprocess.call(` / `subprocess.check_call(` / `subprocess.check_output(` /
+`os.system(` / `os.popen(` の呼び出し構文(開き括弧まで)。docstringやコメント
+中の「subprocess.Popenが呼ばれる」のような散文的な言及は開き括弧を伴わない
+ため誤検知しない。
 
 `scripts/test_pyramid_allowlist.txt` に列挙済みの既存ファイルは除外し、
 リストに無い新規ファイルでパターンが見つかった場合のみエラー終了する。
@@ -24,7 +26,9 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROJECT_ROOT = _SCRIPT_DIR.parent
 _DEFAULT_ALLOWLIST = _SCRIPT_DIR / "test_pyramid_allowlist.txt"
 
-_SUBPROCESS_CALL_RE = re.compile(r"subprocess\.run\(|subprocess\.Popen\(|\bPopen\(")
+_SUBPROCESS_CALL_RE = re.compile(
+    r"subprocess\.(run|Popen|call|check_call|check_output)\(|\bPopen\(|os\.system\(|os\.popen\("
+)
 
 
 def load_allowlist(path: Path) -> set[str]:

--- a/scripts/check_unit_subprocess_placement.py
+++ b/scripts/check_unit_subprocess_placement.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""tests/unit/ 配置lint: 実プロセスをsubprocessで起動しているファイルを検出する。
+
+`tests/unit/` は in-process で完結するテストの置き場であり、実プロセス起動を
+伴うテストは `tests/e2e/` に置く規約になっている(docs/spec/test-convention.md §4)。
+この規約から外れた新規ファイルの紛れ込みを機械的に検知する。
+
+検出パターンは `subprocess.run(` / `subprocess.Popen(` / `Popen(` の呼び出し
+構文(開き括弧まで)。docstringやコメント中の「subprocess.Popenが呼ばれる」の
+ような散文的な言及は開き括弧を伴わないため誤検知しない。
+
+`scripts/test_pyramid_allowlist.txt` に列挙済みの既存ファイルは除外し、
+リストに無い新規ファイルでパターンが見つかった場合のみエラー終了する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+_DEFAULT_ALLOWLIST = _SCRIPT_DIR / "test_pyramid_allowlist.txt"
+
+_SUBPROCESS_CALL_RE = re.compile(r"subprocess\.run\(|subprocess\.Popen\(|\bPopen\(")
+
+
+def load_allowlist(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    names: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        names.add(line)
+    return names
+
+
+def find_violations(unit_dir: Path, allowlist: set[str]) -> list[str]:
+    """subprocess呼び出しパターンを含み、かつ許可リストに無いファイル名一覧を返す(ソート済み)。"""
+    if not unit_dir.is_dir():
+        return []
+    violations: list[str] = []
+    for path in sorted(unit_dir.glob("*.py")):
+        if path.name in allowlist:
+            continue
+        text = path.read_text()
+        if _SUBPROCESS_CALL_RE.search(text):
+            violations.append(path.name)
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=Path, default=_PROJECT_ROOT)
+    parser.add_argument("--allowlist", type=Path, default=_DEFAULT_ALLOWLIST)
+    args = parser.parse_args(argv)
+
+    unit_dir = args.repo_root / "tests" / "unit"
+    allowlist = load_allowlist(args.allowlist)
+
+    violations = find_violations(unit_dir, allowlist)
+
+    if violations:
+        print(
+            "FAIL: 以下のtests/unit/配下のファイルが実プロセスのsubprocess起動を含んでいる"
+            "(規約上はtests/e2e/相当。意図的なら scripts/test_pyramid_allowlist.txt に追加すること):",
+            file=sys.stderr,
+        )
+        for name in violations:
+            print(f"  - tests/unit/{name}", file=sys.stderr)
+        return 1
+
+    print(f"check_unit_subprocess_placement: OK (許可リスト{len(allowlist)}件を除外して違反なし)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_pyramid_allowlist.txt
+++ b/scripts/test_pyramid_allowlist.txt
@@ -1,0 +1,13 @@
+# check_unit_subprocess_placement.py の許可リスト。
+# tests/unit/ 配下だが実プロセスをsubprocessで起動している(規約上はtests/e2e/相当の)
+# 既存ファイルをここに列挙する。1行1ファイル名(拡張子込み、ディレクトリ無し)。
+# `#` で始まる行と空行は無視する。
+#
+# このリストに無い新規ファイルでsubprocess呼び出しパターンが見つかった場合のみ
+# check_unit_subprocess_placement.py はエラー終了する。
+test_go_package.py
+test_gate_check.py
+test_migration_lint.py
+test_pr_size_check.py
+test_hook_state.py
+test_hooks_json_lint.py

--- a/tests/e2e/test_check_test_removal.py
+++ b/tests/e2e/test_check_test_removal.py
@@ -90,3 +90,30 @@ def test_rename_outside_tests_dir_is_ignored(git_repo: Path):
     head = _commit_all(git_repo, "rename non-test file")
 
     assert detect_file_renames(git_repo, base, head) == {}
+
+
+def test_rename_made_independently_on_base_after_head_diverged_is_still_detected(git_repo: Path):
+    """headから見て祖先関係にないbase側だけの独立したrenameも検出できることを確認する。
+
+    3ドット(`base...head`)はmerge-base(base, head)からheadへの差分しか見ないため、
+    head分岐後にbase側だけで起きたrenameを取りこぼす。2ドット(`base..head`)は
+    2つのtree自体を直接比較するため、コミット祖先関係に関係なく検出できる。
+    """
+    root = subprocess.run(
+        ["git", "-C", str(git_repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # head側: test_a.pyには触れず、無関係な変更のみでrootから分岐させる
+    (git_repo / "unrelated.txt").write_text("x\n", encoding="utf-8")
+    head = _commit_all(git_repo, "unrelated head-side change")
+
+    # base側: rootに戻ってから、head側の履歴には無い独立したrenameを行う
+    subprocess.run(["git", "-C", str(git_repo), "checkout", "-q", root], check=True)
+    old_path = git_repo / "tests" / "unit" / "test_a.py"
+    new_path = git_repo / "tests" / "unit" / "test_a_renamed.py"
+    new_path.write_text(old_path.read_text(), encoding="utf-8")
+    old_path.unlink()
+    base = _commit_all(git_repo, "base-side independent rename")
+
+    renames = detect_file_renames(git_repo, base, head)
+    assert renames == {"tests/unit/test_a_renamed.py": "tests/unit/test_a.py"}

--- a/tests/e2e/test_check_test_removal.py
+++ b/tests/e2e/test_check_test_removal.py
@@ -1,0 +1,92 @@
+"""scripts/check_test_removal.py のうち実gitリポジトリを介する
+`detect_file_renames` を検証する。
+
+`collect_test_ids` / `main` が行う git worktree + uv sync + pytest --collect-only
+の統合的な振る舞いは、依存パッケージのインストールを要し実行コストが高いため
+ここでは対象としない。合成リポジトリで高速に検証できる `detect_file_renames`
+のみを対象にする。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.check_test_removal import detect_file_renames  # noqa: E402
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "commit.gpgsign", "false"], check=True)
+
+
+def _commit_all(path: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", message], check=True)
+    out = subprocess.run(["git", "-C", str(path), "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "tests" / "unit").mkdir(parents=True)
+    (repo / "tests" / "unit" / "test_a.py").write_text(
+        "def test_a_one():\n    assert True\n" * 1 + "def test_a_extra():\n    assert True\n" * 20,
+        encoding="utf-8",
+    )
+    (repo / "src.py").write_text("VALUE = 1\n", encoding="utf-8")
+    base = _commit_all(repo, "initial")
+    return repo
+
+
+def test_detects_pure_file_rename_under_tests(git_repo: Path):
+    base = subprocess.run(
+        ["git", "-C", str(git_repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    old_path = git_repo / "tests" / "unit" / "test_a.py"
+    new_path = git_repo / "tests" / "unit" / "test_a_renamed.py"
+    new_path.write_text(old_path.read_text(), encoding="utf-8")
+    old_path.unlink()
+    head = _commit_all(git_repo, "rename test file")
+
+    renames = detect_file_renames(git_repo, base, head)
+    assert renames == {"tests/unit/test_a.py": "tests/unit/test_a_renamed.py"}
+
+
+def test_in_place_modification_is_not_reported_as_rename(git_repo: Path):
+    base = subprocess.run(
+        ["git", "-C", str(git_repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    path = git_repo / "tests" / "unit" / "test_a.py"
+    path.write_text(path.read_text() + "\ndef test_a_two():\n    assert True\n", encoding="utf-8")
+    head = _commit_all(git_repo, "add a test")
+
+    assert detect_file_renames(git_repo, base, head) == {}
+
+
+def test_rename_outside_tests_dir_is_ignored(git_repo: Path):
+    base = subprocess.run(
+        ["git", "-C", str(git_repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    old_path = git_repo / "src.py"
+    new_path = git_repo / "src_renamed.py"
+    new_path.write_text(old_path.read_text(), encoding="utf-8")
+    old_path.unlink()
+    head = _commit_all(git_repo, "rename non-test file")
+
+    assert detect_file_renames(git_repo, base, head) == {}

--- a/tests/unit/test_check_test_dir_coverage.py
+++ b/tests/unit/test_check_test_dir_coverage.py
@@ -1,0 +1,78 @@
+"""scripts/check_test_dir_coverage.py の判定ロジックを検証する unit test。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.check_test_dir_coverage import (  # noqa: E402
+    discover_test_dirs,
+    find_unreferenced_dirs,
+    workflow_text,
+)
+
+
+class TestDiscoverTestDirs:
+    def test_lists_direct_subdirectories_only(self, tmp_path: Path):
+        tests_root = tmp_path / "tests"
+        (tests_root / "unit").mkdir(parents=True)
+        (tests_root / "e2e").mkdir()
+        (tests_root / "unit" / "nested").mkdir()  # 直下ではないので対象外
+
+        assert discover_test_dirs(tests_root) == ["e2e", "unit"]
+
+    def test_excludes_hidden_and_pycache_dirs(self, tmp_path: Path):
+        tests_root = tmp_path / "tests"
+        (tests_root / "unit").mkdir(parents=True)
+        (tests_root / "__pycache__").mkdir()
+        (tests_root / ".pytest_cache").mkdir()
+
+        assert discover_test_dirs(tests_root) == ["unit"]
+
+    def test_excludes_files(self, tmp_path: Path):
+        tests_root = tmp_path / "tests"
+        tests_root.mkdir()
+        (tests_root / "conftest.py").write_text("")
+        (tests_root / "unit").mkdir()
+
+        assert discover_test_dirs(tests_root) == ["unit"]
+
+    def test_missing_tests_root_returns_empty_list(self, tmp_path: Path):
+        assert discover_test_dirs(tmp_path / "no-such-dir") == []
+
+
+class TestWorkflowText:
+    def test_concatenates_yml_files(self, tmp_path: Path):
+        workflows_dir = tmp_path / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "a.yml").write_text("path: tests/unit\n")
+        (workflows_dir / "b.yml").write_text("path: tests/e2e\n")
+
+        text = workflow_text(workflows_dir)
+        assert "tests/unit" in text
+        assert "tests/e2e" in text
+
+    def test_missing_workflows_dir_returns_empty_string(self, tmp_path: Path):
+        assert workflow_text(tmp_path / "no-such-dir") == ""
+
+
+class TestFindUnreferencedDirs:
+    def test_flags_directory_not_mentioned_anywhere(self):
+        combined = "path: tests/unit tests/test_migrations\npath: tests/integration tests/e2e\n"
+        unreferenced = find_unreferenced_dirs(["unit", "e2e", "services"], combined)
+        assert unreferenced == ["services"]
+
+    def test_empty_when_all_referenced(self):
+        combined = "path: tests/unit tests/e2e\n"
+        assert find_unreferenced_dirs(["unit", "e2e"], combined) == []
+
+    def test_substring_match_does_not_require_word_boundary(self):
+        # 判定はディレクトリ名を含む文字列マッチのみ。`tests/unit-extra` のような
+        # 別ディレクトリを指すつもりの記述でも `tests/unit` は「参照あり」判定に
+        # なる(意図: シンプルさ優先。誤検知より過検知緩和側に倒す設計)。
+        combined = "path: tests/unit-extra\n"
+        assert find_unreferenced_dirs(["unit"], combined) == []

--- a/tests/unit/test_check_test_removal.py
+++ b/tests/unit/test_check_test_removal.py
@@ -16,6 +16,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from scripts.check_test_removal import (  # noqa: E402
     apply_renames,
+    decide,
     has_removal_marker,
     parse_collect_output,
     to_function_id,
@@ -110,3 +111,32 @@ class TestHasRemovalMarker:
 
     def test_empty_body_returns_false(self):
         assert has_removal_marker("") is False
+
+
+class TestDecide:
+    def test_no_removed_functions_is_allowed_regardless_of_marker(self):
+        base_ids = {"tests/unit/test_a.py::test_one"}
+        head_ids = {"tests/unit/test_a.py::test_one", "tests/unit/test_a.py::test_two"}
+        removed, allowed = decide(base_ids, head_ids, pr_body="")
+        assert removed == []
+        assert allowed is True
+
+    def test_removed_function_without_marker_is_not_allowed(self):
+        base_ids = {"tests/unit/test_a.py::test_one", "tests/unit/test_a.py::test_two"}
+        head_ids = {"tests/unit/test_a.py::test_one"}
+        removed, allowed = decide(base_ids, head_ids, pr_body="normal description\n")
+        assert removed == ["tests/unit/test_a.py::test_two"]
+        assert allowed is False
+
+    def test_removed_function_with_marker_is_allowed(self):
+        base_ids = {"tests/unit/test_a.py::test_one", "tests/unit/test_a.py::test_two"}
+        head_ids = {"tests/unit/test_a.py::test_one"}
+        removed, allowed = decide(base_ids, head_ids, pr_body="[test-removal: 重複テストの整理]\n")
+        assert removed == ["tests/unit/test_a.py::test_two"]
+        assert allowed is True
+
+    def test_removed_list_is_sorted(self):
+        base_ids = {"tests/unit/test_a.py::test_z", "tests/unit/test_a.py::test_a"}
+        head_ids = set()
+        removed, _allowed = decide(base_ids, head_ids, pr_body="")
+        assert removed == ["tests/unit/test_a.py::test_a", "tests/unit/test_a.py::test_z"]

--- a/tests/unit/test_check_test_removal.py
+++ b/tests/unit/test_check_test_removal.py
@@ -1,0 +1,112 @@
+"""scripts/check_test_removal.py のうちgitを介さない純粋関数を検証する unit test。
+
+git worktree/uv sync/pytest --collect-only を実際に起動する経路
+(`collect_test_ids` / `detect_file_renames` / `main` の統合的な振る舞い)は
+tests/e2e/test_check_test_removal.py で検証する。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.check_test_removal import (  # noqa: E402
+    apply_renames,
+    has_removal_marker,
+    parse_collect_output,
+    to_function_id,
+)
+
+
+class TestToFunctionId:
+    def test_strips_parametrize_suffix_on_plain_function(self):
+        assert to_function_id("tests/unit/test_foo.py::test_bar[case1]") == "tests/unit/test_foo.py::test_bar"
+
+    def test_strips_parametrize_suffix_on_class_method(self):
+        node_id = "tests/unit/test_foo.py::TestFoo::test_bar[case1]"
+        assert to_function_id(node_id) == "tests/unit/test_foo.py::TestFoo::test_bar"
+
+    def test_no_parametrize_suffix_is_unchanged(self):
+        node_id = "tests/unit/test_foo.py::TestFoo::test_bar"
+        assert to_function_id(node_id) == node_id
+
+    def test_parametrize_id_containing_brackets_is_still_stripped_from_first_bracket(self):
+        node_id = "tests/unit/test_foo.py::test_bar[value with [nested] bracket]"
+        assert to_function_id(node_id) == "tests/unit/test_foo.py::test_bar"
+
+
+class TestParseCollectOutput:
+    def test_extracts_node_ids_and_ignores_summary_lines(self):
+        stdout = (
+            "tests/unit/test_a.py::test_one\n"
+            "tests/unit/test_a.py::TestA::test_two[case1]\n"
+            "\n"
+            "2 tests collected in 0.02s\n"
+        )
+        assert parse_collect_output(stdout) == {
+            "tests/unit/test_a.py::test_one",
+            "tests/unit/test_a.py::TestA::test_two",
+        }
+
+    def test_parametrize_id_with_embedded_space_is_kept_as_one_entry(self):
+        # pytestのparametrize idは `[...]` 内に空白を含みうる。行頭が `<path>.py::`
+        # であれば行全体を1つのnode IDとして扱う必要がある。
+        stdout = "tests/unit/test_a.py::TestA::test_two[case with space]\n\n1 test collected in 0.01s\n"
+        assert parse_collect_output(stdout) == {"tests/unit/test_a.py::TestA::test_two"}
+
+    def test_warning_and_deprecation_lines_are_not_mistaken_for_node_ids(self):
+        stdout = (
+            "tests/unit/test_a.py::test_one\n"
+            "=============================== warnings summary ===============================\n"
+            ".venv/lib/python3.12/site-packages/foo.py:14\n"
+            "  DeprecationWarning: foo is deprecated\n"
+        )
+        assert parse_collect_output(stdout) == {"tests/unit/test_a.py::test_one"}
+
+    def test_empty_output_returns_empty_set(self):
+        assert parse_collect_output("") == set()
+
+
+class TestApplyRenames:
+    def test_remaps_path_component_of_matching_ids(self):
+        ids = {"tests/unit/test_old.py::TestFoo::test_bar", "tests/unit/test_other.py::test_baz"}
+        renames = {"tests/unit/test_old.py": "tests/unit/test_new.py"}
+        assert apply_renames(ids, renames) == {
+            "tests/unit/test_new.py::TestFoo::test_bar",
+            "tests/unit/test_other.py::test_baz",
+        }
+
+    def test_no_renames_returns_original_set_unchanged(self):
+        ids = {"tests/unit/test_a.py::test_one"}
+        assert apply_renames(ids, {}) == ids
+
+    def test_id_with_path_not_in_rename_map_is_left_alone(self):
+        ids = {"tests/unit/test_untouched.py::test_one"}
+        renames = {"tests/unit/test_other.py": "tests/unit/test_renamed.py"}
+        assert apply_renames(ids, renames) == ids
+
+
+class TestHasRemovalMarker:
+    def test_detects_marker_line(self):
+        body = "some description\n\n[test-removal: 重複テストの整理]\n\nmore text\n"
+        assert has_removal_marker(body) is True
+
+    def test_detects_marker_with_leading_whitespace(self):
+        body = "  [test-removal: reason here]\n"
+        assert has_removal_marker(body) is True
+
+    def test_no_marker_returns_false(self):
+        assert has_removal_marker("just a normal PR description\n") is False
+
+    def test_marker_text_mentioned_mid_sentence_is_not_a_marker(self):
+        # 行頭一致のみを許可する。文中に埋め込まれた言及では通過させない
+        # (無自覚な削除の見逃しを防ぐ設計)。
+        body = "この変更は [test-removal: ...] のような形式を今後使う予定、という説明文\n"
+        assert has_removal_marker(body) is False
+
+    def test_empty_body_returns_false(self):
+        assert has_removal_marker("") is False

--- a/tests/unit/test_check_unit_subprocess_placement.py
+++ b/tests/unit/test_check_unit_subprocess_placement.py
@@ -1,0 +1,78 @@
+"""scripts/check_unit_subprocess_placement.py の判定ロジックを検証する unit test。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.check_unit_subprocess_placement import (  # noqa: E402
+    find_violations,
+    load_allowlist,
+)
+
+# フィクスチャに書き込む呼び出し構文は文字列連結で組み立てる。このテストファイル
+# 自身も tests/unit/ 配下にあり、対象パターンをリテラルのまま書くと
+# check_unit_subprocess_placement.py 自身のスキャン対象にもなってしまうため。
+_SUBPROCESS_RUN_CALL = "subprocess" + ".run(['ls'])"
+_BARE_POPEN_CALL = "Po" + "pen(['ls'])"
+
+
+class TestLoadAllowlist:
+    def test_parses_names_and_skips_comments_and_blank_lines(self, tmp_path: Path):
+        allowlist_path = tmp_path / "allowlist.txt"
+        allowlist_path.write_text(
+            "# comment\n\ntest_a.py\n  test_b.py  \n# another comment\ntest_c.py\n"
+        )
+        assert load_allowlist(allowlist_path) == {"test_a.py", "test_b.py", "test_c.py"}
+
+    def test_missing_file_returns_empty_set(self, tmp_path: Path):
+        assert load_allowlist(tmp_path / "no-such-file.txt") == set()
+
+
+class TestFindViolations:
+    def test_detects_subprocess_run_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import subprocess\n{_SUBPROCESS_RUN_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_bare_popen_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"from subprocess import Popen\n{_BARE_POPEN_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_allowlisted_file_is_excluded(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_known.py").write_text(f"{_SUBPROCESS_RUN_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist={"test_known.py"}) == []
+
+    def test_docstring_mention_without_call_syntax_is_not_flagged(self, tmp_path: Path):
+        # docstring/コメント中の「subprocess.Popenが呼ばれる」のような散文的言及は
+        # 開き括弧を伴わないため検出対象外。
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_mention_only.py").write_text(
+            '"""正しい引数でsubprocess.Popenが呼ばれることを確認する"""\n'
+            "def test_x():\n    pass\n"
+        )
+
+        assert find_violations(unit_dir, allowlist=set()) == []
+
+    def test_non_python_files_are_ignored(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "notes.txt").write_text(f"{_SUBPROCESS_RUN_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == []
+
+    def test_missing_unit_dir_returns_empty_list(self, tmp_path: Path):
+        assert find_violations(tmp_path / "no-such-dir", allowlist=set()) == []

--- a/tests/unit/test_check_unit_subprocess_placement.py
+++ b/tests/unit/test_check_unit_subprocess_placement.py
@@ -19,6 +19,11 @@ from scripts.check_unit_subprocess_placement import (  # noqa: E402
 # check_unit_subprocess_placement.py 自身のスキャン対象にもなってしまうため。
 _SUBPROCESS_RUN_CALL = "subprocess" + ".run(['ls'])"
 _BARE_POPEN_CALL = "Po" + "pen(['ls'])"
+_SUBPROCESS_CALL_CALL = "subprocess" + ".call(['ls'])"
+_SUBPROCESS_CHECK_CALL_CALL = "subprocess" + ".check_call(['ls'])"
+_SUBPROCESS_CHECK_OUTPUT_CALL = "subprocess" + ".check_output(['ls'])"
+_OS_SYSTEM_CALL = "os" + ".system('ls')"
+_OS_POPEN_CALL = "os" + ".popen('ls')"
 
 
 class TestLoadAllowlist:
@@ -45,6 +50,41 @@ class TestFindViolations:
         unit_dir = tmp_path / "unit"
         unit_dir.mkdir()
         (unit_dir / "test_new.py").write_text(f"from subprocess import Popen\n{_BARE_POPEN_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_subprocess_call_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import subprocess\n{_SUBPROCESS_CALL_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_subprocess_check_call_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import subprocess\n{_SUBPROCESS_CHECK_CALL_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_subprocess_check_output_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import subprocess\n{_SUBPROCESS_CHECK_OUTPUT_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_os_system_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import os\n{_OS_SYSTEM_CALL}\n")
+
+        assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
+
+    def test_detects_os_popen_call(self, tmp_path: Path):
+        unit_dir = tmp_path / "unit"
+        unit_dir.mkdir()
+        (unit_dir / "test_new.py").write_text(f"import os\n{_OS_POPEN_CALL}\n")
 
         assert find_violations(unit_dir, allowlist=set()) == ["test_new.py"]
 


### PR DESCRIPTION
## Summary

- CIに `test-pyramid` jobを新設し、テストスイートの形状を3種類機械チェックする: (1) `tests/` 配下の各サブディレクトリがいずれかのCI jobから実行されているか、(2) `tests/unit/` に実プロセスを起動するテストが紛れ込んでいないか、(3) PRのbase→headでテスト関数が気づかれずに消えていないか
- (1)の実装過程で `tests/services/`（3ファイル・13テスト）がどのCI jobからも実行されていなかった実際の欠落を発見し、既存の `unit` job matrixのpathに追加して解消した
- (3)は意図的な削除であることを示す `[test-removal: <理由>]` マーカーをPR本文に含めることで通過できる（`[no-schema-shape-change]` 等の既存の例外マーカーと同じ運用）

## 背景

短期間でテストファイルが増加した一方、CI側にはテストスイートの構成そのものを検証する仕組みが無かった。実際に、テストディレクトリを新設してもCI設定への追加を忘れれば静かに未実行のまま残ること（`tests/services/`）、`tests/unit/` に実プロセス起動を伴うテストが規約に反して混入しうること、テスト関数が気づかれずに削除されても検知できないこと、の3点を確認した。

## 変更点

- `scripts/check_test_dir_coverage.py`: `tests/` 直下のサブディレクトリを動的に列挙し、`.github/workflows/*.yml` のいずれからも参照されていないディレクトリを検出する
- `scripts/check_unit_subprocess_placement.py`: `tests/unit/*.py` から実プロセスのsubprocess起動パターンを検出する。既存の許容ファイルは `scripts/test_pyramid_allowlist.txt` に列挙する（6ファイル）
- `scripts/check_test_removal.py`: base/headそれぞれのcommitを一時worktreeにcheckoutし、`pytest --collect-only` の結果を関数レベル（parametrize展開前）で比較する。gitのrename検出結果でファイルrenameによる誤検知を吸収する
- `.github/workflows/test.yml`: 上記3チェックを実行する `test-pyramid` job を追加。既存の `unit` job matrixに `tests/services` を追加し、CIで一切実行されていなかった13テストを実行対象に組み込んだ
- `docs/spec/test-convention.md`: 上記CI jobと `[test-removal: ...]` マーカーの運用を追記
- `tests/unit/test_check_test_dir_coverage.py` / `test_check_unit_subprocess_placement.py` / `test_check_test_removal.py`: 各スクリプトの純粋関数部分のunit test
- `tests/e2e/test_check_test_removal.py`: git rename検出のe2e test

## 検証: 直近PR 15件でのリプレイ

`check_test_removal.py` のロジックを、テストファイルの変更を伴う直近マージ済みPR15件（base commit→マージ済みsquash commit）に対して実際に走らせ、検知結果を実diffと突き合わせて手動分類した。

- 15件中9件でテスト関数の消失を検知、6件は検知なし（消えたテスト無し、想定通り）
- 検知9件の内訳:
  - 3件は迷いなく意図的な削除（機能撤去に伴うテスト削除2件、規約違反テストの削除1件）
  - 1件で単純なファイルrenameによる誤検知を発見（30件中18件が偽陽性）。gitのrename検出（`git diff --name-status -M`）でファイルパスを正規化するロジックを追加し、偽陽性を解消（30件→12件、残り12件は実際にファイルごと削除されたテスト）
  - 残り5件（延べ約20関数）は、同一ファイル内での関数リネーム＋アサーション内容の更新が絡む複合ケースだった。ソース側の関数リネームに追従してテスト関数名とアサーション本体の両方が変わっているため、rename検出のようなファイルパスの機械的な正規化では救えない。無理に「安全なリネーム」と判定を確定させず、**判定不可として保留**した。これらのPRは新しい規約下では `[test-removal: ...]` マーカーが1行必要になる

## テスト計画

- `check_test_dir_coverage.py` / `check_unit_subprocess_placement.py`: 変更前のmain（既知の許容ファイルを除く）に対して実行しexit 0になることを確認。`tests/services` 未参照という実際のCI欠落を検出することも確認した
- `check_test_removal.py`: 15件のPRのbase/head commitに対して実際に実行し、検知結果を実diffと突き合わせて分類。renameによる誤検知1件を修正で解消したことを確認した（修正前後でリプレイを再実行し30件→12件を確認）
- 新規追加した unit test は各スクリプトの純粋関数（ディレクトリ列挙・許可リスト読み込み・node ID正規化・rename適用・マーカー判定等）を対象とし、e2e testはgit rename検出の実リポジトリでの振る舞いを対象とする
- 既存の `tests/unit` + `tests/test_migrations` + `tests/services`（3474件）を実行し、新規追加分を含め全てpassすることを確認した。無関係な既存の環境依存失敗8件（relay設定・relay_outboxテーブル関連）が本ブランチとmain双方で再現することを確認しており、本PRの変更とは無関係