### PR TITLE
MCPブリッジのハング対策とsanitize hookのcitation_event_log移行

### DIFF
--- a/hooks/citation_event_log.py
+++ b/hooks/citation_event_log.py
@@ -1,0 +1,159 @@
+"""hook共通: citation_event_log (migration 0046) への書き込みユーティリティ
+
+sanitize_tool_result_hook.py / sanitize_backfill_hook.py の両方が使う
+citation_event_log INSERT ロジックを集約する。src.services.citations_service の
+record_citation_event と同じテーブルへ書くが、hooks は起動コストを抑えるため
+src.db 経由の重い import (sqlite_vec / yoyo) を避け、sqlite3 を直接使う薄い実装に
+している。source / verification_result の許容値だけは citations_service の
+VALID_EVENT_SOURCES / VALID_VERIFICATION_RESULTS と手動で同期させておく
+(migration 0046 の CHECK 制約と一致させる)。
+"""
+import json
+import sqlite3
+import sys
+
+VALID_SOURCES = (
+    "write_auto_convert",
+    "bulk_migration",
+    "transcript_post_tool_use",
+    "transcript_session_start_backfill",
+    "external_doc_sanitize",
+)
+VALID_VERIFICATION_RESULTS = ("exists", "dangling", "skip")
+
+
+def log_event(
+    db_path: str,
+    *,
+    source: str,
+    hook_label: str,
+    session_id: str | None,
+    transcript_path: str | None,
+    tool_name: str | None,
+    before_text: str,
+    after_text: str,
+    verification_result: str | None,
+    extra: dict,
+) -> None:
+    """citation_event_log に 1 行 INSERT する。
+
+    write conn を別張りして close する。session_id/transcript_path はこのテーブルに
+    専用カラムを持たないため extra_json に格納する。INSERT 自体の失敗
+    (source/verification_result のバリデーションエラーを含む) は hook_label 付きで
+    stderr に出すのみで例外を伝播しない (hook は非ブロックが原則のため)。
+    """
+    if source not in VALID_SOURCES:
+        sys.stderr.write(
+            f"[{hook_label}] citation_event_log write skipped: invalid source {source!r}\n"
+        )
+        return
+    if (
+        verification_result is not None
+        and verification_result not in VALID_VERIFICATION_RESULTS
+    ):
+        sys.stderr.write(
+            f"[{hook_label}] citation_event_log write skipped: "
+            f"invalid verification_result {verification_result!r}\n"
+        )
+        return
+    extra_json = json.dumps(
+        {"session_id": session_id, "transcript_path": transcript_path, **extra},
+        ensure_ascii=False,
+    )
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(
+                """
+                INSERT INTO citation_event_log (
+                    source, tool_name, before_text, after_text,
+                    verified_at, verification_result, extra_json
+                ) VALUES (?, ?, ?, ?, datetime('now'), ?, ?)
+                """,
+                (source, tool_name, before_text, after_text, verification_result, extra_json),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        sys.stderr.write(f"[{hook_label}] citation_event_log write failed: {exc}\n")
+
+
+def log_events_batch(
+    db_path: str,
+    *,
+    source: str,
+    hook_label: str,
+    session_id: str | None,
+    transcript_path: str | None,
+    events: list[dict],
+) -> None:
+    """events (block/field 単位の変換結果) を citation_event_log へ一括 INSERT する。
+
+    1 件ごとに connect/commit/close する log_event ではなく、1 connection・1
+    トランザクションで executemany する (大規模 transcript での起動コストを抑える)。
+    各 event は {"tool_name", "before_text", "after_text", "verification_result",
+    "stats"} を持つ想定。verification_result が不正な event は個別にスキップし、
+    残りは INSERT する。
+    """
+    if not events:
+        return
+    if source not in VALID_SOURCES:
+        sys.stderr.write(
+            f"[{hook_label}] citation_event_log batch write skipped: "
+            f"invalid source {source!r}\n"
+        )
+        return
+    rows = []
+    for event in events:
+        verification_result = event["verification_result"]
+        if (
+            verification_result is not None
+            and verification_result not in VALID_VERIFICATION_RESULTS
+        ):
+            sys.stderr.write(
+                f"[{hook_label}] citation_event_log batch write skipped event: "
+                f"invalid verification_result {verification_result!r}\n"
+            )
+            continue
+        extra_json = json.dumps(
+            {
+                "session_id": session_id,
+                "transcript_path": transcript_path,
+                "block_stats": event["stats"],
+            },
+            ensure_ascii=False,
+        )
+        rows.append(
+            (
+                source,
+                event["tool_name"],
+                event["before_text"],
+                event["after_text"],
+                verification_result,
+                extra_json,
+            )
+        )
+    if not rows:
+        return
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """
+                INSERT INTO citation_event_log (
+                    source, tool_name, before_text, after_text,
+                    verified_at, verification_result, extra_json
+                ) VALUES (?, ?, ?, ?, datetime('now'), ?, ?)
+                """,
+                rows,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        sys.stderr.write(f"[{hook_label}] citation_event_log batch write failed: {exc}\n")

--- a/hooks/sanitize_backfill_hook.py
+++ b/hooks/sanitize_backfill_hook.py
@@ -6,15 +6,19 @@ target 不在は [deleted X#NNN] に変換する。
 
 書き戻し方式: atomic rename + backup + mtime 再確認。
 書き込み直前に mtime が変化していれば harness が並行 append 中とみなして書き戻しを中断、
-sanitize_log に failure_reason を記録し sanitize_offset は据え置きで次回再試行する。
+citation_event_log (source='transcript_session_start_backfill') に failure イベントを
+記録し sanitize_offset は据え置きで次回再試行する。
 同一セッションで連続 3 回失敗したら以降の SessionStart はスキップする (ループ防止)。
+書き戻し成功時は、変化した tool_result block 単位で citation_event_log に 1 行ずつ
+INSERT する (write 経路の apply_raw_to_cite_conversion と同じ「field/block 単位で
+1 イベント」規約)。
 
 opt-out:
 - 環境変数 CC_MEMORY_SANITIZE_DISABLE=1: 即 exit 0
 - cwd が cc-memory リポジトリ内 (pyproject.toml [project].name == 'claude-code-memory'
   を上方向探索で検出): 即 exit 0
 
-例外時は stderr 警告 + sanitize_log failure 記録 + exit 0 (Claude Code 起動非ブロック)。
+例外時は stderr 警告 + citation_event_log failure イベント記録 + exit 0 (Claude Code 起動非ブロック)。
 """
 import json
 import os
@@ -262,15 +266,28 @@ def _build_tool_use_id_map(lines: list[dict]) -> dict[str, str]:
     return mp
 
 
+def _stringify_block_content(content: Any) -> str:
+    """tool_result.content (str or list of blocks) を citation_event_log の
+
+    before_text/after_text (TEXT NOT NULL) に格納できる文字列へ変換する。
+    str はそのまま、list はそのまま JSON シリアライズする。
+    """
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, ensure_ascii=False)
+
+
 def _sanitize_transcript_bytes(
     raw_bytes: bytes,
     offset: int,
     ro_conn: sqlite3.Connection,
-) -> tuple[bytes, dict, bool]:
+) -> tuple[bytes, dict, bool, list[dict]]:
     """transcript bytes を読み offset 以降の cc-memory tool_result を sanitize して再構築。
 
     offset 未満の行は元バイト列のままパススルー (byte-perfect 維持)。
-    Returns: (new_bytes, stats, modified)
+    Returns: (new_bytes, stats, modified, events)
+    events は変化した tool_result block 単位のリスト
+    ({tool_name, before_text, after_text, verification_result, stats})。
     """
     lines = _parse_transcript_lines(raw_bytes)
     tool_name_map = _build_tool_use_id_map(lines)
@@ -278,6 +295,7 @@ def _sanitize_transcript_bytes(
     stats = {"sanitized": 0, "dangling": 0, "occurrence": 0}
     out_chunks: list[bytes] = []
     modified = False
+    events: list[dict] = []
 
     for line_info in lines:
         if line_info["start"] < offset:
@@ -310,6 +328,17 @@ def _sanitize_transcript_bytes(
             if new_content != block_content:
                 new_blocks.append({**block, "content": new_content})
                 line_modified = True
+                events.append(
+                    {
+                        "tool_name": tool_name,
+                        "before_text": _stringify_block_content(block_content),
+                        "after_text": _stringify_block_content(new_content),
+                        "verification_result": (
+                            "dangling" if sub_stats["dangling"] else "exists"
+                        ),
+                        "stats": dict(sub_stats),
+                    }
+                )
             else:
                 new_blocks.append(block)
 
@@ -324,7 +353,7 @@ def _sanitize_transcript_bytes(
             out_chunks.append(line_info["bytes"])
 
     new_bytes = b"\n".join(out_chunks)
-    return new_bytes, stats, modified
+    return new_bytes, stats, modified, events
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +415,7 @@ def _write_back_transcript(
 
 
 # ---------------------------------------------------------------------------
-# sanitize_log INSERT
+# citation_event_log INSERT
 # ---------------------------------------------------------------------------
 
 
@@ -394,23 +423,27 @@ def _resolve_db_path() -> str:
     return os.environ.get("CC_MEMORY_DB_PATH", str(DEFAULT_DB_PATH))
 
 
-def _log_sanitize_event(
+def _log_citation_event(
     db_path: str,
     *,
     session_id: str | None,
     transcript_path: str | None,
-    occurrence_count: int,
-    sanitized_count: int,
-    failed_count: int,
-    failure_reason: str | None,
+    tool_name: str | None,
+    before_text: str,
+    after_text: str,
+    verification_result: str | None,
+    extra: dict,
 ) -> None:
-    """sanitize_log に 1 行 INSERT。write conn を別張りして close する。
+    """citation_event_log (migration 0046) に 1 行 INSERT する。
 
-    sanitize_log の CHECK 制約 (session_id IS NOT NULL OR transcript_path IS NOT NULL) を
-    満たさない場合はスキップ。INSERT 自体の失敗は stderr に出すのみで例外を伝播しない。
+    write conn を別張りして close する。session_id/transcript_path はこのテーブルに
+    専用カラムを持たないため extra_json に格納する。INSERT 自体の失敗は stderr に
+    出すのみで例外を伝播しない。
     """
-    if not session_id and not transcript_path:
-        return
+    extra_json = json.dumps(
+        {"session_id": session_id, "transcript_path": transcript_path, **extra},
+        ensure_ascii=False,
+    )
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
@@ -418,26 +451,76 @@ def _log_sanitize_event(
             conn.execute("PRAGMA busy_timeout=5000")
             conn.execute(
                 """
-                INSERT INTO sanitize_log (
-                    session_id, transcript_path, hook_kind,
-                    occurrence_count, sanitized_count, failed_count, failure_reason
-                ) VALUES (?, ?, 'session_start_backfill', ?, ?, ?, ?)
+                INSERT INTO citation_event_log (
+                    source, tool_name, before_text, after_text,
+                    verified_at, verification_result, extra_json
+                ) VALUES ('transcript_session_start_backfill', ?, ?, ?, datetime('now'), ?, ?)
                 """,
-                (
-                    session_id,
-                    transcript_path,
-                    occurrence_count,
-                    sanitized_count,
-                    failed_count,
-                    failure_reason,
-                ),
+                (tool_name, before_text, after_text, verification_result, extra_json),
             )
             conn.commit()
         finally:
             conn.close()
     except Exception as exc:
         sys.stderr.write(
-            f"[sanitize_backfill_hook] sanitize_log write failed: {exc}\n"
+            f"[sanitize_backfill_hook] citation_event_log write failed: {exc}\n"
+        )
+
+
+def _log_citation_events(
+    db_path: str,
+    *,
+    session_id: str | None,
+    transcript_path: str | None,
+    events: list[dict],
+) -> None:
+    """events (block 単位の変換結果) を citation_event_log へ一括 INSERT する。
+
+    大規模 transcript では変化した block 数が数百〜数千に達しうるため、1 件ごとに
+    connect/commit/close する _log_citation_event は使わず、1 connection・1
+    トランザクションで executemany する (SessionStart の起動コストを抑えるため)。
+    """
+    if not events:
+        return
+    rows = []
+    for event in events:
+        extra_json = json.dumps(
+            {
+                "session_id": session_id,
+                "transcript_path": transcript_path,
+                "block_stats": event["stats"],
+            },
+            ensure_ascii=False,
+        )
+        rows.append(
+            (
+                event["tool_name"],
+                event["before_text"],
+                event["after_text"],
+                event["verification_result"],
+                extra_json,
+            )
+        )
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """
+                INSERT INTO citation_event_log (
+                    source, tool_name, before_text, after_text,
+                    verified_at, verification_result, extra_json
+                ) VALUES ('transcript_session_start_backfill', ?, ?, ?, datetime('now'), ?, ?)
+                """,
+                rows,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        sys.stderr.write(
+            f"[sanitize_backfill_hook] citation_event_log batch write failed: {exc}\n"
         )
 
 
@@ -495,7 +578,7 @@ def main() -> int:
         raw_bytes = path.read_bytes()
 
         with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as ro_conn:
-            new_bytes, stats, modified = _sanitize_transcript_bytes(
+            new_bytes, stats, modified, events = _sanitize_transcript_bytes(
                 raw_bytes, offset, ro_conn
             )
 
@@ -505,33 +588,33 @@ def main() -> int:
                 path, new_bytes, original_mtime, int(time.time())
             )
 
-        sanitized = stats["sanitized"]
-        dangling = stats["dangling"]
-        occurrence = stats["occurrence"]
-
         if failure_reason is None:
-            _log_sanitize_event(
-                db_path,
-                session_id=session_id,
-                transcript_path=transcript_path,
-                occurrence_count=occurrence,
-                sanitized_count=sanitized,
-                failed_count=0,
-                failure_reason=None,
-            )
+            # 書き戻しが成功した (または変化がそもそも無かった) 場合のみ、変化した
+            # block 単位で citation_event_log にイベントを記録する。変化が無かった
+            # 呼び出し (events == []) は何も記録しない。
+            if events:
+                _log_citation_events(
+                    db_path,
+                    session_id=session_id,
+                    transcript_path=transcript_path,
+                    events=events,
+                )
             if state:
                 new_offset = len(new_bytes) if modified else file_size
                 state.set_sanitize_offset(new_offset)
                 state.set_sanitize_failure_count(0)
         else:
-            _log_sanitize_event(
+            # 書き戻し失敗時は個々の block イベントを記録せず (実際に永続化されて
+            # いないため)、failure イベント1件のみを記録する。
+            _log_citation_event(
                 db_path,
                 session_id=session_id,
                 transcript_path=transcript_path,
-                occurrence_count=occurrence,
-                sanitized_count=0,
-                failed_count=sanitized + dangling,
-                failure_reason=failure_reason,
+                tool_name=None,
+                before_text="",
+                after_text="",
+                verification_result=None,
+                extra={"failure_reason": failure_reason, "stats": stats, "event_count": len(events)},
             )
             if state:
                 state.set_sanitize_failure_count(failure_count + 1)
@@ -541,14 +624,15 @@ def main() -> int:
     except Exception as exc:
         sys.stderr.write(f"[sanitize_backfill_hook] {exc}\n")
         try:
-            _log_sanitize_event(
+            _log_citation_event(
                 db_path,
                 session_id=session_id,
                 transcript_path=transcript_path,
-                occurrence_count=0,
-                sanitized_count=0,
-                failed_count=0,
-                failure_reason=str(exc),
+                tool_name=None,
+                before_text="",
+                after_text="",
+                verification_result=None,
+                extra={"error": str(exc)},
             )
         except Exception:
             pass

--- a/hooks/sanitize_backfill_hook.py
+++ b/hooks/sanitize_backfill_hook.py
@@ -35,6 +35,7 @@ _project_root = Path(__file__).resolve().parents[1]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+from hooks.citation_event_log import log_event, log_events_batch
 from hooks.hook_state import HookState
 from hooks.hook_transcript import _is_cc_memory_tool
 from src.services.citations_pure import (
@@ -415,113 +416,12 @@ def _write_back_transcript(
 
 
 # ---------------------------------------------------------------------------
-# citation_event_log INSERT
+# db path
 # ---------------------------------------------------------------------------
 
 
 def _resolve_db_path() -> str:
     return os.environ.get("CC_MEMORY_DB_PATH", str(DEFAULT_DB_PATH))
-
-
-def _log_citation_event(
-    db_path: str,
-    *,
-    session_id: str | None,
-    transcript_path: str | None,
-    tool_name: str | None,
-    before_text: str,
-    after_text: str,
-    verification_result: str | None,
-    extra: dict,
-) -> None:
-    """citation_event_log (migration 0046) に 1 行 INSERT する。
-
-    write conn を別張りして close する。session_id/transcript_path はこのテーブルに
-    専用カラムを持たないため extra_json に格納する。INSERT 自体の失敗は stderr に
-    出すのみで例外を伝播しない。
-    """
-    extra_json = json.dumps(
-        {"session_id": session_id, "transcript_path": transcript_path, **extra},
-        ensure_ascii=False,
-    )
-    try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        try:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA busy_timeout=5000")
-            conn.execute(
-                """
-                INSERT INTO citation_event_log (
-                    source, tool_name, before_text, after_text,
-                    verified_at, verification_result, extra_json
-                ) VALUES ('transcript_session_start_backfill', ?, ?, ?, datetime('now'), ?, ?)
-                """,
-                (tool_name, before_text, after_text, verification_result, extra_json),
-            )
-            conn.commit()
-        finally:
-            conn.close()
-    except Exception as exc:
-        sys.stderr.write(
-            f"[sanitize_backfill_hook] citation_event_log write failed: {exc}\n"
-        )
-
-
-def _log_citation_events(
-    db_path: str,
-    *,
-    session_id: str | None,
-    transcript_path: str | None,
-    events: list[dict],
-) -> None:
-    """events (block 単位の変換結果) を citation_event_log へ一括 INSERT する。
-
-    大規模 transcript では変化した block 数が数百〜数千に達しうるため、1 件ごとに
-    connect/commit/close する _log_citation_event は使わず、1 connection・1
-    トランザクションで executemany する (SessionStart の起動コストを抑えるため)。
-    """
-    if not events:
-        return
-    rows = []
-    for event in events:
-        extra_json = json.dumps(
-            {
-                "session_id": session_id,
-                "transcript_path": transcript_path,
-                "block_stats": event["stats"],
-            },
-            ensure_ascii=False,
-        )
-        rows.append(
-            (
-                event["tool_name"],
-                event["before_text"],
-                event["after_text"],
-                event["verification_result"],
-                extra_json,
-            )
-        )
-    try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        try:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA busy_timeout=5000")
-            conn.executemany(
-                """
-                INSERT INTO citation_event_log (
-                    source, tool_name, before_text, after_text,
-                    verified_at, verification_result, extra_json
-                ) VALUES ('transcript_session_start_backfill', ?, ?, ?, datetime('now'), ?, ?)
-                """,
-                rows,
-            )
-            conn.commit()
-        finally:
-            conn.close()
-    except Exception as exc:
-        sys.stderr.write(
-            f"[sanitize_backfill_hook] citation_event_log batch write failed: {exc}\n"
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -593,8 +493,10 @@ def main() -> int:
             # block 単位で citation_event_log にイベントを記録する。変化が無かった
             # 呼び出し (events == []) は何も記録しない。
             if events:
-                _log_citation_events(
+                log_events_batch(
                     db_path,
+                    source="transcript_session_start_backfill",
+                    hook_label="sanitize_backfill_hook",
                     session_id=session_id,
                     transcript_path=transcript_path,
                     events=events,
@@ -606,8 +508,10 @@ def main() -> int:
         else:
             # 書き戻し失敗時は個々の block イベントを記録せず (実際に永続化されて
             # いないため)、failure イベント1件のみを記録する。
-            _log_citation_event(
+            log_event(
                 db_path,
+                source="transcript_session_start_backfill",
+                hook_label="sanitize_backfill_hook",
                 session_id=session_id,
                 transcript_path=transcript_path,
                 tool_name=None,
@@ -624,8 +528,10 @@ def main() -> int:
     except Exception as exc:
         sys.stderr.write(f"[sanitize_backfill_hook] {exc}\n")
         try:
-            _log_citation_event(
+            log_event(
                 db_path,
+                source="transcript_session_start_backfill",
+                hook_label="sanitize_backfill_hook",
                 session_id=session_id,
                 transcript_path=transcript_path,
                 tool_name=None,

--- a/hooks/sanitize_tool_result_hook.py
+++ b/hooks/sanitize_tool_result_hook.py
@@ -30,6 +30,7 @@ _project_root = Path(__file__).resolve().parents[1]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+from hooks.citation_event_log import log_event
 from hooks.hook_transcript import _is_cc_memory_tool
 from src.services.citations_pure import (
     TYPE_CODE_TO_NAME,
@@ -160,50 +161,6 @@ def _resolve_db_path() -> str:
     return os.environ.get("CC_MEMORY_DB_PATH", str(DEFAULT_DB_PATH))
 
 
-def _log_citation_event(
-    db_path: str,
-    *,
-    session_id: str | None,
-    transcript_path: str | None,
-    tool_name: str | None,
-    before_text: str,
-    after_text: str,
-    verification_result: str | None,
-    extra: dict,
-) -> None:
-    """citation_event_log (migration 0046) に 1 行 INSERT する。
-
-    write conn を別張りして close する。session_id/transcript_path はこのテーブルに
-    専用カラムを持たないため extra_json に格納する。INSERT 自体の失敗は stderr に
-    出すのみで例外を伝播しない。
-    """
-    extra_json = json.dumps(
-        {"session_id": session_id, "transcript_path": transcript_path, **extra},
-        ensure_ascii=False,
-    )
-    try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        try:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA busy_timeout=5000")
-            conn.execute(
-                """
-                INSERT INTO citation_event_log (
-                    source, tool_name, before_text, after_text,
-                    verified_at, verification_result, extra_json
-                ) VALUES ('transcript_post_tool_use', ?, ?, ?, datetime('now'), ?, ?)
-                """,
-                (tool_name, before_text, after_text, verification_result, extra_json),
-            )
-            conn.commit()
-        finally:
-            conn.close()
-    except Exception as exc:
-        sys.stderr.write(
-            f"[sanitize_tool_result_hook] citation_event_log write failed: {exc}\n"
-        )
-
-
 def _sanitize_content(content: str, db_path: str) -> tuple[str, dict]:
     """content を read-only conn で sanitize する。
 
@@ -281,8 +238,10 @@ def main() -> int:
         if sanitized_text != content:
             deleted_count = counters.get("deleted_count", 0)
             verification_result = "dangling" if deleted_count else "exists"
-            _log_citation_event(
+            log_event(
                 db_path,
+                source="transcript_post_tool_use",
+                hook_label="sanitize_tool_result_hook",
                 session_id=session_id,
                 transcript_path=transcript_path,
                 tool_name=tool_name,
@@ -304,8 +263,10 @@ def main() -> int:
         try:
             # 例外時は before_text/after_text を空文字・verification_result を NULL
             # にした failure イベントを記録する (NOT NULL 制約は空文字で満たす)。
-            _log_citation_event(
+            log_event(
                 db_path,
+                source="transcript_post_tool_use",
+                hook_label="sanitize_tool_result_hook",
                 session_id=session_id,
                 transcript_path=transcript_path,
                 tool_name=tool_name,

--- a/hooks/sanitize_tool_result_hook.py
+++ b/hooks/sanitize_tool_result_hook.py
@@ -12,8 +12,12 @@ opt-out:
   を上方向探索で検出): 即 exit 0
 
 dangling (target 不在) は `[deleted X#NNN]` 形式へ変換する。
-sanitize_log には 1 行 INSERT (write conn 別張り、WAL モード)。
-例外時は stderr 警告 + sanitize_log に failure_reason 記録 + exit 0 (非ブロック)。
+本文が実際に変化した場合のみ citation_event_log (source='transcript_post_tool_use')
+に 1 行 INSERT する (write conn 別張り、WAL モード)。変化なし (occurrence 0 件) の
+呼び出しは記録しない (write 経路の apply_raw_to_cite_conversion と同じ「変化なし
+イベントは記録しない」規約に合わせる)。
+例外時は stderr 警告 + before_text/after_text 空文字・verification_result NULL の
+failure イベントを citation_event_log に記録 + exit 0 (非ブロック)。
 """
 import json
 import os
@@ -156,23 +160,27 @@ def _resolve_db_path() -> str:
     return os.environ.get("CC_MEMORY_DB_PATH", str(DEFAULT_DB_PATH))
 
 
-def _log_sanitize_event(
+def _log_citation_event(
     db_path: str,
     *,
     session_id: str | None,
     transcript_path: str | None,
-    occurrence_count: int,
-    sanitized_count: int,
-    failed_count: int,
-    failure_reason: str | None,
+    tool_name: str | None,
+    before_text: str,
+    after_text: str,
+    verification_result: str | None,
+    extra: dict,
 ) -> None:
-    """sanitize_log に 1 行 INSERT する。write conn を別張りして close する。
+    """citation_event_log (migration 0046) に 1 行 INSERT する。
 
-    sanitize_log の CHECK 制約 (session_id IS NOT NULL OR transcript_path IS NOT NULL) を
-    満たさない呼び出しはスキップする。INSERT 自体の失敗は stderr に出すのみで例外を伝播しない。
+    write conn を別張りして close する。session_id/transcript_path はこのテーブルに
+    専用カラムを持たないため extra_json に格納する。INSERT 自体の失敗は stderr に
+    出すのみで例外を伝播しない。
     """
-    if not session_id and not transcript_path:
-        return
+    extra_json = json.dumps(
+        {"session_id": session_id, "transcript_path": transcript_path, **extra},
+        ensure_ascii=False,
+    )
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
@@ -180,26 +188,19 @@ def _log_sanitize_event(
             conn.execute("PRAGMA busy_timeout=5000")
             conn.execute(
                 """
-                INSERT INTO sanitize_log (
-                    session_id, transcript_path, hook_kind,
-                    occurrence_count, sanitized_count, failed_count, failure_reason
-                ) VALUES (?, ?, 'post_tool_use', ?, ?, ?, ?)
+                INSERT INTO citation_event_log (
+                    source, tool_name, before_text, after_text,
+                    verified_at, verification_result, extra_json
+                ) VALUES ('transcript_post_tool_use', ?, ?, ?, datetime('now'), ?, ?)
                 """,
-                (
-                    session_id,
-                    transcript_path,
-                    occurrence_count,
-                    sanitized_count,
-                    failed_count,
-                    failure_reason,
-                ),
+                (tool_name, before_text, after_text, verification_result, extra_json),
             )
             conn.commit()
         finally:
             conn.close()
     except Exception as exc:
         sys.stderr.write(
-            f"[sanitize_tool_result_hook] sanitize_log write failed: {exc}\n"
+            f"[sanitize_tool_result_hook] citation_event_log write failed: {exc}\n"
         )
 
 
@@ -229,6 +230,7 @@ def main() -> int:
     db_path = _resolve_db_path()
     session_id: str | None = None
     transcript_path: str | None = None
+    tool_name: str | None = None
     try:
         if os.environ.get("CC_MEMORY_SANITIZE_DISABLE") == "1":
             return 0
@@ -273,45 +275,44 @@ def main() -> int:
             }
         }
         print(json.dumps(output))
-        # occurrence_count = 検出した全 X#NNN (sanitized + dangling + 全 skip カテゴリ)。
-        # コードブロック等で意図的に skip した件数も「検出件数」に含める (運用監視の
-        # 完全性のため)。
-        # sanitized_count = 実際に {{cite:}} に変換した件数。
-        # failed_count は例外による失敗のみを表現する (本 try ブロック内は成功パスなので
-        # 常に 0)。dangling は正常変換 ([deleted X#NNN]) として扱い failed には含めない。
-        # dangling 件数は occurrence と sanitized の差から算出可能 (但し skip カテゴリ
-        # との内訳までは schema 上区別できない: 受容したトレードオフ)。
-        occurrence_count = (
-            counters.get("sanitized_count", 0)
-            + counters.get("skipped_dangling", 0)
-            + counters.get("skipped_in_codeblock", 0)
-            + counters.get("skipped_in_existing_cite", 0)
-            + counters.get("skipped_escape", 0)
-        )
-        _log_sanitize_event(
-            db_path,
-            session_id=session_id,
-            transcript_path=transcript_path,
-            occurrence_count=occurrence_count,
-            sanitized_count=counters.get("sanitized_count", 0),
-            failed_count=0,
-            failure_reason=None,
-        )
+        # 本文が実際に変化した (sanitized または dangling→[deleted] 変換が1件以上
+        # 発生した) 場合のみイベントを記録する。変化なしの呼び出しは記録しない
+        # (write 経路の apply_raw_to_cite_conversion と同じ規約)。
+        if sanitized_text != content:
+            deleted_count = counters.get("deleted_count", 0)
+            verification_result = "dangling" if deleted_count else "exists"
+            _log_citation_event(
+                db_path,
+                session_id=session_id,
+                transcript_path=transcript_path,
+                tool_name=tool_name,
+                before_text=content,
+                after_text=sanitized_text,
+                verification_result=verification_result,
+                extra={
+                    "sanitized_count": counters.get("sanitized_count", 0),
+                    "deleted_count": deleted_count,
+                    "skipped_dangling": counters.get("skipped_dangling", 0),
+                    "skipped_in_codeblock": counters.get("skipped_in_codeblock", 0),
+                    "skipped_in_existing_cite": counters.get("skipped_in_existing_cite", 0),
+                    "skipped_escape": counters.get("skipped_escape", 0),
+                },
+            )
         return 0
     except Exception as exc:
         sys.stderr.write(f"[sanitize_tool_result_hook] {exc}\n")
         try:
-            # 例外時は failure_reason に発生内容を記録する。failed_count は CHECK 制約
-            # (sanitized + failed <= occurrence) を満たすため 0 に固定する (count 系は
-            # 例外前に確定していない可能性がある)。
-            _log_sanitize_event(
+            # 例外時は before_text/after_text を空文字・verification_result を NULL
+            # にした failure イベントを記録する (NOT NULL 制約は空文字で満たす)。
+            _log_citation_event(
                 db_path,
                 session_id=session_id,
                 transcript_path=transcript_path,
-                occurrence_count=0,
-                sanitized_count=0,
-                failed_count=0,
-                failure_reason=str(exc),
+                tool_name=tool_name,
+                before_text="",
+                after_text="",
+                verification_result=None,
+                extra={"error": str(exc)},
             )
         except Exception:
             pass

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -107,12 +107,74 @@ HEARTBEAT_INTERVAL_SEC = _read_heartbeat_interval_sec()
 # 猶予秒数。超過したらtask group全体をキャンセルして強制退場する。
 # stdin EOF = Claude Code終了であり、サーバー側が応答しない限り待ち続ける理由が
 # ない（M#725「MCPブリッジハング調査」の沈黙ゾンビ化仮説への対策）。
-STDIN_EOF_GRACE_SEC = 10.0
+STDIN_EOF_GRACE_SEC_ENV = "CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC"
+DEFAULT_STDIN_EOF_GRACE_SEC = 10.0
+
+
+def _read_stdin_eof_grace_sec() -> float:
+    """env `CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC` から grace 秒数を読む。
+
+    未設定・無効値・0以下の場合は既定値にフォールバックする。
+    """
+    raw = os.environ.get(STDIN_EOF_GRACE_SEC_ENV)
+    if raw is None or raw == "":
+        return DEFAULT_STDIN_EOF_GRACE_SEC
+    try:
+        value = float(raw)
+    except ValueError:
+        print(
+            f"[launcher] WARNING Invalid {STDIN_EOF_GRACE_SEC_ENV}={raw!r}, "
+            f"falling back to default {DEFAULT_STDIN_EOF_GRACE_SEC}s",
+            file=sys.stderr,
+        )
+        return DEFAULT_STDIN_EOF_GRACE_SEC
+    if value <= 0:
+        print(
+            f"[launcher] WARNING {STDIN_EOF_GRACE_SEC_ENV} must be > 0, "
+            f"got {value}, falling back to default {DEFAULT_STDIN_EOF_GRACE_SEC}s",
+            file=sys.stderr,
+        )
+        return DEFAULT_STDIN_EOF_GRACE_SEC
+    return value
+
+
+STDIN_EOF_GRACE_SEC = _read_stdin_eof_grace_sec()
 
 # server_to_stdoutがread_streamから例外オブジェクトを連続して受け取った場合の
 # 上限回数。超過したらストリームが実質的に沈黙していると判断しループを打ち切り、
 # ServerDisconnectedとして外側のリトライに接続する（M#725対策）。
-MAX_CONSECUTIVE_STREAM_EXCEPTIONS = 5
+MAX_CONSECUTIVE_STREAM_EXCEPTIONS_ENV = "CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS"
+DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS = 5
+
+
+def _read_max_consecutive_stream_exceptions() -> int:
+    """env `CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS` から上限回数を読む。
+
+    未設定・無効値・0以下の場合は既定値にフォールバックする。
+    """
+    raw = os.environ.get(MAX_CONSECUTIVE_STREAM_EXCEPTIONS_ENV)
+    if raw is None or raw == "":
+        return DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+    try:
+        value = int(raw)
+    except ValueError:
+        print(
+            f"[launcher] WARNING Invalid {MAX_CONSECUTIVE_STREAM_EXCEPTIONS_ENV}={raw!r}, "
+            f"falling back to default {DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS}",
+            file=sys.stderr,
+        )
+        return DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+    if value <= 0:
+        print(
+            f"[launcher] WARNING {MAX_CONSECUTIVE_STREAM_EXCEPTIONS_ENV} must be > 0, "
+            f"got {value}, falling back to default {DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS}",
+            file=sys.stderr,
+        )
+        return DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+    return value
+
+
+MAX_CONSECUTIVE_STREAM_EXCEPTIONS = _read_max_consecutive_stream_exceptions()
 
 
 class ServerDisconnected(Exception):

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -103,6 +103,17 @@ def _read_heartbeat_interval_sec() -> float:
 
 HEARTBEAT_INTERVAL_SEC = _read_heartbeat_interval_sec()
 
+# stdin EOF後、server_to_stdoutの自然終了（read_streamのクローズ検知）を待つ
+# 猶予秒数。超過したらtask group全体をキャンセルして強制退場する。
+# stdin EOF = Claude Code終了であり、サーバー側が応答しない限り待ち続ける理由が
+# ない（M#725「MCPブリッジハング調査」の沈黙ゾンビ化仮説への対策）。
+STDIN_EOF_GRACE_SEC = 10.0
+
+# server_to_stdoutがread_streamから例外オブジェクトを連続して受け取った場合の
+# 上限回数。超過したらストリームが実質的に沈黙していると判断しループを打ち切り、
+# ServerDisconnectedとして外側のリトライに接続する（M#725対策）。
+MAX_CONSECUTIVE_STREAM_EXCEPTIONS = 5
+
 
 class ServerDisconnected(Exception):
     """サーバー側の切断を示す例外。stdin EOFとの区別に使用する。"""
@@ -349,12 +360,24 @@ async def _bridge() -> None:
 
                 read_streamが終了したとき、stdin_eofがFalseならサーバー側切断と判断し
                 ServerDisconnectedをraiseしてtask group全体をキャンセルする。
+                読み取り中に例外オブジェクトを MAX_CONSECUTIVE_STREAM_EXCEPTIONS 回
+                連続して受け取った場合は、ストリームが実質的に沈黙していると判断し
+                ループを自発的に打ち切る（finally節が同様に ServerDisconnected へ倒す）。
                 """
+                consecutive_exceptions = 0
                 try:
                     async for session_msg_or_exc in read_stream:
                         if isinstance(session_msg_or_exc, Exception):
+                            consecutive_exceptions += 1
                             logger.warning(f"Received exception from server: {session_msg_or_exc}")
+                            if consecutive_exceptions >= MAX_CONSECUTIVE_STREAM_EXCEPTIONS:
+                                logger.warning(
+                                    f"Giving up after {consecutive_exceptions} "
+                                    "consecutive stream exceptions"
+                                )
+                                break
                             continue
+                        consecutive_exceptions = 0
                         message = session_msg_or_exc.message
                         json_bytes = message.model_dump_json(
                             by_alias=True, exclude_none=True
@@ -394,10 +417,43 @@ async def _bridge() -> None:
                 tg へ伝播させて全タスクをキャンセルさせる）。
                 正常終了時は heartbeat_loop が無限ループのため自発的に終わらず、
                 外側 tg の cancel_scope を明示的にキャンセルして道連れにする。
+
+                stdin EOF後、server_to_stdout が STDIN_EOF_GRACE_SEC 以内に自発終了
+                しない場合（サーバー側がストリームを閉じない「沈黙ゾンビ化」、
+                M#725）、eof_watchdog が io_tg 自体をキャンセルして強制退場する。
+                この経路では stdin_eof が既に True のため、server_to_stdout の
+                finally 節は ServerDisconnected を raise しない（意図的な正常終了）。
                 """
+                stdin_done = anyio.Event()
+                stdout_done = anyio.Event()
+
+                async def stdin_to_server_wrapper() -> None:
+                    try:
+                        await stdin_to_server()
+                    finally:
+                        stdin_done.set()
+
+                async def server_to_stdout_wrapper() -> None:
+                    try:
+                        await server_to_stdout()
+                    finally:
+                        stdout_done.set()
+
+                async def eof_watchdog() -> None:
+                    await stdin_done.wait()
+                    with anyio.move_on_after(STDIN_EOF_GRACE_SEC):
+                        await stdout_done.wait()
+                        return
+                    logger.warning(
+                        f"server_to_stdout did not finish within "
+                        f"{STDIN_EOF_GRACE_SEC}s of stdin EOF; forcing bridge exit"
+                    )
+                    io_tg.cancel_scope.cancel()
+
                 async with anyio.create_task_group() as io_tg:
-                    io_tg.start_soon(stdin_to_server)
-                    io_tg.start_soon(server_to_stdout)
+                    io_tg.start_soon(stdin_to_server_wrapper)
+                    io_tg.start_soon(server_to_stdout_wrapper)
+                    io_tg.start_soon(eof_watchdog)
                 tg.cancel_scope.cancel()
 
             async with anyio.create_task_group() as tg:

--- a/tests/unit/test_citation_event_log.py
+++ b/tests/unit/test_citation_event_log.py
@@ -1,0 +1,243 @@
+"""hooks/citation_event_log.py のユニットテスト。
+
+sanitize_tool_result_hook / sanitize_backfill_hook が共有する
+citation_event_log INSERT ヘルパーの契約 (source / verification_result の
+バリデーション、バッチ INSERT の部分スキップ) を検証する。
+"""
+import json
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from hooks import citation_event_log
+
+_CITATION_EVENT_LOG_DDL = """
+CREATE TABLE citation_event_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at TEXT NOT NULL DEFAULT (datetime('now')),
+    source TEXT NOT NULL CHECK (source IN (
+        'write_auto_convert', 'bulk_migration',
+        'transcript_post_tool_use', 'transcript_session_start_backfill',
+        'external_doc_sanitize'
+    )),
+    tool_name TEXT,
+    target_entity_type TEXT CHECK (target_entity_type IS NULL OR target_entity_type IN (
+        'decision', 'activity', 'log', 'material', 'topic'
+    )),
+    target_entity_id INTEGER,
+    target_field TEXT,
+    before_text TEXT NOT NULL,
+    after_text TEXT NOT NULL,
+    verified_at TEXT,
+    verification_result TEXT CHECK (verification_result IS NULL OR verification_result IN (
+        'exists', 'dangling', 'skip'
+    )),
+    extra_json TEXT
+);
+"""
+
+
+@pytest.fixture
+def db_path():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.db")
+        conn = sqlite3.connect(path)
+        try:
+            conn.executescript(_CITATION_EVENT_LOG_DDL)
+            conn.commit()
+        finally:
+            conn.close()
+        yield path
+
+
+def _read_events(path: str) -> list[dict]:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT source, tool_name, before_text, after_text, verification_result, "
+            "extra_json FROM citation_event_log ORDER BY id"
+        ).fetchall()
+        results = []
+        for r in rows:
+            d = dict(r)
+            d["extra"] = json.loads(d.pop("extra_json"))
+            results.append(d)
+        return results
+    finally:
+        conn.close()
+
+
+class TestLogEvent:
+    def test_inserts_row_with_valid_values(self, db_path):
+        citation_event_log.log_event(
+            db_path,
+            source="transcript_post_tool_use",
+            hook_label="test_hook",
+            session_id="sess-1",
+            transcript_path="/tmp/t.jsonl",
+            tool_name="check_in",
+            before_text="M#1",
+            after_text="{{cite:M#1}}",
+            verification_result="exists",
+            extra={"sanitized_count": 1},
+        )
+        events = _read_events(db_path)
+        assert len(events) == 1
+        assert events[0]["source"] == "transcript_post_tool_use"
+        assert events[0]["tool_name"] == "check_in"
+        assert events[0]["before_text"] == "M#1"
+        assert events[0]["after_text"] == "{{cite:M#1}}"
+        assert events[0]["verification_result"] == "exists"
+        assert events[0]["extra"]["session_id"] == "sess-1"
+        assert events[0]["extra"]["transcript_path"] == "/tmp/t.jsonl"
+        assert events[0]["extra"]["sanitized_count"] == 1
+
+    def test_skips_invalid_source(self, db_path, capsys):
+        citation_event_log.log_event(
+            db_path,
+            source="not_a_real_source",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            tool_name=None,
+            before_text="x",
+            after_text="y",
+            verification_result="exists",
+            extra={},
+        )
+        assert _read_events(db_path) == []
+        assert "test_hook" in capsys.readouterr().err
+
+    def test_skips_invalid_verification_result(self, db_path, capsys):
+        citation_event_log.log_event(
+            db_path,
+            source="transcript_post_tool_use",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            tool_name=None,
+            before_text="x",
+            after_text="y",
+            verification_result="not_a_real_result",
+            extra={},
+        )
+        assert _read_events(db_path) == []
+        assert "test_hook" in capsys.readouterr().err
+
+    def test_allows_none_verification_result(self, db_path):
+        """failure イベント記録経路 (verification_result=None) は許可される。"""
+        citation_event_log.log_event(
+            db_path,
+            source="transcript_session_start_backfill",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            tool_name=None,
+            before_text="",
+            after_text="",
+            verification_result=None,
+            extra={"error": "boom"},
+        )
+        events = _read_events(db_path)
+        assert len(events) == 1
+        assert events[0]["verification_result"] is None
+        assert events[0]["extra"]["error"] == "boom"
+
+
+class TestLogEventsBatch:
+    def test_inserts_multiple_rows_in_one_call(self, db_path):
+        citation_event_log.log_events_batch(
+            db_path,
+            source="transcript_session_start_backfill",
+            hook_label="test_hook",
+            session_id="sess-1",
+            transcript_path="/tmp/t.jsonl",
+            events=[
+                {
+                    "tool_name": "check_in",
+                    "before_text": "M#1",
+                    "after_text": "{{cite:M#1}}",
+                    "verification_result": "exists",
+                    "stats": {"sanitized": 1, "dangling": 0, "occurrence": 1},
+                },
+                {
+                    "tool_name": "check_in",
+                    "before_text": "M#9999",
+                    "after_text": "[deleted M#9999]",
+                    "verification_result": "dangling",
+                    "stats": {"sanitized": 0, "dangling": 1, "occurrence": 1},
+                },
+            ],
+        )
+        events = _read_events(db_path)
+        assert len(events) == 2
+        assert events[0]["after_text"] == "{{cite:M#1}}"
+        assert events[0]["extra"]["block_stats"]["sanitized"] == 1
+        assert events[1]["after_text"] == "[deleted M#9999]"
+        assert events[1]["verification_result"] == "dangling"
+
+    def test_noop_on_empty_events(self, db_path):
+        citation_event_log.log_events_batch(
+            db_path,
+            source="transcript_session_start_backfill",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            events=[],
+        )
+        assert _read_events(db_path) == []
+
+    def test_skips_only_invalid_event_keeps_valid_ones(self, db_path, capsys):
+        """1件だけ verification_result が不正な event は個別にスキップし、
+
+        残りの正常な event は INSERT される。
+        """
+        citation_event_log.log_events_batch(
+            db_path,
+            source="transcript_session_start_backfill",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            events=[
+                {
+                    "tool_name": "check_in",
+                    "before_text": "M#1",
+                    "after_text": "{{cite:M#1}}",
+                    "verification_result": "exists",
+                    "stats": {},
+                },
+                {
+                    "tool_name": "check_in",
+                    "before_text": "bad",
+                    "after_text": "bad",
+                    "verification_result": "not_a_real_result",
+                    "stats": {},
+                },
+            ],
+        )
+        events = _read_events(db_path)
+        assert len(events) == 1
+        assert events[0]["before_text"] == "M#1"
+        assert "test_hook" in capsys.readouterr().err
+
+    def test_skips_all_when_source_invalid(self, db_path):
+        citation_event_log.log_events_batch(
+            db_path,
+            source="not_a_real_source",
+            hook_label="test_hook",
+            session_id=None,
+            transcript_path=None,
+            events=[
+                {
+                    "tool_name": "check_in",
+                    "before_text": "M#1",
+                    "after_text": "{{cite:M#1}}",
+                    "verification_result": "exists",
+                    "stats": {},
+                }
+            ],
+        )
+        assert _read_events(db_path) == []

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1104,6 +1104,72 @@ class TestReadMaxRetries:
         assert launcher._read_max_retries() is None
 
 
+class TestReadStdinEofGraceSec:
+    """_read_stdin_eof_grace_sec() のテスト"""
+
+    def test_returns_default_when_env_unset(self, monkeypatch):
+        """env 未設定時は既定値 (10.0秒) を返す"""
+        monkeypatch.delenv("CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC", raising=False)
+        assert launcher._read_stdin_eof_grace_sec() == launcher.DEFAULT_STDIN_EOF_GRACE_SEC
+
+    def test_returns_float_when_env_valid(self, monkeypatch):
+        """env が有効な数値のときはその値を返す"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC", "3.5")
+        assert launcher._read_stdin_eof_grace_sec() == 3.5
+
+    def test_returns_default_on_invalid_string(self, monkeypatch):
+        """env が数値に変換できない文字列のときは既定値にフォールバック"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC", "abc")
+        assert launcher._read_stdin_eof_grace_sec() == launcher.DEFAULT_STDIN_EOF_GRACE_SEC
+
+    def test_returns_default_on_zero_or_negative(self, monkeypatch):
+        """env が 0 以下のときは既定値にフォールバック"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC", "0")
+        assert launcher._read_stdin_eof_grace_sec() == launcher.DEFAULT_STDIN_EOF_GRACE_SEC
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_STDIN_EOF_GRACE_SEC", "-1")
+        assert launcher._read_stdin_eof_grace_sec() == launcher.DEFAULT_STDIN_EOF_GRACE_SEC
+
+
+class TestReadMaxConsecutiveStreamExceptions:
+    """_read_max_consecutive_stream_exceptions() のテスト"""
+
+    def test_returns_default_when_env_unset(self, monkeypatch):
+        """env 未設定時は既定値 (5) を返す"""
+        monkeypatch.delenv(
+            "CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS", raising=False
+        )
+        assert (
+            launcher._read_max_consecutive_stream_exceptions()
+            == launcher.DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+        )
+
+    def test_returns_int_when_env_valid(self, monkeypatch):
+        """env が有効な数値のときはその値を返す"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS", "8")
+        assert launcher._read_max_consecutive_stream_exceptions() == 8
+
+    def test_returns_default_on_invalid_string(self, monkeypatch):
+        """env が数値に変換できない文字列のときは既定値にフォールバック"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS", "abc")
+        assert (
+            launcher._read_max_consecutive_stream_exceptions()
+            == launcher.DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+        )
+
+    def test_returns_default_on_zero_or_negative(self, monkeypatch):
+        """env が 0 以下のときは既定値にフォールバック"""
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS", "0")
+        assert (
+            launcher._read_max_consecutive_stream_exceptions()
+            == launcher.DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+        )
+        monkeypatch.setenv("CC_MEMORY_LAUNCHER_MAX_CONSECUTIVE_STREAM_EXCEPTIONS", "-1")
+        assert (
+            launcher._read_max_consecutive_stream_exceptions()
+            == launcher.DEFAULT_MAX_CONSECUTIVE_STREAM_EXCEPTIONS
+        )
+
+
 class TestBackoffCap:
     def test_backoff_cap_constant(self):
         """BACKOFF_CAP_SEC が 60 秒に設定されている"""

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -588,6 +588,145 @@ class TestBridgeStdinEofWithHeartbeat:
         assert len(register_calls) >= 1
 
 
+def _contains_server_disconnected(exc: BaseException) -> bool:
+    """exc自体、またはBaseExceptionGroupのexceptions配下にServerDisconnectedが
+
+    含まれるかを再帰的に判定する（anyioのtask groupはExceptionGroupへ集約するため）。
+    """
+    if isinstance(exc, launcher.ServerDisconnected):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_contains_server_disconnected(sub) for sub in exc.exceptions)
+    return False
+
+
+class TestBridgeStdinEofGraceTimeout:
+    """_bridge: stdin EOF後、サーバー側がread_streamを閉じない「沈黙ゾンビ化」
+
+    (M#725) 状態でも、STDIN_EOF_GRACE_SEC 経過後に強制的に退場することの検証。
+    fixした対策が無ければ、read_streamが永遠に閉じないため_bridge()はハングし
+    続ける（テストがタイムアウトで失敗する）。
+    """
+
+    def test_bridge_exits_after_grace_period_when_server_stays_silent(
+        self, monkeypatch
+    ):
+        import asyncio
+        import os
+        import time
+        import types
+        from contextlib import asynccontextmanager
+
+        import anyio
+        import mcp.client.streamable_http as streamable_http_module
+
+        # grace期間を短縮し、テストの実時間を抑える
+        monkeypatch.setattr(launcher, "STDIN_EOF_GRACE_SEC", 0.1)
+        monkeypatch.setattr(launcher, "HEARTBEAT_INTERVAL_SEC", 1000.0)
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(**kwargs):
+            # read_stream には何も流さず、write_stream のクローズも監視しない
+            # (=サーバー側が応答しない「沈黙ゾンビ化」を模す)。
+            read_send, read_recv = anyio.create_memory_object_stream(10)
+            write_send, write_recv = anyio.create_memory_object_stream(10)
+
+            async def _get_session_id():
+                return None
+
+            try:
+                yield (read_recv, write_send, _get_session_id)
+            finally:
+                await read_send.aclose()
+                await write_recv.aclose()
+
+        monkeypatch.setattr(
+            streamable_http_module,
+            "streamable_http_client",
+            fake_streamable_http_client,
+        )
+
+        # 実パイプで本物の stdin EOF を即座に発生させる
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)  # 即EOF
+        read_file = os.fdopen(read_fd, "rb", buffering=0)
+        fake_stdin = types.SimpleNamespace(buffer=read_file)
+        monkeypatch.setattr(launcher.sys, "stdin", fake_stdin)
+
+        start = time.monotonic()
+        try:
+            # 対策が無ければここでハングし、外側のwait_forタイムアウト(2.0s)で
+            # 失敗する。対策が効いていればgrace(0.1s)経過後すぐ正常return する。
+            asyncio.run(asyncio.wait_for(launcher._bridge(), timeout=2.0))
+        finally:
+            read_file.close()
+        elapsed = time.monotonic() - start
+
+        # grace期間(0.1s)経過後まもなく退場していること（2.0sタイムアウトに
+        # 頼らずに済んでいること）を確認する
+        assert elapsed < 1.0, f"grace timeoutが効いていない可能性: {elapsed:.2f}s"
+
+
+class TestServerToStdoutConsecutiveExceptionCap:
+    """server_to_stdout: read_streamから例外オブジェクトを
+
+    MAX_CONSECUTIVE_STREAM_EXCEPTIONS 回連続で受け取った場合、無限にcontinueせず
+    ServerDisconnectedへ倒して外側のリトライに接続することの検証 (M#725)。
+    """
+
+    def test_gives_up_after_max_consecutive_exceptions(self, monkeypatch):
+        import asyncio
+        import os
+        import types
+        from contextlib import asynccontextmanager
+
+        import anyio
+        import mcp.client.streamable_http as streamable_http_module
+
+        monkeypatch.setattr(launcher, "MAX_CONSECUTIVE_STREAM_EXCEPTIONS", 3)
+        monkeypatch.setattr(launcher, "HEARTBEAT_INTERVAL_SEC", 1000.0)
+        monkeypatch.setattr(launcher, "STDIN_EOF_GRACE_SEC", 1000.0)
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(**kwargs):
+            read_send, read_recv = anyio.create_memory_object_stream(10)
+            write_send, write_recv = anyio.create_memory_object_stream(10)
+
+            async def _get_session_id():
+                return None
+
+            for _ in range(5):
+                await read_send.send(RuntimeError("stream hiccup"))
+
+            try:
+                yield (read_recv, write_send, _get_session_id)
+            finally:
+                await read_send.aclose()
+                await write_recv.aclose()
+
+        monkeypatch.setattr(
+            streamable_http_module,
+            "streamable_http_client",
+            fake_streamable_http_client,
+        )
+
+        # stdin は EOF に達しない実パイプ (書き込み端を閉じない)
+        read_fd, write_fd = os.pipe()
+        read_file = os.fdopen(read_fd, "rb", buffering=0)
+        fake_stdin = types.SimpleNamespace(buffer=read_file)
+        monkeypatch.setattr(launcher.sys, "stdin", fake_stdin)
+
+        try:
+            with pytest.raises(BaseException) as excinfo:
+                asyncio.run(asyncio.wait_for(launcher._bridge(), timeout=2.0))
+            assert _contains_server_disconnected(excinfo.value), (
+                f"ServerDisconnectedへ倒れていない: {excinfo.value!r}"
+            )
+        finally:
+            os.close(write_fd)
+            read_file.close()
+
+
 class TestServerDisconnected:
     def test_is_exception(self):
         """ServerDisconnectedがExceptionのサブクラスである"""

--- a/tests/unit/test_sanitize_backfill_hook.py
+++ b/tests/unit/test_sanitize_backfill_hook.py
@@ -23,26 +23,35 @@ from src.services.citations_pure import TYPE_TO_TABLE
 # ---------------------------------------------------------------------------
 
 
-_SANITIZE_LOG_DDL = """
-CREATE TABLE sanitize_log (
+_CITATION_EVENT_LOG_DDL = """
+CREATE TABLE citation_event_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id TEXT,
-    transcript_path TEXT,
-    hook_kind TEXT NOT NULL CHECK(hook_kind IN ('post_tool_use', 'session_start_backfill')),
-    occurrence_count INTEGER NOT NULL DEFAULT 0,
-    sanitized_count INTEGER NOT NULL DEFAULT 0,
-    failed_count INTEGER NOT NULL DEFAULT 0,
-    failure_reason TEXT,
-    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
-    CHECK(sanitized_count + failed_count <= occurrence_count),
-    CHECK(session_id IS NOT NULL OR transcript_path IS NOT NULL)
+    occurred_at TEXT NOT NULL DEFAULT (datetime('now')),
+    source TEXT NOT NULL CHECK (source IN (
+        'write_auto_convert', 'bulk_migration',
+        'transcript_post_tool_use', 'transcript_session_start_backfill',
+        'external_doc_sanitize'
+    )),
+    tool_name TEXT,
+    target_entity_type TEXT CHECK (target_entity_type IS NULL OR target_entity_type IN (
+        'decision', 'activity', 'log', 'material', 'topic'
+    )),
+    target_entity_id INTEGER,
+    target_field TEXT,
+    before_text TEXT NOT NULL,
+    after_text TEXT NOT NULL,
+    verified_at TEXT,
+    verification_result TEXT CHECK (verification_result IS NULL OR verification_result IN (
+        'exists', 'dangling', 'skip'
+    )),
+    extra_json TEXT
 );
 """
 
 
 @pytest.fixture
 def fixture_db(monkeypatch):
-    """sanitize_log + 最小 entity テーブル + M#1/D#1/L#1/A#1/T#1 を持つ一時 DB。"""
+    """citation_event_log + 最小 entity テーブル + M#1/D#1/L#1/A#1/T#1 を持つ一時 DB。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         conn = sqlite3.connect(db_path)
@@ -50,7 +59,7 @@ def fixture_db(monkeypatch):
             for table in TYPE_TO_TABLE.values():
                 conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
                 conn.execute(f"INSERT INTO {table} (id) VALUES (1)")
-            conn.executescript(_SANITIZE_LOG_DDL)
+            conn.executescript(_CITATION_EVENT_LOG_DDL)
             conn.commit()
         finally:
             conn.close()
@@ -122,15 +131,21 @@ def _run_hook(stdin_payload: dict) -> tuple[str, str, int]:
     return fake_stdout.getvalue(), fake_stderr.getvalue(), code
 
 
-def _read_sanitize_logs(db_path: str) -> list[dict]:
+def _read_citation_events(db_path: str) -> list[dict]:
+    """citation_event_log の全行を読み、extra_json を dict に展開して返す。"""
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT session_id, transcript_path, hook_kind, occurrence_count, "
-            "sanitized_count, failed_count, failure_reason FROM sanitize_log ORDER BY id"
+            "SELECT source, tool_name, before_text, after_text, verification_result, "
+            "extra_json FROM citation_event_log ORDER BY id"
         ).fetchall()
-        return [dict(r) for r in rows]
+        results = []
+        for r in rows:
+            d = dict(r)
+            d["extra"] = json.loads(d.pop("extra_json"))
+            results.append(d)
+        return results
     finally:
         conn.close()
 
@@ -170,13 +185,18 @@ def test_case_01_initial_backfill_whole_transcript(fixture_db, state_dir, tmp_pa
     state = HookState("sess-1")
     assert state.get_sanitize_offset() == transcript.stat().st_size
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["hook_kind"] == "session_start_backfill"
-    assert logs[0]["sanitized_count"] == 3
-    assert logs[0]["failed_count"] == 0
-    assert logs[0]["occurrence_count"] == 3
-    assert logs[0]["failure_reason"] is None
+    # 変化した tool_result block 単位で1イベント (block 2件が変化)
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 2
+    assert events[0]["source"] == "transcript_session_start_backfill"
+    assert events[0]["tool_name"] == _TOOL_NAME
+    assert events[0]["before_text"] == "found M#1 and D#1 here"
+    assert events[0]["after_text"] == "found {{cite:M#1}} and {{cite:D#1}} here"
+    assert events[0]["verification_result"] == "exists"
+    assert events[1]["before_text"] == "another ref M#1"
+    assert events[1]["after_text"] == "another ref {{cite:M#1}}"
+    total_sanitized = sum(e["extra"]["block_stats"]["sanitized"] for e in events)
+    assert total_sanitized == 3
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +237,9 @@ def test_case_02_incremental_backfill_only_past_offset(fixture_db, state_dir, tm
     assert new_entries[3]["message"]["content"][0]["content"] == \
         "new ref {{cite:D#1}}"
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["sanitized_count"] == 1
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["extra"]["block_stats"]["sanitized"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +250,7 @@ def test_case_02_incremental_backfill_only_past_offset(fixture_db, state_dir, tm
 def test_case_03_empty_transcript_path_no_op(fixture_db, state_dir):
     _, _, code = _run_hook({"session_id": "sess-1", "transcript_path": "", "cwd": "/tmp"})
     assert code == 0
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
     state = HookState("sess-1")
     assert state.get_sanitize_offset() == 0
 
@@ -291,10 +311,8 @@ def test_case_05_non_tool_result_entries_untouched(fixture_db, state_dir, tmp_pa
     # 1 文字も書き換わっていない
     assert transcript.read_bytes() == original
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["sanitized_count"] == 0
-    assert logs[0]["occurrence_count"] == 0
+    # tool_result block が1つも無いため、変化もイベント記録も発生しない
+    assert _read_citation_events(fixture_db) == []
 
 
 # ---------------------------------------------------------------------------
@@ -323,8 +341,9 @@ def test_case_06_non_cc_memory_tool_result_skipped(fixture_db, state_dir, tmp_pa
     assert new_entries[3]["message"]["content"][0]["content"] == \
         "cc-memory {{cite:M#1}} ref"
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert logs[0]["sanitized_count"] == 1
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["extra"]["block_stats"]["sanitized"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -357,11 +376,12 @@ def test_case_07_skip_codeblock_escape_existing_cite(fixture_db, state_dir, tmp_
     assert "{{cite:M#1}}" in out  # 既存 cite 維持
     assert "{{cite:D#1}}" in out  # 通常の D#1 のみ変換
 
-    logs = _read_sanitize_logs(fixture_db)
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
     # コードブロック等は occurrence に含まれるが sanitized されない。
     # sanitized=1 (D#1) + dangling=0 + skipped=4 (M#1 inline / fence / escape / existing cite) = 5
-    assert logs[0]["sanitized_count"] == 1
-    assert logs[0]["occurrence_count"] == 5
+    assert events[0]["extra"]["block_stats"]["sanitized"] == 1
+    assert events[0]["extra"]["block_stats"]["occurrence"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -384,11 +404,12 @@ def test_case_08_dangling_becomes_deleted_marker(fixture_db, state_dir, tmp_path
     out = new_entries[1]["message"]["content"][0]["content"]
     assert out == "known {{cite:M#1}}, missing [deleted M#9999]"
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert logs[0]["sanitized_count"] == 1
-    assert logs[0]["failed_count"] == 0  # dangling は failed_count に入らない
-    assert logs[0]["occurrence_count"] == 2
-    assert logs[0]["failure_reason"] is None
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    # dangling が1件以上含まれる場合、verification_result は 'dangling' (混在時の代表値)
+    assert events[0]["verification_result"] == "dangling"
+    assert events[0]["extra"]["block_stats"]["sanitized"] == 1
+    assert events[0]["extra"]["block_stats"]["dangling"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -407,22 +428,22 @@ def test_case_09_offset_progresses_idempotently(fixture_db, state_dir, tmp_path)
     # 1 回目
     _, _, code = _run_hook(_payload(str(transcript)))
     assert code == 0
-    first_logs = _read_sanitize_logs(fixture_db)
-    assert first_logs[0]["sanitized_count"] == 1
+    first_events = _read_citation_events(fixture_db)
+    assert len(first_events) == 1
+    assert first_events[0]["extra"]["block_stats"]["sanitized"] == 1
     first_offset = HookState("sess-1").get_sanitize_offset()
 
-    # 2 回目 (差分なし)
+    # 2 回目 (差分なし) → 変化が無いので新規イベントは記録されない
     _, _, code = _run_hook(_payload(str(transcript)))
     assert code == 0
-    second_logs = _read_sanitize_logs(fixture_db)
-    assert len(second_logs) == 2
-    assert second_logs[1]["sanitized_count"] == 0  # 二度目は何もしない
+    second_events = _read_citation_events(fixture_db)
+    assert len(second_events) == 1
     assert HookState("sess-1").get_sanitize_offset() == first_offset
 
 
 # ---------------------------------------------------------------------------
-# Case #10: hook 内例外 → stderr warning + sanitize_log 記録 + exit 0 +
-#           offset 据え置き (次回再試行)
+# Case #10: hook 内例外 → stderr warning + citation_event_log に failure イベント
+#           記録 + exit 0 + offset 据え置き (次回再試行)
 # ---------------------------------------------------------------------------
 
 
@@ -448,9 +469,12 @@ def test_case_10_exception_warns_logs_and_keeps_offset(fixture_db, state_dir, tm
     # スキャン/sanitize フェーズ例外も連続失敗カウンタを進める
     assert HookState("sess-1").get_sanitize_failure_count() == 1
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["failure_reason"] == "database is locked"
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["before_text"] == ""
+    assert events[0]["after_text"] == ""
+    assert events[0]["verification_result"] is None
+    assert events[0]["extra"]["error"] == "database is locked"
 
 
 def test_case_10_repeated_scan_exceptions_trigger_skip(fixture_db, state_dir, tmp_path, monkeypatch):
@@ -471,13 +495,13 @@ def test_case_10_repeated_scan_exceptions_trigger_skip(fixture_db, state_dir, tm
         _, _, code = _run_hook(_payload(str(transcript)))
         assert code == 0
     assert HookState("sess-1").get_sanitize_failure_count() == 3
-    logs_at_3 = _read_sanitize_logs(fixture_db)
-    assert len(logs_at_3) == 3
+    events_at_3 = _read_citation_events(fixture_db)
+    assert len(events_at_3) == 3
 
-    # 4 回目は loop guard で何もしない (log 件数据え置き)
+    # 4 回目は loop guard で何もしない (event 件数据え置き)
     _, _, code = _run_hook(_payload(str(transcript)))
     assert code == 0
-    assert _read_sanitize_logs(fixture_db) == logs_at_3
+    assert _read_citation_events(fixture_db) == events_at_3
 
 
 # ---------------------------------------------------------------------------
@@ -498,7 +522,7 @@ def test_case_11_env_disable_short_circuits(fixture_db, state_dir, tmp_path, mon
     _, _, code = _run_hook(_payload(str(transcript)))
     assert code == 0
     assert transcript.read_bytes() == original
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
     assert HookState("sess-1").get_sanitize_offset() == 0
 
 
@@ -527,7 +551,7 @@ def test_case_12_cwd_in_cc_memory_repo_skipped(fixture_db, state_dir, tmp_path):
     _, _, code = _run_hook(_payload(str(transcript), cwd=str(nested)))
     assert code == 0
     assert transcript.read_bytes() == original
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
 
 
 # ---------------------------------------------------------------------------
@@ -552,8 +576,10 @@ def test_case_13_perf_under_threshold(fixture_db, state_dir, tmp_path):
     assert code == 0
     assert elapsed < 10.0, f"hook took too long: {elapsed:.2f}s"
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert logs[0]["sanitized_count"] == 1000
+    events = _read_citation_events(fixture_db)
+    # 1000 block 全てが変化したので block 単位で 1000 イベント
+    assert len(events) == 1000
+    assert sum(e["extra"]["block_stats"]["sanitized"] for e in events) == 1000
 
 
 # ---------------------------------------------------------------------------
@@ -619,10 +645,10 @@ def test_case_15_write_back_success_uses_atomic_rename(tmp_path):
     assert leftover == [], f"leftover files: {leftover}"
 
 
-def test_case_15_harness_race_recorded_in_sanitize_log(
+def test_case_15_harness_race_recorded_as_failure_event(
     fixture_db, state_dir, tmp_path, monkeypatch
 ):
-    """main() 経由で harness_race を検出した場合 sanitize_log に failure 記録 + offset 据え置き。"""
+    """main() 経由で harness_race を検出した場合 citation_event_log に failure 記録 + offset 据え置き。"""
     transcript = tmp_path / "transcript.jsonl"
     entries = [
         _make_assistant_entry("toolu_01"),
@@ -640,9 +666,10 @@ def test_case_15_harness_race_recorded_in_sanitize_log(
     assert code == 0
     assert transcript.read_bytes() == original_bytes
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["failure_reason"] == "harness_race"
-    assert logs[0]["sanitized_count"] == 0
-    assert logs[0]["failed_count"] == 1
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["before_text"] == ""
+    assert events[0]["after_text"] == ""
+    assert events[0]["verification_result"] is None
+    assert events[0]["extra"]["failure_reason"] == "harness_race"
     assert HookState("sess-1").get_sanitize_offset() == 0

--- a/tests/unit/test_sanitize_tool_result_hook.py
+++ b/tests/unit/test_sanitize_tool_result_hook.py
@@ -21,26 +21,35 @@ from src.services.citations_pure import TYPE_TO_TABLE
 # ---------------------------------------------------------------------------
 
 
-_SANITIZE_LOG_DDL = """
-CREATE TABLE sanitize_log (
+_CITATION_EVENT_LOG_DDL = """
+CREATE TABLE citation_event_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id TEXT,
-    transcript_path TEXT,
-    hook_kind TEXT NOT NULL CHECK(hook_kind IN ('post_tool_use', 'session_start_backfill')),
-    occurrence_count INTEGER NOT NULL DEFAULT 0,
-    sanitized_count INTEGER NOT NULL DEFAULT 0,
-    failed_count INTEGER NOT NULL DEFAULT 0,
-    failure_reason TEXT,
-    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
-    CHECK(sanitized_count + failed_count <= occurrence_count),
-    CHECK(session_id IS NOT NULL OR transcript_path IS NOT NULL)
+    occurred_at TEXT NOT NULL DEFAULT (datetime('now')),
+    source TEXT NOT NULL CHECK (source IN (
+        'write_auto_convert', 'bulk_migration',
+        'transcript_post_tool_use', 'transcript_session_start_backfill',
+        'external_doc_sanitize'
+    )),
+    tool_name TEXT,
+    target_entity_type TEXT CHECK (target_entity_type IS NULL OR target_entity_type IN (
+        'decision', 'activity', 'log', 'material', 'topic'
+    )),
+    target_entity_id INTEGER,
+    target_field TEXT,
+    before_text TEXT NOT NULL,
+    after_text TEXT NOT NULL,
+    verified_at TEXT,
+    verification_result TEXT CHECK (verification_result IS NULL OR verification_result IN (
+        'exists', 'dangling', 'skip'
+    )),
+    extra_json TEXT
 );
 """
 
 
 @pytest.fixture
 def fixture_db(monkeypatch):
-    """sanitize_log + 最小 entity テーブル + M#1/D#1/L#1/A#1/T#1 を持つ一時 DB。"""
+    """citation_event_log + 最小 entity テーブル + M#1/D#1/L#1/A#1/T#1 を持つ一時 DB。"""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         conn = sqlite3.connect(db_path)
@@ -50,7 +59,7 @@ def fixture_db(monkeypatch):
                     f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)"
                 )
                 conn.execute(f"INSERT INTO {table} (id) VALUES (1)")
-            conn.executescript(_SANITIZE_LOG_DDL)
+            conn.executescript(_CITATION_EVENT_LOG_DDL)
             conn.commit()
         finally:
             conn.close()
@@ -71,15 +80,21 @@ def _run_hook(stdin_payload: dict) -> tuple[str, int]:
     return fake_stdout.getvalue(), code
 
 
-def _read_sanitize_logs(db_path: str) -> list[dict]:
+def _read_citation_events(db_path: str) -> list[dict]:
+    """citation_event_log の全行を読み、extra_json を dict に展開して返す。"""
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT session_id, transcript_path, hook_kind, occurrence_count, "
-            "sanitized_count, failed_count, failure_reason FROM sanitize_log ORDER BY id"
+            "SELECT source, tool_name, before_text, after_text, verification_result, "
+            "extra_json FROM citation_event_log ORDER BY id"
         ).fetchall()
-        return [dict(r) for r in rows]
+        results = []
+        for r in rows:
+            d = dict(r)
+            d["extra"] = json.loads(d.pop("extra_json"))
+            results.append(d)
+        return results
     finally:
         conn.close()
 
@@ -117,14 +132,16 @@ def test_case_01_valid_target_converted_to_cite(fixture_db):
         {"type": "text", "text": "ref to {{cite:M#1}} and {{cite:D#1}} here"}
     ]
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["session_id"] == "sess-abc"
-    assert logs[0]["hook_kind"] == "post_tool_use"
-    assert logs[0]["sanitized_count"] == 2
-    assert logs[0]["failed_count"] == 0
-    assert logs[0]["occurrence_count"] == 2
-    assert logs[0]["failure_reason"] is None
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["source"] == "transcript_post_tool_use"
+    assert events[0]["tool_name"] == _TOOL_NAME
+    assert events[0]["before_text"] == "ref to M#1 and D#1 here"
+    assert events[0]["after_text"] == "ref to {{cite:M#1}} and {{cite:D#1}} here"
+    assert events[0]["verification_result"] == "exists"
+    assert events[0]["extra"]["session_id"] == "sess-abc"
+    assert events[0]["extra"]["sanitized_count"] == 2
+    assert events[0]["extra"]["deleted_count"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +154,7 @@ def test_case_02_non_cc_memory_tool_is_noop(fixture_db):
     stdout, code = _run_hook(payload)
     assert code == 0
     assert stdout == ""  # no updatedToolOutput 出力
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +167,7 @@ def test_case_03_env_disable_short_circuits(fixture_db, monkeypatch):
     stdout, code = _run_hook(_payload("ref to M#1"))
     assert code == 0
     assert stdout == ""
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +188,7 @@ def test_case_04_cwd_in_cc_memory_repo_skipped(fixture_db, tmp_path):
     stdout, code = _run_hook(payload)
     assert code == 0
     assert stdout == ""
-    assert _read_sanitize_logs(fixture_db) == []
+    assert _read_citation_events(fixture_db) == []
 
 
 def test_case_04_cwd_in_unrelated_project_not_skipped(fixture_db, tmp_path):
@@ -190,11 +207,11 @@ def test_case_04_cwd_in_unrelated_project_not_skipped(fixture_db, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case #5: content に X#NNN が無い → 何も変換しない、log は count=0 で INSERT
+# Case #5: content に X#NNN が無い → 何も変換しない、本文が変化しないので event も記録しない
 # ---------------------------------------------------------------------------
 
 
-def test_case_05_no_raw_literals_logs_zero(fixture_db):
+def test_case_05_no_raw_literals_logs_nothing(fixture_db):
     stdout, code = _run_hook(_payload("plain text without any ids"))
     assert code == 0
     out = json.loads(stdout)
@@ -202,11 +219,7 @@ def test_case_05_no_raw_literals_logs_zero(fixture_db):
         {"type": "text", "text": "plain text without any ids"}
     ]
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["occurrence_count"] == 0
-    assert logs[0]["sanitized_count"] == 0
-    assert logs[0]["failed_count"] == 0
+    assert _read_citation_events(fixture_db) == []
 
 
 # ---------------------------------------------------------------------------
@@ -224,12 +237,13 @@ def test_case_06_code_block_literals_preserved(fixture_db):
         {"type": "text", "text": "see `M#1 inline` and outside {{cite:D#1}} too"}
     ]
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["sanitized_count"] == 1
-    assert logs[0]["failed_count"] == 0
-    # occurrence は全 X#NNN を含む (コードブロック内も検出件数に含める)
-    assert logs[0]["occurrence_count"] == 2
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["verification_result"] == "exists"
+    assert events[0]["extra"]["sanitized_count"] == 1
+    assert events[0]["extra"]["deleted_count"] == 0
+    # skipped_in_codeblock はコードブロック内でスキップした件数 (M#1 inline の1件)
+    assert events[0]["extra"]["skipped_in_codeblock"] == 1
 
 
 def test_case_06_fenced_code_block_preserved(fixture_db):
@@ -260,14 +274,13 @@ def test_case_07_dangling_target_becomes_deleted_marker(fixture_db):
         {"type": "text", "text": "known {{cite:M#1}}, missing [deleted M#9999999] here"}
     ]
 
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    # dangling は正常変換扱い: failed_count には入らず、occurrence と sanitized の差で
-    # 表現される。failed_count は例外失敗のみを表す。
-    assert logs[0]["sanitized_count"] == 1
-    assert logs[0]["failed_count"] == 0
-    assert logs[0]["occurrence_count"] == 2
-    assert logs[0]["failure_reason"] is None
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    # dangling が1件以上含まれる場合、verification_result は 'dangling' (混在時の代表値)
+    assert events[0]["verification_result"] == "dangling"
+    assert events[0]["after_text"] == "known {{cite:M#1}}, missing [deleted M#9999999] here"
+    assert events[0]["extra"]["sanitized_count"] == 1
+    assert events[0]["extra"]["deleted_count"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -285,17 +298,20 @@ def test_case_08_sqlite_operational_error_logged_as_failure(fixture_db, monkeypa
     assert code == 0
     # 変換失敗時は updatedToolOutput を返さない (transcript を壊さない)
     assert stdout == ""
-    logs = _read_sanitize_logs(fixture_db)
-    assert len(logs) == 1
-    assert logs[0]["failure_reason"] == "database is locked"
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["before_text"] == ""
+    assert events[0]["after_text"] == ""
+    assert events[0]["verification_result"] is None
+    assert events[0]["extra"]["error"] == "database is locked"
 
 
 # ---------------------------------------------------------------------------
-# Case #9: Python 例外 (JSON parse 失敗) → warning + failure_reason 記録
+# Case #9: Python 例外 (JSON parse 失敗) → warning + failure イベント記録
 # ---------------------------------------------------------------------------
 
 
-def test_case_09_invalid_json_logs_failure_reason(fixture_db):
+def test_case_09_invalid_json_logs_failure_event(fixture_db):
     fake_stdin = io.StringIO("not-a-json-blob")
     fake_stdout = io.StringIO()
     fake_stderr = io.StringIO()
@@ -305,9 +321,14 @@ def test_case_09_invalid_json_logs_failure_reason(fixture_db):
         code = sanitize_tool_result_hook.main()
     assert code == 0
     assert fake_stdout.getvalue() == ""
-    # session_id / transcript_path が不明なので sanitize_log は記録できない (CHECK 制約)
-    # → log 0 件で OK、stderr に警告だけ出る
     assert "[sanitize_tool_result_hook]" in fake_stderr.getvalue()
+    # citation_event_log には session_id/transcript_path 専用カラムが無いため
+    # (CHECK 制約も無い)、不明なままでも failure イベントが1件記録される
+    events = _read_citation_events(fixture_db)
+    assert len(events) == 1
+    assert events[0]["verification_result"] is None
+    assert events[0]["extra"]["session_id"] is None
+    assert "error" in events[0]["extra"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sanitize_tool_result_hook.py
+++ b/tests/unit/test_sanitize_tool_result_hook.py
@@ -328,7 +328,8 @@ def test_case_09_invalid_json_logs_failure_event(fixture_db):
     assert len(events) == 1
     assert events[0]["verification_result"] is None
     assert events[0]["extra"]["session_id"] is None
-    assert "error" in events[0]["extra"]
+    # json.loads("not-a-json-blob") が送出する JSONDecodeError の実メッセージまで検証する
+    assert events[0]["extra"]["error"] == "Expecting value: line 1 column 1 (char 0)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

2つの独立した修正を含む。

**MCPブリッジ (`src/launcher.py`)**
- stdin EOF後にサーバー側が `read_stream` を閉じない「沈黙ゾンビ化」でブリッジが無期限にハングするケースに対し、猶予秒数 (`STDIN_EOF_GRACE_SEC`, 10秒) 経過後に強制的にtask groupをキャンセルして退場するようにした。stdin EOF起因のため、この経路では `ServerDisconnected` は投げず正常終了する。
- `server_to_stdout` が `read_stream` から例外オブジェクトを連続で受け取り続けるケース（無限に `continue` していた）に上限 (`MAX_CONSECUTIVE_STREAM_EXCEPTIONS`, 5回) を設け、超過したら `ServerDisconnected` として外側のリトライへ接続するようにした。

**sanitize hook (`hooks/sanitize_tool_result_hook.py` / `hooks/sanitize_backfill_hook.py`)**
- ログ記録先を集計カウンタ型の `sanitize_log`（migration 0044、INSERT経路が未実装のまま据え置かれていた）から、migration 0046で新設済みの `citation_event_log` へ移行した。
- `sanitize_tool_result_hook`: 本文が実際に変化したtool_response単位で1イベントを記録（変化なしの呼び出しは記録しない。write経路の `apply_raw_to_cite_conversion` と同じ規約）。
- `sanitize_backfill_hook`: 変化した `tool_result` block単位で1イベントを記録。大規模transcriptでの起動コストを抑えるため、block単位イベントは1 connectionで `executemany` する一括INSERTにした。
- 例外・書き戻し失敗時は `before_text`/`after_text` 空文字・`verification_result` NULLのfailureイベントを記録する。

## 補足

- `citation_event_log` テーブル自体はmigration 0046で既に作られており、本PRはINSERT経路を新設するのみでスキーマ変更はない。
- 2つの修正は依存関係が無いため、レビューしやすいよう別コミットに分けている。

## テスト計画

- `src/launcher.py`: stdin EOF後にサーバーが無応答のまま (`read_stream` が閉じない) でも `STDIN_EOF_GRACE_SEC` 経過後に `_bridge()` が正常returnすることを検証するテストを追加 (`TestBridgeStdinEofGraceTimeout`)。対策前はこのシナリオでハングし続ける。
- `src/launcher.py`: `read_stream` から例外オブジェクトを `MAX_CONSECUTIVE_STREAM_EXCEPTIONS` 回連続受信した場合に `ServerDisconnected` へ倒れることを検証するテストを追加 (`TestServerToStdoutConsecutiveExceptionCap`)。
- 既存の `_bridge()` 系テスト（heartbeat並行動作、stdin EOF正常終了、identityヘッダ付与等）が引き続き通ることを確認。
- `hooks/sanitize_tool_result_hook.py` / `hooks/sanitize_backfill_hook.py`: 既存のエッジケーステスト群を `citation_event_log` スキーマ・block/field単位のイベント記録に合わせて全面的に書き換え、変換成功・dangling・コードブロック/エスケープskip・例外時failureイベント・書き戻し失敗 (harness_race)・大規模transcript(1000 block)でのイベント記録件数などを検証。
- `tests/unit`・`tests/test_migrations`・`tests/services` を全件実行し、3450 passed / 1 xfailed / 1 failed（`test_habit_projection.py` のreadonly権限テストで、コンテナがroot実行のため `chmod 0o500` が効かない環境依存の既存問題。本PRの変更とは無関係）。

## Revert

R1: migration非接触。revert commitのみで戻る。


---
_Generated by [Claude Code](https://claude.ai/code/session_016vgrV8jD4M4K8ZwuEoJgA2)_